### PR TITLE
704 untranscribed books showed a padlock and "Complete OCR first" to readers

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1509,6 +1509,18 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                   the left of the label. "First translation" reads as plain text
                   to the right of Translated (full history lives in Editions &
                   translations). */}
+              {/* Untranscribed books say so. This row used to render only when
+                  ocrPct > 0, so the 704 visible books with NO OCR showed no
+                  status at all — and a missing badge reads as "nothing wrong",
+                  not "no text here". The reader then clicked "Read this book"
+                  into a pane that had nothing to show. */}
+              {ocrPct === 0 && (
+                <div className="flex flex-wrap items-center gap-x-3 md:gap-x-4 gap-y-1 mt-3 md:mt-4 text-[10.5px] md:text-[13.5px] font-medium">
+                  <span title={`${totalPages} scans available; no pages transcribed yet`} style={{ color: 'rgba(245,240,232,0.55)' }}>
+                    Scans only — not transcribed yet
+                  </span>
+                </div>
+              )}
               {ocrPct > 0 && (
                 <div className="flex flex-wrap items-center gap-x-3 md:gap-x-4 gap-y-1 mt-3 md:mt-4 text-[10.5px] md:text-[13.5px] font-medium">
                   <span title={`${ocrCount} of ${totalPages} pages transcribed`} style={{ color: '#8fbfe6' }}>

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1945,7 +1945,13 @@ export default function TranslationEditor({
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                        {paired ? 'English · Berthelot' : translationText ? translationLangLabel : 'Step 2: Translate'}
+                        {/* Was 'Step 2: Translate' when the panel was empty — pipeline
+                            stage numbering shown to readers. The label describes what
+                            the panel holds, so it should not change based on whether
+                            the work has been done yet. translationLangLabel resolves
+                            without a translation present (falls back to English /
+                            Modernized). */}
+                        {paired ? 'English · Berthelot' : translationLangLabel}
                       </span>
                       {!paired && translationText && (
                         <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-sage)' }}>
@@ -2199,19 +2205,47 @@ export default function TranslationEditor({
                         </AuthCheck>
                       </div>
                     ) : (
-                      <div className="h-full flex flex-col items-center justify-center text-center px-4">
-                        <div className="w-16 h-16 rounded-full flex items-center justify-center mb-4" style={{ background: 'var(--bg-warm, #f5f3f0)' }}>
-                          <svg className="w-8 h-8" style={{ color: 'var(--text-faint, #c4c0b8)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                          </svg>
+                      /* Untranscribed page. 704 visible books have no OCR at
+                         all, so this is a public-facing state, not an operator
+                         one — it used to show a PADLOCK and "Complete OCR
+                         first" to every reader, which reads as paywalled
+                         content in a free library and as pipeline jargon
+                         besides. Editors keep the operational wording; readers
+                         are told plainly what they have and what they don't. */
+                      <AuthCheck
+                        role="inner_circle"
+                        fallback={
+                          <div className="h-full flex flex-col items-center justify-center text-center px-4">
+                            <div className="w-16 h-16 rounded-full flex items-center justify-center mb-4" style={{ background: 'var(--bg-warm, #f5f3f0)' }}>
+                              <svg className="w-8 h-8" style={{ color: 'var(--text-faint, #c4c0b8)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 5a2 2 0 012-2h8l6 6v10a2 2 0 01-2 2H6a2 2 0 01-2-2V5z" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14 3v6h6" />
+                              </svg>
+                            </div>
+                            <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-muted)' }}>
+                              Not transcribed yet
+                            </h3>
+                            <p className="text-sm max-w-xs" style={{ color: 'var(--text-faint)' }}>
+                              The scan is here and free to read, but this page has no transcription
+                              yet, so there is nothing to translate from.
+                            </p>
+                          </div>
+                        }
+                      >
+                        <div className="h-full flex flex-col items-center justify-center text-center px-4">
+                          <div className="w-16 h-16 rounded-full flex items-center justify-center mb-4" style={{ background: 'var(--bg-warm, #f5f3f0)' }}>
+                            <svg className="w-8 h-8" style={{ color: 'var(--text-faint, #c4c0b8)' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                            </svg>
+                          </div>
+                          <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-muted)' }}>
+                            Complete OCR first
+                          </h3>
+                          <p className="text-sm max-w-xs" style={{ color: 'var(--text-faint)' }}>
+                            The original text needs to be transcribed before it can be translated.
+                          </p>
                         </div>
-                        <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-muted)' }}>
-                          Complete OCR first
-                        </h3>
-                        <p className="text-sm max-w-xs" style={{ color: 'var(--text-faint)' }}>
-                          The original text needs to be transcribed before it can be translated.
-                        </p>
-                      </div>
+                      </AuthCheck>
                     )}
                   </div>
 


### PR DESCRIPTION
**704 visible books have zero OCR.** 128 of them have been opened by a reader. This is what those readers got.

## Book page: no signal at all

The OCR/Translated status row rendered only when `ocrPct > 0`. So a book with no transcription showed *nothing* — and a missing badge reads as "nothing wrong", not "there is no text in here".

[*Magia vera sacra sacratissima*](https://sourcelibrary.org/book/magia-vera-sacra-sacratissima) — 134 scans, 40 reads, 0 transcribed — presented an unqualified **Read this book** button next to "134 scans" and no other status. A reader cannot distinguish it from the 1524 Aldine Iliad, which shows "✓ OCR ✓ Translated" in the same spot.

Now: `Scans only — not transcribed yet`.

## Reader: a padlock, in a free library

Clicking through gave a beautiful 6,420 × 3,720 scan on the left and, on the right:

> 🔒 **Complete OCR first**
> The original text needs to be transcribed before it can be translated.

Two problems. It's operator language — "complete OCR" is an instruction to whoever runs the pipeline, not information for a reader. And the padlock says *restricted*, when the truth is the opposite: the scan is right there, free, at full resolution. It reads like a paywall on a project whose whole point is open access.

Readers now get a document icon and:

> **Not transcribed yet**
> The scan is here and free to read, but this page has no transcription yet, so there is nothing to translate from.

Editors keep the operational wording, via the same `AuthCheck role="inner_circle"` pattern already used ~60 lines above for the request-translation flow.

## Panel header

The same pane was titled **"Step 2: Translate"** whenever it was empty — pipeline stage numbering shown to the public. A panel label should describe what the panel holds, not which stage hasn't run yet, so it now always shows the language label (English / Modernized / Español). That value resolves correctly with no translation present; it falls back on `book.language`, not on `page.translation`.

## Scope

This changes **what the reader is told**, not what is published. No book is hidden, no data is written, no OCR is queued. The 704 books stay exactly as available as they were — the scans are genuinely valuable and worth browsing, which is precisely why the padlock was the wrong message.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 163 files, 2,335 tests, all passing
- Rendered locally against prod data: the zero-OCR book page (new badge), its reader (new empty state, logged out), and the 1524 Aldine Iliad reader as a control — confirmed unchanged, still renders its translation with no new strings leaking in

## Out of scope

- **The 1,090 books stalled at ~25 OCR'd pages** out of 100+. Those *do* show an honest "6% OCR" badge, so they're less acutely misleading than the zero case, but a reader still hits a wall partway through. Deciding between finishing them, labelling the boundary in the reader, or unpublishing them is a product call, not a copy fix.
- **Whether these 704 should be visible at all.** Unpublishing is a data decision needing explicit sign-off per the Data Protection rules; this PR assumes they stay and just describes them truthfully.
- Queuing OCR for them. The pipeline is deliberately paused, and this is a five-figure-a-month decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
