### PR TITLE
A blank leaf is not a translated page: 32% of books reported over 100% translated

### DIFF
--- a/scripts/batch/realtime-translate.mjs
+++ b/scripts/batch/realtime-translate.mjs
@@ -264,8 +264,14 @@ async function processBook(book, pages, prompts, db, globalStats) {
     try {
       // VISIBLE pages only (page_number > 0). Soft-hidden pages never render, so
       // counting them corrupts the visible-only read-path convention (issue #3293).
+      // page_type != 'blank' mirrors isTranslatedPage() in lib/page-counts.mjs:
+      // a blank leaf carries the placeholder "[Blank page — no translatable
+      // content]" and must not count as translated, or `translation_pct`
+      // exceeds 100 (blank pages are subtracted from its denominator).
       const translatedCount = await db.collection('pages').countDocuments({
-        book_id: book.id, ...VISIBLE_PAGE_MATCH, 'translation.data': { $exists: true, $ne: '' }
+        book_id: book.id, ...VISIBLE_PAGE_MATCH,
+        'translation.data': { $exists: true, $ne: '' },
+        page_type: { $ne: 'blank' },
       });
       await db.collection('books').updateOne(
         { id: book.id },

--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -34,6 +34,30 @@ export function hasTranslation(page) {
   return typeof data === 'string' && data !== '';
 }
 
+/** True iff the page is a blank leaf (flyleaf, endpaper, empty verso). */
+export function isBlankPage(page) {
+  return (page?.page_type ?? '') === 'blank';
+}
+
+/**
+ * True iff a page counts toward `pages_translated`.
+ *
+ * A blank leaf does NOT, even though it carries translation text: the
+ * translator writes the literal placeholder "[Blank page — no translatable
+ * content]" onto every blank page. Measured 2026-08-08, that was 87,777 pages
+ * — flyleaves and endpapers — counted as translations, 99.8% of them under 120
+ * characters.
+ *
+ * It also made `translation_pct` exceed 100 on 6,228 live books (32% of the
+ * public library), because blank pages are subtracted from the denominator
+ * (`pages_ocr - pages_blank`) while still being counted in the numerator. The
+ * Blue Qur'an reported **1000% translated**: 60 pages, 54 of them blank, over a
+ * denominator of 6.
+ */
+export function isTranslatedPage(page) {
+  return hasTranslation(page) && !isBlankPage(page);
+}
+
 /**
  * Aggregation pipeline that returns { total, with_ocr, with_translation }
  * for the VISIBLE pages of one book. Used by the batch collectors.
@@ -57,6 +81,9 @@ export function buildVisiblePageCountPipeline(bookId) {
             ],
           },
         },
+        // Mirrors isTranslatedPage(): blank leaves carry a placeholder, not a
+        // translation, and must not count here — they are already excluded
+        // from the denominator via `pages_blank`.
         with_translation: {
           $sum: {
             $cond: [
@@ -64,6 +91,7 @@ export function buildVisiblePageCountPipeline(bookId) {
                 { $ne: ['$translation.data', null] },
                 { $ne: ['$translation.data', ''] },
                 { $ifNull: ['$translation.data', false] },
+                { $ne: [{ $ifNull: ['$page_type', ''] }, 'blank'] },
               ] },
               1, 0,
             ],
@@ -84,6 +112,6 @@ export function countVisiblePageStats(pages) {
   return {
     total: visible.length,
     with_ocr: visible.filter(hasOcr).length,
-    with_translation: visible.filter(hasTranslation).length,
+    with_translation: visible.filter(isTranslatedPage).length,
   };
 }

--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -72,12 +72,25 @@ async function syncPageCounts(db) {
             ],
           },
         },
+        // A blank page is NOT a translated page. The translator writes the
+        // literal placeholder "[Blank page — no translatable content]" onto
+        // every blank leaf, so a naive non-empty check counted 87,777 flyleaves
+        // and endpapers as translations (99.8% of them under 120 characters).
+        //
+        // That is also what made `translation_pct` exceed 100: blank pages are
+        // subtracted from the denominator below via `pages_blank`, but were
+        // still counted here in the numerator. The Blue Qur'an reported
+        // **1000% translated** — 60 pages of which 54 were blank, over a
+        // denominator of 6. Measured 2026-08-08: every one of 300 sampled
+        // over-100% books had translated blank pages, and excluding them lands
+        // each on exactly 100%.
         pages_translated: {
           $sum: {
             $cond: [
               { $and: [
                 { $eq: [{ $type: '$translation.data' }, 'string'] },
                 { $gt: [{ $strLenCP: '$translation.data' }, 0] },
+                { $ne: [{ $ifNull: ['$page_type', ''] }, 'blank'] },
               ] },
               1, 0,
             ],

--- a/src/lib/page-counts.ts
+++ b/src/lib/page-counts.ts
@@ -38,6 +38,11 @@ export function buildVisiblePageCountPipeline(bookId: string): Document[] {
             ],
           },
         },
+        // Blank leaves carry the placeholder "[Blank page — no translatable
+        // content]", not a translation, and are already excluded from the
+        // denominator via `pages_blank` — counting them here is what pushed
+        // `translation_pct` over 100 on 6,228 live books. Mirror of the .mjs
+        // isTranslatedPage() rule; keep the two in step.
         with_translation: {
           $sum: {
             $cond: [
@@ -45,6 +50,7 @@ export function buildVisiblePageCountPipeline(bookId: string): Document[] {
                 { $ne: ['$translation.data', null] },
                 { $ne: ['$translation.data', ''] },
                 { $ifNull: ['$translation.data', false] },
+                { $ne: [{ $ifNull: ['$page_type', ''] }, 'blank'] },
               ] },
               1, 0,
             ],

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -20,6 +20,8 @@ import {
   isVisiblePage,
   hasOcr,
   hasTranslation,
+  isBlankPage,
+  isTranslatedPage,
   buildVisiblePageCountPipeline,
   countVisiblePageStats,
 } from '../../scripts/lib/page-counts.mjs';
@@ -96,5 +98,70 @@ describe('page-counts convention (#3293)', () => {
     expect(stats.with_translation).toBe(581); // not 20, not 890
     // >90%-readable and >5% gates both see the visible truth
     expect(stats.with_translation / stats.total).toBeGreaterThan(0.9);
+  });
+});
+
+/**
+ * Blank leaves are not translations.
+ *
+ * The translator writes the literal placeholder "[Blank page — no translatable
+ * content]" onto every blank page, so a plain non-empty check counted 87,777
+ * flyleaves and endpapers as translated work (99.8% under 120 characters).
+ *
+ * Worse, it broke the ratio: `translation_pct` divides by
+ * `pages_ocr - pages_blank`, so blank pages left the denominator while staying
+ * in the numerator. 6,228 live books — 32% of the public library — reported
+ * over 100% translated. The Blue Qur'an reported 1000%: 60 pages, 54 blank,
+ * denominator 6.
+ */
+describe('blank pages are excluded from pages_translated', () => {
+  const blankPage = {
+    page_number: 4,
+    page_type: 'blank',
+    ocr: { data: '<page-type>blank</page-type>' },
+    translation: { data: '[Blank page — no translatable content]' },
+  };
+
+  it('isBlankPage identifies the blank page_type', () => {
+    expect(isBlankPage(blankPage)).toBe(true);
+    expect(isBlankPage({ page_type: 'text' })).toBe(false);
+    expect(isBlankPage({})).toBe(false);
+    expect(isBlankPage(null)).toBe(false);
+  });
+
+  it('isTranslatedPage rejects a blank page that carries placeholder text', () => {
+    // hasTranslation stays literal — the text IS non-empty…
+    expect(hasTranslation(blankPage)).toBe(true);
+    // …but it does not count as translated work.
+    expect(isTranslatedPage(blankPage)).toBe(false);
+    expect(isTranslatedPage({ page_type: 'text', translation: { data: 'real' } })).toBe(true);
+    expect(isTranslatedPage({ translation: { data: 'real' } })).toBe(true);
+  });
+
+  it('the pipeline excludes blank pages from with_translation', () => {
+    const group = buildVisiblePageCountPipeline('b1')[1].$group;
+    expect(JSON.stringify(group.with_translation)).toContain('blank');
+  });
+
+  it('reproduces the Blue Qur\'an: 60 pages, 54 blank, and no longer 1000%', () => {
+    const pages = [];
+    for (let n = 1; n <= 6; n++) {
+      pages.push({ page_number: n, page_type: 'text', ocr: { data: 'o' }, translation: { data: 'real translation' } });
+    }
+    for (let n = 7; n <= 60; n++) {
+      pages.push({
+        page_number: n, page_type: 'blank',
+        ocr: { data: '<page-type>blank</page-type>' },
+        translation: { data: '[Blank page — no translatable content]' },
+      });
+    }
+    const stats = countVisiblePageStats(pages);
+    expect(stats.total).toBe(60);
+    expect(stats.with_ocr).toBe(60);
+    expect(stats.with_translation).toBe(6); // was 60 — the numerator bug
+
+    // translation_pct divides by (pages_ocr - pages_blank) = 60 - 54 = 6.
+    const denominator = stats.with_ocr - 54;
+    expect((stats.with_translation / denominator) * 100).toBe(100); // was 1000
   });
 });


### PR DESCRIPTION
## The bug

`translation_pct` = `pages_translated / (pages_ocr - pages_blank)`. Blank pages were subtracted from the denominator but still counted in the numerator, so the ratio could not help exceeding 100.

Measured on prod 2026-08-08: **6,228 live books — 32% of the public library — have a stored `translation_pct` above 100.** Recomputing from page data finds 6,266 (stored values lag the pages slightly). The worst is the Blue Qur'an at **1000%** — 60 pages, 54 of them blank, over a denominator of 6.

The cause is that blank leaves genuinely do carry translation text. The translator writes the literal placeholder onto every one:

```
OCR:  <language>None</language>\n<page-type>blank</page-type>\n<meta>This image shows two facing blank pages…
TRANS: [Blank page — no translatable content]
```

**87,777 pages** are like this — flyleaves, endpapers, empty versos — 99.8% of them under 120 characters. All 300 sampled over-100% books had translated blank pages, and excluding them lands every single one on exactly 100.00%.

## The fix

At the definition, not per-writer. `scripts/lib/page-counts.mjs` gains `isBlankPage()` and `isTranslatedPage()` (= `hasTranslation && !isBlankPage`), used by both the aggregation pipeline and its pure-JS twin — which covers the batch collectors and `translate-core`.

`hasTranslation` deliberately stays literal. "Carries non-empty text" and "counts as translated work" are different questions, and only the second one changed.

The two writers that run their own queries are updated to match: `sync-worker.mjs`'s aggregation and `realtime-translate.mjs`'s `countDocuments`. So is the TS twin, `src/lib/page-counts.ts`. That's every live writer of `pages_translated` — checked by grep, because fixing one helper and calling it done is how the R2 key bug shipped twice in one week.

Downstream, this also corrects `is_fully_translated`, `over_90_translated`, the Supabase catalog's `translation_pct` and `ocr_pct`, the KDP admin view and the CSV export — all of which read the same counter.

## This lowers public numbers, on purpose

Recomputed across all 19,465 live books:

| | before | after | delta |
|---|---|---|---|
| translated pages | 4,887,266 | 4,804,842 | **−82,424** (−1.69%) |
| books over 100% | 6,266 | **0** | — |
| `over_90_translated` | 17,453 | 17,279 | −174 |
| `is_fully_translated` | 15,741 | **14,172** | **−1,569** |

The last row is the one to look at. **1,569 books currently badged "fully translated" are not.** They have genuinely untranslated non-blank pages, and were clearing the bar only because blank placeholders padded the numerator. 1,643 books change badge state in total.

I'd argue that's the strongest reason to merge rather than a reason to hesitate — the corrected numbers are the true ones, and a reader who opens a "fully translated" book and hits untranslated pages is a worse outcome than a smaller headline. But it is a visible change to stats on `/about/progress`, so it should be a deliberate call, not a surprise.

## No backfill needed

`sync-worker` reconciles every book's counters every 2 hours and deliberately does **not** honour `processing_control.paused` (it does no paid work), so the stored values correct themselves after this deploys. Verified at `scripts/workers/sync-worker.mjs:865`.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 159 files, 2,286 tests, all passing
- The pinning test (`tests/unit/page-counts.test.ts`, #3293) gains 5 cases, including a reproduction of the Blue Qur'an: 60 pages / 54 blank / denominator 6, asserting 100% where it was 1000%
- Impact table above recomputed directly from `pages`, not from stored counters

## Out of scope

- **Why 87,777 pages are blank at all** is a separate question. Some are genuine flyleaves; the Blue Qur'an having 54 of 60 pages classified blank (gold script on indigo) looks like the classifier mis-firing on low-contrast folios. Worth its own investigation — this PR only stops blanks from counting as translations.
- A handful of one-off `scripts/analysis/*` scripts count translated pages with their own inline query and will still over-count. They feed no public surface; left alone to keep this reviewable.
- `realtime-translate.mjs:149` seeds translation context from the previous page and can still pick a blank placeholder. Low impact, separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
