### PR TITLE
FT v2 Tier 3: badge render source = graded verdict with legacy fallback (#3726)

### DIFF
--- a/scripts/eval/ft-render-diff.ts
+++ b/scripts/eval/ft-render-diff.ts
@@ -1,0 +1,87 @@
+/**
+ * ft-render-diff — what does the Tier 3 render swap actually change? (#3726)
+ *
+ * READ-ONLY. For every badged visible book, compares:
+ *   BEFORE — what every card surface rendered until this branch: the claim
+ *            defaulted to 'candidate', so the label was always the search
+ *            statement ("No prior translation found" / in-progress variant).
+ *   AFTER  — ftRenderProps on the Atlas doc (verdict-first with legacy
+ *            fallback), which is exactly what cards render once the catalog
+ *            columns are populated and this branch deploys.
+ *
+ * Writes a transition report to scripts/output/ so the label changes can be
+ * reviewed before the apply (the discipline the July demotion runs set).
+ *
+ * Usage: set -a; source .env.production.local; set +a; npx tsx scripts/eval/ft-render-diff.ts
+ */
+import { writeFileSync } from 'fs';
+import { MongoClient } from 'mongodb';
+import { ftRenderProps } from '@/lib/first-translation/render';
+import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { isTranslationReadable } from '@/lib/first-translation/derive';
+
+async function main() {
+const uri = process.env.MONGODB_URI;
+if (!uri) throw new Error('MONGODB_URI not set');
+
+const client = await MongoClient.connect(uri);
+const books = client.db('bookstore').collection('books');
+
+const cursor = books.find(
+  { is_first_translation: true, visible: true },
+  {
+    projection: {
+      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, language: 1,
+      pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1,
+      'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
+      'first_translation.our_completeness': 1,
+      'translation_verification.disposition': 1,
+      'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
+    },
+  },
+);
+
+const transitions = new Map<string, { count: number; sample: Array<{ id: string; title: string }> }>();
+let total = 0;
+let confirmedAfter = 0;
+
+for await (const b of cursor) {
+  total++;
+  const inProgress = !isTranslationReadable(b);
+  const before = firstTranslationBadge(undefined, b.language, inProgress); // claim defaults to candidate
+  const ft = ftRenderProps(b);
+  const after = firstTranslationBadge(ft.disposition, b.language, inProgress, ft.claim);
+  if (ft.claim === 'confirmed') confirmedAfter++;
+  if (before === after) continue;
+  const key = `${before} → ${after}`;
+  const t = transitions.get(key) ?? { count: 0, sample: [] };
+  t.count++;
+  if (t.sample.length < 5) t.sample.push({ id: b.id, title: b.display_title || b.title });
+  transitions.set(key, t);
+}
+
+const changed = [...transitions.values()].reduce((s, t) => s + t.count, 0);
+const report = {
+  measured_at: new Date().toISOString(),
+  scope: 'is_first_translation: true, visible: true',
+  total_badged_visible: total,
+  labels_changed: changed,
+  labels_unchanged: total - changed,
+  confirmed_register_after: confirmedAfter,
+  transitions: Object.fromEntries(
+    [...transitions.entries()].sort((a, b) => b[1].count - a[1].count),
+  ),
+};
+
+const out = `scripts/output/ft-render-diff-${new Date().toISOString().slice(0, 10)}.json`;
+writeFileSync(out, JSON.stringify(report, null, 2));
+console.log(JSON.stringify({ ...report, transitions: undefined }, null, 2));
+for (const [k, v] of [...transitions.entries()].sort((a, b) => b[1].count - a[1].count)) {
+  console.log(`\n${v.count}× ${k}`);
+  for (const s of v.sample) console.log(`   e.g. ${s.id} — ${s.title}`);
+}
+console.log(`\nFull report: ${out}`);
+await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/migration/add-ft-verdict-columns.sql
+++ b/scripts/migration/add-ft-verdict-columns.sql
@@ -1,0 +1,11 @@
+-- #3726 Tier 3: project the graded FT verdict into books_catalog so card
+-- surfaces can render the earned claim register without an Atlas fetch.
+-- Pure projections of books.first_translation.* and the two #3524 screens;
+-- all nullable, so the add is non-breaking and pre-rebuild rows simply
+-- render the candidate register (the fail-toward direction).
+ALTER TABLE books_catalog
+  ADD COLUMN IF NOT EXISTS ft_verdict text,
+  ADD COLUMN IF NOT EXISTS ft_evidence_strength text,
+  ADD COLUMN IF NOT EXISTS ft_our_completeness text,
+  ADD COLUMN IF NOT EXISTS ft_source_screen text,
+  ADD COLUMN IF NOT EXISTS ft_translator_screen text;

--- a/scripts/migration/rebuild-books-catalog.mjs
+++ b/scripts/migration/rebuild-books-catalog.mjs
@@ -83,6 +83,11 @@ function transformBook(book) {
     source_work_dates: Array.isArray(book.source_work_dates) ? book.source_work_dates : null,
     ft_disposition: book.translation_verification?.disposition || null,
     ft_reasoning: book.translation_verification?.reasoning || null,
+    ft_verdict: book.first_translation?.verdict || null,
+    ft_evidence_strength: book.first_translation?.evidence_strength || null,
+    ft_our_completeness: book.first_translation?.our_completeness || null,
+    ft_source_screen: book.source_language_screen?.verdict || null,
+    ft_translator_screen: book.translator_author_screen?.verdict || null,
     description: book.ai_metadata?.description || book.description || null,
     subject_keywords: Array.isArray(book.subject_keywords) ? book.subject_keywords : null,
     translation_pct: (() => {
@@ -120,6 +125,11 @@ const projection = {
   resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1,
   source_work_dates: 1,
   'translation_verification.disposition': 1, 'translation_verification.reasoning': 1,
+  // Graded FT verdict + screens (#3726 Tier 3) — pure projections; the render
+  // decision lives in src/lib/first-translation/render.ts, never here.
+  'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
+  'first_translation.our_completeness': 1,
+  'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
   'ai_metadata.description': 1, description: 1, subject_keywords: 1,
 };
 

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -124,6 +124,11 @@ function transformBook(book) {
     source_work_dates: Array.isArray(book.source_work_dates) ? book.source_work_dates : null,
     ft_disposition: book.translation_verification?.disposition || null,
     ft_reasoning: book.translation_verification?.reasoning || null,
+    ft_verdict: book.first_translation?.verdict || null,
+    ft_evidence_strength: book.first_translation?.evidence_strength || null,
+    ft_our_completeness: book.first_translation?.our_completeness || null,
+    ft_source_screen: book.source_language_screen?.verdict || null,
+    ft_translator_screen: book.translator_author_screen?.verdict || null,
     description: book.ai_metadata?.description || book.description || null,
     subject_keywords: Array.isArray(book.subject_keywords) ? book.subject_keywords : null,
     // Computed columns
@@ -198,6 +203,11 @@ const projection = {
   resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1, text_role: 1,
   source_work_dates: 1,
   'translation_verification.disposition': 1, 'translation_verification.reasoning': 1,
+  // Graded FT verdict + screens (#3726 Tier 3) — pure projections; the render
+  // decision lives in src/lib/first-translation/render.ts, never here.
+  'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
+  'first_translation.our_completeness': 1,
+  'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
   'ai_metadata.description': 1, description: 1, subject_keywords: 1,
 };
 

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { translationPercent } from '@/lib/translation-percent';
+import { ftRenderProps } from '@/lib/first-translation/render';
 import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -37,6 +38,7 @@ interface Book {
   summary?: { data: string } | string;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
   publisher?: string;
   place_of_publication?: string;
   image_source?: { contributing_library?: string; provider_name?: string };
@@ -95,21 +97,37 @@ const BOOK_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
   author_entity_id: 1, language: 1, published: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1,
   pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1, year: 1,
-  summary: 1, is_first_translation: 1, ft_disposition: 1,
+  summary: 1, is_first_translation: 1,
+  // What ftRenderProps needs to pick the claim register (#3726 Tier 3). The
+  // old `ft_disposition: 1` projected a field Mongo books never had.
+  'translation_verification.disposition': 1,
+  'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
+  'first_translation.our_completeness': 1,
+  'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
   publisher: 1, place_of_publication: 1, resource_type: 1, content_type: 1,
   'image_source.contributing_library': 1, 'image_source.provider_name': 1,
 };
 
 function computeBooks(raw: any[]): Book[] {
-  return raw.map((b: any) => ({
-    ...b,
-    pages_count: b.pages_count || 0,
-    pages_translated: b.pages_translated || 0,
-    // Shared definition. The formula that stood here divided by
-    // (pages_ocr − pages_blank), which exceeds 100% on 5,835 live books because
-    // "blank" leaves do get translated. See src/lib/translation-percent.ts.
-    translation_percent: translationPercent(b),
-  }));
+  return raw.map((b: any) => {
+    const ft = ftRenderProps(b);
+    const {
+      first_translation: _ft, translation_verification: _tv,
+      source_language_screen: _sls, translator_author_screen: _tas,
+      ...rest
+    } = b;
+    return {
+      ...rest,
+      pages_count: b.pages_count || 0,
+      pages_translated: b.pages_translated || 0,
+      // Shared definition. The formula that stood here divided by
+      // (pages_ocr − pages_blank), which exceeds 100% on 5,835 live books because
+      // "blank" leaves do get translated. See src/lib/translation-percent.ts.
+      translation_percent: translationPercent(b),
+      ft_disposition: ft.disposition,
+      ft_claim: ft.claim,
+    };
+  });
 }
 
 /**

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -21,6 +21,7 @@ import { ART_EXCLUDED_RESOURCE_TYPES, bookTitle, sanitizeThumbnail, withTimeout 
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { isTranslationReadable } from '@/lib/first-translation/derive';
+import { ftRenderProps, type FtRenderSource } from '@/lib/first-translation/render';
 import { browseBooks } from '@/lib/books-catalog';
 import { supabase } from '@/lib/supabase';
 import { authorUrl } from '@/lib/slugify';
@@ -120,6 +121,7 @@ interface BookItem {
   read_count?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
   resource_type?: string;
 }
 
@@ -137,6 +139,7 @@ interface CuratedHighlight {
   thumbnail_blob?: string;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
   language?: string;
   // Carried through the merge so the badge can be qualified when the
   // translation is barely started (#3435).
@@ -418,7 +421,26 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1,
     photo: 1, categories: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, published: 1, read_count: 1,
     resource_type: 1, commons_width: 1, commons_height: 1,
-    is_first_translation: 1, ft_disposition: 1,
+    is_first_translation: 1,
+    // What ftRenderProps needs to pick the claim register (#3726 Tier 3).
+    // (The old `ft_disposition: 1` here projected a field Mongo books never
+    // had — every card silently fell to the candidate register.)
+    'translation_verification.disposition': 1,
+    'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
+    'first_translation.our_completeness': 1,
+    'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
+  };
+
+  // Compute the badge render pair once, server-side, and drop the raw
+  // subdocuments so client payloads stay lean.
+  const withFtRender = <T extends Record<string, unknown>>(b: T) => {
+    const ft = ftRenderProps(b as FtRenderSource);
+    const {
+      first_translation: _ft, translation_verification: _tv,
+      source_language_screen: _sls, translator_author_screen: _tas,
+      ...rest
+    } = b;
+    return { ...rest, ft_disposition: ft.disposition, ft_claim: ft.claim };
   };
 
   // Extract curated highlights from collection document
@@ -682,7 +704,10 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
         slug: book.slug as string | undefined,
         thumbnail: sanitizeThumbnail(book.thumbnail_blob as string) || sanitizeThumbnail(book.thumbnail as string),
         is_first_translation: book.is_first_translation as boolean | undefined,
-        ft_disposition: (book.translation_verification as Record<string, unknown> | undefined)?.disposition as string | undefined,
+        ...(() => {
+          const ft = ftRenderProps(book as FtRenderSource);
+          return { ft_disposition: ft.disposition, ft_claim: ft.claim };
+        })(),
         language: book.language as string | undefined,
         pages_count: book.pages_count as number | undefined,
         pages_ocr: book.pages_ocr as number | undefined,
@@ -742,14 +767,13 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
       const exBooks = await withTimeout(
         db.collection('books').find(
           { id: { $in: [...allBookIds] }, visible: true },
-          { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, 'translation_verification.disposition': 1 } },
+          { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, 'translation_verification.disposition': 1, 'first_translation.verdict': 1, 'first_translation.evidence_strength': 1, 'first_translation.our_completeness': 1, 'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1 } },
         ).toArray(),
         8000, [],
       );
-      exhibitionBooks = exBooks.map(b => ({
+      exhibitionBooks = exBooks.map(b => withFtRender({
         ...b,
         thumbnail: sanitizeThumbnail(b.thumbnail_blob as string) || sanitizeThumbnail(b.thumbnail as string),
-        ft_disposition: (b.translation_verification as Record<string, unknown> | undefined)?.disposition as string | undefined,
       })) as unknown as BookItem[];
     }
   }
@@ -757,14 +781,12 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
   return {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     collection: collectionClean as any,
-    books: sanitizeBookThumbs(books) as unknown as BookItem[],
+    books: sanitizeBookThumbs(
+      (books as Record<string, unknown>[]).map(withFtRender),
+    ) as unknown as BookItem[],
     highlights: mergedHighlights,
     firstTranslations: sanitizeBookThumbs(
-      (firstTranslations as Record<string, unknown>[]).map((b) => ({
-        ...b,
-        ft_disposition: (b.ft_disposition as string | undefined)
-          || ((b.translation_verification as Record<string, unknown> | undefined)?.disposition as string | undefined),
-      })),
+      (firstTranslations as Record<string, unknown>[]).map(withFtRender),
     ) as unknown as BookItem[],
     total,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1177,7 +1199,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                     )}
                     {b.is_first_translation && (b.pages_translated ?? 0) > 0 && (
                       <span className="inline-block mt-1 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
-                        {firstTranslationBadge(b.ft_disposition, b.language, !isTranslationReadable(b))}
+                        {firstTranslationBadge(b.ft_disposition, b.language, !isTranslationReadable(b), b.ft_claim)}
                       </span>
                     )}
                   </Link>
@@ -1237,7 +1259,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                       </p>
                     )}
                     <span className="inline-block mt-1 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
-                      {firstTranslationBadge(b.ft_disposition, b.language, !isTranslationReadable(b))}
+                      {firstTranslationBadge(b.ft_disposition, b.language, !isTranslationReadable(b), b.ft_claim)}
                     </span>
                   </Link>
                 );
@@ -1351,7 +1373,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                     {featured.author}{featured.year ? `, ${featured.year}` : ''}
                     {featured.is_first_translation && (
                       <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
-                        {firstTranslationBadge(featured.ft_disposition, featured.language, !isTranslationReadable(featured))}
+                        {firstTranslationBadge(featured.ft_disposition, featured.language, !isTranslationReadable(featured), featured.ft_claim)}
                       </span>
                     )}
                   </p>
@@ -1525,7 +1547,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                           {h.author}{h.year ? `, ${h.year}` : ''}
                           {h.is_first_translation && (
                             <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
-                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h))}
+                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h), h.ft_claim)}
                             </span>
                           )}
                         </p>
@@ -1578,7 +1600,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                           {h.author}{h.year ? `, ${h.year}` : ''}
                           {h.is_first_translation && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
-                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h))}
+                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h), h.ft_claim)}
                             </span>
                           )}
                         </p>
@@ -1630,7 +1652,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                           {h.author}{h.year ? `, ${h.year}` : ''}
                           {h.is_first_translation && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
-                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h))}
+                              {firstTranslationBadge(h.ft_disposition, h.language, !isTranslationReadable(h), h.ft_claim)}
                             </span>
                           )}
                         </p>

--- a/src/components/browse/AuthorBibliography.tsx
+++ b/src/components/browse/AuthorBibliography.tsx
@@ -29,6 +29,7 @@ interface AuthorBook {
   translation_percent?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
   publisher?: string;
   place_of_publication?: string;
 }
@@ -137,7 +138,7 @@ export default function AuthorBibliography({ books }: { books: AuthorBook[] }) {
                         </span>
                         {book.is_first_translation && (
                           <span className="inline-block ml-2 bg-accent-gold/15 text-[10px] px-1.5 py-0.5 rounded-full font-medium align-middle" style={{ color: 'var(--accent-gold-dark)' }}>
-                            {firstTranslationBadge(book.ft_disposition, book.language)}
+                            {firstTranslationBadge(book.ft_disposition, book.language, undefined, book.ft_claim)}
                           </span>
                         )}
                         {hasOriginalTitle && (

--- a/src/components/catalog/ScholarCatalog.tsx
+++ b/src/components/catalog/ScholarCatalog.tsx
@@ -9,6 +9,7 @@ import {
 import AuthorName from '@/components/AuthorName';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { ftRenderProps } from '@/lib/first-translation/render';
 import CatalogPagination from '@/components/collections/CatalogPagination';
 
 const PER_PAGE = 60;
@@ -40,6 +41,13 @@ interface BookItem {
   published?: string | null;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  // Raw graded-verdict projections from books_catalog (#3726 Tier 3);
+  // ftRenderProps resolves them into the badge register at render time.
+  ft_verdict?: string | null;
+  ft_evidence_strength?: string | null;
+  ft_our_completeness?: string | null;
+  ft_source_screen?: string | null;
+  ft_translator_screen?: string | null;
   image_source_provider?: string | null;
 }
 
@@ -625,7 +633,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
                         </span>
                         {isPublishedFirstTranslation(book) && (
                           <span className="shrink-0 inline-block bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium">
-                            {firstTranslationBadge(book.ft_disposition, book.language ?? undefined)}
+                            {(() => { const ft = ftRenderProps(book); return firstTranslationBadge(ft.disposition, book.language ?? undefined, undefined, ft.claim); })()}
                           </span>
                         )}
                       </div>
@@ -680,7 +688,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
                           </Link>
                           {isPublishedFirstTranslation(book) && (
                             <span className="shrink-0 inline-block bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium">
-                              {firstTranslationBadge(book.ft_disposition, book.language ?? undefined)}
+                              {(() => { const ft = ftRenderProps(book); return firstTranslationBadge(ft.disposition, book.language ?? undefined, undefined, ft.claim); })()}
                             </span>
                           )}
                           <CopyPermalink slug={book.slug} id={book.id} />

--- a/src/components/collections/CollectionListView.tsx
+++ b/src/components/collections/CollectionListView.tsx
@@ -23,6 +23,7 @@ interface BookItem {
   read_count?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
   resource_type?: string;
 }
 
@@ -135,7 +136,7 @@ export default function CollectionListView({
                     </span>
                     {book.is_first_translation && (
                       <span className="inline-block ml-2 bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium align-middle">
-                        {firstTranslationBadge(book.ft_disposition, book.language)}
+                        {firstTranslationBadge(book.ft_disposition, book.language, undefined, book.ft_claim)}
                       </span>
                     )}
                     {/* Author on mobile (hidden on sm+) */}

--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -28,6 +28,7 @@ interface BookRef {
   thumbnail_blob?: string;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  ft_claim?: 'confirmed' | 'candidate';
 }
 
 interface GalleryImage {
@@ -279,7 +280,7 @@ function SectionsBlock({ sections, books }: {
                       <AuthorName author={book.author} />{book.year ? `, ${book.year}` : ''}
                       {book.is_first_translation && (
                         <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
-                          {firstTranslationBadge(book.ft_disposition, book.language)}
+                          {firstTranslationBadge(book.ft_disposition, book.language, undefined, book.ft_claim)}
                         </span>
                       )}
                     </p>

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -72,13 +72,21 @@ export interface CatalogBookDetail extends CatalogBook {
   source_work_dates: Array<{ type: string; date_display: string; author?: string }> | null;
   ft_disposition: string | null;
   ft_reasoning: string | null;
+  // Graded FT verdict + screens (#3726 Tier 3): raw projections of
+  // books.first_translation.* and the #3524 screens, so card surfaces can
+  // compute the claim register via ftRenderProps without an Atlas fetch.
+  ft_verdict: string | null;
+  ft_evidence_strength: string | null;
+  ft_our_completeness: string | null;
+  ft_source_screen: string | null;
+  ft_translator_screen: string | null;
   description: string | null;
   subject_keywords: string[] | null;
   created_at: string | null;
   updated_at: string | null;
 }
 
-const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published';
+const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 

--- a/src/lib/first-translation/render.ts
+++ b/src/lib/first-translation/render.ts
@@ -1,0 +1,113 @@
+/**
+ * One render decision for every badge surface, whatever fed it (#3726 Tier 3).
+ *
+ * Card surfaces render from two payloads for the same book: the Supabase
+ * `books_catalog` row (a projection) and the Atlas doc (complete). Before this
+ * helper, every card passed the legacy `ft_disposition` and let the claim
+ * default to `candidate` — so the graded verdict the rebuilt FT system produces
+ * never reached a card, and a cross-checked first rendered exactly like a
+ * legacy shim.
+ *
+ * `ftRenderProps` accepts either payload shape and returns the two values
+ * `firstTranslationBadge` needs:
+ *
+ *  - `claim` — 'confirmed' only when the REAL classifier
+ *    (`classifyFirstTranslationClaim`) says so; every other state, including
+ *    the ones a catalog row cannot express, collapses to 'candidate'. The
+ *    collapse direction is the invariant: a payload that cannot prove the
+ *    stronger register never gets it (#3686 — assert the payload can answer,
+ *    fail toward the weaker claim).
+ *  - `disposition` — verdict-mapped when a graded verdict is present
+ *    (VERDICT_TO_DISPOSITION), falling back to the legacy disposition
+ *    otherwise. In the candidate register the badge ignores disposition, so
+ *    the fallback only ever shades labels for confirmed books.
+ */
+
+import { classifyFirstTranslationClaim, type ScreenedBook } from './candidate';
+import { resolveFirstTranslation } from './derive';
+import {
+  VERDICT_TO_DISPOSITION,
+  type EvidenceStrength,
+  type FirstTranslation,
+  type FirstTranslationVerdict,
+  type OurCompleteness,
+} from './types';
+
+/**
+ * The loose union of an Atlas doc and a `books_catalog` row. Every field is
+ * optional — the helper is honest about absent data by construction.
+ */
+export interface FtRenderSource {
+  // Atlas shapes (preferred when present)
+  first_translation?: FirstTranslation | null;
+  translation_verification?: { disposition?: string; translations_found?: unknown[] } | null;
+  source_language_screen?: { verdict?: string } | null;
+  translator_author_screen?: { verdict?: string } | null;
+  // Catalog-row projections of the same facts
+  ft_verdict?: string | null;
+  ft_evidence_strength?: string | null;
+  ft_our_completeness?: string | null;
+  ft_source_screen?: string | null;
+  ft_translator_screen?: string | null;
+  ft_disposition?: string | null;
+  // Shared render-gate fields
+  language?: string | null;
+  visible?: boolean;
+  pages_translated?: number | null;
+  is_first_translation?: boolean;
+}
+
+export interface FtRenderProps {
+  claim: 'confirmed' | 'candidate';
+  disposition: string | undefined;
+}
+
+/** Rebuild the minimal ScreenedBook the classifier needs from either payload. */
+function toScreenedBook(b: FtRenderSource): ScreenedBook {
+  const first_translation: FirstTranslation | null =
+    b.first_translation?.verdict
+      ? b.first_translation
+      : b.ft_verdict
+        ? {
+            verdict: b.ft_verdict as FirstTranslationVerdict,
+            evidence_strength: (b.ft_evidence_strength ?? 'weak') as EvidenceStrength,
+            our_completeness: (b.ft_our_completeness ?? 'unknown') as OurCompleteness,
+            match_key: 'none',
+            resolver: 'tier1_catalog',
+          }
+        : null;
+
+  const sourceVerdict = b.source_language_screen?.verdict ?? b.ft_source_screen ?? undefined;
+  const translatorVerdict =
+    b.translator_author_screen?.verdict ?? b.ft_translator_screen ?? undefined;
+
+  return {
+    first_translation,
+    translation_verification: b.translation_verification ?? undefined,
+    language: b.language ?? undefined,
+    // Card feeds are visible-only surfaces; an Atlas doc says for itself.
+    visible: b.visible ?? true,
+    pages_translated: b.pages_translated ?? 0,
+    source_language_screen: sourceVerdict
+      ? { verdict: sourceVerdict as NonNullable<ScreenedBook['source_language_screen']>['verdict'] }
+      : null,
+    translator_author_screen: translatorVerdict === 'hold' ? { verdict: 'hold' } : null,
+  };
+}
+
+export function ftRenderProps(b: FtRenderSource): FtRenderProps {
+  const book = toScreenedBook(b);
+  const { claim } = classifyFirstTranslationClaim(book);
+  const resolved = resolveFirstTranslation(book);
+  const disposition =
+    (resolved?.verdict ? VERDICT_TO_DISPOSITION[resolved.verdict] : undefined) ??
+    b.ft_disposition ??
+    b.translation_verification?.disposition ??
+    undefined;
+  return {
+    // Only the earned register asserts; every other state — candidate,
+    // defeated, not_applicable, unknown — renders the search statement.
+    claim: claim === 'confirmed' ? 'confirmed' : 'candidate',
+    disposition,
+  };
+}

--- a/tests/unit/first-translation-render.test.ts
+++ b/tests/unit/first-translation-render.test.ts
@@ -1,0 +1,129 @@
+/**
+ * ftRenderProps — the one render decision for badge surfaces (#3726 Tier 3).
+ *
+ * The invariant this suite pins (from first-translation-claims.md): a one-sided
+ * check on a two-sided change is a coin flip you will read as a pass. So both
+ * registers carry positive controls — a book that MUST assert, and books that
+ * MUST NOT — over both payload shapes (Atlas doc and catalog row).
+ */
+import { describe, expect, it } from 'vitest';
+import { ftRenderProps } from '@/lib/first-translation/render';
+import type { FirstTranslation } from '@/lib/first-translation/types';
+
+const strongVerdict = (over: Partial<FirstTranslation> = {}): FirstTranslation => ({
+  verdict: 'first_no_prior',
+  evidence_strength: 'strong',
+  our_completeness: 'unknown',
+  match_key: 'author_title',
+  resolver: 'tier2_agent',
+  ...over,
+});
+
+const atlasBook = (over: Record<string, unknown> = {}) => ({
+  first_translation: strongVerdict(),
+  visible: true,
+  pages_translated: 100,
+  language: 'Latin',
+  ...over,
+});
+
+const catalogRow = (over: Record<string, unknown> = {}) => ({
+  ft_verdict: 'first_no_prior',
+  ft_evidence_strength: 'strong',
+  ft_our_completeness: 'unknown',
+  is_first_translation: true,
+  pages_translated: 100,
+  language: 'Latin',
+  ...over,
+});
+
+describe('ftRenderProps — confirmed register (positive controls)', () => {
+  it('asserts for a strong first_no_prior Atlas doc', () => {
+    expect(ftRenderProps(atlasBook())).toEqual({
+      claim: 'confirmed',
+      disposition: 'confirmed_first',
+    });
+  });
+
+  it('asserts for the same book seen through a catalog row', () => {
+    expect(ftRenderProps(catalogRow())).toEqual({
+      claim: 'confirmed',
+      disposition: 'confirmed_first',
+    });
+  });
+
+  it('moderate evidence also earns the register', () => {
+    expect(ftRenderProps(catalogRow({ ft_evidence_strength: 'moderate' })).claim).toBe('confirmed');
+  });
+
+  it('maps verdict shades to label dispositions (from_source, modern)', () => {
+    expect(
+      ftRenderProps(atlasBook({ first_translation: strongVerdict({ verdict: 'first_from_source' }) }))
+        .disposition,
+    ).toBe('first_from_source');
+    expect(ftRenderProps(catalogRow({ ft_verdict: 'first_modern' })).disposition).toBe(
+      'first_modern_translation',
+    );
+  });
+
+  it('first_complete asserts only when OUR item is complete', () => {
+    expect(
+      ftRenderProps(
+        catalogRow({ ft_verdict: 'first_complete', ft_our_completeness: 'complete' }),
+      ).claim,
+    ).toBe('confirmed');
+    expect(
+      ftRenderProps(
+        catalogRow({ ft_verdict: 'first_complete', ft_our_completeness: 'partial' }),
+      ).claim,
+    ).toBe('candidate');
+  });
+});
+
+describe('ftRenderProps — candidate register (the fail-toward direction)', () => {
+  it('weak evidence never asserts', () => {
+    expect(ftRenderProps(catalogRow({ ft_evidence_strength: 'weak' })).claim).toBe('candidate');
+  });
+
+  it('a missing verdict never asserts, whatever the legacy disposition reads', () => {
+    const r = ftRenderProps(
+      catalogRow({ ft_verdict: null, ft_evidence_strength: null, ft_disposition: 'confirmed_first' }),
+    );
+    expect(r.claim).toBe('candidate');
+    // Legacy disposition still flows through for surfaces that shade on it.
+    expect(r.disposition).toBe('confirmed_first');
+  });
+
+  it('a not_first verdict never asserts (defeated collapses to candidate)', () => {
+    expect(ftRenderProps(catalogRow({ ft_verdict: 'not_first' })).claim).toBe('candidate');
+  });
+
+  it('an english-source screen defeats assertion even over a strong verdict', () => {
+    expect(ftRenderProps(catalogRow({ ft_source_screen: 'english_source' })).claim).toBe(
+      'candidate',
+    );
+  });
+
+  it('a translator-screen hold defeats assertion (review, not exclusion)', () => {
+    expect(ftRenderProps(catalogRow({ ft_translator_screen: 'hold' })).claim).toBe('candidate');
+  });
+
+  it('zero translated pages fails the render gate', () => {
+    expect(ftRenderProps(catalogRow({ pages_translated: 0 })).claim).toBe('candidate');
+  });
+
+  it('an Atlas legacy-only book (no verdict object) is candidate with its legacy shade', () => {
+    const r = ftRenderProps(
+      atlasBook({
+        first_translation: null,
+        translation_verification: { disposition: 'first_modern_translation' },
+      }),
+    );
+    expect(r.claim).toBe('candidate');
+    expect(r.disposition).toBe('first_modern_translation');
+  });
+
+  it('an empty payload is candidate with no disposition', () => {
+    expect(ftRenderProps({})).toEqual({ claim: 'candidate', disposition: undefined });
+  });
+});


### PR DESCRIPTION
Part of #3726 (FT v2 rationalization), following Tiers 1–2 in #3727. Approach approved by Derek: **fallback render** — verdict where present, legacy disposition where absent, and the nightly derive closes the coverage gap over time.

## The problem

The rebuilt FT system's graded verdict (`books.first_translation`) never reached a card. Every card surface passed the legacy `ft_disposition` and let the claim register default to `candidate` — and two Atlas-fed pages (collections, author) even projected `ft_disposition: 1` from Mongo, **a field books documents never had**, so their cards silently always rendered the weak register. The 627 books with evidence strong enough to assert (the same set #3686 found vanishing from meta descriptions) rendered indistinguishably from legacy shims.

## The change

- **`src/lib/first-translation/render.ts`** — `ftRenderProps(source)`: one render decision for every badge surface. Accepts either payload (Atlas doc or `books_catalog` row), classifies through the REAL `classifyFirstTranslationClaim` (verdict-first via `resolveFirstTranslation`, legacy-shim fallback), returns `{claim, disposition}` where disposition is verdict-mapped (`VERDICT_TO_DISPOSITION`) with legacy fallback. Any state the payload can't prove collapses to `candidate` — the fail-toward-weaker direction is the invariant.
- **`books_catalog` + writers** — five new nullable columns (`ft_verdict`, `ft_evidence_strength`, `ft_our_completeness`, `ft_source_screen`, `ft_translator_screen`), pure projections in `sync-books-catalog.mjs` / `rebuild-books-catalog.mjs`; no logic in the writers. **DDL already applied to prod** (verified via information_schema). Pre-population rows render candidate — graceful.
- **Call-site sweep** — collections page (6 sites), author page, ScholarCatalog (2), ExhibitionLayout, CollectionListView, AuthorBibliography now pass the resolved register. Phantom Mongo projections replaced with the real fields.
- **`scripts/eval/ft-render-diff.ts`** — read-only production diff of every badged book's label, before vs after.

## Measured impact (production, 2026-08-08)

Of **5,929** badged visible books: **627 gain the assertive register** ("First Translation" / "First Complete/Modern/from-X"), **5,302 render exactly as before**, **0 lose anything** (the boolean is untouched; demotions still flow only through the nightly reconcile). Every transition is candidate→assertive on evidence-carrying books; full transition table with samples in `scripts/output/ft-render-diff-2026-08-08.json` (untracked).

## Out of scope

- CollectionBookCard's dark-glass "First Translation" tag — spec-governed copy (collection-book-card-design.md), boolean-gated; a register question for a separate design decision.
- Mycology page's phantom `ft_disposition: 1` projection — no badge render downstream, left as-is.
- Retiring the 14-file legacy `translation_verification` write surface — after this settles.

## Post-merge steps

1. Run `rebuild-books-catalog.mjs` on Hetzner to populate the five columns corpus-wide (the 5-min sync only touches updated books).
2. CF purge is automatic via post-deploy-warm.

## Verification

- `npx tsc --noEmit` clean; **2,195/2,195** unit tests pass including 13 new both-register tests for `ftRenderProps` (positive controls on both directions, per the one-sided-check trap in first-translation-claims.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6zTnLdLvMK7PyBgFA7KMj