### PR TITLE
feat(pipeline): the budget dial — paid dispatch behind a hard daily spend ceiling (#3737)

### DIFF
--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -44,6 +44,27 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Transliteration | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
 | Summary/Index/Chapters | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
 
+## The Budget Dial (#3737)
+
+Spend is a **number**, not a switch. `system_config.processing_control.daily_budget_usd`
+is the ceiling for paid dispatch; `scripts/lib/spend-guard.mjs` gates orchestrator
+Phase 2 (OCR submit) and Phase 4 (translation dispatch) against today's measured
+`gemini_usage` spend (UTC day, ObjectId-range — the `timestamp` field is a string on
+old rows). **Default-closed:** unset/null/0 means NO paid dispatch even when
+`paused: false` — flipping the old pause flag can no longer reopen unbounded spending.
+In-flight work always finishes; `--phase N --book=ID` operator runs bypass the dial
+exactly as they bypass the pause. Enrichment (Phases 6–7) isn't gated directly but its
+spend counts toward the measured total, and its volume is downstream of gated phases.
+`cost_usd` is a computed estimate and some rows lack it → the guard can UNDERCOUNT;
+treat the ceiling as a brake, not accounting. The guard logs `spend $X / $Y` every cycle.
+
+**To turn the line on (Derek):**
+1. Set the dial: `db.system_config.updateOne({_id:'processing_control'}, {$set:{daily_budget_usd: 5}})` — start at $5/day.
+2. Unpause: `{$set:{paused:false}}` (same doc).
+3. Re-add the scheduler line to the live Hetzner crontab — it already exists in `scripts/workers/crontab.production` line 20 (`*/2 * * * * … scheduler.mjs`); the live crontab lost it during the pause era.
+4. Watch `/var/log/sourcelibrary/scheduler.log` + `pipeline.log` for the `[spend-guard]` lines; first candidates processed should be `loop_quarantine_hold` books once those are re-enrolled.
+5. Failure at step 4 = no `[spend-guard]` line at all → the box hasn't pulled main yet (auto-pull ~5 min) or the crontab line didn't take (`crontab -l | grep scheduler`).
+
 ## Emergency Controls
 
 - **Stop all:** Set `system_config._id: 'processing_control'` → `paused: true`

--- a/scripts/lib/spend-guard.mjs
+++ b/scripts/lib/spend-guard.mjs
@@ -1,0 +1,80 @@
+/**
+ * spend-guard — the budget dial (issue #3737).
+ *
+ * Makes pipeline spend a NUMBER someone sets rather than a switch someone
+ * fears. The orchestrator's paid dispatch phases (2: OCR submit, 4:
+ * translation dispatch) call budgetAllowsDispatch() before creating work;
+ * once today's measured Gemini spend reaches the ceiling, dispatch stops.
+ * In-flight work always finishes — nothing is killed mid-book.
+ *
+ * The dial: `system_config.processing_control.daily_budget_usd`.
+ *   - unset / null / 0  → NO paid dispatch (default-closed: flipping the old
+ *     `paused` flag off must not reopen unbounded spending by accident)
+ *   - positive number   → dispatch until today's spend reaches it (UTC day)
+ *
+ * Spend is measured from `gemini_usage`. Two deliberate choices:
+ *   - Rows are selected by **ObjectId time range**, not the `timestamp` field —
+ *     old rows store timestamp as a string, and Date-range queries silently
+ *     return nothing (known trap, pipeline-architecture "Known Bugs" #1).
+ *   - `cost_usd` is a computed estimate, not billed truth, and some writers
+ *     omit it. Missing costs count as 0, so the guard can UNDERCOUNT — treat
+ *     the ceiling as a strong brake, not an accounting system. The costless
+ *     row count is returned so the log shows how blind the measurement is.
+ */
+
+import { ObjectId } from 'mongodb';
+
+/** Start of the current UTC day. */
+export function utcDayStart(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+/** Today's measured Gemini spend: { usd, rows, costlessRows }. */
+export async function getTodaySpendUsd(db, now = new Date()) {
+  const minId = ObjectId.createFromTime(Math.floor(utcDayStart(now).getTime() / 1000));
+  const [agg] = await db.collection('gemini_usage').aggregate([
+    { $match: { _id: { $gte: minId } } },
+    {
+      $group: {
+        _id: null,
+        usd: { $sum: { $ifNull: ['$cost_usd', 0] } },
+        rows: { $sum: 1 },
+        costlessRows: { $sum: { $cond: [{ $ifNull: ['$cost_usd', false] }, 0, 1] } },
+      },
+    },
+  ]).toArray();
+  return { usd: agg?.usd || 0, rows: agg?.rows || 0, costlessRows: agg?.costlessRows || 0 };
+}
+
+/** The dial's current value, or null when unset/invalid. */
+export function readDailyBudgetUsd(control) {
+  const v = control?.daily_budget_usd;
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : null;
+}
+
+/**
+ * The gate. Returns true iff paid dispatch may proceed right now, and logs
+ * one line either way so the dial is always visible in the phase logs.
+ *
+ * opts.bypass mirrors the pause-flag semantics for explicit single-book
+ * operator runs (--phase N --book=ID): a human at the wheel outranks the dial
+ * for one book, exactly as they outrank the pause.
+ */
+export async function budgetAllowsDispatch(db, label, { bypass = false, control: preloadedControl } = {}) {
+  if (bypass) {
+    console.log(`  [spend-guard] ${label}: BYPASS (explicit --book operator run)`);
+    return true;
+  }
+  const control = preloadedControl
+    ?? await db.collection('system_config').findOne({ _id: 'processing_control' });
+  const budget = readDailyBudgetUsd(control);
+  if (budget === null) {
+    console.log(`  [spend-guard] ${label}: no daily_budget_usd set — paid dispatch stays OFF (the dial is default-closed).`);
+    return false;
+  }
+  const spend = await getTodaySpendUsd(db);
+  const allowed = spend.usd < budget;
+  const blind = spend.costlessRows > 0 ? ` (${spend.costlessRows} rows without cost_usd — spend is undercounted)` : '';
+  console.log(`  [spend-guard] ${label}: spend $${spend.usd.toFixed(2)} / $${budget.toFixed(2)} today (UTC), ${spend.rows} calls${blind} → ${allowed ? 'DISPATCH' : 'CEILING REACHED — no new dispatch'}`);
+  return allowed;
+}

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -26,6 +26,7 @@ import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
+import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
 import { getTranslateModelForBook } from '../lib/translate-core.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
@@ -3789,7 +3790,7 @@ Rules:
     // Two-pass strategy:
     //   Pass 1 ("preview"): First 25 pages of first-translation books — gives readers content fast
     //   Pass 2 ("full"): Remaining pages for books that already have preview OCR
-    if (shouldRun(2)) {
+    if (shouldRun(2) && await budgetAllowsDispatch(db, 'Phase 2 (OCR submit)', { bypass: !!BOOK_OVERRIDE })) {
       console.log('\n--- Phase 2: OCR submission ---');
 
       // Ordering gate: never OCR a book before Phase 1.97 has deduped it, else
@@ -4395,7 +4396,7 @@ Rules:
     // ── Phase 4: Dispatch translation to Lambda via SQS FIFO ──
     // Hetzner focuses on OCR; Lambdas scale out translation.
     // Creates a job record, enqueues pages to SQS FIFO, Lambdas process sequentially per book.
-    if (shouldRun(4)) {
+    if (shouldRun(4) && await budgetAllowsDispatch(db, 'Phase 4 (translation dispatch)', { bypass: !!BOOK_OVERRIDE })) {
       console.log('\n--- Phase 4: Dispatch translation to Lambda (SQS FIFO) ---');
 
       // Zombie job reaper: cancel ANY job stuck in processing with no update for >1h.

--- a/tests/unit/spend-guard.test.ts
+++ b/tests/unit/spend-guard.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The budget dial (issue #3737): default-closed, UTC-day windowed, and
+ * measured via ObjectId time range (the `timestamp` field is a string on old
+ * rows — Date-range matching silently returns nothing).
+ */
+import { describe, it, expect } from 'vitest';
+import { ObjectId } from 'mongodb';
+import {
+  utcDayStart,
+  getTodaySpendUsd,
+  readDailyBudgetUsd,
+  budgetAllowsDispatch,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/spend-guard.mjs';
+
+function makeDbStub({ spendUsd = 0, rows = 0, costlessRows = 0, budget }: {
+  spendUsd?: number; rows?: number; costlessRows?: number; budget?: unknown;
+}) {
+  const calls: { aggregates: unknown[][]; findOnes: number } = { aggregates: [], findOnes: 0 };
+  const db = {
+    collection(name: string) {
+      return {
+        aggregate: (pipeline: unknown[]) => {
+          calls.aggregates.push(pipeline);
+          return { toArray: async () => (rows === 0 && spendUsd === 0 && costlessRows === 0
+            ? []
+            : [{ _id: null, usd: spendUsd, rows, costlessRows }]) };
+        },
+        findOne: async () => { calls.findOnes++; return name === 'system_config' ? { _id: 'processing_control', daily_budget_usd: budget } : null; },
+      };
+    },
+  };
+  return { db, calls };
+}
+
+describe('utcDayStart', () => {
+  it('returns midnight UTC of the given instant', () => {
+    const d = utcDayStart(new Date('2026-08-08T17:45:12.345Z'));
+    expect(d.toISOString()).toBe('2026-08-08T00:00:00.000Z');
+  });
+});
+
+describe('readDailyBudgetUsd — the dial is default-closed', () => {
+  it.each([
+    ['unset', undefined], ['null', null], ['zero', 0], ['negative', -5],
+    ['string number', '5'], ['NaN', NaN], ['Infinity', Infinity],
+  ])('%s → null (no paid dispatch)', (_n, v) => {
+    expect(readDailyBudgetUsd({ daily_budget_usd: v })).toBeNull();
+    expect(readDailyBudgetUsd(undefined)).toBeNull();
+  });
+  it('a positive finite number is the ceiling', () => {
+    expect(readDailyBudgetUsd({ daily_budget_usd: 5 })).toBe(5);
+    expect(readDailyBudgetUsd({ daily_budget_usd: 0.5 })).toBe(0.5);
+  });
+});
+
+describe('getTodaySpendUsd', () => {
+  it('selects rows by ObjectId range from UTC midnight (never the timestamp field)', async () => {
+    const { db, calls } = makeDbStub({ spendUsd: 1.23, rows: 10 });
+    await getTodaySpendUsd(db, new Date('2026-08-08T17:00:00Z'));
+    const match = (calls.aggregates[0][0] as { $match: { _id: { $gte: ObjectId } } }).$match;
+    expect(match._id.$gte).toBeInstanceOf(ObjectId);
+    expect(match._id.$gte.getTimestamp().toISOString()).toBe('2026-08-08T00:00:00.000Z');
+  });
+  it('empty day → zeros', async () => {
+    const { db } = makeDbStub({});
+    expect(await getTodaySpendUsd(db)).toEqual({ usd: 0, rows: 0, costlessRows: 0 });
+  });
+});
+
+describe('budgetAllowsDispatch', () => {
+  it('refuses when no budget is set — and never queries spend (negative control)', async () => {
+    const { db, calls } = makeDbStub({ budget: null });
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
+    expect(calls.aggregates.length).toBe(0);
+  });
+  it('dispatches under the ceiling', async () => {
+    const { db } = makeDbStub({ spendUsd: 2.5, rows: 40, budget: 5 });
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(true);
+  });
+  it('refuses at the ceiling', async () => {
+    const { db } = makeDbStub({ spendUsd: 5, rows: 80, budget: 5 });
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
+  });
+  it('refuses above the ceiling', async () => {
+    const { db } = makeDbStub({ spendUsd: 9.99, rows: 200, budget: 5 });
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
+  });
+  it('bypass (explicit --book operator run) skips both reads', async () => {
+    const { db, calls } = makeDbStub({ budget: null });
+    expect(await budgetAllowsDispatch(db, 'test', { bypass: true })).toBe(true);
+    expect(calls.findOnes).toBe(0);
+    expect(calls.aggregates.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements #3737. Pipeline spend becomes a **number someone sets**, not a switch someone fears.

## Mechanism

`scripts/lib/spend-guard.mjs` gates the orchestrator's two paid dispatch phases (2: OCR submit, 4: translation dispatch) against today's measured `gemini_usage` spend, keyed to `processing_control.daily_budget_usd`.

- **Default-closed:** unset/null/0/invalid → no paid dispatch even when `paused: false`. Flipping the old pause flag can no longer accidentally reopen unbounded spending. (The no-budget path never queries spend — negative-controlled in the test.)
- **ObjectId-range measurement** from UTC midnight — never the `timestamp` field, which is a string on old rows and silently matches nothing with Date ranges.
- **Undercount acknowledged:** `cost_usd` is computed and some writers omit it; costless rows are counted and logged so the blindness is visible. A brake, not accounting.
- **Operator bypass:** `--phase N --book=ID` runs bypass the dial exactly as they bypass the pause.
- **In-flight work finishes** — only new dispatch stops. One `[spend-guard] spend $X / $Y` log line per cycle.

## What does NOT happen in this PR

Nothing turns on. The pipeline stays paused, no budget is set, and the scheduler crontab line (already in `crontab.production:20`) is **not** re-added to the live box. The 5-step enable runbook (set dial → unpause → crontab → watch logs → failure tells) is in `memory/pipeline-ops.md` — turning the line on is Derek's explicit action.

## Verification

16 new tests (`tests/unit/spend-guard.test.ts`), full suite 2,198 green, `tsc --noEmit` clean.

First candidates when the dial turns: the 1,393 `loop_quarantine_hold` books (routing fix from #3729 makes them safe), then reader requests (#3087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx