### PR TITLE
fix(archive): record the archiving on the book, not only on its pages

### DIFF
--- a/src/app/api/books/[id]/archive-images/route.ts
+++ b/src/app/api/books/[id]/archive-images/route.ts
@@ -18,6 +18,17 @@ const ARCHIVABLE_SOURCES_REGEX = /archive\.org|gallica\.bnf\.fr|digitale-sammlun
  * Download images from external sources and upload to Vercel Blob.
  * Supports: Internet Archive, Gallica (BnF), MDZ (Bavarian State Library)
  * This makes images available even when source sites are down.
+ *
+ * Writes `archived_photo` (plus a thumbnail) per page and syncs the book's
+ * `pages_archived` counter — see the recount near the end of the handler for why that
+ * matters.
+ *
+ * KNOWN GAP, deliberate: this route does NOT generate `display_photo` variants, which is
+ * what the reader actually reads. The worker archivers do (via `uploadPageVariants`), so a
+ * book archived through this route has `archived_photo` on every page and no display
+ * variant, and falls back to the source URL until the display backfill sweep reaches it.
+ * That sweep is live and cursor-driven, so the gap closes on its own; it is recorded here
+ * only so the asymmetry is not mistaken for a bug in the reader.
  */
 export const POST = withAuth(async (request, session, context) => {
   try {
@@ -208,6 +219,26 @@ export const POST = withAuth(async (request, session, context) => {
         { photo_original: { $regex: ARCHIVABLE_SOURCES_REGEX } },
       ],
     });
+
+    // Record the work on the BOOK, not just on its pages (#3712).
+    //
+    // `books.pages_archived` is a cached count of pages holding an `archived_photo`,
+    // and selectors key on it rather than on the pages: archive-erara picks work with
+    // `pages_archived: { $not: { $gte: 1 } }`, and archiving-watchdog treats a book as
+    // progressing only when it is > 0. This route used to write `archived_photo` onto
+    // every page and never touch the book, so a book fully archived here still read 0 —
+    // permanently eligible for re-archiving, and a re-run re-downloaded every page from
+    // the source. That is the expensive half: full-bandwidth refetches against providers
+    // that rate-limit or block us.
+    //
+    // Set from the recount above, never an increment. The route is called repeatedly with
+    // `limit`, and the Cloudflare edge times out around 100s while the function keeps
+    // working to its 300s maxDuration — so callers legitimately retry work that in fact
+    // completed, and an increment would drift every time that happens.
+    await db.collection('books').updateOne(
+      { id: bookId },
+      { $set: { pages_archived: archivedPages, updated_at: new Date() } }
+    );
 
     const successCount = results.filter(r => r.success).length;
     const failedCount = results.filter(r => !r.success).length;


### PR DESCRIPTION
Closes #3712.

## The bug

`POST /api/books/[id]/archive-images` writes `archived_photo` onto every page and never touches `books`. But `books.pages_archived` is a **cached** count, and the selectors key on the counter, not on the pages:

- `archive-erara.mjs` picks work with `pages_archived: { $not: { $gte: 1 } }`
- `archiving-watchdog.mjs` treats a book as progressing only when it is `> 0`

So a book fully archived through this route still reads `0` — permanently eligible for re-archiving, and a re-run **re-downloads every page from the source**. That is the expensive half, and not in dollars: it is full-bandwidth refetching against providers that rate-limit or block us outright (e-rara already 403s our datacenter IPs).

Observed on Aristotelis Opera Vol. III (`6a761f56af6d06b393a52a44`): 762/762 pages carrying `archived_photo`, book reading `pages_archived: 0`.

Same family as the `archived_photo` invariant in CLAUDE.md, inverted — there a *wrong* write made a page look done and hid it from repair; here a *correct* write isn't recorded, so the work is simply repeated.

## The fix

The handler already recounts archived pages to build its response. This persists that number.

**Set from the recount, never incremented.** The route is called repeatedly with `limit`, and the Cloudflare edge times out at ~100s while the function runs to its 300s `maxDuration` — so callers legitimately retry work that in fact completed (I hit exactly this driving Vol. III: two calls returned 524 and both had archived their pages). An increment would drift on every one of those.

## Also documented, not fixed

This route writes no `display_photo` variants — the worker archivers do, via `uploadPageVariants`. A book archived here therefore has `archived_photo` on every page and no display variant, and the reader falls back to the source URL. Vol. III: 0/762 display variants against 762/762 archived; Vol. V, archived by the normal worker, has both.

Left as-is deliberately: the display backfill sweep is live and cursor-driven, so the gap closes on its own. Recorded in the handler docblock so the asymmetry isn't mistaken for a reader bug.

## Verification

`npx tsc --noEmit` clean. The counter path is the same recount the endpoint has always returned in `archivedPages`, so the stored value and the reported value cannot disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)