### PR TITLE
fix(pipeline): a status must not claim work the book cannot show

### DIFF
--- a/.claude/docs/invariants/pipeline-status-truth.md
+++ b/.claude/docs/invariants/pipeline-status-truth.md
@@ -1,0 +1,74 @@
+# Pipeline status must not claim work the book cannot show
+
+**Read this when:** writing or changing a pipeline phase, calling `setPipelineStatus`,
+advancing `pipeline_auto.status` from anywhere, or adding a guard that asserts some stage
+"really did its job."
+
+*Added 2026-08-08 from #3740 / PR #3765.*
+
+---
+
+**`pipeline_auto.status` is what every phase selects on.** Written ahead of its output, a
+book becomes permanently *past* the phase that would have filled it in: nothing errors,
+nothing retries, and it never appears in a queue again. **A status that runs ahead of the
+work is worse than no status.**
+
+Measured 2026-08-08 across 58,635 text books: **28,263** sat past enrichment with no
+summary, **27,867** past chapters with no chapters. None of them were failing loudly.
+
+## How it happened — the shape to watch for
+
+The orchestrator wrote the *success* status on the *failure* path, unlabelled:
+
+- **Phase 7** writes `chapters_complete` from three places — chapters extracted, book under
+  10 pages, and `extract-chapters` failed `MAX_RETRIES` times (`// Non-critical — skip`).
+- **Phase 6** does the same in its `catch`: after `MAX_RETRIES` throws it writes
+  `summary_indexed` and increments `log.enriched`.
+
+The two skips only ever bumped an **in-memory counter that dies with the run**. So
+`chapters_complete` conflates *extracted*, *too short to have any*, and *we gave up* — three
+different books, one indistinguishable status.
+
+**Rule:** if a phase advances the status on a path where the output was not produced, it
+must record why, on the document, at that moment. `log.x_skipped++` is not a record.
+
+## Absence is not failure — the half that turns a guard into an outage
+
+The obvious predicate (*the field is non-empty*) is wrong, and wrong in a way worse than
+the bug it fixes. Absence has two causes that are indistinguishable after the fact: the
+stage failed, or **the stage correctly decided there was nothing to do**. A single-work
+volume legitimately has no chapters; a 6-page pamphlet is not meant to have them; an
+English book needs no translation.
+
+A predicate reading absence as failure would re-stall ~28K books permanently, most with no
+reader impact — a far bigger outage than the silent-success bug.
+
+**So a status is satisfied by output OR by an explicitly recorded skip**, and the skip is
+written at decision time with a *reason*, not a boolean — you will want to know why when
+the policy changes. Enforced by `statusOutputViolation` /`STATUS_OUTPUT_CLAIMS` in
+`scripts/workers/pipeline-orchestrator.mjs`; the skip fields are
+`<stage>_skipped_reason` under `pipeline_auto`.
+
+## Change behaviour in observe mode first
+
+The guard sits at `setPipelineStatus`, which **53 call sites** pass through. Flipping all of
+them at once, in a pipeline about to be restarted, is how a silent-success bug becomes an
+outage. Default is observe: record the violation to `audit_log` and
+`pipeline_auto.output_missing`, then still advance. `STATUS_GUARD_ENFORCE=1` refuses and
+parks at `needs_attention`. Flip it only once the recorded violations look right.
+
+## Measuring this
+
+`scripts/audit/status-output-drift.mjs`, sharing the guard's predicates — change one, change
+both. **Two filters are load-bearing:**
+
+1. `resource_type` absent + `pages_count > 20`. Artwork records have no pages and are
+   *correctly* `complete`. Counting them read **25,244** broken books where the truth is
+   **344**.
+2. A recorded skip counts as satisfied, or the audit re-reports every legitimate skip
+   forever.
+
+Same family as the `archived_photo` invariant in `CLAUDE.md` (a marker that records work
+becomes its own skip condition) and `archive-fetch-failures.md`. Repairing the existing
+backlog means re-running enrichment at scale — budget-dial work (#3737), visible books
+first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - `books.edition_key`, "same edition?", duplicate queues, other-scans rails, USTC/VD16/ESTC ids → `edition-identity.md`
 - Bekker/Stephanus references, `locus_anchors`, `/api/locus`, "which page is 1094a?" → `canonical-loci.md`
 - `entities.books[]`, book-index generation, page citations from the index → `entity-page-attribution.md`
+- Pipeline phases, `pipeline_auto.status`, `setPipelineStatus`, "assert the stage really ran" guards → `pipeline-status-truth.md`
 - Measuring OCR agreement / calibration / page difficulty → `page-revisions-corpus.md`
 - Asserting, badging, or counting "first translation" → `first-translation-claims.md`
 

--- a/scripts/audit/status-output-drift.mjs
+++ b/scripts/audit/status-output-drift.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Status-output drift: books whose pipeline status claims work that was never done.
+ *
+ * `pipeline_auto.status` is what every phase selects on. When a status is written ahead
+ * of its output, the book is permanently "past" the phase that would have filled it in —
+ * nothing errors, nothing retries, and it never appears in any queue again. This counts
+ * that population (#3740).
+ *
+ * The predicates here are deliberately the same ones enforced by `statusOutputViolation`
+ * in `scripts/workers/pipeline-orchestrator.mjs`. If you change one, change both, or the
+ * guard and the audit will disagree about what "done" means.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/audit/status-output-drift.mjs
+ *   node --env-file=.env.production.local scripts/audit/status-output-drift.mjs --samples
+ *
+ * TWO FILTERS ARE LOAD-BEARING — omit them and the numbers are fiction:
+ *  1. `resource_type` absent. Artwork records have no pages and are CORRECTLY `complete`.
+ *     Counting them gave 25,244 "broken" books on the first pass; the true figure was 349.
+ *  2. A recorded skip counts as satisfied. A book under 10 pages has no chapters because
+ *     it should not have any. Treating absence as failure would condemn ~28K books to
+ *     permanent retry — a worse outage than the bug.
+ */
+import { MongoClient } from 'mongodb';
+
+const SAMPLES = process.argv.includes('--samples');
+
+/** Text books only — see filter (1) above. */
+const TEXT = { resource_type: { $exists: false }, pages_count: { $gt: 20 } };
+
+const AFTER_ENRICH = ['summary_indexed', 'enriched', 'chapters_complete', 'images_submitted', 'images_complete', 'cover_selected', 'complete'];
+const AFTER_CHAPTERS = ['chapters_complete', 'images_submitted', 'images_complete', 'cover_selected', 'complete'];
+
+const missing = (field) => ({ $or: [{ [field]: { $exists: false } }, { [field]: null }, { [field]: '' }] });
+const noSkip = (field) => ({ [`pipeline_auto.${field}`]: { $in: [null, ''] } });
+
+const CHECKS = [
+  { name: 'past enrichment, no summary',        filter: { 'pipeline_auto.status': { $in: AFTER_ENRICH }, ...missing('summary'), ...noSkip('summary_skipped_reason') } },
+  { name: 'past chapters, no chapters',         filter: { 'pipeline_auto.status': { $in: AFTER_CHAPTERS }, $or: [{ chapters: { $exists: false } }, { chapters: { $size: 0 } }], ...noSkip('chapters_skipped_reason') } },
+  { name: 'complete/cover_selected, no cover',  filter: { 'pipeline_auto.status': { $in: ['cover_selected', 'complete'] }, cover_page: { $exists: false }, ...noSkip('cover_skipped_reason') } },
+  { name: 'complete, zero OCR pages',           filter: { 'pipeline_auto.status': 'complete', $or: [{ pages_ocr: 0 }, { pages_ocr: { $exists: false } }], ...noSkip('ocr_skipped_reason') } },
+  { name: 'archive_complete, zero archived',    filter: { 'pipeline_auto.status': 'archive_complete', $or: [{ pages_archived: 0 }, { pages_archived: { $exists: false } }], ...noSkip('archive_skipped_reason') } },
+];
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const B = client.db('bookstore').collection('books');
+
+const withStatus = await B.countDocuments({ ...TEXT, 'pipeline_auto.status': { $exists: true } });
+console.log(`text books carrying a pipeline status: ${withStatus}\n`);
+console.log('STATUS CLAIMS OUTPUT THE BOOK DOES NOT HAVE (and no skip was recorded)\n');
+
+for (const check of CHECKS) {
+  const all = await B.countDocuments({ ...TEXT, ...check.filter });
+  const vis = await B.countDocuments({ ...TEXT, ...check.filter, visible: true });
+  console.log(`${String(all).padStart(6)}  ${check.name.padEnd(38)} (${vis} visible)`);
+  if (SAMPLES && all > 0) {
+    const s = await B.find({ ...TEXT, ...check.filter }).project({ id: 1, title: 1, pages_count: 1, pages_ocr: 1, visible: 1 }).limit(3).toArray();
+    s.forEach(b => console.log(`          ${b.id} ${b.visible ? 'PUB' : 'hid'} ${b.pages_ocr || 0}/${b.pages_count}pp ${String(b.title).slice(0, 46)}`));
+  }
+}
+
+// Books the guard has already flagged in observe mode — this should grow to zero once the
+// skip reasons are recorded at their decision points and the backlog is repaired.
+const flagged = await B.countDocuments({ 'pipeline_auto.output_missing': { $exists: true } });
+console.log(`\nflagged live by the status guard (observe mode): ${flagged}`);
+
+await client.close();

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -905,7 +905,7 @@ async function setPipelineStatus(db, bookId, status, extra = {}) {
     { id: bookId },
     {
       projection: {
-        'pipeline_auto.status': 1, title: 1, pipeline_auto: 1,
+        title: 1, pipeline_auto: 1,
         summary: 1, chapters: 1, cover_page: 1,
         pages_ocr: 1, pages_archived: 1, pages_count: 1,
       },

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -854,12 +854,88 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * What each "done" status claims the book now HAS (#3740).
+ *
+ * Measured 2026-08-08 across 58,605 text books: 28,233 sat past enrichment with no
+ * summary and 27,837 past chapters with no chapters. Nothing was broken loudly — the
+ * statuses were simply written ahead of the work, and every downstream phase selects on
+ * status, so those books are permanently "past" the phases that would have filled them
+ * in. A status that runs ahead of the work is worse than no status.
+ *
+ * `skip` is the other half and is not optional. Absence has two causes that are
+ * indistinguishable after the fact: the stage failed, or the stage correctly decided
+ * there was nothing to do. A single-work volume legitimately has no chapters; a book
+ * under 10 pages is not meant to have them. If the predicate read absence as failure,
+ * ~28K books would re-stall permanently — a far bigger outage than the bug. So a status
+ * is satisfied by **output OR an explicitly recorded skip**, and the phase that decides
+ * to skip must say so at the moment it decides, because that is the only moment the
+ * reason exists.
+ */
+const STATUS_OUTPUT_CLAIMS = {
+  archive_complete:  { has: b => (b.pages_archived || 0) > 0,                      skip: 'archive_skipped_reason',     want: 'pages_archived > 0' },
+  ocr_complete:      { has: b => (b.pages_ocr || 0) > 0,                           skip: 'ocr_skipped_reason',         want: 'pages_ocr > 0' },
+  summary_indexed:   { has: b => !!b.summary,                                      skip: 'summary_skipped_reason',     want: 'a summary' },
+  chapters_complete: { has: b => Array.isArray(b.chapters) && b.chapters.length > 0, skip: 'chapters_skipped_reason',  want: 'chapters' },
+  cover_selected:    { has: b => b.cover_page != null,                             skip: 'cover_skipped_reason',       want: 'a cover_page' },
+};
+
+// Default is OBSERVE, not enforce. Flipping behaviour at 53 call sites in a pipeline that
+// is about to be restarted is how you turn a silent-success bug into an outage, and the
+// predicates above have not yet been proven against every path that writes a status.
+// Observe mode records the violation and still advances; once the recorded violations
+// look right, STATUS_GUARD_ENFORCE=1 makes it refuse.
+const STATUS_GUARD_ENFORCE = process.env.STATUS_GUARD_ENFORCE === '1';
+
+/**
+ * Does this status tell the truth about the book? Returns null when fine, else a reason.
+ * Satisfied by real output, by a skip reason recorded on the document, or by one being
+ * written in this very call (`extra`).
+ */
+function statusOutputViolation(book, status, extra = {}) {
+  const claim = STATUS_OUTPUT_CLAIMS[status];
+  if (!claim) return null;
+  if (claim.has(book)) return null;
+  if (extra[claim.skip] || book?.pipeline_auto?.[claim.skip]) return null;
+  return `status '${status}' claims ${claim.want}, book has none and no ${claim.skip} was recorded`;
+}
+
 async function setPipelineStatus(db, bookId, status, extra = {}) {
   const book = await db.collection('books').findOne(
     { id: bookId },
-    { projection: { 'pipeline_auto.status': 1, title: 1 } }
+    {
+      projection: {
+        'pipeline_auto.status': 1, title: 1, pipeline_auto: 1,
+        summary: 1, chapters: 1, cover_page: 1,
+        pages_ocr: 1, pages_archived: 1, pages_count: 1,
+      },
+    }
   );
   const prevStatus = book?.pipeline_auto?.status;
+
+  const violation = book ? statusOutputViolation(book, status, extra) : null;
+  if (violation) {
+    console.log(`  [status-guard] ${bookId}: ${violation}${STATUS_GUARD_ENFORCE ? ' — REFUSED' : ''}`);
+    db.collection('audit_log').insertOne({
+      action: 'pipeline_status_output_missing',
+      book_id: bookId,
+      book_title: book?.title,
+      metadata: { attempted: status, from: prevStatus || 'none', violation, enforced: STATUS_GUARD_ENFORCE },
+      timestamp: new Date(),
+    }).catch(() => {});
+
+    if (STATUS_GUARD_ENFORCE) {
+      // Park it where a sweep can find it, rather than advancing past the work.
+      await db.collection('books').updateOne(
+        { id: bookId },
+        { $set: { 'pipeline_auto.status': 'needs_attention', 'pipeline_auto.last_updated': new Date(),
+                  'pipeline_auto.error': violation, updated_at: new Date() } }
+      );
+      return;
+    }
+    // Observe mode: advance, but leave a mark so the population stays countable.
+    extra = { ...extra, output_missing: violation, output_missing_at: new Date() };
+  }
 
   await db.collection('books').updateOne(
     { id: bookId },
@@ -4731,7 +4807,13 @@ Rules:
         } catch (err) {
           const retries = book.pipeline_auto?.retry_count || 0;
           if (retries >= MAX_RETRIES) {
-            await setPipelineStatus(db, book.id, 'summary_indexed', { retry_count: 0 });
+            // Gave up after repeated throws, but the book is still counted as enriched
+            // and moved on. Record the reason so the summary_indexed population can be
+            // split into "has a summary" and "we stopped trying" (#3740).
+            await setPipelineStatus(db, book.id, 'summary_indexed', {
+              retry_count: 0,
+              summary_skipped_reason: `summary+index threw ${retries} times (last: ${err.message?.slice(0, 120)}); advanced as non-critical`,
+            });
             log.enriched++;
           } else {
             await setPipelineStatus(db, book.id, 'translate_complete', { retry_count: retries + 1 });
@@ -4765,7 +4847,14 @@ Rules:
         try {
           if ((book.pages_count || 0) < 10) {
             if (!DRY_RUN) {
-              await setPipelineStatus(db, book.id, 'chapters_complete', { retry_count: 0 });
+              // A legitimate skip: too short to have chapters. Record WHY on the book —
+              // `log.chapters_skipped` is an in-memory counter that dies with the run, so
+              // this decision used to leave no trace and the book became indistinguishable
+              // from one whose extraction failed (#3740).
+              await setPipelineStatus(db, book.id, 'chapters_complete', {
+                retry_count: 0,
+                chapters_skipped_reason: `book has ${book.pages_count || 0} pages, fewer than the 10-page minimum for chapter extraction`,
+              });
             }
             log.chapters_skipped++;
             continue;
@@ -4790,8 +4879,13 @@ Rules:
           } else {
             const retries = book.pipeline_auto?.retry_count || 0;
             if (retries >= MAX_RETRIES) {
-              // Non-critical — skip
-              await setPipelineStatus(db, book.id, 'chapters_complete', { retry_count: 0 });
+              // Non-critical — give up, but say so. This path writes the SUCCESS status
+              // after repeated FAILURE; unlabelled, it is why "chapters_complete with no
+              // chapters" cannot be told apart from a book that legitimately has none.
+              await setPipelineStatus(db, book.id, 'chapters_complete', {
+                retry_count: 0,
+                chapters_skipped_reason: `extract-chapters failed ${retries} times (last: HTTP ${res.status}); advanced as non-critical`,
+              });
               log.chapters_skipped++;
             } else {
               await setPipelineStatus(db, book.id, 'summary_indexed', { retry_count: retries + 1 });


### PR DESCRIPTION
Addresses the core of #3740.

## What's wrong

`pipeline_auto.status` is what every phase selects on. Written ahead of its output, a book becomes permanently *past* the phase that would have filled it in — nothing errors, nothing retries, it never appears in a queue again.

Measured across 58,635 text books:

| status claims | books lacking it |
|---|---|
| past enrichment, no summary | **28,263** (1,162 visible) |
| past chapters, no chapters | **27,867** (793 visible) |
| complete/cover_selected, no cover | 1,127 |
| complete, zero OCR | 344 |
| archive_complete, zero archived | 257 |

**The orchestrator has been laundering failures into success.** Phase 7 writes `chapters_complete` from three paths — chapters extracted, book under 10 pages, and extraction failed `MAX_RETRIES` times (`// Non-critical — skip`) — and the two skips only increment `log.chapters_skipped`, an in-memory counter that dies with the run. Phase 6 does the same in its `catch`: after `MAX_RETRIES` throws it writes `summary_indexed` and counts the book as enriched.

So "chapters_complete with no chapters" conflates *extracted*, *too short to have any*, and *we gave up*. Three very different books, one indistinguishable status. That is the whole 28K.

## The fix, and the half that matters more

A precondition at `setPipelineStatus` — the one function all 53 call sites go through.

But the obvious predicate (*the field is non-empty*) is wrong in a way that is worse than the bug. **Absence has two causes and they are indistinguishable after the fact:** the stage failed, or the stage correctly decided there was nothing to do. A single-work volume legitimately has no chapters; a 6-page pamphlet is not meant to. A predicate reading absence as failure would re-stall ~28K books permanently, most with no reader impact — a far bigger outage than what it fixes.

So: **a status is satisfied by output OR by an explicitly recorded skip**, and the three skip paths above now write their reason *at the moment they decide*, because that is the only moment the reason exists. No silent skips.

## Observe first, enforce later

Default is **observe, not enforce**. Flipping behaviour at 53 call sites in a pipeline that is about to be restarted is exactly how a silent-success bug becomes an outage, and these predicates have not been proven against every path that writes a status.

- **Observe (default):** records the violation to `audit_log` and `pipeline_auto.output_missing`, then still advances. Costs nothing, makes the population countable going forward.
- **`STATUS_GUARD_ENFORCE=1`:** refuses, parks at `needs_attention` with the reason — visible to exactly the sweep that never found these books.

Flip it once the recorded violations look right.

## Also ships

`scripts/audit/status-output-drift.mjs`, using the same predicates as the guard (change one, change both). Two filters in it are load-bearing and documented: artwork records have no pages and are correctly `complete` — counting them read **25,244** broken books where the true figure is **344** — and a recorded skip counts as satisfied.

## Verification

`node --check` clean; orchestrator dry-run completes normally; the audit runs against production and reproduces the table above. The predicates are the same conditions used to measure the population, so guard and audit cannot disagree.

**Not in scope:** repairing the existing 28K. That means re-running enrichment at scale and belongs behind the budget dial (#3737), in priority order — the ~99 visible-and-empty books first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)