### PR TITLE
feat(work): citable canonical-reference URLs — /work/republic/at/328b

### DIFF
--- a/src/app/work/[id]/at/[ref]/route.ts
+++ b/src/app/work/[id]/at/[ref]/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /work/republic/at/328b — a citable canonical-reference URL.
+ *
+ * Resolves a Bekker/Stephanus reference against `locus_anchors` and 307s to the
+ * leaf that carries it (via /book/[id]/page-number/[num], which finds the exact
+ * reader page). Only canon works with a `locus` config resolve here; everything
+ * else bounces to the work page. A miss bounces back with ?locus_miss=<ref> so
+ * the jump box can explain, because "we hold no anchor there" must never look
+ * like a dead link.
+ *
+ * Same discipline as /api/locus (#3661): a witness is a leaf on which the
+ * reference was PRINTED (or frame-bracketed in a verified root edition) —
+ * nothing interpolated. Matching is by page, never section: the leaf carrying
+ * 328a–328c may be anchored "328 c" and is still the right leaf for 328b.
+ * Work attribution accepts the boundary alternate (`work_header_alt`) because a
+ * work's opening leaves often sit under the previous work's running head.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { canonWork } from '@/lib/canon-works';
+import { parseLocusQuery, type LocusSystem } from '@/lib/locus';
+import { findWorkByHead } from '@/lib/locus-works';
+
+interface AnchorDoc {
+  book_id: string;
+  book_slug: string | null;
+  system: LocusSystem;
+  ref_label: string;
+  page_number: number;
+  basis: 'printed' | 'frame';
+  work_header: string | null;
+  work_header_alt: string | null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ref: string }> }
+) {
+  const { id: rawId, ref: rawRef } = await params;
+  const id = decodeURIComponent(rawId);
+  const refStr = decodeURIComponent(rawRef);
+
+  const canon = canonWork(id);
+  const workUrl = new URL(`/work/${encodeURIComponent(id)}`, request.url);
+  if (!canon?.locus) return NextResponse.redirect(workUrl, 307);
+
+  const miss = () => {
+    workUrl.searchParams.set('locus_miss', refStr);
+    return NextResponse.redirect(workUrl, 307);
+  };
+
+  const parsed = parseLocusQuery(refStr);
+  if (!parsed) return miss();
+
+  const db = await getReadDb();
+  const anchors = (await db
+    .collection('locus_anchors')
+    .find(
+      { ref_page: parsed.ref.page, system: canon.locus.system },
+      { projection: { _id: 0 } }
+    )
+    .sort({ ref_sort: 1 })
+    .limit(200)
+    .toArray()) as unknown as AnchorDoc[];
+
+  const target = canon.locus.workSlug;
+  const hits = anchors.filter((a) => {
+    const w = findWorkByHead(a.work_header, a.system);
+    const alt = findWorkByHead(a.work_header_alt, a.system);
+    return w?.slug === target || alt?.slug === target;
+  });
+  if (hits.length === 0) return miss();
+
+  // Root editions (the very books the numbering systems come from) outrank
+  // margin editions; printed anchors outrank frame-bracketed ones.
+  const rootBookIds = new Set(
+    (await db
+      .collection('locus_books')
+      .find({ system: canon.locus.system, mechanism: 'pagination' }, { projection: { _id: 0, book_id: 1 } })
+      .toArray()).map((b) => b.book_id as string)
+  );
+  const rank = (a: AnchorDoc) =>
+    (rootBookIds.has(a.book_id) ? 0 : 2) + (a.basis === 'printed' ? 0 : 1);
+  const witness = [...hits].sort((a, b) => rank(a) - rank(b))[0];
+
+  return NextResponse.redirect(
+    new URL(`/book/${witness.book_slug || witness.book_id}/page-number/${witness.page_number}`, request.url),
+    307
+  );
+}

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -9,6 +9,7 @@ import { canonWork, canonWorkForWorkId, workEditionsFilter, type CanonWork } fro
 import { authorUrl, bookUrl } from '@/lib/slugify';
 import { locusEdition } from '@/lib/locus-editions';
 import { jsonLdHtml } from '@/lib/json-ld';
+import LocusJumpBox from '@/components/work/LocusJumpBox';
 
 // Must be a finite number — `false` would cache a bad-render fallback forever
 // (e.g. the noindex metadata below) until the next deploy.
@@ -326,6 +327,15 @@ export default async function WorkPage({ params }: PageProps) {
                 <ReadNowCard book={readNow.english} lane="Read in English" />
               )}
             </div>
+            {canon?.locus && (
+              <div className="mt-4">
+                <LocusJumpBox
+                  workSlug={canon.slug}
+                  systemLabel={canon.locus.system === 'bekker' ? 'Bekker' : 'Stephanus'}
+                  example={canon.locus.example}
+                />
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/work/LocusJumpBox.tsx
+++ b/src/components/work/LocusJumpBox.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+/**
+ * Citation jump box for canon work pages with a registered locus system:
+ * type "328b", land on the leaf that carries it (via /work/[slug]/at/[ref]).
+ *
+ * The miss notice reads ?locus_miss= client-side (useSearchParams inside
+ * Suspense) so the server-rendered page stays fully static/ISR — reading
+ * searchParams in the server component would force dynamic rendering.
+ */
+import { Suspense, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function MissNotice() {
+  const searchParams = useSearchParams();
+  const missed = searchParams.get('locus_miss');
+  if (!missed) return null;
+  return (
+    <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mt-3">
+      No leaf in our registered editions carries &ldquo;{missed}&rdquo;. The reference may be
+      outside the ranges we hold anchors for — nothing is interpolated, so we only land on
+      pages where the number was actually printed.
+    </p>
+  );
+}
+
+export default function LocusJumpBox({
+  workSlug,
+  systemLabel,
+  example,
+}: {
+  workSlug: string;
+  /** "Bekker" | "Stephanus" */
+  systemLabel: string;
+  /** Placeholder reference, e.g. "1094a" or "328b" */
+  example: string;
+}) {
+  const [value, setValue] = useState('');
+  const router = useRouter();
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const ref = value.trim();
+        if (ref) router.push(`/work/${workSlug}/at/${encodeURIComponent(ref)}`);
+      }}
+      className="rounded-xl border border-stone-200 bg-white p-4"
+    >
+      <label htmlFor="locus-ref" className="block text-sm font-medium text-stone-700">
+        Jump to a {systemLabel} reference
+      </label>
+      <p className="text-xs text-stone-500 mt-0.5 mb-2">
+        Standard citations land on the exact leaf — e.g. {example}.
+      </p>
+      <div className="flex gap-2">
+        <input
+          id="locus-ref"
+          type="text"
+          inputMode="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={example}
+          className="flex-1 min-w-0 rounded-lg border border-stone-300 px-3 py-1.5 text-base text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-stone-400"
+        />
+        <button
+          type="submit"
+          className="rounded-lg bg-stone-800 hover:bg-stone-700 text-white text-sm px-4 py-1.5 transition-colors"
+        >
+          Go
+        </button>
+      </div>
+      <Suspense fallback={null}>
+        <MissNotice />
+      </Suspense>
+    </form>
+  );
+}

--- a/src/lib/canon-works.ts
+++ b/src/lib/canon-works.ts
@@ -35,6 +35,14 @@ export interface CanonWork {
   workIds: string[];
   /** Verified work_id values of collected editions containing this work */
   collectedWorkIds?: string[];
+  /**
+   * Canonical citation config (enables /work/[slug]/at/[ref] and the jump
+   * box). `workSlug` must be a slug from src/lib/locus-works.ts — it filters
+   * anchors by running head, which is how a Stephanus number is disambiguated
+   * between dialogues. `example` is a reader-facing reference inside the
+   * work's real range.
+   */
+  locus?: { system: 'bekker' | 'stephanus'; workSlug: string; example: string };
 }
 
 const PLATO_COLLECTED = ['Q139619812', 'plato-opera-ficino']; // Stephanus 1578; Ficino's Latin Opera
@@ -80,6 +88,7 @@ export const CANON_WORKS: CanonWork[] = [
     originalLanguage: 'Greek',
     workIds: ['plato-republic'],
     collectedWorkIds: PLATO_COLLECTED,
+    locus: { system: 'stephanus', workSlug: 'republic', example: '328b' },
   },
   {
     slug: 'timaeus',
@@ -90,6 +99,7 @@ export const CANON_WORKS: CanonWork[] = [
     originalLanguage: 'Greek',
     workIds: ['Q371884', 'plato-timaeus'],
     collectedWorkIds: PLATO_COLLECTED,
+    locus: { system: 'stephanus', workSlug: 'timaeus', example: '29d' },
   },
   {
     slug: 'phaedo',
@@ -100,6 +110,7 @@ export const CANON_WORKS: CanonWork[] = [
     originalLanguage: 'Greek',
     workIds: ['Q244161'],
     collectedWorkIds: PLATO_COLLECTED,
+    locus: { system: 'stephanus', workSlug: 'phaedo', example: '64a' },
   },
   {
     slug: 'laws-plato',
@@ -110,6 +121,7 @@ export const CANON_WORKS: CanonWork[] = [
     originalLanguage: 'Greek',
     workIds: ['Q752285'],
     collectedWorkIds: PLATO_COLLECTED,
+    locus: { system: 'stephanus', workSlug: 'laws', example: '624a' },
   },
   {
     slug: 'nicomachean-ethics',
@@ -119,6 +131,7 @@ export const CANON_WORKS: CanonWork[] = [
     era: '4th century BCE',
     originalLanguage: 'Greek',
     workIds: ['aristotle-nicomachean-ethics'],
+    locus: { system: 'bekker', workSlug: 'nicomachean-ethics', example: '1094a' },
   },
   {
     slug: 'metaphysics',
@@ -128,6 +141,7 @@ export const CANON_WORKS: CanonWork[] = [
     era: '4th century BCE',
     originalLanguage: 'Greek',
     workIds: ['aristotle-metaphysics'],
+    locus: { system: 'bekker', workSlug: 'metaphysics', example: '980a' },
   },
   {
     slug: 'organon',
@@ -146,6 +160,7 @@ export const CANON_WORKS: CanonWork[] = [
     era: '4th century BCE',
     originalLanguage: 'Greek',
     workIds: ['local:a:aristotle:soul'],
+    locus: { system: 'bekker', workSlug: 'de-anima', example: '402a' },
   },
   {
     slug: 'herodotus-histories',


### PR DESCRIPTION
## What

Phase 2 of #3736: canonical citations become stable, shareable URLs.

- **`/work/[id]/at/[ref]`** (route handler): resolves a Bekker/Stephanus reference against `locus_anchors` and 307s to the leaf that carries it, via the existing `/book/[id]/page-number/[num]` hop into the reader. Resolution follows the `/api/locus` discipline (#3661): page-level matching (never section), boundary running-head alternates honored, nothing interpolated. Root editions (`mechanism: 'pagination'`) and printed anchors outrank marginal/frame ones — a citation lands on the very edition its numbering system comes from.
- **Jump box** on canon work pages with a locus config: type `328b` on `/work/republic`, land on the leaf. Misses bounce back with `?locus_miss=` and an explanation (read client-side in Suspense — the page stays ISR-static).
- **7 canon works wired**: Republic, Timaeus, Phaedo, Laws (Stephanus); Nicomachean Ethics, Metaphysics, On the Soul (Bekker). Organon deliberately skipped — it's a corpus of several locus works, not one.

**Out of scope:** jump box inside the book reader itself (Phase 2's other half — separate PR), locus coverage beyond the 11 registered editions, line-level resolution (anchors are page-level by design).

## Verification
- `/work/republic/at/328b` → Stephanus vol. 2, scan page 340 — the exact boundary leaf `canonical-loci.md` documents (printed 328 under the `PLATONIS` head, matched via `work_header_alt`).
- `/work/nicomachean-ethics/at/1094a` → Bekker Opera vol. 2, page 310 — the page the #3653 MCP agent had to reconstruct by hand.
- Miss (`/at/999z`) → bounces to the work page with the notice; non-locus works (`/work/aeneid/at/…`) → clean bounce; page-number hop 308s into the reader.
- `npx tsc --noEmit` clean (dev-server-free run).

Phase 2 of #3736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)