### PR TITLE
fix(work-identity): stop the resolver deciding by SPARQL row order, and audit author anchors

### DIFF
--- a/scripts/analysis/resolve-work-ids-wikidata.mjs
+++ b/scripts/analysis/resolve-work-ids-wikidata.mjs
@@ -13,6 +13,7 @@
  */
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { anchorProblem } from '../lib/author-anchor-classes.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const LANG = (process.argv.find(a=>a.startsWith('--lang='))||'--lang=greek').split('=')[1].toLowerCase();
@@ -27,14 +28,32 @@ const GENERIC = new Set(['letters','poems','poem','life','lives','works','fragme
 const tok = t => new Set(deacc(t).replace(/[\(\[].*?[\)\]]/g,' ').split(/ [—–-] |:| with | trans| edited/)[0]
   .replace(/[^a-z0-9 ]/g,' ').split(/\s+/).filter(w=>w.length>3 && !STOP.has(w)));
 
+// Wikidata class for "version, edition, or translation". An item of this class
+// is a *manifestation* of a work, not the work — filing a book under one makes a
+// cluster that can never join the work's other editions.
+const Q_EDITION = 'Q3331189';
+
 // ---- SPARQL: works for a batch of author QIDs ----
 async function worksForAuthors(qids){
   const values = qids.map(q=>`wd:${q}`).join(' ');
   // label only — altLabels injected foreign tokens into container items
   // ("Fragments"), defeating the generic-skip and faking matches.
+  //
+  // The P31 filter is load-bearing, not tidiness. Wikidata routinely carries the
+  // work AND its editions under the same P50 and the SAME English label:
+  // Polybius has THREE items labelled "The Histories" — Q250816 (the work),
+  // Q16038921 ("edition of…") and Q53748127 ("1920s translation by W. R. Paton").
+  // Containment scores all three at 1.00, and the tie-break below keeps whichever
+  // arrived first, so the chosen work_id depended on SPARQL row order — the same
+  // book resolved to Q250816 or Q53748127 across runs, written at HIGH and
+  // auto-applied. Dropping edition-class items removes the ambiguity at source.
+  // (The `^opera |^the works of|collected works` label blocklist further down is
+  // the older, hand-grown symptom of this; it stays as belt-and-braces for items
+  // that carry no P31 at all.)
   const query = `SELECT ?author ?w ?wLabel WHERE {
     VALUES ?author { ${values} }
     ?w wdt:P50 ?author .
+    FILTER NOT EXISTS { ?w wdt:P31/wdt:P279* wd:${Q_EDITION} }
     SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
   }`;
   const r = await fetch('https://query.wikidata.org/sparql?'+new URLSearchParams({query, format:'json'}),
@@ -50,6 +69,42 @@ async function worksForAuthors(qids){
     byAuthor.get(a).push({ qid:b.w.value.split('/').pop(), label, _tt:tok(label) });
   }
   return byAuthor;
+}
+
+// ---- Author anchors: every candidate hangs off authors.wikidata_id, so a wrong
+// anchor poisons every match under it. Two real cases found 2026-08-08:
+//   authors/sextus   → Q1270100, the *Sentences of Sextus*, a collection of
+//                      maxims — a TEXT used as a person. Four visible books.
+//   authors/longinus → Q436634, Cassius Longinus — the Neoplatonist to whom
+//                      On the Sublime was wrongly ascribed, not its author.
+// The first fails SILENTLY (P50 of a text returns no works → "HIGH 0", which
+// reads identically to "nothing to link"). The second is a real human and is
+// NOT caught here — right-class/wrong-person needs a different instrument.
+// The test is a denylist, not `P31 = Q5`: see scripts/lib/author-anchor-classes
+// for why Homer, Hermes Trismegistus and Orpheus must pass.
+async function validateAuthorAnchors(qids){
+  const bad = new Map();
+  for(let i=0;i<qids.length;i+=50){
+    const values = qids.slice(i,i+50).map(q=>`wd:${q}`).join(' ');
+    const query = `SELECT ?a ?type WHERE { VALUES ?a { ${values} } OPTIONAL { ?a wdt:P31 ?type } }`;
+    const r = await fetch('https://query.wikidata.org/sparql?'+new URLSearchParams({query, format:'json'}),
+      { headers:{ 'User-Agent':UA, 'Accept':'application/sparql-results+json' }, signal:AbortSignal.timeout(60000) });
+    if(!r.ok) throw new Error('SPARQL(anchor-check) '+r.status);
+    const d = await r.json();
+    const types = new Map();
+    for(const b of d.results.bindings){
+      const a = b.a.value.split('/').pop();
+      const t = b.type?.value?.split('/').pop();
+      if(!types.has(a)) types.set(a, new Set());
+      if(t) types.get(a).add(t);
+    }
+    for(const q of qids.slice(i,i+50)){
+      const problem = anchorProblem(types.get(q));
+      if(problem) bad.set(q, problem);
+    }
+    await sleep(800);
+  }
+  return bad;
 }
 const sleep = ms => new Promise(r=>setTimeout(r,ms));
 
@@ -67,16 +122,43 @@ const aidToAuthorTok = new Map(authors.map(a=>[a._id, tok(a.name||'')]));  // au
 const qids = [...new Set([...aidToQid.values()].map(q=>q.replace(/^wd:/,'')))];
 console.log(`${LANG}: ${books.length} unlinked books w/ author; ${qids.length} distinct author QIDs to query Wikidata`);
 
-// fetch works per author (batched)
+// Validate the anchors before spending any matching effort on them.
+let badAnchors = new Map();
+try {
+  badAnchors = await validateAuthorAnchors(qids);
+} catch(e){
+  console.error(`FATAL: could not validate author anchors — ${e.message}`);
+  console.error('Refusing to continue: an unvalidated anchor can mis-file every book under it.');
+  process.exit(1);
+}
+if(badAnchors.size){
+  const qidToAid = new Map([...aidToQid].map(([a,q])=>[q.replace(/^wd:/,''),a]));
+  console.log(`\n!! ${badAnchors.size} BAD AUTHOR ANCHOR(S) in \`authors.wikidata_id\` — skipped, fix these:`);
+  for(const [q,why] of badAnchors) console.log(`   ${(qidToAid.get(q)||'?').padEnd(30)} ${q.padEnd(11)} ${why}`);
+  console.log('');
+}
+const goodQids = qids.filter(q=>!badAnchors.has(q));
+
+// fetch works per author (batched). A transport failure here must NOT be
+// reported as "nothing to link" — 502/429 from WDQS are routine, and swallowing
+// them yielded a confident "HIGH 0" that looks exactly like a clean empty run.
+// (Repo invariant: absence is not failure; a skip must be recorded, not implied.)
 const worksByQid = new Map();
-for(let i=0;i<qids.length;i+=40){
-  const batch = qids.slice(i,i+40);
+const failedBatches = [];
+for(let i=0;i<goodQids.length;i+=40){
+  const batch = goodQids.slice(i,i+40);
   try { const m = await worksForAuthors(batch); for(const [a,ws] of m) worksByQid.set(a,ws); }
-  catch(e){ console.log(`  SPARQL batch ${i} failed: ${e.message}`); }
+  catch(e){ console.log(`  SPARQL batch ${i} failed: ${e.message}`); failedBatches.push({ i, n: batch.length, err: e.message }); }
   await sleep(800);
 }
 const totalWorks = [...worksByQid.values()].reduce((s,w)=>s+w.length,0);
 console.log(`fetched ${totalWorks} works across ${worksByQid.size} authors from Wikidata`);
+if(failedBatches.length){
+  const lost = failedBatches.reduce((s,f)=>s+f.n,0);
+  console.error(`\n!! ${failedBatches.length} SPARQL batch(es) failed — ${lost}/${goodQids.length} author QIDs were never queried.`);
+  console.error('   This run is INCOMPLETE. Counts below are a floor, not a result; --apply is refused.');
+  if(APPLY){ console.error('   Re-run when Wikidata is reachable.'); await mc.close(); process.exit(2); }
+}
 
 const out={high:[],medium:[],low:[]};
 for(const b of books){
@@ -102,6 +184,24 @@ for(const b of books){
     if(cont>bestCont || (cont===bestCont && inter>bestInter)){ bestCont=cont; bestInter=inter; best=w; bestTT=wtt; }
   }
   if(!best || bestInter===0){ continue; }
+  // A strict `>` keeps whichever candidate SPARQL happened to return first, so a
+  // genuine tie resolved differently run to run. Ties are ambiguity, not a
+  // winner: count them and demote instead of picking arbitrarily.
+  const tied = cands.filter(w=>{
+    if(w.qid===best.qid) return false;
+    const wtt = new Set([...w._tt].filter(x=>!aTok.has(x)));
+    if(!wtt.size || [...wtt].every(x=>GENERIC.has(x))) return false;
+    if(wtt.has('fragments')||wtt.has('fragment')) return false;
+    if(/with an english translation|amddiffyniad|^opera |^the works of|collected works|complete works/i.test(w.label)) return false;
+    let inter=0; for(const x of wtt) if(bt.has(x)) inter++;
+    return inter===bestInter && inter/wtt.size===bestCont;
+  });
+  if(tied.length){
+    out.low.push({ book:b.title.slice(0,48), role:b.text_role||'?', bookId:b.id, authorQid:qid,
+      work:best.label.slice(0,40), qid:best.qid, cont:+bestCont.toFixed(2), inter:bestInter,
+      ambiguous:[best.qid, ...tied.map(t=>t.qid)], reason:`tied at cont=${bestCont.toFixed(2)} with ${tied.length} other candidate(s)` });
+    continue;
+  }
   const wTokens=[...bestTT];
   const generic = wTokens.length===1 && GENERIC.has(wTokens[0]);
   const rec={ book:b.title.slice(0,48), role:b.text_role||'?', bookId:b.id, authorQid:qid,
@@ -112,7 +212,12 @@ for(const b of books){
   else if(bestCont>=0.8 && generic) out.medium.push(rec);
   else out.low.push(rec);
 }
-console.log(`\n${LANG}: HIGH ${out.high.length} | MEDIUM(generic, review) ${out.medium.length} | LOW ${out.low.length}`);
+const ambiguous = out.low.filter(r=>r.ambiguous);
+console.log(`\n${LANG}: HIGH ${out.high.length} | MEDIUM(generic, review) ${out.medium.length} | LOW ${out.low.length}${ambiguous.length?` (of which ${ambiguous.length} AMBIGUOUS — tied candidates, demoted not guessed)`:''}`);
+if(ambiguous.length){
+  console.log('\n=== AMBIGUOUS (tied; would previously have been decided by SPARQL row order) ===');
+  for(const r of ambiguous.slice(0,20)) console.log(`  "${r.book}" → ${r.ambiguous.join(' / ')}  ${r.reason}`);
+}
 console.log('\n=== HIGH proposals (evidence) ===');
 for(const r of out.high.slice(0,40)) console.log(`  [${r.role.slice(0,4)}] "${r.book}" → ${r.qid} "${r.work}" cont=${r.cont} (author ${r.authorQid})`);
 fs.writeFileSync(`/tmp/wikidata-work-proposals-${LANG}.json`, JSON.stringify(out,null,2));

--- a/scripts/audit/author-anchor-validity.mjs
+++ b/scripts/audit/author-anchor-validity.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * author-anchor-validity.mjs — standing audit of `authors.wikidata_id`.
+ *
+ * Every work-identity candidate hangs off an author's Wikidata QID: the
+ * resolver SPARQLs `?w wdt:P50 <anchor>` and matches titles among the results.
+ * A wrong anchor therefore poisons every book under it, and does so QUIETLY —
+ * if the anchor is a text rather than a person, P50 returns nothing and the run
+ * prints "HIGH 0", which is indistinguishable from a clean empty result.
+ *
+ * Found by hand on 2026-08-08 (#3742):
+ *   authors/sextus → Q1270100, the *Sentences of Sextus*, a 2nd-century
+ *   collection of maxims — a TEXT used as a person. Four visible books hung
+ *   off it. This audit catches that class.
+ *
+ * THE TEST IS A DENYLIST, NOT `P31 = Q5`, and that distinction matters here more
+ * than in most corpora. The first draft of this audit demanded Q5 (human) and
+ * flagged 38 anchors — including **Homer** (Q21070568, "human whose existence is
+ * disputed"), **Hermes Trismegistus** (Q61002 pseudonym / Q16685255 epithet),
+ * **Orpheus** (mythological Greek character), Enoch, Vyāsa, the Sibyl and
+ * Chiron. Those are not errors: attributed and legendary authorship is exactly
+ * what a library of Hermetica, Orphica and Vedic texts is *made of*. Gating the
+ * resolver on Q5 would have silently skipped the collection's core.
+ *
+ * So we deny only classes that cannot be an author under any reading — a work,
+ * a reference book, or a disambiguation page — and let every flavour of
+ * person-like entity through.
+ *
+ * LIMIT, stated plainly: this checks the anchor is not a THING. It cannot check
+ * it is the RIGHT person. The same session found authors/longinus → Q436634 =
+ * Cassius Longinus, the Neoplatonist to whom On the Sublime was wrongly
+ * ascribed — a real human, so it passes here and always will. Right-class/
+ * wrong-person needs a different instrument (birth/death window vs. our books'
+ * dates); deliberately out of scope rather than half-done.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/author-anchor-validity.mjs                 # audit all anchors
+ *   node scripts/audit/author-anchor-validity.mjs --min-books 5   # only anchors carrying >=5 books
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import { anchorProblem } from '../lib/author-anchor-classes.mjs';
+
+const UA = 'SourceLibrary-author-anchor-audit/1.0 (https://sourcelibrary.org; team@sourcelibrary.org)';
+const MIN_BOOKS = parseInt((process.argv.find(a => a.startsWith('--min-books=')) || '').split('=')[1]
+  || process.argv[process.argv.indexOf('--min-books') + 1] || '0', 10) || 0;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
+const db = mc.db('bookstore');
+
+const anchors = await db.collection('authors')
+  .find({ wikidata_id: { $exists: true, $ne: null } }, { projection: { _id: 1, canonical_name: 1, wikidata_id: 1 } })
+  .toArray();
+// how many books each anchor actually carries — severity, so the report ranks by blast radius
+const counts = new Map((await db.collection('books').aggregate([
+  { $match: { author_id: { $in: anchors.map(a => a._id) } } },
+  { $group: { _id: '$author_id', n: { $sum: 1 } } },
+]).toArray()).map(r => [r._id, r.n]));
+
+const scope = anchors.filter(a => (counts.get(a._id) || 0) >= MIN_BOOKS);
+console.log(`${anchors.length} anchors with a wikidata_id; auditing ${scope.length} (min-books=${MIN_BOOKS})`);
+
+const qids = [...new Set(scope.map(a => String(a.wikidata_id).replace(/^wd:/, '')))];
+const typeOf = new Map();
+let failed = 0;
+for (let i = 0; i < qids.length; i += 50) {
+  const values = qids.slice(i, i + 50).map(q => `wd:${q}`).join(' ');
+  const query = `SELECT ?a ?type WHERE { VALUES ?a { ${values} } OPTIONAL { ?a wdt:P31 ?type } }`;
+  try {
+    const r = await fetch('https://query.wikidata.org/sparql?' + new URLSearchParams({ query, format: 'json' }),
+      { headers: { 'User-Agent': UA, Accept: 'application/sparql-results+json' }, signal: AbortSignal.timeout(60000) });
+    if (!r.ok) throw new Error('SPARQL ' + r.status);
+    const d = await r.json();
+    for (const b of d.results.bindings) {
+      const a = b.a.value.split('/').pop();
+      const t = b.type?.value?.split('/').pop();
+      if (!typeOf.has(a)) typeOf.set(a, new Set());
+      if (t) typeOf.get(a).add(t);
+    }
+  } catch (e) {
+    // Never let a transport failure read as "all clean" — record the gap.
+    console.error(`  batch ${i}: ${e.message} — ${qids.slice(i, i + 50).length} anchors NOT checked`);
+    failed += qids.slice(i, i + 50).length;
+    for (const q of qids.slice(i, i + 50)) typeOf.set(q, null);
+  }
+  process.stdout.write(`\r  checked ${Math.min(i + 50, qids.length)}/${qids.length}`);
+  await sleep(700);
+}
+console.log('');
+
+const bad = [];
+for (const a of scope) {
+  const q = String(a.wikidata_id).replace(/^wd:/, '');
+  const t = typeOf.get(q);
+  if (t === null) continue;                       // unchecked, already reported
+  const books = counts.get(a._id) || 0;
+  const problem = anchorProblem(t);
+  if (problem) bad.push({ ...a, books, why: problem });
+}
+bad.sort((x, y) => y.books - x.books);
+
+console.log(`\n${bad.length} INVALID anchor(s)${failed ? `; ${failed} not checked (SPARQL failures — rerun)` : ''}`);
+for (const b of bad) console.log(`  ${String(b.books).padStart(5)} books  ${b._id.padEnd(34)} ${String(b.wikidata_id).padEnd(11)} ${b.canonical_name?.slice(0, 26).padEnd(26)} ${b.why}`);
+fs.writeFileSync('/tmp/author-anchor-validity.json', JSON.stringify({ checked: qids.length - failed, unchecked: failed, bad }, null, 2));
+console.log(`\nfull -> /tmp/author-anchor-validity.json`);
+if (failed) { console.error('INCOMPLETE — some anchors were never checked; this is a floor, not a clean bill.'); await mc.close(); process.exit(2); }
+await mc.close();

--- a/scripts/lib/author-anchor-classes.mjs
+++ b/scripts/lib/author-anchor-classes.mjs
@@ -1,0 +1,46 @@
+/**
+ * Shared rule for "can this Wikidata item be an author anchor?"
+ *
+ * Used by scripts/audit/author-anchor-validity.mjs (the standing sweep) and
+ * scripts/analysis/resolve-work-ids-wikidata.mjs (the pre-flight check), so the
+ * two can never drift apart.
+ *
+ * THE RULE IS A DENYLIST, NOT `P31 = Q5`. Demanding "human" flags 38 anchors in
+ * this corpus, and the great majority are correct: Homer (Q21070568, "human
+ * whose existence is disputed"), Hermes Trismegistus (Q61002 pseudonym /
+ * Q16685255 epithet), Orpheus (mythological Greek character), Enoch, Vyāsa,
+ * the Sibyl, Chiron. Attributed and legendary authorship is what a library of
+ * Hermetica, Orphica and Vedic texts is largely made of — gating on Q5 would
+ * silently skip the collection's core.
+ *
+ * So deny only what cannot be an author under any reading: a work, a reference
+ * book, or a disambiguation page. Everything person-like passes.
+ */
+export const NEVER_AN_AUTHOR = new Map([
+  // Disambiguation pages — a list of people, never one person.
+  ['Q4167410',  'Wikimedia disambiguation page'],
+  ['Q22808320', 'Wikimedia human name disambiguation page'],
+  // A WORK standing in for its author. The most damaging kind, because such an
+  // anchor often still returns plausible P50 results instead of failing loudly.
+  ['Q7725634',  'literary work'],
+  ['Q47461344', 'written work'],
+  ['Q12765855', 'philosophical work'],
+  ['Q2271441',  'sententiae'],
+  ['Q13136',    'reference work'],
+  ['Q521983',   'etymological dictionary'],
+  ['Q913554',   'grimoire'],
+  ['Q693',      'fable'],
+  ['Q571',      'book'],
+  ['Q3331189',  'version, edition, or translation'],
+  ['Q234460',   'text'],
+  // Plainly a mis-link.
+  ['Q1569167',  'video game character'],
+]);
+
+/** @returns {string|null} reason the anchor is invalid, or null if it is usable. */
+export function anchorProblem(p31Set) {
+  if (!p31Set || !p31Set.size) return 'no P31 (deleted, redirected, or bad QID)';
+  const hit = [...p31Set].filter(x => NEVER_AN_AUTHOR.has(x));
+  if (hit.length) return `${hit.map(h => `${h} (${NEVER_AN_AUTHOR.get(h)})`).join(', ')} — a thing, not a person`;
+  return null;
+}


### PR DESCRIPTION
Three correctness fixes to `resolve-work-ids-wikidata.mjs`, plus a standing audit of the anchors it depends on. Found while hand-adjudicating work identity for five Greek authors (#3742) — this is the generalisable half of that.

The resolver auto-writes at HIGH under `--apply`, so a wrong write is expensive even at low volume.

## 1. The resolver's answer depended on SPARQL row order

Wikidata routinely carries a work **and its editions** under the same `P50` and the *same English label*. Polybius has three items labelled "The Histories":

| QID | what it is |
|---|---|
| `Q250816` | the work |
| `Q16038921` | "edition of The Histories by Polybius" |
| `Q53748127` | "1920s translation by W. R. Paton" |

The SPARQL had no `P31` filter, so all three were candidates. Containment scores all three at **1.00**, and the tie-break is `cont > bestCont` (strict), which keeps whichever row arrived first. Replaying the matcher offline with the candidate list in two orders:

```
HIGH [order A] "The Histories of Polybius, Vol. 1" → Q250816     cont=1.00
HIGH [order B] "The Histories of Polybius, Vol. 1" → Q53748127   cont=1.00
```

Same book, same code, different `work_id`, written at HIGH and auto-applied. Fixed by excluding edition-class items (`P31/P279* Q3331189`) at the source. The `^opera |^the works of|collected works` label blocklist already in the file looks like the older hand-grown symptom of the same problem; it stays as belt-and-braces for items carrying no `P31`.

## 2. Ties now demote instead of guessing

Even with editions gone, a genuine tie is ambiguity. It now goes to LOW with the tied QIDs recorded, rather than being settled by candidate order.

## 3. Anchors are validated, and SPARQL failures are no longer silent

Every candidate hangs off `authors.wikidata_id`. I hit a 502 and then a 429 during this work, and both printed `HIGH 0 | MEDIUM 0 | LOW 0` — indistinguishable from a clean empty run. Failures are now reported and `--apply` refuses on an incomplete fetch. (Repo invariant: absence is not failure.)

## The audit: 20 bad anchors in production

`scripts/audit/author-anchor-validity.mjs` sweeps all 3,331 anchors carrying books. 20 are a **work or a disambiguation page used as a person**:

```
105 books  mao-yuanyi-compiler  Q2553722    written work (the Wubei Zhi itself)
 10 books  albumazar            Q112076367  disambiguation page
  6 books  aelian               Q380785     disambiguation page
  6 books  artemidorus          Q450544     human-name disambiguation page
  5 books  paul-nagel           Q16874452   human-name disambiguation page
  4 books  morienus             Q4257922    reference work
  … 14 more, incl. suidas → an etymological dictionary, mr-foster → a video game character
```

### The denylist is the point, and `P31 = Q5` would have been a bad regression

My first draft demanded "human" and flagged **38** anchors — including **Homer** (`Q21070568`, "human whose existence is disputed"), **Hermes Trismegistus** (`Q61002` pseudonym / `Q16685255` epithet), **Orpheus** (mythological Greek character), Enoch, Vyāsa, the Sibyl and Chiron.

Those aren't errors. Attributed and legendary authorship is what a library of Hermetica, Orphica and Vedic texts is largely *made of* — gating the resolver on Q5 would have silently skipped the collection's core. So the rule denies only what cannot be an author under any reading (a work, a reference book, a disambiguation page) and lets every person-like class through. It lives in `scripts/lib/author-anchor-classes.mjs` so the audit and the resolver can't drift.

Verified with a positive control before trusting it: fed the two QIDs that were genuinely wrong in production plus two known-good ones, and confirmed it flags `Q1270100` (the *Sentences of Sextus*, a text used as a person) while passing the rest.

## Out of scope, deliberately

- **The 20 bad anchors are reported, not repaired.** No data is written by this PR. Each needs the correct QID chosen by hand — that's a separate, reviewable change.
- **"Wrong person" is not detectable here.** `authors/longinus` pointed at Cassius Longinus (a real human, wrong attribution) and passes this audit and always will. That needs a different instrument — birth/death window against our books' dates — and I'd rather leave it undone than half-done.
- **No change to `mint-local-work-ids.mjs`.** Its volume-holding behaviour is deliberate ("under-cluster over mis-cluster") and correct.