### PR TITLE
feat(monitoring): the semantic monitoring surface — stage coverage from data, never job counters (#3756 §B)

### DIFF
--- a/scripts/lib/stage-coverage.mjs
+++ b/scripts/lib/stage-coverage.mjs
@@ -1,0 +1,379 @@
+/**
+ * stage-coverage — one coverage measurement per pipeline stage (#3756 §B/§A1).
+ *
+ * The v1 archaeology's loudest finding: of the most expensive incidents, zero
+ * were caught by monitoring, because monitoring watched JOB COUNTERS and the
+ * counters lied. Every measurement here is therefore computed from the DATA
+ * (rows and fields that exist), never from job status.
+ *
+ * Each measurement returns:
+ *   { stage, status: 'ok' | 'probe_broken', covered, total, queue_depth, detail? }
+ *
+ * POSITIVE CONTROLS (the probe-needs-a-positive-control lesson): before
+ * counting, each measurement runs a known-satisfiable sub-query — "at least
+ * one row satisfies the covered predicate" — with a findOne. If the control
+ * finds nothing, the measurement reports status:'probe_broken' with
+ * covered:null instead of reporting 0 coverage. A broken probe and an empty
+ * pipeline must never look the same (that is exactly how #2973-class freezes
+ * and the #3362 silent-success class went unnoticed).
+ *
+ * Query discipline: countDocuments with simple predicates only;
+ * estimatedDocumentCount where exact totals aren't needed; every query
+ * carries maxTimeMS. No unbounded aggregations over `pages`.
+ *
+ * Conventions reused:
+ *   - visible pages: page_number > 0 (scripts/lib/page-counts.mjs, #3293)
+ *   - live books: visible:true && pages_count>0 (canonical public filter)
+ *   - archive failure markers: archived_photo starting 'failed:'
+ *   - #2430 canary: gallery_images rows with a detection above the
+ *     thumbnail-quality bar but no extracted_url — the batch collector writes
+ *     bbox-only rows and generate-thumbnails materializes them; rows stuck in
+ *     that state are the images queue.
+ */
+
+import { VISIBLE_PAGE_MATCH } from './page-counts.mjs';
+
+const COUNT_MAX_TIME_MS = 10 * 60_000; // nightly job; pages is ~5M docs
+const CONTROL_MAX_TIME_MS = 60_000;
+
+/** Canonical "live" book filter used across public APIs. */
+export const LIVE_BOOK_MATCH = { visible: true, pages_count: { $gt: 0 } };
+
+/** Non-empty string, not an archive-failure marker. */
+const ARCHIVED_OK = { $type: 'string', $ne: '', $not: /^failed:/ };
+
+/**
+ * Pure: fold the positive-control outcome into a measurement.
+ * controlOk=false means the probe could not find even one known-present case,
+ * so its counts are untrustworthy — report the probe broken, never 0 coverage.
+ */
+export function finalizeMeasurement(measurement, controlOk) {
+  const { stage, covered, total, queue_depth, detail } = measurement;
+  if (!controlOk) {
+    return {
+      stage,
+      status: 'probe_broken',
+      covered: null,
+      total: total ?? null,
+      queue_depth: null,
+      ...(detail !== undefined ? { detail } : {}),
+    };
+  }
+  return {
+    stage,
+    status: 'ok',
+    covered,
+    total,
+    queue_depth,
+    ...(detail !== undefined ? { detail } : {}),
+  };
+}
+
+/**
+ * Pure: annotate current stages with `delta` (covered − previous covered).
+ * Delta is null when either side is missing or probe_broken — a broken probe
+ * must not manufacture a zero delta (which findStalled would then flag).
+ */
+export function computeStageDeltas(currentStages, previousStages) {
+  const prev = new Map((previousStages ?? []).map((s) => [s.stage, s]));
+  return (currentStages ?? []).map((s) => {
+    const p = prev.get(s.stage);
+    const comparable =
+      s.status === 'ok' && typeof s.covered === 'number' &&
+      p?.status === 'ok' && typeof p.covered === 'number';
+    return { ...s, delta: comparable ? s.covered - p.covered : null };
+  });
+}
+
+/**
+ * Pure: the I54 "quietly stops advancing" detector — stages with work waiting
+ * (queue_depth > 0) whose coverage did not move (delta === 0). Broken probes
+ * and stages without a comparable delta are excluded: null is not zero.
+ */
+export function findStalled(stagesWithDeltas) {
+  return (stagesWithDeltas ?? [])
+    .filter(
+      (s) =>
+        s.status === 'ok' &&
+        typeof s.queue_depth === 'number' &&
+        s.queue_depth > 0 &&
+        s.delta === 0,
+    )
+    .map((s) => s.stage);
+}
+
+/** Pure: parse a PostgREST Content-Range header ("0-0/36079" or "*\/36079"). */
+export function parseContentRangeCount(header) {
+  if (typeof header !== 'string') return null;
+  const m = header.match(/\/(\d+)\s*$/);
+  return m ? Number(m[1]) : null;
+}
+
+// ── Mongo helpers ───────────────────────────────────────────────────────────
+
+async function controlFound(coll, predicate) {
+  try {
+    const doc = await coll.findOne(predicate, {
+      projection: { _id: 1 },
+      maxTimeMS: CONTROL_MAX_TIME_MS,
+    });
+    return doc != null;
+  } catch {
+    // A timed-out or failed control is indistinguishable from a broken probe.
+    return false;
+  }
+}
+
+function count(coll, predicate) {
+  return coll.countDocuments(predicate, { maxTimeMS: COUNT_MAX_TIME_MS });
+}
+
+// ── Stage measurements ──────────────────────────────────────────────────────
+
+/** archived — pages whose archived_photo is a real URL (not a failure marker). */
+export async function measureArchived(db) {
+  const pages = db.collection('pages');
+  const coveredPredicate = { archived_photo: ARCHIVED_OK };
+  if (!(await controlFound(pages, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'archived' }, false);
+  }
+  const [total, covered, failed] = await Promise.all([
+    pages.estimatedDocumentCount(),
+    count(pages, coveredPredicate),
+    count(pages, { archived_photo: /^failed:/ }),
+  ]);
+  return finalizeMeasurement(
+    {
+      stage: 'archived',
+      covered,
+      total,
+      // Failure markers are not queue — an archiver selects on the field being
+      // empty, so marked pages are invisible to it (see Data Protection
+      // corollary in CLAUDE.md). They're surfaced in detail instead.
+      queue_depth: Math.max(0, total - covered - failed),
+      detail: { failed_markers: failed },
+    },
+    true,
+  );
+}
+
+/** ocr — visible pages carrying non-empty ocr.data (page-level, not books.pages_ocr). */
+export async function measureOcr(db) {
+  const pages = db.collection('pages');
+  const coveredPredicate = { ...VISIBLE_PAGE_MATCH, 'ocr.data': { $type: 'string', $ne: '' } };
+  if (!(await controlFound(pages, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'ocr' }, false);
+  }
+  const [total, covered] = await Promise.all([
+    count(pages, VISIBLE_PAGE_MATCH),
+    count(pages, coveredPredicate),
+  ]);
+  return finalizeMeasurement(
+    { stage: 'ocr', covered, total, queue_depth: Math.max(0, total - covered) },
+    true,
+  );
+}
+
+/** translated — visible pages carrying non-empty translation.data (#3293 convention). */
+export async function measureTranslated(db) {
+  const pages = db.collection('pages');
+  const coveredPredicate = { ...VISIBLE_PAGE_MATCH, 'translation.data': { $type: 'string', $ne: '' } };
+  if (!(await controlFound(pages, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'translated' }, false);
+  }
+  const [total, covered] = await Promise.all([
+    count(pages, VISIBLE_PAGE_MATCH),
+    count(pages, coveredPredicate),
+  ]);
+  return finalizeMeasurement(
+    { stage: 'translated', covered, total, queue_depth: Math.max(0, total - covered) },
+    true,
+  );
+}
+
+/** summaries — live books with a summary (object with data, or legacy string). */
+export async function measureSummaries(db) {
+  const books = db.collection('books');
+  const coveredPredicate = { ...LIVE_BOOK_MATCH, summary: { $exists: true, $nin: [null, ''] } };
+  if (!(await controlFound(books, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'summaries' }, false);
+  }
+  const [total, covered] = await Promise.all([
+    count(books, LIVE_BOOK_MATCH),
+    count(books, coveredPredicate),
+  ]);
+  return finalizeMeasurement(
+    { stage: 'summaries', covered, total, queue_depth: Math.max(0, total - covered) },
+    true,
+  );
+}
+
+/** chapters — live books with a non-empty chapters array. */
+export async function measureChapters(db) {
+  const books = db.collection('books');
+  const coveredPredicate = { ...LIVE_BOOK_MATCH, 'chapters.0': { $exists: true } };
+  if (!(await controlFound(books, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'chapters' }, false);
+  }
+  const [total, covered] = await Promise.all([
+    count(books, LIVE_BOOK_MATCH),
+    count(books, coveredPredicate),
+  ]);
+  return finalizeMeasurement(
+    { stage: 'chapters', covered, total, queue_depth: Math.max(0, total - covered) },
+    true,
+  );
+}
+
+/**
+ * images — gallery_images rows with a materialized extracted_url.
+ * queue_depth is the #2430 canary: detections above the thumbnail-quality bar
+ * (gallery_quality >= 0.5, generate-thumbnails' --min-quality) with no
+ * extracted_url — bbox-only rows the batch collector wrote that the
+ * thumbnail materializer hasn't picked up.
+ */
+export async function measureImages(db) {
+  const gallery = db.collection('gallery_images');
+  const coveredPredicate = { extracted_url: { $type: 'string', $ne: '' } };
+  if (!(await controlFound(gallery, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'images' }, false);
+  }
+  const [total, covered, bboxOnlyPending] = await Promise.all([
+    gallery.estimatedDocumentCount(),
+    count(gallery, coveredPredicate),
+    count(gallery, {
+      $or: [{ extracted_url: { $exists: false } }, { extracted_url: null }],
+      gallery_quality: { $gte: 0.5 },
+    }),
+  ]);
+  return finalizeMeasurement(
+    {
+      stage: 'images',
+      covered,
+      total,
+      queue_depth: bboxOnlyPending,
+      detail: { bbox_only_pending: bboxOnlyPending },
+    },
+    true,
+  );
+}
+
+/** Exact row count of a Supabase table via PostgREST HEAD + Prefer: count=exact. */
+export async function supabaseTableCount(table, { fetchImpl = fetch } = {}) {
+  const url = (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '').replace(/\/$/, '');
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  try {
+    const res = await fetchImpl(`${url}/rest/v1/${table}?select=*`, {
+      method: 'HEAD',
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Prefer: 'count=exact',
+        Range: '0-0',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok && res.status !== 206) return null;
+    return parseContentRangeCount(res.headers.get('content-range'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * embeddings — Supabase row counts (REST HEAD, count=exact). Coverage is
+ * book_embeddings rows vs live books (the only pair with a shared unit);
+ * the other four tables are reported in detail as raw row counts.
+ * Positive control: book_embeddings (known to hold tens of thousands of rows)
+ * must return a parseable, nonzero count — otherwise the probe is broken
+ * (bad env, changed REST behaviour, dropped table), not an empty corpus.
+ */
+export async function measureEmbeddings(db, { fetchImpl = fetch } = {}) {
+  const [bookEmb, pageTr, artworkEmb, galleryTextEmb, clipEmb] = await Promise.all([
+    supabaseTableCount('book_embeddings', { fetchImpl }),
+    supabaseTableCount('page_translations', { fetchImpl }),
+    supabaseTableCount('artwork_embeddings', { fetchImpl }),
+    supabaseTableCount('gallery_text_embeddings', { fetchImpl }),
+    supabaseTableCount('clip_embeddings', { fetchImpl }),
+  ]);
+  const detail = {
+    book_embeddings: bookEmb,
+    page_translations: pageTr,
+    artwork_embeddings: artworkEmb,
+    gallery_text_embeddings: galleryTextEmb,
+    clip_embeddings: clipEmb,
+  };
+  if (bookEmb == null || bookEmb === 0) {
+    return finalizeMeasurement({ stage: 'embeddings', detail }, false);
+  }
+  const total = await count(db.collection('books'), LIVE_BOOK_MATCH);
+  return finalizeMeasurement(
+    {
+      stage: 'embeddings',
+      covered: bookEmb,
+      total,
+      // book_embeddings includes hidden books, so covered can exceed total;
+      // the queue is only meaningful when live books outnumber embedding rows.
+      queue_depth: Math.max(0, total - bookEmb),
+      detail,
+    },
+    true,
+  );
+}
+
+/** identity — live books carrying BOTH work_id and edition_key (#3260/#3710). */
+export async function measureIdentity(db) {
+  const books = db.collection('books');
+  const nonEmpty = { $exists: true, $nin: [null, ''] };
+  const coveredPredicate = { ...LIVE_BOOK_MATCH, work_id: nonEmpty, edition_key: nonEmpty };
+  if (!(await controlFound(books, coveredPredicate))) {
+    return finalizeMeasurement({ stage: 'identity' }, false);
+  }
+  const [total, covered, withWork, withEdition] = await Promise.all([
+    count(books, LIVE_BOOK_MATCH),
+    count(books, coveredPredicate),
+    count(books, { ...LIVE_BOOK_MATCH, work_id: nonEmpty }),
+    count(books, { ...LIVE_BOOK_MATCH, edition_key: nonEmpty }),
+  ]);
+  return finalizeMeasurement(
+    {
+      stage: 'identity',
+      covered,
+      total,
+      queue_depth: Math.max(0, total - covered),
+      detail: { with_work_id: withWork, with_edition_key: withEdition },
+    },
+    true,
+  );
+}
+
+/** All stage measurements, in line order. A throwing measurement is recorded
+ *  as probe_broken rather than sinking the whole snapshot. */
+export async function measureAllStages(db, { fetchImpl = fetch } = {}) {
+  const measurements = [
+    ['archived', () => measureArchived(db)],
+    ['ocr', () => measureOcr(db)],
+    ['translated', () => measureTranslated(db)],
+    ['summaries', () => measureSummaries(db)],
+    ['chapters', () => measureChapters(db)],
+    ['images', () => measureImages(db)],
+    ['embeddings', () => measureEmbeddings(db, { fetchImpl })],
+    ['identity', () => measureIdentity(db)],
+  ];
+  const out = [];
+  for (const [stage, fn] of measurements) {
+    try {
+      out.push(await fn());
+    } catch (err) {
+      out.push({
+        ...finalizeMeasurement({ stage }, false),
+        detail: { error: String(err?.message || err).slice(0, 300) },
+      });
+    }
+  }
+  return out;
+}

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -142,3 +142,5 @@
 17 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-traffic-anomaly.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/traffic-anomaly-alert.mjs" >> /var/log/sourcelibrary/traffic-anomaly.log 2>&1
 # Identity worker — Phase 0: stamps normalized_title/author + edition_key on any book missing them (#3730)
 40 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-identity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/identity-worker.mjs" >> /var/log/sourcelibrary/identity-worker.log 2>&1
+# Stage coverage snapshot — nightly semantic monitoring, coverage from data not job counters (#3756). NOT YET ACTIVE — enable after first supervised run.
+#15 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-stage-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/stage-coverage-snapshot.mjs" >> /var/log/sourcelibrary/stage-coverage.log 2>&1

--- a/scripts/workers/stage-coverage-snapshot.mjs
+++ b/scripts/workers/stage-coverage-snapshot.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * stage-coverage-snapshot — the nightly semantic monitoring job (#3756 §B).
+ *
+ * Runs every stage measurement in scripts/lib/stage-coverage.mjs (coverage
+ * computed from DATA — rows and fields — never job counters), compares
+ * against the previous snapshot, and writes one timeseries doc to
+ * `stage_coverage_snapshots`:
+ *
+ *   {
+ *     timestamp,
+ *     stages: [{ stage, status, covered, total, queue_depth, delta, detail? }],
+ *     stalled: [stage...],        // queue_depth > 0 and delta === 0 (I54 detector)
+ *     dial: { paused, daily_budget_usd },
+ *     spend_today_usd, spend_rows, spend_costless_rows,
+ *     collector_last_run: { cron, timestamp, status } | null,
+ *   }
+ *
+ * The /platform/admin/line page and /api/admin/line read this collection.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *     node scripts/workers/stage-coverage-snapshot.mjs
+ *   node scripts/workers/stage-coverage-snapshot.mjs --dry-run   # print, don't write
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+import { measureAllStages, computeStageDeltas, findStalled } from '../lib/stage-coverage.mjs';
+import { getTodaySpendUsd, readDailyBudgetUsd } from '../lib/spend-guard.mjs';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/** Latest cron_runs row for the batch collector, whichever writer named it. */
+async function getCollectorLastRun(db) {
+  const row = await db
+    .collection('cron_runs')
+    .find(
+      { cron: { $in: ['batch-collector-worker', 'collect-batch', 'collect-batch-results'] } },
+      { projection: { cron: 1, timestamp: 1, finished_at: 1, status: 1, summary: 1 } },
+    )
+    .sort({ timestamp: -1 })
+    .limit(1)
+    .maxTimeMS(30_000)
+    .next();
+  if (!row) return null;
+  return {
+    cron: row.cron,
+    // batch-collector-worker writes `timestamp`; older archive-style writers
+    // use `finished_at` — take whichever exists.
+    timestamp: row.timestamp || row.finished_at || null,
+    status: row.status || null,
+  };
+}
+
+await withMongo(async (db) => {
+  const started = Date.now();
+
+  const [rawStages, control, spend, collectorLastRun, previous] = await Promise.all([
+    measureAllStages(db),
+    db.collection('system_config').findOne({ _id: 'processing_control' }),
+    getTodaySpendUsd(db),
+    getCollectorLastRun(db),
+    db.collection('stage_coverage_snapshots').find({}).sort({ timestamp: -1 }).limit(1).next(),
+  ]);
+
+  const stages = computeStageDeltas(rawStages, previous?.stages);
+  const stalled = findStalled(stages);
+
+  const doc = {
+    timestamp: new Date(),
+    stages,
+    stalled,
+    dial: {
+      paused: !!control?.paused,
+      daily_budget_usd: readDailyBudgetUsd(control),
+    },
+    spend_today_usd: spend.usd,
+    spend_rows: spend.rows,
+    spend_costless_rows: spend.costlessRows,
+    collector_last_run: collectorLastRun,
+    duration_ms: Date.now() - started,
+  };
+
+  if (DRY_RUN) {
+    console.log(JSON.stringify(doc, null, 2));
+  } else {
+    await db.collection('stage_coverage_snapshots').insertOne(doc);
+  }
+
+  // One-line human summary — this is what the cron log shows.
+  const pct = (s) =>
+    s.status !== 'ok' ? 'BROKEN' : s.total ? `${((100 * s.covered) / s.total).toFixed(1)}%` : '—';
+  const parts = stages.map((s) => `${s.stage} ${pct(s)}`);
+  const broken = stages.filter((s) => s.status === 'probe_broken').map((s) => s.stage);
+  console.log(
+    `[stage-coverage] ${parts.join(' | ')} | stalled: ${stalled.length ? stalled.join(',') : 'none'}` +
+      `${broken.length ? ` | PROBE BROKEN: ${broken.join(',')}` : ''}` +
+      ` | dial: ${doc.dial.paused ? 'PAUSED' : 'running'} budget=$${doc.dial.daily_budget_usd ?? 'unset'}` +
+      ` spend=$${doc.spend_today_usd.toFixed(2)} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
+  );
+}, { timeoutMs: 30 * 60_000 });

--- a/src/app/api/admin/line/route.ts
+++ b/src/app/api/admin/line/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/line — the semantic monitoring surface (#3756 §B).
+ *
+ * Returns the latest `stage_coverage_snapshots` doc (written nightly by
+ * scripts/workers/stage-coverage-snapshot.mjs), plus the previous snapshot
+ * and the newest snapshot at least ~7 days old so callers can compute
+ * night-over-night and 7-day deltas. Never runs the measurements itself —
+ * same read-a-precomputed-doc pattern as /platform/admin/metrics.
+ *
+ * CRON_SECRET bearer auth, same as /api/admin/key-fingerprints.
+ */
+export async function GET(request: NextRequest) {
+  const auth = request.headers.get('authorization');
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const db = await getDb();
+  const snapshots = db.collection('stage_coverage_snapshots');
+
+  const [latest, previous] = await snapshots
+    .find({})
+    .sort({ timestamp: -1 })
+    .limit(2)
+    .toArray();
+
+  if (!latest) {
+    return NextResponse.json({ latest: null, previous: null, week_ago: null });
+  }
+
+  // Newest snapshot at least ~7 days older than the latest (6.5d tolerance so
+  // a slightly-early nightly run still qualifies).
+  const cutoff = new Date(new Date(latest.timestamp).getTime() - 6.5 * 24 * 3600 * 1000);
+  const weekAgo = await snapshots
+    .find({ timestamp: { $lte: cutoff } })
+    .sort({ timestamp: -1 })
+    .limit(1)
+    .next();
+
+  return NextResponse.json({ latest, previous: previous ?? null, week_ago: weekAgo ?? null });
+}

--- a/src/app/platform/(protected)/admin/line/page.tsx
+++ b/src/app/platform/(protected)/admin/line/page.tsx
@@ -1,0 +1,218 @@
+/**
+ * /platform/admin/line — the full pipeline line, measured semantically (#3756 §B).
+ *
+ * Renders the latest `stage_coverage_snapshots` doc written nightly by
+ * scripts/workers/stage-coverage-snapshot.mjs. Every number here is computed
+ * from DATA (rows and fields that exist), never job counters — the v1
+ * archaeology's core lesson. The page never runs the measurements itself;
+ * same read-a-precomputed-doc pattern as the metrics dashboard.
+ *
+ * Per stage: coverage %, queue depth, 7-day delta (vs the newest snapshot at
+ * least ~7 days old), a red STALLED badge (queue nonempty, nightly delta zero
+ * — the I54 "quietly stops advancing" detector), and a PROBE BROKEN badge
+ * when a measurement's positive control failed (a broken probe must never
+ * read as 0% coverage). Header: dial state, spend today, last collector run.
+ *
+ * Gated by the protected layout (requireSuperAdmin).
+ */
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+
+interface StageMeasurement {
+  stage: string;
+  status: 'ok' | 'probe_broken';
+  covered: number | null;
+  total: number | null;
+  queue_depth: number | null;
+  delta?: number | null;
+  detail?: Record<string, number | string | null>;
+}
+
+interface Snapshot {
+  timestamp: Date | string;
+  stages: StageMeasurement[];
+  stalled?: string[];
+  dial?: { paused?: boolean; daily_budget_usd?: number | null };
+  spend_today_usd?: number;
+  spend_costless_rows?: number;
+  collector_last_run?: { cron?: string; timestamp?: Date | string | null; status?: string | null } | null;
+  duration_ms?: number;
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  archived: 'Archived (page images on R2)',
+  ocr: 'OCR (visible pages with ocr.data)',
+  translated: 'Translated (visible pages with translation.data)',
+  summaries: 'Summaries (live books)',
+  chapters: 'Chapters (live books)',
+  images: 'Images (gallery rows materialized)',
+  embeddings: 'Embeddings (book_embeddings vs live books)',
+  identity: 'Identity (work_id + edition_key, live books)',
+};
+
+const num = (n: number | null | undefined) => (n == null ? '—' : n.toLocaleString('en-US'));
+const pct = (s: StageMeasurement) =>
+  s.status !== 'ok' || s.covered == null || !s.total ? '—' : `${((100 * s.covered) / s.total).toFixed(1)}%`;
+
+const C = {
+  card: { background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '16px 18px' } as const,
+  big: { fontSize: 26, fontWeight: 700, color: '#e6edf3', lineHeight: 1.1 } as const,
+  label: { fontSize: 12, color: '#8b949e', marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.4 } as const,
+  th: { textAlign: 'left' as const, fontSize: 11, color: '#8b949e', textTransform: 'uppercase' as const, letterSpacing: 0.4, padding: '8px 10px', borderBottom: '1px solid #30363d' },
+  td: { fontSize: 13, color: '#c9d1d9', padding: '8px 10px', borderBottom: '1px solid #21262d', verticalAlign: 'top' as const },
+  badge: { display: 'inline-block', fontSize: 11, fontWeight: 700, borderRadius: 4, padding: '2px 7px', marginLeft: 8, letterSpacing: 0.4 } as const,
+};
+
+function DeltaArrow({ delta }: { delta: number | null | undefined }) {
+  if (delta == null) return <span style={{ color: '#56606b' }}>—</span>;
+  const flat = delta === 0;
+  const up = delta > 0;
+  const color = flat ? '#8b949e' : up ? '#3fb950' : '#f85149';
+  const arrow = flat ? '→' : up ? '▲' : '▼';
+  return (
+    <span style={{ color, fontWeight: 600 }}>
+      {arrow} {delta > 0 ? '+' : ''}{delta.toLocaleString('en-US')}
+    </span>
+  );
+}
+
+/** 7-day covered delta: null unless both sides measured ok. */
+function sevenDayDelta(current: StageMeasurement, weekAgo?: Snapshot | null): number | null {
+  if (!weekAgo || current.status !== 'ok' || current.covered == null) return null;
+  const prev = weekAgo.stages?.find((s) => s.stage === current.stage);
+  if (!prev || prev.status !== 'ok' || prev.covered == null) return null;
+  return current.covered - prev.covered;
+}
+
+export default async function LinePage() {
+  const db = await getDb();
+  const snapshots = db.collection<Snapshot>('stage_coverage_snapshots');
+
+  const latest = await snapshots.find({}).sort({ timestamp: -1 }).limit(1).next();
+
+  if (!latest) {
+    return (
+      <div style={{ maxWidth: 980 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700 }}>The Line</h1>
+        <p style={{ color: '#8b949e', marginTop: 12 }}>
+          No stage-coverage snapshot yet. Run{' '}
+          <code style={{ color: '#c9d1d9' }}>node scripts/workers/stage-coverage-snapshot.mjs</code>{' '}
+          on the pipeline box (or enable its crontab line) to write the first one.
+        </p>
+      </div>
+    );
+  }
+
+  const cutoff = new Date(new Date(latest.timestamp).getTime() - 6.5 * 24 * 3600 * 1000);
+  const weekAgo = await snapshots
+    .find({ timestamp: { $lte: cutoff } })
+    .sort({ timestamp: -1 })
+    .limit(1)
+    .next();
+
+  const stalledSet = new Set(latest.stalled ?? []);
+  const generatedAt = new Date(latest.timestamp).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+  const collector = latest.collector_last_run;
+  const collectorWhen = collector?.timestamp
+    ? new Date(collector.timestamp).toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
+    : 'never seen';
+
+  return (
+    <div style={{ maxWidth: 980 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 700 }}>The Line</h1>
+      <p style={{ fontSize: 13, color: '#8b949e', margin: '4px 0 20px' }}>
+        Per-stage coverage measured from data (rows and fields), never job counters. Snapshot: {generatedAt}
+        {weekAgo ? ` · 7-day deltas vs ${new Date(weekAgo.timestamp).toISOString().slice(0, 10)}` : ' · no 7-day baseline yet'}
+      </p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12, marginBottom: 24 }}>
+        <div style={C.card}>
+          <div style={{ ...C.big, color: latest.dial?.paused ? '#f85149' : '#3fb950' }}>
+            {latest.dial?.paused ? 'PAUSED' : 'Running'}
+          </div>
+          <div style={C.label}>Pipeline dial</div>
+        </div>
+        <div style={C.card}>
+          <div style={C.big}>
+            {latest.dial?.daily_budget_usd != null ? `$${latest.dial.daily_budget_usd.toFixed(2)}` : 'unset'}
+          </div>
+          <div style={C.label}>Daily budget (unset = no paid dispatch)</div>
+        </div>
+        <div style={C.card}>
+          <div style={C.big}>${(latest.spend_today_usd ?? 0).toFixed(2)}</div>
+          <div style={C.label}>Spend today (UTC)</div>
+          {(latest.spend_costless_rows ?? 0) > 0 && (
+            <div style={{ fontSize: 11, color: '#d29922', marginTop: 4 }}>
+              {num(latest.spend_costless_rows)} usage rows without cost — undercounted
+            </div>
+          )}
+        </div>
+        <div style={C.card}>
+          <div style={{ ...C.big, fontSize: 16, paddingTop: 6 }}>{collectorWhen}</div>
+          <div style={C.label}>Last batch collector run{collector?.status ? ` (${collector.status})` : ''}</div>
+        </div>
+      </div>
+
+      <div style={{ ...C.card, padding: 0, overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={C.th}>Stage</th>
+              <th style={{ ...C.th, textAlign: 'right' }}>Coverage</th>
+              <th style={{ ...C.th, textAlign: 'right' }}>Covered / total</th>
+              <th style={{ ...C.th, textAlign: 'right' }}>Queue depth</th>
+              <th style={{ ...C.th, textAlign: 'right' }}>7-day Δ covered</th>
+            </tr>
+          </thead>
+          <tbody>
+            {latest.stages.map((s) => {
+              const broken = s.status === 'probe_broken';
+              const stalled = stalledSet.has(s.stage);
+              return (
+                <tr key={s.stage}>
+                  <td style={C.td}>
+                    <span style={{ color: '#e6edf3', fontWeight: 600 }}>{s.stage}</span>
+                    {broken && (
+                      <span style={{ ...C.badge, background: '#3d1d1f', color: '#f85149', border: '1px solid #f85149' }}>
+                        PROBE BROKEN
+                      </span>
+                    )}
+                    {stalled && !broken && (
+                      <span style={{ ...C.badge, background: '#3d1d1f', color: '#f85149', border: '1px solid #f85149' }}>
+                        STALLED
+                      </span>
+                    )}
+                    <div style={{ fontSize: 11, color: '#6e7681', marginTop: 2 }}>{STAGE_LABELS[s.stage] ?? ''}</div>
+                    {s.detail && (
+                      <div style={{ fontSize: 11, color: '#56606b', marginTop: 2 }}>
+                        {Object.entries(s.detail).map(([k, v]) => `${k}: ${typeof v === 'number' ? v.toLocaleString('en-US') : String(v)}`).join(' · ')}
+                      </div>
+                    )}
+                  </td>
+                  <td style={{ ...C.td, textAlign: 'right', fontWeight: 700, color: broken ? '#f85149' : '#e6edf3' }}>
+                    {broken ? '?' : pct(s)}
+                  </td>
+                  <td style={{ ...C.td, textAlign: 'right' }}>{num(s.covered)} / {num(s.total)}</td>
+                  <td style={{ ...C.td, textAlign: 'right', color: (s.queue_depth ?? 0) > 0 ? '#d29922' : '#8b949e' }}>
+                    {num(s.queue_depth)}
+                  </td>
+                  <td style={{ ...C.td, textAlign: 'right' }}>
+                    <DeltaArrow delta={sevenDayDelta(s, weekAgo)} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <p style={{ fontSize: 12, color: '#6e7681', marginTop: 16, lineHeight: 1.5 }}>
+        STALLED = queue depth &gt; 0 and covered didn&apos;t move since the previous nightly snapshot (the
+        &ldquo;quietly stops advancing&rdquo; detector). PROBE BROKEN = the measurement&apos;s positive control found no
+        known-present case, so its counts are untrustworthy — fix the probe before believing any number in that row.
+        Written nightly by <code>scripts/workers/stage-coverage-snapshot.mjs</code>; API twin at <code>/api/admin/line</code>.
+      </p>
+    </div>
+  );
+}

--- a/tests/unit/stage-coverage.test.ts
+++ b/tests/unit/stage-coverage.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Pins the pure logic of the semantic monitoring surface (#3756 §B):
+ *
+ *  - finalizeMeasurement: a failed positive control must yield
+ *    status:'probe_broken' with covered:null — a broken probe and an empty
+ *    pipeline must never look the same (the probe-needs-a-positive-control
+ *    lesson: "not found" is worthless until the probe returned "found").
+ *  - computeStageDeltas: deltas only exist between two OK measurements;
+ *    a broken side yields null, never a fabricated 0.
+ *  - findStalled: the I54 "quietly stops advancing" detector — queue_depth>0
+ *    and delta===0. null deltas and broken probes are excluded: null is not
+ *    zero, and flagging a broken probe as "stalled" would misdirect triage.
+ *  - parseContentRangeCount: the Supabase REST count parser.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { finalizeMeasurement, computeStageDeltas, findStalled, parseContentRangeCount } from '../../scripts/lib/stage-coverage.mjs';
+
+type Stage = {
+  stage: string;
+  status: 'ok' | 'probe_broken';
+  covered: number | null;
+  total: number | null;
+  queue_depth: number | null;
+  delta?: number | null;
+  detail?: Record<string, unknown>;
+};
+
+const ok = (stage: string, covered: number, total: number, queue = 0): Stage => ({
+  stage, status: 'ok', covered, total, queue_depth: queue,
+});
+
+describe('finalizeMeasurement (positive-control behavior)', () => {
+  it('passes counts through when the control found a known-present case', () => {
+    const m = finalizeMeasurement({ stage: 'ocr', covered: 100, total: 200, queue_depth: 100 }, true);
+    expect(m).toEqual({ stage: 'ocr', status: 'ok', covered: 100, total: 200, queue_depth: 100 });
+  });
+
+  it('reports probe_broken with covered:null when the control fails — NEVER 0 coverage', () => {
+    const m = finalizeMeasurement({ stage: 'ocr', covered: 0, total: 200, queue_depth: 200 }, false);
+    expect(m.status).toBe('probe_broken');
+    expect(m.covered).toBeNull(); // not 0 — that's the whole point
+    expect(m.queue_depth).toBeNull();
+    expect(m.total).toBe(200); // the denominator is still informative
+  });
+
+  it('keeps detail on a broken measurement (it carries the diagnosis)', () => {
+    const m = finalizeMeasurement({ stage: 'embeddings', detail: { book_embeddings: null } }, false);
+    expect(m.status).toBe('probe_broken');
+    expect(m.detail).toEqual({ book_embeddings: null });
+  });
+});
+
+describe('computeStageDeltas', () => {
+  it('computes covered deltas per stage against the previous snapshot', () => {
+    const current = [ok('ocr', 110, 200, 90), ok('translated', 50, 200, 150)];
+    const previous = [ok('ocr', 100, 200, 100), ok('translated', 50, 200, 150)];
+    const out = computeStageDeltas(current, previous);
+    expect(out.find((s: Stage) => s.stage === 'ocr')!.delta).toBe(10);
+    expect(out.find((s: Stage) => s.stage === 'translated')!.delta).toBe(0);
+  });
+
+  it('yields null when the stage is missing from the previous snapshot', () => {
+    const out = computeStageDeltas([ok('images', 5, 10, 5)], [ok('ocr', 1, 2)]);
+    expect(out[0].delta).toBeNull();
+  });
+
+  it('yields null (not 0) when either side is probe_broken', () => {
+    const brokenNow: Stage = { stage: 'ocr', status: 'probe_broken', covered: null, total: 200, queue_depth: null };
+    const out1 = computeStageDeltas([brokenNow], [ok('ocr', 100, 200)]);
+    expect(out1[0].delta).toBeNull();
+
+    const brokenPrev: Stage = { stage: 'ocr', status: 'probe_broken', covered: null, total: 200, queue_depth: null };
+    const out2 = computeStageDeltas([ok('ocr', 100, 200)], [brokenPrev]);
+    expect(out2[0].delta).toBeNull();
+  });
+
+  it('handles a missing previous snapshot entirely (first run)', () => {
+    const out = computeStageDeltas([ok('ocr', 100, 200)], undefined);
+    expect(out[0].delta).toBeNull();
+  });
+
+  it('can go negative — a regression is a signal, not an error', () => {
+    const out = computeStageDeltas([ok('summaries', 90, 100, 10)], [ok('summaries', 95, 100, 5)]);
+    expect(out[0].delta).toBe(-5);
+  });
+});
+
+describe('findStalled (queue nonempty, coverage not advancing)', () => {
+  it('flags a stage with work waiting and zero delta', () => {
+    const stages = [{ ...ok('translated', 50, 200, 150), delta: 0 }];
+    expect(findStalled(stages)).toEqual(['translated']);
+  });
+
+  it('does not flag a stage that advanced', () => {
+    const stages = [{ ...ok('translated', 60, 200, 140), delta: 10 }];
+    expect(findStalled(stages)).toEqual([]);
+  });
+
+  it('does not flag an empty queue — done is not stalled', () => {
+    const stages = [{ ...ok('identity', 200, 200, 0), delta: 0 }];
+    expect(findStalled(stages)).toEqual([]);
+  });
+
+  it('does not flag a null delta (first run / missing baseline) — null is not zero', () => {
+    const stages = [{ ...ok('translated', 50, 200, 150), delta: null }];
+    expect(findStalled(stages)).toEqual([]);
+  });
+
+  it('excludes probe_broken stages — a broken probe is its own alarm', () => {
+    const stages = [
+      { stage: 'ocr', status: 'probe_broken' as const, covered: null, total: 200, queue_depth: null, delta: null },
+      { ...ok('chapters', 10, 100, 90), delta: 0 },
+    ];
+    expect(findStalled(stages)).toEqual(['chapters']);
+  });
+
+  it('flags a regression whose queue is nonempty only when delta is exactly 0', () => {
+    // A negative delta is a REGRESSION — reported via the delta itself, not
+    // the stalled list (stalled means "quietly stopped", not "went backwards").
+    const stages = [{ ...ok('summaries', 90, 100, 10), delta: -5 }];
+    expect(findStalled(stages)).toEqual([]);
+  });
+});
+
+describe('parseContentRangeCount', () => {
+  it('parses the standard PostgREST shapes', () => {
+    expect(parseContentRangeCount('0-0/36079')).toBe(36079);
+    expect(parseContentRangeCount('*/4420000')).toBe(4420000);
+    expect(parseContentRangeCount('0-24/205000')).toBe(205000);
+  });
+
+  it('returns null for garbage, missing headers, and unknown totals', () => {
+    expect(parseContentRangeCount(null)).toBeNull();
+    expect(parseContentRangeCount(undefined)).toBeNull();
+    expect(parseContentRangeCount('')).toBeNull();
+    expect(parseContentRangeCount('0-24/*')).toBeNull(); // count not computed
+    expect(parseContentRangeCount('bytes 0-99/100x')).toBeNull();
+  });
+});


### PR DESCRIPTION
Implements section B (+A1) of #3756 — the v1 archaeology's loudest demand: monitoring that watches semantic outputs (rows written, fields present), never job counters, with positive controls so a broken probe can never masquerade as 0% coverage.

## What's in scope

**`scripts/lib/stage-coverage.mjs`** — one measurement per stage, each returning `{stage, covered, total, queue_depth}` from data:

| stage | covered | total | queue_depth |
|---|---|---|---|
| archived | pages with non-marker `archived_photo` | all pages (estimated) | unarchived minus `failed:` markers (markers in `detail` — they're invisible to archivers, not queue) |
| ocr | visible pages with `ocr.data` | visible pages | difference |
| translated | visible pages with `translation.data` (#3293 convention via `page-counts.mjs`) | visible pages | difference |
| summaries / chapters | live books with `summary` / non-empty `chapters` | live books (`visible && pages_count>0`) | difference |
| images | `gallery_images` with `extracted_url` | all rows (estimated) | **the #2430 canary**: bbox-only rows with `gallery_quality ≥ 0.5` and no `extracted_url` |
| embeddings | `book_embeddings` rows (Supabase REST HEAD `count=exact`) | live books | difference; other 4 tables' raw counts in `detail` |
| identity | live books with BOTH `work_id` and `edition_key` | live books | difference; per-field counts in `detail` |

Every measurement runs a **positive control** first (findOne on the covered predicate, capped maxTimeMS). Control fails → `status:'probe_broken'`, `covered:null` — never 0. All counts are `countDocuments` with simple predicates or `estimatedDocumentCount`; no unbounded aggregations over `pages`.

**`scripts/workers/stage-coverage-snapshot.mjs`** — nightly job writing one doc to `stage_coverage_snapshots`: stages with deltas vs the previous snapshot, `stalled` (queue_depth>0 && delta===0 — the I54 detector; null deltas and broken probes excluded, null is not zero), dial state, spend today (reuses `spend-guard.mjs`), last batch-collector `cron_runs` row. One-line log summary. Crontab line added **commented** (04:15) — enable after a supervised first run.

**`/api/admin/line`** — latest + previous + week-ago snapshots; CRON_SECRET bearer auth mirroring `/api/admin/key-fingerprints`.

**`/platform/admin/line`** — server component (no client JS) behind the `requireSuperAdmin` layout: per-stage coverage %, queue depth, 7-day delta arrow, red STALLED / PROBE BROKEN badges, dial + spend + collector header. Reads the precomputed doc — same pattern as `/platform/admin/metrics`.

**Tests** — `tests/unit/stage-coverage.test.ts` pins the delta/stalled computation and the positive-control behavior as pure functions (16 tests).

## Out of scope (deliberately)

- **A2** (enrolling embeddings/enrichment as dial-gated phases) — separate orchestrator change.
- **The daily-digest alert rule** — the `stalled` list is computed and stored; wiring it into the weekly digest / pipeline-health-alert is a follow-up so this PR stays one concern.
- **Activating the cron** — the line ships commented; first run should be supervised (it counts a ~5M-row collection several times).

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run tests/unit/` — 165 files / 2262 tests green
- `node --check` on both .mjs files
- Not run against production (per task instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx