### PR TITLE
fix(citation): say what we did to the text — in both directions

### DIFF
--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
-import { citationYear, citationYearOrNd } from '@/lib/publication-date';
+import { generateCitations, type Citation } from '@/lib/citation';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
@@ -13,18 +13,6 @@ import { isBookReadable } from '@/lib/book-access';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
-}
-
-interface Citation {
-  inline: string;           // (Drebbel 1628, p. 15)
-  footnote: string;         // Full footnote citation
-  bibliography: string;     // Bibliography entry
-  bibtex: string;           // BibTeX format
-  chicago: string;          // Chicago style
-  mla: string;              // MLA style
-  url: string;              // Direct link to page in Source Library
-  short_url: string;        // Shortlink for sharing (e.g., Twitter)
-  doi_url?: string;         // Clickable DOI URL
 }
 
 interface QuoteResponse {
@@ -44,117 +32,6 @@ interface QuoteResponse {
   context?: {
     previous_page?: string;
     next_page?: string;
-  };
-}
-
-function formatAccessedDate(): string {
-  const d = new Date();
-  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
-  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-}
-
-function generateCitations(
-  book: Book,
-  pageNumber: number,
-  bookId: string,
-  pageId: string,
-  baseUrl: string,
-  edition?: TranslationEdition
-): Citation {
-  // `published` is free text: 23% of the corpus is not a year, and ~1,500 books
-  // carry raw Wikidata QuickStatements ("1573date QS:P571,+1573-...Z/9"). That
-  // string was landing in the BibTeX `year` field and the inline citation, i.e.
-  // straight into scholars' bibliographies. Assert a bare year or `n.d.`.
-  const year = citationYearOrNd(book.published);
-  // BibTeX keys must stay alphanumeric — 'n.d.' would emit a key with dots.
-  const bibtexYearKey = citationYear(book.published) ?? 'nd';
-  const author = book.author || 'Unknown';
-  const title = book.display_title || book.title;
-  const doi = edition?.doi || book.doi;
-  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
-  const accessed = formatAccessedDate();
-  const translationYear = edition?.published_at
-    ? new Date(edition.published_at).getFullYear()
-    : new Date().getFullYear();
-
-  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
-  const authorParts = author.split(',').map(s => s.trim());
-  const authorLastFirst = authorParts.length === 2
-    ? `${authorParts[0]}, ${authorParts[1]}`
-    : author;
-  const authorFirstLast = authorParts.length === 2
-    ? `${authorParts[1]} ${authorParts[0]}`
-    : author;
-
-  // Original-edition imprint (place, publisher, format, USTC) of the source
-  // printing being translated — the bibliographic record of the original work,
-  // distinct from the Source Library translation credit. Mirrors the "Cite"
-  // dropdown (CiteButton) and the bibliographic panel (BibliographicInfo).
-  const pubImprint = [book.place_published, book.publisher].filter(Boolean).join(': ');
-  const imprint = [pubImprint, book.format, book.ustc_id ? `USTC ${book.ustc_id}` : ''].filter(Boolean).join('. ');
-  const imprintStr = imprint ? `${imprint}. ` : '';
-
-  // Inline citation
-  const inline = `(${authorParts[0]} ${year}, p. ${pageNumber})`;
-
-  // Footnote (Chicago style note)
-  const footnote = `${authorFirstLast}, ${title}, ${imprintStr}trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
-
-  // Bibliography entry
-  const bibliography = `${authorLastFirst}. ${title}. ${imprintStr}Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`;
-
-  // BibTeX — original imprint (address/publisher) + translation credit (note)
-  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${bibtexYearKey}`;
-  const bibtexLines = [
-    `@book{${bibtexKey},`,
-    `  author = {${authorLastFirst}},`,
-    `  title = {${title}},`,
-    `  year = {${year}},`,
-  ];
-  if (book.place_published) bibtexLines.push(`  address = {${book.place_published}},`);
-  bibtexLines.push(`  publisher = {${book.publisher || 'Source Library'}},`);
-  bibtexLines.push(`  translator = {Source Library},`);
-  if (doi) {
-    bibtexLines.push(`  doi = {${doi}},`);
-    bibtexLines.push(`  url = {${doiUrl}},`);
-  }
-  const bibtexNote = [`Translation published ${translationYear}`];
-  if (book.format) bibtexNote.push(book.format);
-  if (book.ustc_id) bibtexNote.push(`USTC ${book.ustc_id}`);
-  bibtexLines.push(`  note = {${bibtexNote.join('; ')}}`);
-  bibtexLines.push(`}`);
-  const bibtex = bibtexLines.join('\n');
-
-  // Chicago (Author-Date)
-  const chicago = `${authorLastFirst}. ${year}. ${title}. ${imprintStr}Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`;
-
-  // MLA
-  const mla = `${authorLastFirst}. ${title}. ${imprintStr}Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
-
-  // Direct URL to page in Source Library (pinned to edition version).
-  // baseUrl is derived from the request host so quotes returned from
-  // tenant subdomains link back to the same subdomain.
-  //
-  // Built from the book's slug, not the requested id: this URL gets printed
-  // into papers and footnotes, so it has to say which book it is. Calling the
-  // API by id would otherwise mint a permanent citation to /book/<objectid>.
-  const editionVersion = edition?.version;
-  const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
-
-  // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
-
-  return {
-    inline,
-    footnote,
-    bibliography,
-    bibtex,
-    chicago,
-    mla,
-    url,
-    short_url,
-    doi_url: doiUrl,
   };
 }
 

--- a/src/lib/citation.ts
+++ b/src/lib/citation.ts
@@ -1,0 +1,164 @@
+/**
+ * Building the citation apparatus for a served page.
+ *
+ * Lifted out of `src/app/api/books/[id]/quote/route.ts` so it can be tested.
+ * It could not be, sitting in a route file, and that is how it came to assert
+ * "Translated by Source Library" over an English book the translator's own
+ * work — see the credit logic below and #3724.
+ */
+import { citationYear, citationYearOrNd } from '@/lib/publication-date';
+import { getShortUrl } from '@/lib/shortlinks';
+import { readerPageUrl } from '@/lib/slugify';
+import type { Book, TranslationEdition } from '@/lib/types';
+
+export interface Citation {
+  inline: string;
+  footnote: string;
+  bibliography: string;
+  bibtex: string;
+  chicago: string;
+  mla: string;
+  url: string;
+  short_url: string;
+  doi_url?: string;
+}
+
+function formatAccessedDate(): string {
+  const d = new Date();
+  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+}
+
+export function generateCitations(
+  book: Book,
+  pageNumber: number,
+  bookId: string,
+  pageId: string,
+  baseUrl: string,
+  edition?: TranslationEdition
+): Citation {
+  // `published` is free text: 23% of the corpus is not a year, and ~1,500 books
+  // carry raw Wikidata QuickStatements ("1573date QS:P571,+1573-...Z/9"). That
+  // string was landing in the BibTeX `year` field and the inline citation, i.e.
+  // straight into scholars' bibliographies. Assert a bare year or `n.d.`.
+  const year = citationYearOrNd(book.published);
+  // BibTeX keys must stay alphanumeric — 'n.d.' would emit a key with dots.
+  const bibtexYearKey = citationYear(book.published) ?? 'nd';
+  const author = book.author || 'Unknown';
+  const title = book.display_title || book.title;
+  const doi = edition?.doi || book.doi;
+  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
+  const accessed = formatAccessedDate();
+  const translationYear = edition?.published_at
+    ? new Date(edition.published_at).getFullYear()
+    : new Date().getFullYear();
+
+  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
+  const authorParts = author.split(',').map(s => s.trim());
+  const authorLastFirst = authorParts.length === 2
+    ? `${authorParts[0]}, ${authorParts[1]}`
+    : author;
+  const authorFirstLast = authorParts.length === 2
+    ? `${authorParts[1]} ${authorParts[0]}`
+    : author;
+
+  // Original-edition imprint (place, publisher, format, USTC) of the source
+  // printing being translated — the bibliographic record of the original work,
+  // distinct from the Source Library translation credit. Mirrors the "Cite"
+  // dropdown (CiteButton) and the bibliographic panel (BibliographicInfo).
+  const pubImprint = [book.place_published, book.publisher].filter(Boolean).join(': ');
+  const imprint = [pubImprint, book.format, book.ustc_id ? `USTC ${book.ustc_id}` : ''].filter(Boolean).join('. ');
+  const imprintStr = imprint ? `${imprint}. ` : '';
+
+  /**
+   * WHAT DID WE ACTUALLY DO TO THIS TEXT? The credit has to match, in both
+   * directions (#3724).
+   *
+   * Every format used to assert `Translated by Source Library` unconditionally.
+   * On a book that was printed in English that is false twice over: we did not
+   * translate Taylor's 1818 Aristotle — Taylor did — so the line claimed his
+   * work and erased him in the same breath. Measured on production before this
+   * change: `/api/books/6956953e…/quote?page=46` returned "trans. Source
+   * Library" over an English page Taylor rendered himself.
+   *
+   * The inverse error is the one #3724 was opened about: 17,825 of 19,465 live
+   * books (91.6%) serve English we produced, and the *inline* form — the one
+   * people paste into running prose — said only "(Aristotle 1818, p. 46)".
+   *
+   * So: name the rendering when it is ours, stay silent when it is not, and
+   * never claim a named translator's work.
+   */
+  const isEnglishOriginal = (book.language || '').trim().toLowerCase().startsWith('english');
+  const renderingCredit = isEnglishOriginal
+    ? null
+    : { short: `trans. Source Library ${translationYear}`, long: `Translated by Source Library. ${translationYear}.` };
+
+  // Inline citation. Carries the rendering credit when the English is ours —
+  // this is the form that gets pasted into prose, and it was the only one that
+  // said nothing.
+  const inline = renderingCredit
+    ? `(${authorParts[0]} ${year}, p. ${pageNumber}, ${renderingCredit.short})`
+    : `(${authorParts[0]} ${year}, p. ${pageNumber})`;
+
+  // Footnote (Chicago style note)
+  const footnote = `${authorFirstLast}, ${title}, ${imprintStr}${renderingCredit ? `${renderingCredit.short.replace(`Source Library ${translationYear}`, `Source Library (${translationYear})`)}, ` : ''}${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
+
+  // Bibliography entry
+  const bibliography = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${doi ? `DOI: ${doi}.` : `Accessed ${accessed}.`}`;
+
+  // BibTeX — original imprint (address/publisher) + translation credit (note)
+  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${bibtexYearKey}`;
+  const bibtexLines = [
+    `@book{${bibtexKey},`,
+    `  author = {${authorLastFirst}},`,
+    `  title = {${title}},`,
+    `  year = {${year}},`,
+  ];
+  if (book.place_published) bibtexLines.push(`  address = {${book.place_published}},`);
+  bibtexLines.push(`  publisher = {${book.publisher || 'Source Library'}},`);
+  if (renderingCredit) bibtexLines.push(`  translator = {Source Library},`);
+  if (doi) {
+    bibtexLines.push(`  doi = {${doi}},`);
+    bibtexLines.push(`  url = {${doiUrl}},`);
+  }
+  const bibtexNote = renderingCredit
+    ? [`Translation published ${translationYear}`]
+    : ['Text transcribed from the printed page by Source Library'];
+  if (book.format) bibtexNote.push(book.format);
+  if (book.ustc_id) bibtexNote.push(`USTC ${book.ustc_id}`);
+  bibtexLines.push(`  note = {${bibtexNote.join('; ')}}`);
+  bibtexLines.push(`}`);
+  const bibtex = bibtexLines.join('\n');
+
+  // Chicago (Author-Date)
+  const chicago = `${authorLastFirst}. ${year}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${doi ? `${doiUrl}.` : `Accessed ${accessed}.`}`;
+
+  // MLA
+  const mla = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `Translated by Source Library, ${translationYear}.` : ''}${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
+
+  // Direct URL to page in Source Library (pinned to edition version).
+  // baseUrl is derived from the request host so quotes returned from
+  // tenant subdomains link back to the same subdomain.
+  //
+  // Built from the book's slug, not the requested id: this URL gets printed
+  // into papers and footnotes, so it has to say which book it is. Calling the
+  // API by id would otherwise mint a permanent citation to /book/<objectid>.
+  const editionVersion = edition?.version;
+  const vParam = editionVersion ? `?v=${editionVersion}` : '';
+  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
+
+  // Short URL for sharing
+  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
+
+  return {
+    inline,
+    footnote,
+    bibliography,
+    bibtex,
+    chicago,
+    mla,
+    url,
+    short_url,
+    doi_url: doiUrl,
+  };
+}

--- a/tests/unit/citation-rendering-credit.test.ts
+++ b/tests/unit/citation-rendering-credit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The citation apparatus must describe what we actually did to the text (#3724).
+ *
+ * These tests could not exist before this change: `generateCitations` lived
+ * inside a route file, where nothing could import it, and that is how it came to
+ * assert "Translated by Source Library" over an English book rendered by a named
+ * historical translator.
+ *
+ * Measured on production before the fix, `/api/books/6956953e…/quote?page=46`
+ * (Taylor's 1818 Aristotle, an ENGLISH book) returned:
+ *
+ *     footnote: "Aristotle, The Rhetoric… trans. Source Library (2026), 46."
+ *
+ * We did not translate that. Taylor did.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateCitations } from '@/lib/citation';
+import type { Book } from '@/lib/types';
+
+const base = {
+  id: 'bk1',
+  slug: 'a-book',
+  title: 'A Title',
+  author: 'Aristotle',
+  published: '1818',
+  place_published: 'London',
+  publisher: 'Valpy',
+} as unknown as Book;
+
+const greekBook = { ...base, language: 'Greek' } as Book;
+const englishBook = { ...base, language: 'English' } as Book;
+
+const cite = (book: Book) =>
+  generateCitations(book, 46, 'bk1', 'pg1', 'https://sourcelibrary.org');
+
+describe('rendering credit — text we produced', () => {
+  const c = cite(greekBook);
+
+  it('names Source Library in every long form', () => {
+    expect(c.footnote).toContain('Source Library');
+    expect(c.bibliography).toContain('Translated by Source Library');
+    expect(c.chicago).toContain('Translated by Source Library');
+    expect(c.mla).toContain('Translated by Source Library');
+    expect(c.bibtex).toContain('translator = {Source Library}');
+  });
+
+  it('names it INLINE too — the form people paste into prose', () => {
+    // This is what #3724 was opened about: 91.6% of live books serve English we
+    // produced, and the inline form said only "(Aristotle 1818, p. 46)".
+    expect(c.inline).toContain('Source Library');
+    expect(c.inline).toContain('p. 46');
+  });
+});
+
+describe('rendering credit — text we did NOT produce', () => {
+  const c = cite(englishBook);
+
+  it('claims no translation on a book printed in English', () => {
+    for (const form of [c.inline, c.footnote, c.bibliography, c.chicago, c.mla]) {
+      expect(form).not.toContain('Translated by Source Library');
+      expect(form).not.toContain('trans. Source Library');
+    }
+    expect(c.bibtex).not.toContain('translator = {Source Library}');
+  });
+
+  it('says instead what we did do', () => {
+    expect(c.bibtex).toContain('transcribed from the printed page');
+  });
+
+  it('still produces a usable citation', () => {
+    // Removing a false claim must not leave a broken or empty apparatus.
+    expect(c.inline).toBe('(Aristotle 1818, p. 46)');
+    expect(c.footnote).toContain('Aristotle');
+    expect(c.footnote).toContain('46');
+    expect(c.chicago).toMatch(/Accessed |doi\.org/);
+    expect(c.bibtex).toContain('author = {Aristotle}');
+  });
+});
+
+describe('the author is never displaced', () => {
+  it('keeps the historical author in the author position in both cases', () => {
+    // Naming our rendering must not turn Source Library into the author. The
+    // page is still Aristotle's work, whoever put it into English.
+    for (const book of [greekBook, englishBook]) {
+      const c = cite(book);
+      expect(c.bibtex).toContain('author = {Aristotle}');
+      expect(c.inline.startsWith('(Aristotle')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Option A from #3724, chosen after the measurement.

## The reported problem, narrowed

A reader reported that all six citation formats render `author = Aristotle` over text we produced. Reading the code first: **five of six already credited "Translated by Source Library"** — footnote, bibliography, chicago, mla, and the bibtex `translator` field. Only `inline` said nothing — and inline is the form people paste into prose. Fixed there.

## The unreported problem, which is worse

The credit was **unconditional**, so a book printed in English was also cited as our translation. Verified on production before touching anything:

```
GET /api/books/6956953e8c9559f6c2db0b6d/quote?page=46     ← Taylor 1818, an ENGLISH book
footnote: "Aristotle, The Rhetoric… trans. Source Library (2026), 46."
```

**We did not translate that. Taylor did.** The line claimed a named historical translator's work and erased him in the same breath — the mirror of the reported bug, and nobody had noticed it.

The credit is now conditional on what actually happened: named where the English is ours, silent where it is not, and the bibtex note says "transcribed from the printed page" rather than inventing a translation. **The historical author stays in the author position in both cases** — naming our rendering must not displace whose work it is.

## Scale, and why it was worth doing

| | |
|---|---|
| Live books serving English we produced | **17,825 / 19,465 (91.6%)** |
| Translated pages | **4,887,266** |
| Pages ending on the translator's edit marker | **~300,000** |

That last figure comes from two independently-shaped samples — `$match`-then-`$sample` over 1,474 pages and `$sample`-then-filter over 3,881 — landing at **6.1%** and **6.2%**. I did not plan the cross-check; the slower query finished after I had replaced it.

## Extracted so it can be tested

`generateCitations` lived inside a route file where nothing could import it, which is how it drifted this far. Moved **verbatim by script** to `src/lib/citation.ts` rather than retyped. The tests that were impossible before now cover both directions — including that removing a false claim doesn't leave a broken apparatus, and that Source Library never becomes the author.

`tsc` clean · 2,241 unit tests pass (6 new).

## Noted, not fixed

The imprint renders a pipe-separated publisher (`A. J. Valpy|James Black and Son`) straight into citations. Separate bug, spotted while verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNGn75hQdSrAEFQQAUkc9T