### PR TITLE
fix(#3368): text-shift repair for the bulk-JP2 offset's self-consistent cohort

### DIFF
--- a/scripts/lib/text-shift.mjs
+++ b/scripts/lib/text-shift.mjs
@@ -1,0 +1,86 @@
+/**
+ * Pure transform for the p(N+1) -> p(N) text-shift repair.
+ *
+ * Two incidents produced a book whose stored TEXT runs one leaf behind the true
+ * page sequence: the e-rara cover-sheet offset (#3186, repaired by
+ * scripts/maintenance/repair-erara-text-shift.mjs) and the bulk-JP2 zip-ordinal
+ * offset (#3368) for pages whose OCR was transcribed FROM the shifted archive.
+ * In both cases the correct text for page N currently sits on page N+1, so the
+ * repair moves the text fields one page left and clears the last page of each
+ * affected run (its text was never produced).
+ *
+ * This module is the deterministic core of that repair, extracted so it can be
+ * unit-tested without a database: given the page docs, produce the list of
+ * moves. All I/O — snapshots to page_revisions, bulk writes, book_events —
+ * stays in the calling script.
+ *
+ * IMPORTANT: deciding WHETHER a book should be shifted is not this module's
+ * job. The caller must establish (via the dHash alignment check in
+ * scripts/lib/page-alignment.mjs) that the book really is shift+1, and passes
+ * that verdict in. Anything other than 'shift+1' produces zero moves — fail
+ * closed, so a miswired caller cannot shift an aligned book.
+ */
+
+/**
+ * The fields that travel with a page's text. Mirrors
+ * repair-erara-text-shift.mjs exactly: the two text payloads, their
+ * derivatives, and the layout metadata OCR produces alongside them.
+ */
+export const SHIFT_FIELDS = ['ocr', 'translation', 'translation_summary', 'translation_keywords', 'page_type', 'columns'];
+
+/**
+ * Compute the moves for a p(N+1) -> p(N) text shift.
+ *
+ * Unlike the e-rara repair (whole-book shift — every page came from the same
+ * offset PDF), a bulk-JP2 book is often archived by several paths: only the
+ * pages the bulk archiver wrote are shifted, and pages archived per-page from
+ * IIIF are aligned and must not move. So the shift operates on the TARGET
+ * subset only, and a target page may pull text from its successor only when
+ * that successor is itself a target — a non-target successor holds the text of
+ * its own (correct) leaf, not the leaf the target page needs. Target pages
+ * whose successor is missing or non-target are CLEARED: the text they need was
+ * never transcribed anywhere (`cleared: true`; the caller flags them for
+ * re-OCR).
+ *
+ * @param {Array<object>} pages  ALL page docs of the book (any order; sorted
+ *                               internally by page_number). Non-target pages
+ *                               are needed to resolve run boundaries.
+ * @param {object}  opts
+ * @param {string}  opts.verdict   alignment verdict from checkAlignment();
+ *                                 anything but 'shift+1' -> zero moves.
+ * @param {(p:object)=>boolean} [opts.isTarget]  which pages the defective
+ *                                 writer produced; defaults to
+ *                                 archive_metadata.source === 'bulk_jp2'.
+ * @returns {Array<{page_number:number, src_page_number:number|null, cleared:boolean, set:object, unset:string[]}>}
+ *   One move per target page. `set` holds the field values to write (taken
+ *   from the successor), `unset` the fields to remove (successor lacks them,
+ *   or the page is cleared). Field-wise, exactly like the e-rara repair: a
+ *   field the successor doesn't carry is unset rather than left stale.
+ */
+export function computeTextShiftMoves(pages, { verdict, isTarget } = {}) {
+  if (verdict !== 'shift+1') return [];
+  const target = isTarget ?? (p => p?.archive_metadata?.source === 'bulk_jp2');
+  const sorted = [...pages].sort((a, b) => a.page_number - b.page_number);
+  const byNum = new Map(sorted.map(p => [p.page_number, p]));
+
+  const moves = [];
+  for (const p of sorted) {
+    if (!target(p)) continue;
+    const src = byNum.get(p.page_number + 1);
+    const srcUsable = Boolean(src && target(src));
+    const set = {};
+    const unset = [];
+    for (const f of SHIFT_FIELDS) {
+      if (srcUsable && src[f] !== undefined) set[f] = src[f];
+      else unset.push(f);
+    }
+    moves.push({
+      page_number: p.page_number,
+      src_page_number: srcUsable ? src.page_number : null,
+      cleared: !srcUsable,
+      set,
+      unset,
+    });
+  }
+  return moves;
+}

--- a/scripts/maintenance/repair-bulkjp2-text-shift.mjs
+++ b/scripts/maintenance/repair-bulkjp2-text-shift.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Text-shift repair for the bulk-JP2 leaf offset (#3368) — the SELF-CONSISTENT
+ * cohort. Mirrors scripts/maintenance/repair-erara-text-shift.mjs.
+ *
+ * archive-bulk.mjs equated the IA *_jp2.zip ordinal with the IIIF leaf number;
+ * on items with a leading excluded leaf (Color Card etc.) every archived image
+ * is one leaf behind the true sequence. Audit: scripts/audit/
+ * bulk-archive-alignment.mjs. What decides the repair path is which image the
+ * OCR was transcribed from:
+ *
+ *   - Pages OCR'd BEFORE archival read the IIIF source: their TEXT is correct
+ *     and the IMAGE is the outlier. Those books (severity high/partial) are
+ *     repaired image-side by repair-bulk-jp2-offset.mjs. This script REFUSES
+ *     them — shifting their (correct) text would corrupt it.
+ *   - Pages OCR'd AFTER archival read the shifted archive: their text runs one
+ *     leaf behind the true sequence, exactly the e-rara shape. For those
+ *     (severity:none books) the correct text for page N sits on page N+1, and
+ *     THIS script moves it: text p(N+1) -> p(N) over the bulk_jp2 pages, last
+ *     page of each run cleared + flagged needs_reocr.
+ *
+ * ⚠ SEQUENCING: a severity:none book is currently self-consistent — text and
+ * image agree (both shifted). Shifting the text alone makes the truth better
+ * but the READING experience worse until the images are re-archived from IIIF.
+ * Complete the repair by re-archiving the images afterwards (and purging
+ * Cloudflare); the book_events record and the
+ * archive_metadata.jp2_text_shift_awaiting_image_rearchive flag track that.
+ *
+ * Every replaced ocr/translation value is snapshotted to page_revisions first
+ * (source: 'shift-repair-bulkjp2-2026-08') and each book gets a book_events
+ * record — fully reversible. The shift transform itself is pure and
+ * unit-tested: scripts/lib/text-shift.mjs.
+ *
+ * Guards (all fail closed):
+ *   - only books the audit called shift+1 (--from), or re-derived live
+ *     (--rederive / --book) via the shared dHash check with the vote gate of
+ *     repair-bulk-jp2-offset.mjs (>=2 shift votes, ZERO aligned votes);
+ *   - REFUSE books with any pre-archival bulk_jp2 OCR (their text is correct);
+ *   - skip books already image-repaired (jp2_offset_repaired) — their stale
+ *     pages carry needs_reocr flags and a whole-book shift would be wrong;
+ *   - skip books with hidden_reason set (takedowns etc. — #3099: sweeps must
+ *     respect it);
+ *   - skip books containing split pages (flagged for manual repair);
+ *   - idempotent via book_events (existing text_shift_repair event = skip).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/repair-bulkjp2-text-shift.mjs --from scripts/output/bulk-archive-alignment.jsonl            # dry run
+ *   node scripts/maintenance/repair-bulkjp2-text-shift.mjs --from scripts/output/bulk-archive-alignment.jsonl --apply
+ *   node scripts/maintenance/repair-bulkjp2-text-shift.mjs --book <mongoIdString>                                        # single book, re-derives live
+ *   node scripts/maintenance/repair-bulkjp2-text-shift.mjs --from <jsonl> --rederive --limit 5 --apply
+ *
+ * Flags:
+ *   --from PATH   JSONL from scripts/audit/bulk-archive-alignment.mjs; rows
+ *                 with verdict shift+1 are the candidate set
+ *   --book ID     candidate book by Mongo _id string (repeatable; implies a
+ *                 live re-derive for that book unless --from also lists it)
+ *   --rederive    re-run the dHash alignment check live instead of trusting
+ *                 the audit rows (network: archive.org + R2)
+ *   --limit N     stop after N candidate books
+ *   --apply       write; default is dry run
+ */
+
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import dotenv from 'dotenv';
+import { nanoid } from 'nanoid';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { checkAlignment, hashBuffer, readerVisibleShift } from '../lib/page-alignment.mjs';
+import { computeTextShiftMoves, SHIFT_FIELDS } from '../lib/text-shift.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+dotenv.config({ path: resolve(REPO_ROOT, '.env.production.local') });
+dotenv.config({ path: resolve(REPO_ROOT, '.env.local') });
+
+const args = process.argv.slice(2);
+/** Accept both `--name value` and `--name=value`. */
+const flag = (name, dflt) => {
+  const eq = args.find(a => a.startsWith(`--${name}=`));
+  if (eq) return eq.slice(name.length + 3);
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] !== undefined ? args[i + 1] : dflt;
+};
+const APPLY = args.includes('--apply');
+const REDERIVE = args.includes('--rederive');
+const FROM = flag('from');
+const LIMIT = parseInt(flag('limit', '0'), 10) || 0;
+const BOOKS = args.flatMap((a, i) => {
+  if (a.startsWith('--book=')) return [a.slice(7)];
+  if (a === '--book' && args[i + 1]) return [args[i + 1]];
+  return [];
+});
+
+const SOURCE_LABEL = 'shift-repair-bulkjp2-2026-08';
+const IA_LEAF_RE = /\/page\/n\d+/;
+const thumbnail = u => String(u).replace(/\/full\/pct:\d+\//, '/full/pct:12/');
+
+async function hashUrl(url) {
+  const r = await fetch(url, { signal: AbortSignal.timeout(45_000) });
+  if (!r.ok) throw new Error(`http ${r.status}`);
+  return hashBuffer(Buffer.from(await r.arrayBuffer()));
+}
+
+/** Candidate list: audit rows (verdict shift+1) and/or explicit --book ids. */
+function buildQueue() {
+  const queue = [];
+  const seen = new Set();
+  const push = (id, fromAudit) => {
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    queue.push({ id, fromAudit });
+  };
+  if (FROM) {
+    const rows = fs.readFileSync(FROM, 'utf8').trim().split('\n')
+      .filter(l => l.trim()).map(l => JSON.parse(l));
+    const shifted = rows.filter(r => r.verdict === 'shift+1');
+    // Worst-off-in-this-cohort first: most self-consistent (= shifted-text) pages.
+    shifted.sort((a, b) => (b.self_consistent_pages || 0) - (a.self_consistent_pages || 0));
+    for (const r of shifted) push(r.book_id, true);
+    console.log(`from-audit: ${rows.length} rows, ${shifted.length} shift+1 candidates`);
+  }
+  for (const id of BOOKS) push(id, false);
+  return queue;
+}
+
+async function repairBook(db, { id: bookId, fromAudit }) {
+  const book = await db.collection('books').findOne(
+    { $expr: { $eq: [{ $toString: '$_id' }, bookId] } },
+    { projection: { title: 1, id: 1, visible: 1, hidden_reason: 1, archive_metadata: 1 } },
+  );
+  if (!book) { console.log(`[SKIP] ${bookId}: book not found`); return 'error'; }
+
+  console.log(`\n=== ${(book.title || '').slice(0, 66)}`);
+  console.log(`    ${bookId} | visible=${book.visible === true}`);
+
+  // Takedowns and other deliberate hides: leave their text alone (#3099).
+  if (book.hidden_reason) {
+    console.log(`  [SKIP] hidden_reason set (${String(book.hidden_reason).slice(0, 60)}) — not touching`);
+    return 'skipped-hidden';
+  }
+  // Image-repaired books had their stale pages flagged needs_reocr by
+  // repair-bulk-jp2-offset.mjs; a whole-book shift on top would be wrong.
+  if (book.archive_metadata?.jp2_offset_repaired) {
+    console.log('  [SKIP] images already re-archived (jp2_offset_repaired) — stale pages are flagged needs_reocr, nothing to shift');
+    return 'skipped-repaired';
+  }
+  const already = await db.collection('book_events').findOne(
+    { book_id: bookId, type: 'text_shift_repair' }, { projection: { _id: 1 } });
+  if (already) { console.log('  [SKIP] already repaired (book_events)'); return 'skipped-done'; }
+
+  const pages = await db.collection('pages').find({ book_id: bookId })
+    .sort({ page_number: 1 }).toArray();
+  const bulk = pages.filter(p => p.archive_metadata?.source === 'bulk_jp2');
+  console.log(`    ${pages.length} pages, ${bulk.length} bulk_jp2`);
+  if (!bulk.length) { console.log('  [SKIP] no bulk_jp2 pages'); return 'skipped-nobulk'; }
+
+  if (pages.some(p => p.split_side)) {
+    console.log('  [SKIP] split pages present — flagging for manual repair');
+    if (APPLY) {
+      await db.collection('books').updateOne({ _id: book._id },
+        { $set: { text_shift_repair_manual: true, updated_at: new Date() } });
+    }
+    return 'skipped-split';
+  }
+
+  // Direction gate — the crucial one. Pre-archival OCR read the IIIF source, so
+  // its text is CORRECT; those books belong to repair-bulk-jp2-offset.mjs
+  // (image-side). Only a book whose bulk_jp2 text uniformly read the shifted
+  // archive is safe to shift.
+  const split = readerVisibleShift(bulk);
+  console.log(`    OCR timing: ${split.visible} pre-archival, ${split.consistent} post-archival, ${split.unknown} unknown`);
+  if (split.visible > 0) {
+    console.log(`  [REFUSE] ${split.visible} pre-archival pages hold CORRECT text — this book is the image-repair cohort (repair-bulk-jp2-offset.mjs), not a text-shift candidate`);
+    return 'refused-prearchival';
+  }
+
+  // Shift gate: the archive must really be shifted. Trust the audit row unless
+  // asked to re-derive; --book ids not present in the audit are always
+  // re-derived — never shift on say-so alone.
+  let verdict = 'shift+1';
+  if (REDERIVE || !fromAudit) {
+    const align = await checkAlignment(pages, {
+      hashUrl,
+      sourceUrlFor: p => thumbnail(p.photo_original || p.photo),
+      isUsableSource: p => IA_LEAF_RE.test(String(p.photo_original || p.photo)),
+      candidates: bulk,
+    });
+    const v = align.votes || { aligned: 0, shift: 0, checked: 0 };
+    console.log(`    alignment (live): ${align.verdict} (${align.detail})`);
+    // Vote gate, same rationale as repair-bulk-jp2-offset.mjs: unanimity is too
+    // brittle (one flaky fetch demotes a real shift to `ambiguous`), but
+    // requiring >=2 shift votes and ZERO aligned votes stays strictly safe.
+    verdict = (v.shift >= 2 && v.aligned === 0) ? 'shift+1' : align.verdict;
+    if (verdict !== 'shift+1') {
+      console.log(`  [REFUSE] insufficient evidence of a shift (aligned=${v.aligned} shift=${v.shift} of ${v.checked})`);
+      return 'refused-notshifted';
+    }
+  }
+
+  const moves = computeTextShiftMoves(pages, { verdict });
+  const byNum = new Map(pages.map(p => [p.page_number, p]));
+  const cleared = moves.filter(m => m.cleared);
+  const clearedWithText = cleared.filter(m => byNum.get(m.page_number)?.ocr?.data);
+  let revisionCount = 0;
+  for (const m of moves) {
+    const dst = byNum.get(m.page_number);
+    for (const f of ['ocr', 'translation']) if (dst?.[f]?.data) revisionCount++;
+  }
+  console.log(`    plan: ${moves.length} moves (${cleared.length} cleared, ${clearedWithText.length} of those need re-OCR), ${revisionCount} page_revisions snapshots`);
+  console.log('    ⚠ follow-up required: re-archive this book\'s images from IIIF, then purge Cloudflare — until then text and image DISAGREE on-page');
+
+  if (!APPLY) { console.log('  [DRY RUN] no writes — pass --apply'); return 'dry-run'; }
+
+  const now = new Date();
+  // Snapshot everything we will overwrite, then write shifted values from the
+  // in-memory copy (no ordering hazard) — same shape as the e-rara repair.
+  const revisions = [];
+  const bulkOps = [];
+  for (const m of moves) {
+    const dst = byNum.get(m.page_number);
+    for (const f of ['ocr', 'translation']) {
+      if (dst[f]?.data) {
+        revisions.push({
+          id: nanoid(12), page_id: dst.id, book_id: bookId, field: f,
+          data: dst[f].data, model: dst[f].model ?? null, language: dst[f].language ?? null,
+          prompt_version: dst[f].prompt_version ?? null, source: SOURCE_LABEL,
+          edited_by: null, job_id: null, original_date: dst[f].updated_at ?? null, created_at: now,
+        });
+      }
+    }
+    const set = { ...m.set, updated_at: now, text_shift_repaired_at: now };
+    if (m.cleared && dst.ocr?.data) {
+      set.needs_reocr = true;
+      set.needs_reocr_reason = 'bulkjp2-text-shift-cleared-#3368';
+    }
+    const update = { $set: set };
+    if (m.unset.length) update.$unset = Object.fromEntries(m.unset.map(f => [f, '']));
+    bulkOps.push({ updateOne: { filter: { _id: dst._id }, update } });
+  }
+
+  if (revisions.length) await db.collection('page_revisions').insertMany(revisions);
+  if (bulkOps.length) await db.collection('pages').bulkWrite(bulkOps);
+
+  const pagesOcr = await db.collection('pages').countDocuments({ book_id: bookId, 'ocr.data': { $exists: true, $ne: '' } });
+  const pagesTr = await db.collection('pages').countDocuments({ book_id: bookId, 'translation.data': { $exists: true, $ne: '' } });
+  await db.collection('books').updateOne(
+    { _id: book._id },
+    { $set: {
+      pages_ocr: pagesOcr, pages_translated: pagesTr, updated_at: now,
+      'archive_metadata.jp2_text_shift_repaired_at': now,
+      // The other half of the repair: the archived images are still one leaf
+      // behind. Cleared once the book is re-archived from IIIF.
+      'archive_metadata.jp2_text_shift_awaiting_image_rearchive': true,
+    } },
+  );
+  await db.collection('book_events').insertOne({
+    book_id: bookId, type: 'text_shift_repair', at: now, source: 'repair-bulkjp2-text-shift',
+    details: {
+      shift: 'text p(N+1)->p(N)', fields: SHIFT_FIELDS,
+      pages: pages.length, bulk_jp2_pages: bulk.length, moves: moves.length,
+      cleared: cleared.length, needs_reocr: clearedWithText.length,
+      revisions: revisions.length, revision_source: SOURCE_LABEL,
+      reason: 'bulk-JP2 zip-ordinal offset (#3368); OCR read the shifted archive',
+      follow_up: 're-archive images from IIIF at the correct leaf, then purge Cloudflare',
+    },
+  });
+  console.log(`  [OK] shifted ${moves.length} pages, snapshotted ${revisions.length} values`);
+  return 'repaired';
+}
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set — source .env.production.local first'); process.exit(1); }
+let queue = buildQueue();
+if (!queue.length) { console.error('nothing to do — pass --from <jsonl> and/or --book <id>'); process.exit(1); }
+if (LIMIT) queue = queue.slice(0, LIMIT);
+
+const mongo = new MongoClient(uri);
+await mongo.connect();
+const db = mongo.db('bookstore');
+
+console.log(APPLY ? `*** APPLY MODE — writing *** (${queue.length} candidate books)` : `--- dry run --- (${queue.length} candidate books)`);
+const tally = {};
+for (const item of queue) {
+  let outcome;
+  try { outcome = await repairBook(db, item); }
+  catch (err) { outcome = 'error'; console.log(`  [ERR] ${item.id}: ${err.message?.slice(0, 120)}`); }
+  tally[outcome] = (tally[outcome] || 0) + 1;
+}
+console.log(`\nDone. ${JSON.stringify(tally)}`);
+if (APPLY && tally.repaired) {
+  console.log('\nREMEMBER: these books now need their images re-archived from IIIF');
+  console.log('(archive_metadata.jp2_text_shift_awaiting_image_rearchive: true), then a Cloudflare purge.');
+}
+await mongo.close();

--- a/tests/unit/bulkjp2-text-shift.test.ts
+++ b/tests/unit/bulkjp2-text-shift.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs script module, no types
+import { computeTextShiftMoves, SHIFT_FIELDS } from '../../scripts/lib/text-shift.mjs';
+
+/**
+ * Pins the p(N+1) -> p(N) text-shift transform used by
+ * scripts/maintenance/repair-bulkjp2-text-shift.mjs (#3368).
+ *
+ * The transform is pure — pages in, moves out — so the repair's core logic is
+ * testable without Mongo. The invariants that matter:
+ *   - anything but a shift+1 verdict produces ZERO moves (fail closed);
+ *   - only bulk_jp2 pages move, and only from bulk_jp2 successors;
+ *   - the last page of each affected run is cleared, never left stale.
+ */
+
+type Page = {
+  page_number: number;
+  archive_metadata?: { source?: string };
+  [k: string]: unknown;
+};
+
+const bulkPage = (n: number, fields: Record<string, unknown> = {}): Page => ({
+  page_number: n,
+  archive_metadata: { source: 'bulk_jp2' },
+  ocr: { data: `ocr-${n}`, model: 'm', updated_at: `t${n}` },
+  translation: { data: `tr-${n}` },
+  page_type: `type-${n}`,
+  ...fields,
+});
+
+const iiifPage = (n: number): Page => ({
+  page_number: n,
+  archive_metadata: { source: 'iiif' },
+  ocr: { data: `ocr-${n}` },
+});
+
+describe('computeTextShiftMoves', () => {
+  it('shifts every bulk_jp2 page one left and clears the last', () => {
+    const pages = [bulkPage(1), bulkPage(2), bulkPage(3)];
+    const moves = computeTextShiftMoves(pages, { verdict: 'shift+1' });
+
+    expect(moves.map((m: { page_number: number }) => m.page_number)).toEqual([1, 2, 3]);
+
+    // p1 takes p2's text, p2 takes p3's.
+    expect(moves[0].src_page_number).toBe(2);
+    expect(moves[0].cleared).toBe(false);
+    expect(moves[0].set.ocr).toEqual({ data: 'ocr-2', model: 'm', updated_at: 't2' });
+    expect(moves[1].set.ocr.data).toBe('ocr-3');
+
+    // Last page of the run: nothing holds its text — cleared, all fields unset.
+    expect(moves[2].cleared).toBe(true);
+    expect(moves[2].src_page_number).toBeNull();
+    expect(moves[2].set).toEqual({});
+    expect(moves[2].unset).toEqual(SHIFT_FIELDS);
+  });
+
+  it('NEGATIVE CONTROL: an aligned book produces zero moves', () => {
+    const pages = [bulkPage(1), bulkPage(2), bulkPage(3)];
+    expect(computeTextShiftMoves(pages, { verdict: 'aligned' })).toEqual([]);
+  });
+
+  it('fails closed on ambiguous, unknown, and missing verdicts', () => {
+    const pages = [bulkPage(1), bulkPage(2)];
+    expect(computeTextShiftMoves(pages, { verdict: 'ambiguous' })).toEqual([]);
+    expect(computeTextShiftMoves(pages, { verdict: 'unknown' })).toEqual([]);
+    expect(computeTextShiftMoves(pages, {})).toEqual([]);
+    expect(computeTextShiftMoves(pages)).toEqual([]);
+  });
+
+  it('a book with no bulk_jp2 pages produces zero moves even when shifted', () => {
+    const pages = [iiifPage(1), iiifPage(2), iiifPage(3)];
+    expect(computeTextShiftMoves(pages, { verdict: 'shift+1' })).toEqual([]);
+  });
+
+  it('never moves text across a path boundary: a non-bulk successor clears, not copies', () => {
+    // Mixed-path book (the Homiliae shape): pages 1-2 bulk_jp2, 3-4 per-page
+    // IIIF. Page 3's text belongs to leaf 3 — pulling it onto page 2 would
+    // corrupt an aligned page's text into a shifted slot.
+    const pages = [bulkPage(1), bulkPage(2), iiifPage(3), iiifPage(4)];
+    const moves = computeTextShiftMoves(pages, { verdict: 'shift+1' });
+
+    expect(moves.map((m: { page_number: number }) => m.page_number)).toEqual([1, 2]);
+    expect(moves[0].src_page_number).toBe(2);
+    expect(moves[1].cleared).toBe(true); // run tail — NOT fed from iiif p3
+    expect(moves[1].set).toEqual({});
+  });
+
+  it('clears at a page-number gap instead of skipping leaves', () => {
+    // p2 is missing: p1's true text (leaf 1) lives nowhere we can reach —
+    // copying p3's text onto p1 would put it two leaves off.
+    const pages = [bulkPage(1), bulkPage(3), bulkPage(4)];
+    const moves = computeTextShiftMoves(pages, { verdict: 'shift+1' });
+
+    expect(moves[0]).toMatchObject({ page_number: 1, cleared: true, src_page_number: null });
+    expect(moves[1]).toMatchObject({ page_number: 3, src_page_number: 4, cleared: false });
+  });
+
+  it('is field-wise: fields the successor lacks are unset, not left stale', () => {
+    const pages = [
+      bulkPage(1),
+      bulkPage(2, { translation: undefined, page_type: undefined }),
+    ];
+    const moves = computeTextShiftMoves(pages, { verdict: 'shift+1' });
+
+    expect(moves[0].set.ocr.data).toBe('ocr-2');
+    expect(moves[0].set).not.toHaveProperty('translation');
+    expect(moves[0].unset).toContain('translation');
+    expect(moves[0].unset).toContain('page_type');
+  });
+
+  it('sorts by page_number internally', () => {
+    const pages = [bulkPage(3), bulkPage(1), bulkPage(2)];
+    const moves = computeTextShiftMoves(pages, { verdict: 'shift+1' });
+    expect(moves.map((m: { page_number: number }) => m.page_number)).toEqual([1, 2, 3]);
+    expect(moves[0].src_page_number).toBe(2);
+    expect(moves[2].cleared).toBe(true);
+  });
+
+  it('honors a custom isTarget predicate', () => {
+    const pages = [iiifPage(1), iiifPage(2)];
+    const moves = computeTextShiftMoves(pages, {
+      verdict: 'shift+1',
+      isTarget: (p: Page) => p.archive_metadata?.source === 'iiif',
+    });
+    expect(moves).toHaveLength(2);
+    expect(moves[0].src_page_number).toBe(2);
+  });
+});


### PR DESCRIPTION
Text-side repair for the bulk-JP2 leaf offset (#3368), mirroring `scripts/maintenance/repair-erara-text-shift.mjs` (#3186). Code only — nothing has been run against production; the operator dry-runs, then applies.

## Which cohort this repairs — and which it refuses

The #3369 audit split the 59 shift+1 books by OCR timing, and the two halves need **opposite** repairs:

| cohort | text | image | repair |
|---|---|---|---|
| pre-archival OCR (severity high/partial, 20 reader-visible books) | correct (read IIIF) | shifted | **image-side** — `repair-bulk-jp2-offset.mjs`, already merged in #3369 |
| post-archival OCR (severity `none`, 39 books) | one leaf behind (read the shifted archive) | shifted | **text-side** — this PR: shift text p(N+1)→p(N), then re-archive images |

`severity: none` books are self-consistent today (text and image agree — both wrong against the true leaf sequence: wrong scan under each page number, text disagreeing with the `photo_original`/IIIF citation pointer). The full repair is this text shift **plus** an image re-archive from IIIF. The script stamps `archive_metadata.jp2_text_shift_awaiting_image_rearchive`, records the follow-up in `book_events`, and the dry run warns that until the images are re-archived the book *reads* worse, not better — sequencing is the operator's call.

## In scope

- **`scripts/maintenance/repair-bulkjp2-text-shift.mjs`** — dry-run by default, `--apply` gate, `--book=<id>` single-book mode, `--from=<jsonl>` (the audit's output; `scripts/output/bulk-archive-alignment.jsonl` is an untracked operator artifact, so also) `--rederive` to recompute alignment live via the shared `page-alignment.mjs`. Snapshots EVERY replaced ocr/translation value to `page_revisions` with source **`shift-repair-bulkjp2-2026-08`** (segmentable per `data-provenance.md`, like `shift-repair-erara-2026-07`), writes a `book_events` record, recounts `pages_ocr`/`pages_translated`. Shifts the same six fields as the e-rara repair: `ocr`, `translation`, `translation_summary`, `translation_keywords`, `page_type`, `columns`.
- **Guards, all fail closed:** REFUSE any book with pre-archival bulk_jp2 OCR (its text is correct — that's the image-repair cohort); refuse non-shift+1 verdicts (vote gate on rederive: ≥2 shift votes and zero aligned, same rationale as `repair-bulk-jp2-offset.mjs`); skip `hidden_reason` books (#3099), split-page books (flagged `text_shift_repair_manual`), already-image-repaired books (`jp2_offset_repaired` — their stale pages already carry `needs_reocr`), and already-shifted books (idempotent via `book_events`); a `--book` id not present in the audit JSONL is always re-derived, never shifted on say-so.
- **`scripts/lib/text-shift.mjs`** — the shift transform as a pure function (`computeTextShiftMoves`), so the repair's core is testable without Mongo. Key divergences from the whole-book e-rara shift, forced by mixed-path books (the Homiliae false-negative lesson from the audit): only `bulk_jp2` pages move; text never crosses an archive-path boundary (a non-bulk successor holds its own correct leaf's text); the tail page of each affected run is cleared + flagged `needs_reocr` rather than left stale; any verdict other than `shift+1` produces zero moves.
- **`tests/unit/bulkjp2-text-shift.test.ts`** — 9 cases pinning the transform, including the required negative control (aligned book ⇒ zero moves), fail-closed on ambiguous/unknown/missing verdicts, mixed-path boundaries, page-number gaps, and field-wise unsets.

## The archiver fix (task 2 of #3368): already present on main, verified — no changes needed

The handoff's "fixes shipped" list landed in **#3369's squash merge (`4ce51ba5`)**, which included `scripts/workers/archive-bulk.mjs` (+138 lines). Verified wired into the current write path on `origin/main`, not just present in the libs:

- `fetchAccessLeaves()` + `indexJp2FilesByLeaf()` (`scripts/lib/ia-access-leaves.mjs`) feed `resolveSrcFile()` — scandata access-leaf mapping, filename-keyed (not positional) zip lookup.
- Fail-closed pre-write verification: `verifyLeafMapping()` dHashes a decoded 3-page sample against each page's own IIIF URL **before any write**; a mismatch — or an unverifiable mapping with no scandata — marks the book `bulk_unsuitable` (+ `bulk_align_failed`) and refuses it. `--skip-align-check` exists for proven-aligned backfills and is never default.

## Out of scope, deliberately

- Running the repair (operator: dry-run → `--apply`).
- The image re-archive for the text-shifted cohort. `repair-bulk-jp2-offset.mjs` refuses severity-none books by design, and its pre-archival gate would still refuse them after a text shift — the follow-up wants a small extension there keyed on `jp2_text_shift_awaiting_image_rearchive`, or a scoped re-archive pass. Kept out to keep this PR one concern.
- Per-page text recovery for the `needs_reocr` pages of already-image-repaired books (some are recoverable from a shifted neighbour, but only page-by-page, not as a whole-book shift).

## Verification

- `node --check` clean on both new .mjs files.
- `npx vitest run` — 2354/2355 passing; the one failure is `tests/unit/fetch-stall-timeout.test.ts` ("completes a slow but steadily-progressing body"), a timing-sensitive test untouched since #3477/#3493 that fails or passes depending on machine load (observed both across three runs with identical code). Unrelated to this PR. The 9 new tests pass in every run.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx
