### PR TITLE
fix(ft): a fragment cannot defeat a first-translation claim, and neither can the wrong text

### DIFF
--- a/scripts/maintenance/ingest-ft-verify-results.mjs
+++ b/scripts/maintenance/ingest-ft-verify-results.mjs
@@ -91,6 +91,12 @@ function buildPriors(r) {
       translator: t.translator || undefined,
       pub_year: t.pub_year != null ? String(t.pub_year) : undefined,
       completeness: t.completeness || completenessFor(r.result),
+      // The judgement that decides whether this prior DEFEATS the claim. See
+      // PriorRelationship in types.ts. Carried through because dropping it is
+      // what let a prior verified as translating a different witness be read as
+      // a defeater — Kerns 2008 renders Yonge's Middle English, not the Latin
+      // Secretum secretorum, and the badge came off anyway (2026-08-08).
+      relationship: t.relationship || undefined,
       source_url: t.source_url || r.evidence_url || undefined,
     }));
   }
@@ -102,6 +108,7 @@ function buildPriors(r) {
       translator: t.translator || undefined,
       pub_year: t.year != null && t.year !== 0 ? String(t.year) : (t.pub_year != null ? String(t.pub_year) : undefined),
       completeness: t.completeness || completenessFor(r.result),
+      relationship: t.relationship || undefined,
       source_url: t.source_url || r.evidence_url || undefined,
     }));
   }

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -105,6 +105,43 @@ function toCited(p: NonNullable<FirstTranslationAttempt['priors']>[number]): Cit
   };
 }
 
+/**
+ * Does this prior actually DEFEAT a first-translation claim?
+ *
+ * Two conditions, both of which the model already promised and neither of which
+ * the grader was checking.
+ *
+ * 1. COMPLETENESS. A demote requires a COMPLETE prior. The ft-verify contract
+ *    has always said so ("demote survives only if result == confirmed_complete")
+ *    but the grader keyed on `result === 'found'` and the priors' YEARS alone,
+ *    never their completeness — so an `excerpt` defeated a claim exactly as a
+ *    complete edition did. Measured 2026-08-08: of 429 books graded `not_first`,
+ *    31 had NO complete prior anywhere and 7 had already lost their badge —
+ *    al-Jāḥiẓ's *Kitāb al-Ḥayawān* among them, whose every English rendering is
+ *    a fragment and for which no complete translation exists in any catalogue.
+ *
+ * 2. RELATIONSHIP. `PriorRelationship` is documented in types.ts as the field
+ *    that "determines whether the candidate defeats first" — and the grader
+ *    hardcoded `same_text`, the value that always defeats, while the ingest
+ *    never carried the agent's actual judgement. So a prior verified as
+ *    translating a DIFFERENT WITNESS (Kerns 2008 renders Yonge's Middle English,
+ *    not the Latin *Secretum secretorum*) or a DIFFERENT WORK was recorded
+ *    faithfully and then read as a defeater. Only `same_text` and
+ *    `same_work_diff_edition` defeat; `different_source_language` and
+ *    `related_distinct_work` explicitly do not, per POLICY 2.
+ *
+ * An ABSENT relationship keeps the old default (`same_text`), because most
+ * historical rows predate the field and silently reversing them would be its own
+ * mass rewrite. Absence is not evidence of a non-defeating relationship.
+ */
+export function priorDefeatsClaim(
+  p: NonNullable<FirstTranslationAttempt['priors']>[number],
+): boolean {
+  const rel = (p as { relationship?: string }).relationship;
+  if (rel && rel !== 'same_text' && rel !== 'same_work_diff_edition') return false;
+  return /^complete$/i.test(String(p.completeness ?? ''));
+}
+
 const NOT_APPLICABLE_RE = /^\s*not[_ ]applicable\b/i;
 // Legacy backfills embed the judgment mid-notes ("[legacy_ai] status=not_applicable; …"),
 // which the anchored form misses — so an "original English work, FT does not apply"
@@ -220,15 +257,42 @@ export function deriveVerdictFromAttempts(
         best_attempt_id: strongest.attempt_id,
       };
     }
-    // Grade by the trustworthy priors' years: registry refs (year unknown) and any
-    // post-1900 prior defeat outright; all-parseable-and-pre-1900 → first_modern.
     const hasRegistryRef = trustFound.some((a) => (a.found_refs?.length ?? 0) > 0);
-    const years = trustFound
-      .flatMap((a) => (a.priors ?? []).filter((p) => evaluatePrior(bi, toCited(p)).trustworthy))
-      .map(priorYear);
+    const trustworthyPriors = trustFound
+      .flatMap((a) => a.priors ?? [])
+      .filter((p) => evaluatePrior(bi, toCited(p)).trustworthy);
+
+    // ONLY priors that actually defeat the claim may grade it. See
+    // priorDefeatsClaim: complete, and of a defeating relationship.
+    const defeating = trustworthyPriors.filter(priorDefeatsClaim);
+    const families = new Set(trustFound.map(attemptFamily)).size;
+
+    // A found sighting with nothing that defeats is NOT a demote. A registry ref
+    // still counts (its completeness is unknown by construction, and the
+    // registry is the layer that resolved it), so it keeps the old path.
+    if (!hasRegistryRef && trustworthyPriors.length > 0 && defeating.length === 0) {
+      // Distinguish "we found only fragments" from "we could not tell". The
+      // first is a real, badgeable finding — our edition may be the first
+      // COMPLETE one. The second is an unrun check and must not read as either.
+      const allKnownPartial = trustworthyPriors.every((p) =>
+        /^(partial|excerpts?)$/i.test(String(p.completeness ?? '')));
+      return {
+        verdict: allKnownPartial ? 'first_complete' : 'needs_review',
+        evidence_strength: allKnownPartial && families >= 2 ? 'moderate' : 'weak',
+        our_completeness: 'unknown',
+        match_key: bestMatchKey(trustFound),
+        prior_relationship: 'partial',
+        prior_refs: strongest.found_refs?.length ? strongest.found_refs : undefined,
+        resolver: methodToResolver(strongest.method),
+        best_attempt_id: strongest.attempt_id,
+      };
+    }
+
+    // Grade by the DEFEATING priors' years: registry refs (year unknown) and any
+    // post-1900 prior defeat outright; all-parseable-and-pre-1900 → first_modern.
+    const years = (defeating.length ? defeating : trustworthyPriors).map(priorYear);
     const allPre1900 =
       !hasRegistryRef && years.length > 0 && years.every((y) => y !== null && y < 1900);
-    const families = new Set(trustFound.map(attemptFamily)).size;
     return {
       verdict: allPre1900 ? 'first_modern' : 'not_first',
       evidence_strength: families >= 2 ? 'strong' : 'moderate',

--- a/tests/unit/first-translation-defeat-rules.test.ts
+++ b/tests/unit/first-translation-defeat-rules.test.ts
@@ -1,0 +1,86 @@
+/**
+ * What actually defeats a first-translation claim (#3687, 2026-08-08).
+ *
+ * Written after three badges came off overnight that should not have. The
+ * grader keyed on a found sighting and the priors' YEARS, and never read the two
+ * fields the model documents as decisive:
+ *
+ *   completeness  — the ft-verify contract has always said a demote requires
+ *                   `confirmed_complete`; the grader never checked it, so an
+ *                   `excerpt` defeated a claim exactly as a complete edition did.
+ *   relationship  — types.ts documents PriorRelationship as the field that
+ *                   "determines whether the candidate defeats first", and the
+ *                   grader hardcoded `same_text` (always defeats) while the
+ *                   ingest dropped the agent's actual judgement.
+ *
+ * Measured blast radius before the fix: of 429 books graded `not_first`, 31 had
+ * NO complete prior anywhere (7 already demoted) and 44 had priors of unknown
+ * completeness (36 already demoted).
+ *
+ * Every case below is a real book from that audit.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { priorDefeatsClaim } from '@/lib/first-translation/derive-from-evidence';
+
+type Prior = Parameters<typeof priorDefeatsClaim>[0];
+const prior = (o: Partial<Prior> & Record<string, unknown>) =>
+  ({ english_title: 'X', ...o }) as Prior;
+
+describe('completeness: a fragment cannot defeat a first-translation claim', () => {
+  it('al-Jahiz — every English rendering is an excerpt, so none defeats', () => {
+    // Kitab al-Hayawan: Kopf 1953 (excerpt), Montgomery 2013 (partial). No
+    // complete seven-volume English translation exists in any catalogue, and
+    // this book was demoted anyway.
+    expect(priorDefeatsClaim(prior({ translator: 'Lothar Kopf', pub_year: '1953', completeness: 'excerpt' }))).toBe(false);
+    expect(priorDefeatsClaim(prior({ translator: 'James E. Montgomery', pub_year: '2013', completeness: 'partial' }))).toBe(false);
+  });
+
+  it('a complete prior DOES defeat', () => {
+    expect(priorDefeatsClaim(prior({ translator: 'P.G. Walsh', pub_year: '1999', completeness: 'complete' }))).toBe(true);
+  });
+
+  it('unknown completeness does NOT defeat — "we could not tell" is not "complete"', () => {
+    // 44 books sat in this state, 36 of them already demoted. An unrun check
+    // must never read as a finding.
+    expect(priorDefeatsClaim(prior({ translator: 'A B', pub_year: '1980', completeness: 'unknown' }))).toBe(false);
+    expect(priorDefeatsClaim(prior({ translator: 'A B', pub_year: '1980' }))).toBe(false);
+  });
+});
+
+describe('relationship: a complete prior of the WRONG text cannot defeat either', () => {
+  it('Secretum secretorum — Kerns 2008 renders Yonge\'s Middle English, not the Latin', () => {
+    // Complete, post-1900, and verified as translating a different witness.
+    // Recorded faithfully, read as a defeater, badge removed.
+    expect(priorDefeatsClaim(prior({
+      translator: 'Linda K. Kerns', pub_year: '2008', completeness: 'complete',
+      relationship: 'different_source_language',
+    }))).toBe(false);
+  });
+
+  it('a prior on a related but distinct work does not defeat', () => {
+    // Peers 1923 translates the Llibre d'amic e amat, embedded in Blanquerna —
+    // not the Llibre de contemplacio at all.
+    expect(priorDefeatsClaim(prior({
+      translator: 'E. Allison Peers', pub_year: '1923', completeness: 'complete',
+      relationship: 'related_distinct_work',
+    }))).toBe(false);
+  });
+
+  it('same_text and same_work_diff_edition DO defeat', () => {
+    for (const relationship of ['same_text', 'same_work_diff_edition']) {
+      expect(priorDefeatsClaim(prior({ pub_year: '1990', completeness: 'complete', relationship })), relationship).toBe(true);
+    }
+  });
+
+  it('an ABSENT relationship keeps the defeating default', () => {
+    // Deliberate. Most historical rows predate the field, and silently reversing
+    // them would be its own mass rewrite. Absence is not evidence of a
+    // non-defeating relationship.
+    expect(priorDefeatsClaim(prior({ pub_year: '1990', completeness: 'complete' }))).toBe(true);
+  });
+
+  it('relationship cannot rescue a fragment — both conditions must hold', () => {
+    expect(priorDefeatsClaim(prior({ pub_year: '1990', completeness: 'partial', relationship: 'same_text' }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Three badges came off overnight that should not have — Boethius, al-Jāḥiẓ's *Kitāb al-Ḥayawān*, and *Secretum secretorum*, all three verified hours earlier as **badge stands** or **regrade, don't demote**.

## Two fields the model documents as decisive, neither of which was read

**Completeness.** The ft-verify contract has always said a demote requires `confirmed_complete`. The grader keyed on `result === 'found'` and the priors' **years alone** — so an `excerpt` defeated a claim exactly as a complete edition did. *Kitāb al-Ḥayawān*, whose every English rendering is a fragment and for which no complete translation exists in any catalogue, was demoted on Kopf 1953 (excerpt) and Montgomery 2013 (partial).

**Relationship.** `types.ts` documents `PriorRelationship` as the field that *"determines whether the candidate defeats first"*. The grader **hardcoded `same_text`** — the value that always defeats — and the ingest dropped the agent's judgement entirely. So Kerns 2008, verified as translating **Yonge's Middle English** rather than the Latin *Secretum secretorum*, was recorded faithfully and read as a defeater.

## Measured blast radius, before the fix

Of 429 books graded `not_first`:

| priors | count | flags already removed |
|---|---|---|
| at least one **complete** | 354 | 332 |
| **all partial/excerpt** | **31** | **7** |
| some **unknown** | 44 | 36 |

## The fix

- `priorDefeatsClaim()` requires completeness `complete` **and** a defeating relationship (`same_text` / `same_work_diff_edition`).
- **An absent relationship keeps the old defeating default.** Deliberate: most rows predate the field and silently reversing them would be its own mass rewrite. Absence is not evidence of a non-defeating relationship.
- A found sighting with nothing that defeats now grades **`first_complete`** when every prior is *known* partial/excerpt — a real badgeable finding, since ours may be the first complete edition — and **`needs_review`** when any completeness is unknown. *"We could not tell"* must never read as *"we found nothing complete."*
- The ingest carries `relationship` through from `registry_rows` and `priors[]`.

## Dry run over production

```
99 verdicts change · not_first 429 → 265 · 33 books become first_complete
```

**Not applied.** The code lands first; the re-derive and any restore are separate, reviewed steps.

## Residual, not fixed here

Older low-quality attempts still contribute priors even when a newer verified attempt corrects them. Calvin still grades `not_first` off a stale gemini row marking Battles 1960 "complete", although the 2026-08-07 verification recorded it as **partial** (the *Institutio* is 2 of 59 volumes). That is the *"an immutable log is a history, not a state"* problem and needs its own fix — flagging rather than widening this PR.

Found during #3687. Tests use real books from that audit as fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)