### PR TITLE
feat(pipeline): priority ordering, semantic health at the door, DB-first stitch prompt, v2 architecture doc (#3756)

### DIFF
--- a/.claude/docs/archive/pipeline-architecture-v1-2026-04.md
+++ b/.claude/docs/archive/pipeline-architecture-v1-2026-04.md
@@ -1,0 +1,462 @@
+# Source Library Pipeline Architecture
+
+> Authoritative reference as of April 2, 2026. Detailed enough for any developer (human or AI) to operate, debug, or migrate the pipeline.
+>
+> **See also:** `pipeline.md` for the full processing pipeline (states, crons, prompts, costs).
+
+---
+
+## Table of Contents
+
+1. [Where Everything Runs](#where-everything-runs)
+2. [Book Lifecycle (State Machine)](#book-lifecycle-state-machine)
+3. [OCR (Gemini Batch API on Hetzner)](#ocr-gemini-batch-api-on-hetzner)
+4. [Translation (Hetzner Inline Worker)](#translation-hetzner-inline-worker)
+5. [Adaptive Limits (Backpressure)](#adaptive-limits-backpressure)
+6. [Emergency Controls](#emergency-controls)
+7. [Current Velocity](#current-velocity-march-18-2026)
+8. [Cost per Page](#cost-per-page-measured)
+9. [Archiving to Cloudflare R2](#archiving-to-cloudflare-r2)
+10. [Known Bugs and Gotchas](#known-bugs--gotchas)
+11. [Batch API Failure History](#batch-api-failure-history)
+12. [How to Switch Back to Vercel](#how-to-switch-back-to-vercel)
+13. [Observability](#observability)
+14. [Hetzner Server Setup (Disaster Recovery)](#hetzner-server-setup-disaster-recovery)
+
+---
+
+## Where Everything Runs
+
+### Vercel (4 lightweight crons)
+
+These are NOT pipeline orchestration -- they handle social posting, health checks, and reporting only.
+
+| Route | Schedule | Purpose |
+|-------|----------|---------|
+| `/api/cron/social-post` | Every 3h | Post to social media |
+| `/api/cron/social-reset` | Daily midnight | Reset social post state |
+| `/api/cron/health-check` | Hourly | System health monitoring |
+| `/api/cron/daily-pipeline-report` | Daily 6am | Email pipeline summary |
+
+Note: `enrich-books` cron code exists in the codebase but is NOT in `vercel.json` -- enrichment runs from Hetzner now.
+
+### Hetzner (root@46.224.122.120, cax31, "clawdbot") -- ALL pipeline orchestration
+
+- Main script: `scripts/workers/pipeline-orchestrator.mjs` (~2000 lines)
+- Independent phase crons with per-phase lock files
+- **Crontab is versioned** at `scripts/workers/crontab.production` (dumped 2026-03-27)
+
+#### Hetzner Cron Schedule
+
+> **Since late March 2026:** All Hetzner crons are managed by a **unified scheduler** (`scripts/workers/scheduler.mjs`, PRs #647/#649). The scheduler is the single crontab entry that spawns all workers below. It enforces a global ~60-connection budget, probes DB health before spawning, and respects `processing_control.paused`. Individual phase crons no longer run independently.
+
+**Pipeline core (high frequency, managed by scheduler):**
+
+| Worker | Interval | Lock file | Purpose |
+|--------|----------|-----------|---------|
+| `pipeline-orchestrator.mjs` (main) | */2 min | `sl-pipeline.lock` | All phases (fallback orchestrator) |
+| `translate-worker.mjs` | */2 min | `sl-translate.lock` | Inline translation via Gemini (no Lambda) |
+| `batch-collector.mjs` | */10 min | `sl-collector.lock` | Poll Gemini Batch API |
+| `archive-bulk.mjs` | */10 min | `sl-archive-bulk.lock` | IA bulk JP2 zip download -> R2 |
+
+**Archiving & image processing (medium frequency):**
+
+| Cron | Interval | Lock file | Purpose |
+|------|----------|-----------|---------|
+| `archive-ocr.mjs` | */30 min | `sl-archive-ocr.lock` | Per-page IIIF download -> R2 |
+| `backfill-display-images.mjs` | */30 min | `sl-display-backfill.lock` | Split-aware display+thumb variant backfill (#1814; replaced the retired `resize-worker.mjs`) |
+| `sync-worker.mjs` | */2 hr | `sl-sync.lock` | Page count cache refresh |
+
+**Daily maintenance:**
+
+| Cron | Time | Lock file | Purpose |
+|------|------|-----------|---------|
+| `warm-author-pages.mjs` | 5:00 UTC | `sl-warm-authors.lock` | ISR cache warmup for author pages |
+| `prewarm-browse.mjs` | 5:15 UTC | `sl-prewarm.lock` | ISR cache warmup for browse pages |
+| `pipeline-health-alert.mjs` | 7:00 UTC | `sl-health.lock` | Daily throughput + storage alerts |
+
+**Vercel proxy (calls Vercel endpoints from Hetzner):**
+
+| Cron | Interval | Lock file | Purpose |
+|------|----------|-----------|---------|
+| `cron-caller.mjs social-post` | */3 hr | `sl-social-post.lock` | Calls Vercel endpoint |
+| `cron-caller.mjs social-reset` | Daily midnight | -- | Calls Vercel endpoint |
+| `cron-caller.mjs daily-pipeline-report` | Daily 6am | -- | Calls Vercel endpoint |
+
+### AWS Lambda (eu-central-1)
+
+| Function | Runtime | Memory | Timeout | Last Modified |
+|----------|---------|--------|---------|---------------|
+| `sourcelibrary-ocr-processor` | Node 24 | 384 MB | 240s | Mar 9 |
+| `sourcelibrary-translation-processor` | Node 24 | 384 MB | 90s | Mar 16 |
+
+- IAM user: `sourcelibrary` (account 984498058219)
+- Narrow permissions: can deploy but can't list functions/queues or read CloudWatch
+
+Deploy command:
+```bash
+npm run lambda:prepare && secret-lover run -- bash -c \
+  'export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_SOURCELIBRARY; \
+   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_SOURCELIBRARY; \
+   aws lambda update-function-code \
+     --function-name sourcelibrary-ocr-processor \
+     --zip-file fileb://dist/packages/ocr-processor.zip \
+     --region eu-central-1'
+```
+
+### SQS Queues (eu-central-1)
+
+| Queue | Type | Notes |
+|-------|------|-------|
+| OCR | Standard (parallel) | -- |
+| Translation | FIFO (sequential per job) | MessageGroupId = job ID |
+| Image extraction | Standard (parallel) | -- |
+| Write results | Standard | Batched: 10 messages, 5s window |
+
+### MongoDB Atlas (db: bookstore)
+
+- ~17K live books + ~24.5K warehouse books, ~3.1M live pages + ~6.4M warehouse pages (as of 2026-04-01)
+- Key collections: `books`, `books_warehouse`, `pages`, `pages_warehouse`, `jobs`, `batch_jobs`, `gemini_usage`, `cron_runs`, `system_config`, `page_revisions`
+- **Saturates at ~40 concurrent Lambda jobs** -- adaptive limits prevent this
+
+---
+
+## Book Lifecycle (State Machine)
+
+```
+Import (API or batch script)
+  |
+  v
+Phase 0: Auto-enroll (books created <14 days, no pipeline_auto)
+  -> queued
+  |
+  v
+Phase 1: Archive check (Hetzner downloads images to R2)
+  -> archiving -> archive_complete (or 24h timeout, advances anyway)
+  |
+  v
+Phase 2: OCR submission (Hetzner builds JSONL, submits to Gemini Batch API)
+  -> ocr_submitted
+  |
+  v
+Phase 3: OCR completion (batch-collector polls Gemini, saves to pages)
+  -> ocr_complete
+  |
+  v
+Phase 3.5: Metadata enrichment (language, categories, description, dates)
+  -> metadata_enriched
+  |
+  v
+Phase 3.7: Transliteration (inline on Hetzner for non-Latin scripts: Greek, Hebrew, Arabic, Chinese, etc.)
+  [No status change -- adds transliteration.data to pages]
+  |
+  v
+Phase 4: Translation dispatch (job created, Hetzner translate-worker picks up)
+  -> translate_submitted
+  |
+  v
+Phase 5: Translation completion (translate-worker processes pages sequentially per book)
+  -> translate_complete
+  |
+  v
+Enrichment (summary + index generation via Gemini)
+  -> enriching -> enriched
+  |
+  v
+Chapter extraction
+  -> chapters -> chapters_complete
+  |
+  v
+Image extraction (Lambda workers via SQS standard queue)
+  -> images_submitted -> images_complete
+  |
+  v
+Finalization (validates >10% OCR coverage)
+  -> complete
+```
+
+### Failure States
+
+| Status | Meaning |
+|--------|---------|
+| `failed` | After 3 retries |
+| `needs_attention` | Manual triage required |
+| `empty_shell` | 0-page imports |
+| `paused` | Manually or automatically paused |
+
+Non-critical phases (enrichment, chapters) skip ahead on persistent failure rather than blocking the pipeline.
+
+---
+
+## OCR (Gemini Batch API on Hetzner)
+
+**Why Hetzner:** 50% cost discount via Batch API, no timeout for hours-long batch waits.
+
+### Flow
+
+1. Phase 2 downloads page images locally from IIIF URLs
+2. Builds JSONL file with OCR prompts + base64 images
+3. File upload for >20 pages (via Gemini File API), inline for <=20 pages
+4. One job per book (was 25 small jobs, changed to avoid 100 concurrent limit)
+5. File-based batches hold ~150 pages per job
+6. API key rotation: `GEMINI_API_KEY_2`, `GEMINI_API_KEY_TIER3`, `GEMINI_API_KEY`
+7. `batch-collector.mjs` polls every 10 min, saves results to `pages.ocr.data`
+
+### Configuration Constants
+
+| Constant | Value |
+|----------|-------|
+| `OCR_INLINE_BATCH_SIZE` | 20 |
+| `OCR_FILE_BATCH_SIZE` | 150 |
+| `MAX_ACTIVE_BATCH_OCR` | 500 |
+| Model | `gemini-3-flash-preview` |
+
+### Cost
+
+$0.0017/page (measured from `gemini_usage`: $354 / 211K pages over 7 days)
+
+---
+
+## Translation (Hetzner Inline Worker)
+
+**Why not Batch API:** Cross-page context continuity. Each page must see the previous page's translation to maintain coherent output. The Batch API returns results in arbitrary order -- this was learned the hard way on Feb 18 when 17K pages got wrong translations.
+
+**Why Hetzner, not Lambda/SQS:** The `translate-worker.mjs` calls Gemini directly, avoiding SQS/Lambda overhead and enabling model routing (flash for BPH, lite for others). Lambda translation still exists for preview and manual jobs.
+
+### Flow (Production)
+
+1. Orchestrator Phase 4 creates a `jobs` record, sets book to `translate_submitted`
+2. `translate-worker.mjs` (Hetzner cron, every 2 min) picks up books in `translate_submitted`
+3. Translates pages sequentially per book (previous page's translation as context)
+4. Calls Gemini directly -- model: `gemini-3-flash-preview` (BPH) or `gemini-3.1-flash-lite-preview` (others)
+5. Writes translation directly to `pages` collection
+6. Rotates API keys on rate limits (up to 11 keys)
+7. Concurrency: 15 books simultaneously (tuned for 60-connection budget), 8,000 page cap per run
+
+### Legacy Lambda Path (Fallback)
+
+Lambda translation processor + SQS FIFO queue still work. Used only for:
+- Preview translation (first 25 pages via `preview-translate.ts`)
+- Manual job submission via `/api/jobs/queue-books`
+
+### Special Cases
+
+- **English books** use `ENGLISH_MODERNIZATION_PROMPT` instead of the translation prompt
+
+### Cost
+
+$0.0045/page (measured: $408 / 91K pages over 7 days)
+
+---
+
+## Adaptive Limits (Backpressure)
+
+Stored in `system_config._id: 'adaptive_limits'`
+
+| Resource | Min | Default | Max |
+|----------|-----|---------|-----|
+| OCR books/run | 2 | 10 | 20 |
+| OCR Lambda concurrency | 3 | 10 | 20 |
+| Translation books/run | 2 | 20 | 50 |
+| Translation Lambda concurrency | 3 | 15 | 30 |
+| Global active jobs | 5 | 20 | 40 |
+| Image extraction/run | 3 | 10 | 20 |
+
+### Health Signal Responses
+
+| Health State | Action |
+|--------------|--------|
+| Healthy | Ramp up 20% |
+| Degraded | Reduce 50% |
+| Critical | Slam to minimums + cancel pending |
+
+Health signals: DB query latency, active job count, cron duration, SQS depth.
+
+**Override:** `PATCH /api/admin/adaptive-limits` with `locked: true`
+
+---
+
+## Emergency Controls
+
+| Action | How |
+|--------|-----|
+| Stop all processing | Set `system_config._id: 'processing_control'` -> `paused: true` |
+| Resume processing | `POST /api/admin/emergency-stop?resume=true` |
+| Selective pause | Set `paused_phases: ['ocr','translation','images']` |
+
+**WARNING:** `paused: true` does NOT stop Lambda workers that are already running. You must CANCEL the jobs in MongoDB to actually stop in-flight work.
+
+---
+
+## Current Velocity (March 18, 2026)
+
+### Last 24 Hours
+
+| Type | Calls | Pages | Cost |
+|------|-------|-------|------|
+| Translation | 57,893 | 56,475 | $221.51 |
+| Index | 4,012 | 44,568 | $23.57 |
+| Transliteration | 21,160 | -- | $17.92 |
+| OCR | 10,921 | 53,083 | $7.17 |
+| FT verification | 1,046 | -- | $4.93 |
+| Image extraction | 966 | 966 | $1.65 |
+| Summary | 91 | 1,602 | $0.70 |
+| Chapters | 93 | 22,417 | $0.69 |
+| **Total** | -- | -- | **$278.14** |
+
+### Last 7 Days
+
+| Type | Calls | Pages | Cost |
+|------|-------|-------|------|
+| Translation | 106,781 | 91,256 | $407.82 |
+| OCR | 139,013 | 211,327 | $354.30 |
+| Index | 19,138 | 163,258 | $112.20 |
+| Transliteration | 21,160 | -- | $17.92 |
+| FT verification | 2,348 | -- | $13.76 |
+| Other | 1,122 | 23,688 | $8.19 |
+| Chapters | 436 | 86,005 | $3.00 |
+| Summary | 306 | 5,126 | $2.40 |
+| Image extraction | 966 | 966 | $1.65 |
+| **Total** | -- | -- | **$921.24** |
+
+### Projections
+
+- Current run rate: ~$130/day average over 7 days, spiking to $278 today
+- Monthly estimate: **~$3,700-$4,000/month**
+- Remaining backlog: ~20K books with no OCR, ~24K with no translation
+- Full processing of backlog: **~$35K** at current per-page costs
+
+---
+
+## Cost per Page (Measured)
+
+| Phase | $/page | Per 300-page book |
+|-------|--------|-------------------|
+| OCR (batch) | $0.0017 | $0.51 |
+| Translation (realtime) | $0.0045 | $1.35 |
+| Index generation | $0.0007 | $0.21 |
+| Image extraction | $0.0017 | $0.51 |
+| Transliteration | ~$0.001 | $0.30 |
+| **Full pipeline** | **~$0.009** | **~$2.70** |
+
+---
+
+## Archiving to Cloudflare R2
+
+Scripts: `archive-ocr.mjs` (every 30 min), `archive-bulk.mjs` (every 10 min), `archive-erara.mjs` (Mac local, every 30 min)
+
+### Flow
+
+1. Finds pages with `photo` set but no `archived_photo` (no OCR required — archiving is a prerequisite for OCR)
+2. Downloads from source IIIF URL
+3. Uploads to `https://images.sourcelibrary.org/archived/{bookId}/{pageNumber}.jpg`
+4. Stores `archive_metadata.archived_at`, `source_url`, `bytes`
+
+### R2 Cost
+
+- Storage: $0.015/GB/month
+- Writes: $4.50/M operations
+- Egress: Free within Cloudflare
+
+---
+
+## Known Bugs & Gotchas
+
+1. **`gemini_usage.timestamp` is a string, not Date.** Date-range queries with Date objects return nothing. Use ObjectId range filtering as a workaround.
+
+2. **Hetzner crontab is local, not in git.** If the server dies, cron config is lost. Must recreate manually from the table in this document.
+
+3. **`paused: true` doesn't stop running Lambdas.** Must cancel jobs in MongoDB to stop in-flight work.
+
+4. **MongoDB saturates at ~40 concurrent Lambda jobs.** Adaptive limits prevent this, but be aware when adjusting limits manually.
+
+5. **Gemini Batch API files are key-scoped.** Must use the same API key for file upload AND job creation. A different key cannot see the uploaded file.
+
+6. **Stale Vercel connection pools after DB recovery.** After any MongoDB outage or failover, redeploy Vercel to reset connection pools.
+
+---
+
+## Batch API Failure History
+
+| Date | Issue | Root Cause | Fix |
+|------|-------|-----------|-----|
+| Feb 18 | 17K pages got wrong translations | Batch results return in arbitrary order; code used array index to match | Match by `metadata.key` instead |
+| Feb 19-20 | 553 orphan jobs in DB | DB records created before Gemini submission; submission failed silently | Atomic insert + submit |
+| Feb 28 | File upload key mismatch | Uploaded with Key 1, created job with Key 0 (files are key-scoped) | Use same key for upload + create |
+| Mar 17 | 700 inline jobs exceeded limit | Many small books -> >100 concurrent batch jobs | One job per book via file upload |
+
+---
+
+## How to Switch Back to Vercel
+
+All pipeline code still exists in the codebase. To re-enable Vercel-based orchestration:
+
+### Steps
+
+1. Add crons back to `vercel.json`:
+```json
+{ "path": "/api/cron/post-import-pipeline", "schedule": "*/10 * * * *" },
+{ "path": "/api/cron/process-batches", "schedule": "*/2 * * * *" },
+{ "path": "/api/cron/submit-batch-ocr", "schedule": "*/10 * * * *" },
+{ "path": "/api/cron/enrich-books", "schedule": "*/10 * * * *" }
+```
+
+2. Disable Hetzner crons (comment out in crontab on `46.224.122.120`)
+
+3. Test that 300s timeout is sufficient -- the March 17 bounded-query optimizations (50 books/cycle) should keep cycles under 300s
+
+4. Cost impact: +$195/month on Vercel plan
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `vercel.json` | Cron schedule |
+| `src/app/api/cron/post-import-pipeline/route.ts` | Main orchestrator |
+| `src/app/api/cron/process-batches/route.ts` | Batch collector |
+| `src/app/api/cron/submit-batch-ocr/route.ts` | OCR submission |
+| `src/app/api/cron/enrich-books/route.ts` | Enrichment |
+| `src/lib/sqs-client.ts` | SQS queue config |
+| `src/lib/queue-utils.ts` | Job enqueueing |
+| `src/lib/gemini-batch.ts` | Batch API client |
+
+---
+
+## Observability
+
+### MongoDB Collections for Monitoring
+
+| Collection | Purpose |
+|------------|---------|
+| `cron_runs` | Execution logs per cron (duration, status, actions, errors) |
+| `gemini_usage` | Every AI call (4.22M records), indexed by type/status/book_id/timestamp |
+| `jobs` | Lambda job tracking |
+| `batch_jobs` | Gemini Batch API job tracking |
+| `page_revisions` | Full OCR/translation history per page |
+| `audit_log` | Admin actions |
+
+### Key API Routes
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/books/{id}/history` | Chronological timeline (6 data sources) |
+| `GET /api/admin/adaptive-limits` | Current limits + health |
+| `POST /api/admin/emergency-stop` | Pause/resume processing |
+| `GET /api/admin/processing-dashboard` | Metrics overview |
+
+---
+
+## Hetzner Server Setup (Disaster Recovery)
+
+If the Hetzner server needs to be recreated from scratch:
+
+1. **Provision:** cax31 (ARM, 8 vCPU, 16GB RAM) -- cheap, plenty for orchestration
+2. **Clone repo:** `git clone <repo-url> /root/sourcelibrary`
+3. **Install runtime:** Node.js 24, then `npm install`
+4. **Environment:** Copy `.env.production.local` from Vercel or local machine
+5. **Set up crontab:** Use entries from the [Hetzner Cron Schedule](#hetzner-cron-schedule) table above
+6. **Create lock directory:** `mkdir -p /root/sourcelibrary/locks`
+7. **Test:** Run `pipeline-orchestrator.mjs --phase 0` manually
+8. **Verify:** Check `cron_runs` collection for successful entries
+
+**WARNING:** There may be local patches on the current server that are not in git. SSH in and check for uncommitted changes before rebuilding from scratch.

--- a/.claude/docs/pipeline-architecture.md
+++ b/.claude/docs/pipeline-architecture.md
@@ -1,462 +1,181 @@
-# Source Library Pipeline Architecture
+# Source Library Pipeline Architecture (v2)
 
-> Authoritative reference as of April 2, 2026. Detailed enough for any developer (human or AI) to operate, debug, or migrate the pipeline.
+> The full line as of August 2026 — stages, the one door, the budget dial, the lanes,
+> and where things actually run. The v1 document (April 2026, the orchestrated era at
+> full throttle) is archived verbatim at `archive/pipeline-architecture-v1-2026-04.md`;
+> its velocity/cost tables and cron schedule describe a topology that no longer runs.
 >
-> **See also:** `pipeline.md` for the full processing pipeline (states, crons, prompts, costs).
+> **See also:** `pipeline.md` (states, prompts, per-phase detail), `memory/pipeline-ops.md`
+> (operational reference, priority ordering, lessons), `translating-a-book.md` (the
+> per-book runbook), `batch-processing.md` (Batch API mechanics).
+> Epics: #3725 (rationalization), #3756 (the full line).
 
 ---
 
-## Table of Contents
+## The line is longer than the state machine
 
-1. [Where Everything Runs](#where-everything-runs)
-2. [Book Lifecycle (State Machine)](#book-lifecycle-state-machine)
-3. [OCR (Gemini Batch API on Hetzner)](#ocr-gemini-batch-api-on-hetzner)
-4. [Translation (Hetzner Inline Worker)](#translation-hetzner-inline-worker)
-5. [Adaptive Limits (Backpressure)](#adaptive-limits-backpressure)
-6. [Emergency Controls](#emergency-controls)
-7. [Current Velocity](#current-velocity-march-18-2026)
-8. [Cost per Page](#cost-per-page-measured)
-9. [Archiving to Cloudflare R2](#archiving-to-cloudflare-r2)
-10. [Known Bugs and Gotchas](#known-bugs--gotchas)
-11. [Batch API Failure History](#batch-api-failure-history)
-12. [How to Switch Back to Vercel](#how-to-switch-back-to-vercel)
-13. [Observability](#observability)
-14. [Hetzner Server Setup (Disaster Recovery)](#hetzner-server-setup-disaster-recovery)
-
----
-
-## Where Everything Runs
-
-### Vercel (4 lightweight crons)
-
-These are NOT pipeline orchestration -- they handle social posting, health checks, and reporting only.
-
-| Route | Schedule | Purpose |
-|-------|----------|---------|
-| `/api/cron/social-post` | Every 3h | Post to social media |
-| `/api/cron/social-reset` | Daily midnight | Reset social post state |
-| `/api/cron/health-check` | Hourly | System health monitoring |
-| `/api/cron/daily-pipeline-report` | Daily 6am | Email pipeline summary |
-
-Note: `enrich-books` cron code exists in the codebase but is NOT in `vercel.json` -- enrichment runs from Hetzner now.
-
-### Hetzner (root@46.224.122.120, cax31, "clawdbot") -- ALL pipeline orchestration
-
-- Main script: `scripts/workers/pipeline-orchestrator.mjs` (~2000 lines)
-- Independent phase crons with per-phase lock files
-- **Crontab is versioned** at `scripts/workers/crontab.production` (dumped 2026-03-27)
-
-#### Hetzner Cron Schedule
-
-> **Since late March 2026:** All Hetzner crons are managed by a **unified scheduler** (`scripts/workers/scheduler.mjs`, PRs #647/#649). The scheduler is the single crontab entry that spawns all workers below. It enforces a global ~60-connection budget, probes DB health before spawning, and respects `processing_control.paused`. Individual phase crons no longer run independently.
-
-**Pipeline core (high frequency, managed by scheduler):**
-
-| Worker | Interval | Lock file | Purpose |
-|--------|----------|-----------|---------|
-| `pipeline-orchestrator.mjs` (main) | */2 min | `sl-pipeline.lock` | All phases (fallback orchestrator) |
-| `translate-worker.mjs` | */2 min | `sl-translate.lock` | Inline translation via Gemini (no Lambda) |
-| `batch-collector.mjs` | */10 min | `sl-collector.lock` | Poll Gemini Batch API |
-| `archive-bulk.mjs` | */10 min | `sl-archive-bulk.lock` | IA bulk JP2 zip download -> R2 |
-
-**Archiving & image processing (medium frequency):**
-
-| Cron | Interval | Lock file | Purpose |
-|------|----------|-----------|---------|
-| `archive-ocr.mjs` | */30 min | `sl-archive-ocr.lock` | Per-page IIIF download -> R2 |
-| `backfill-display-images.mjs` | */30 min | `sl-display-backfill.lock` | Split-aware display+thumb variant backfill (#1814; replaced the retired `resize-worker.mjs`) |
-| `sync-worker.mjs` | */2 hr | `sl-sync.lock` | Page count cache refresh |
-
-**Daily maintenance:**
-
-| Cron | Time | Lock file | Purpose |
-|------|------|-----------|---------|
-| `warm-author-pages.mjs` | 5:00 UTC | `sl-warm-authors.lock` | ISR cache warmup for author pages |
-| `prewarm-browse.mjs` | 5:15 UTC | `sl-prewarm.lock` | ISR cache warmup for browse pages |
-| `pipeline-health-alert.mjs` | 7:00 UTC | `sl-health.lock` | Daily throughput + storage alerts |
-
-**Vercel proxy (calls Vercel endpoints from Hetzner):**
-
-| Cron | Interval | Lock file | Purpose |
-|------|----------|-----------|---------|
-| `cron-caller.mjs social-post` | */3 hr | `sl-social-post.lock` | Calls Vercel endpoint |
-| `cron-caller.mjs social-reset` | Daily midnight | -- | Calls Vercel endpoint |
-| `cron-caller.mjs daily-pipeline-report` | Daily 6am | -- | Calls Vercel endpoint |
-
-### AWS Lambda (eu-central-1)
-
-| Function | Runtime | Memory | Timeout | Last Modified |
-|----------|---------|--------|---------|---------------|
-| `sourcelibrary-ocr-processor` | Node 24 | 384 MB | 240s | Mar 9 |
-| `sourcelibrary-translation-processor` | Node 24 | 384 MB | 90s | Mar 16 |
-
-- IAM user: `sourcelibrary` (account 984498058219)
-- Narrow permissions: can deploy but can't list functions/queues or read CloudWatch
-
-Deploy command:
-```bash
-npm run lambda:prepare && secret-lover run -- bash -c \
-  'export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_SOURCELIBRARY; \
-   export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_SOURCELIBRARY; \
-   aws lambda update-function-code \
-     --function-name sourcelibrary-ocr-processor \
-     --zip-file fileb://dist/packages/ocr-processor.zip \
-     --region eu-central-1'
-```
-
-### SQS Queues (eu-central-1)
-
-| Queue | Type | Notes |
-|-------|------|-------|
-| OCR | Standard (parallel) | -- |
-| Translation | FIFO (sequential per job) | MessageGroupId = job ID |
-| Image extraction | Standard (parallel) | -- |
-| Write results | Standard | Batched: 10 messages, 5s window |
-
-### MongoDB Atlas (db: bookstore)
-
-- ~17K live books + ~24.5K warehouse books, ~3.1M live pages + ~6.4M warehouse pages (as of 2026-04-01)
-- Key collections: `books`, `books_warehouse`, `pages`, `pages_warehouse`, `jobs`, `batch_jobs`, `gemini_usage`, `cron_runs`, `system_config`, `page_revisions`
-- **Saturates at ~40 concurrent Lambda jobs** -- adaptive limits prevent this
-
----
-
-## Book Lifecycle (State Machine)
+`pipeline_auto.status` ends at `complete`, but a *readable, findable* book needs more.
+The full line:
 
 ```
-Import (API or batch script)
-  |
-  v
-Phase 0: Auto-enroll (books created <14 days, no pipeline_auto)
-  -> queued
-  |
-  v
-Phase 1: Archive check (Hetzner downloads images to R2)
-  -> archiving -> archive_complete (or 24h timeout, advances anyway)
-  |
-  v
-Phase 2: OCR submission (Hetzner builds JSONL, submits to Gemini Batch API)
-  -> ocr_submitted
-  |
-  v
-Phase 3: OCR completion (batch-collector polls Gemini, saves to pages)
-  -> ocr_complete
-  |
-  v
-Phase 3.5: Metadata enrichment (language, categories, description, dates)
-  -> metadata_enriched
-  |
-  v
-Phase 3.7: Transliteration (inline on Hetzner for non-Latin scripts: Greek, Hebrew, Arabic, Chinese, etc.)
-  [No status change -- adds transliteration.data to pages]
-  |
-  v
-Phase 4: Translation dispatch (job created, Hetzner translate-worker picks up)
-  -> translate_submitted
-  |
-  v
-Phase 5: Translation completion (translate-worker processes pages sequentially per book)
-  -> translate_complete
-  |
-  v
-Enrichment (summary + index generation via Gemini)
-  -> enriching -> enriched
-  |
-  v
-Chapter extraction
-  -> chapters -> chapters_complete
-  |
-  v
-Image extraction (Lambda workers via SQS standard queue)
-  -> images_submitted -> images_complete
-  |
-  v
-Finalization (validates >10% OCR coverage)
-  -> complete
+import → archive → OCR → translate → distill → images → finalize   ← the state machine
+                                          ↓ downstream (no status field yet — #3756 A1)
+                       embeddings · identity (work/edition) · discoverability
 ```
 
-### Failure States
+**The seven core stages** (each with its status transitions, run by orchestrator phases):
 
-| Status | Meaning |
-|--------|---------|
-| `failed` | After 3 retries |
-| `needs_attention` | Manual triage required |
-| `empty_shell` | 0-page imports |
-| `paused` | Manually or automatically paused |
+| # | Stage | Status flow | Mechanism |
+|---|-------|-------------|-----------|
+| 1 | Import/enroll | → `queued` | import scripts/APIs; Phase 0 auto-enrolls |
+| 2 | Archive | `archiving` → `archive_complete` | Hetzner + local-Mac archivers → R2 |
+| 3 | OCR | → `ocr_submitted` → `ocr_complete` | Phase 2 submit (Gemini Batch, 50% off) + collector |
+| 4 | Translate | → `translate_submitted` → `translate_complete` | Phase 4 dispatch → translate-worker (sequential, cross-page context) |
+| 5 | Distill | → `enriched` → `chapters_complete` | enrich-worker: summary+index, chapters |
+| 6 | Images | → `images_submitted` → `images_complete` | Phase 8 extraction (Lambda/batch) |
+| 7 | Finalize | → `cover_selected` → `complete` | Phase 8.9 + 9 (the live "finalize tail") |
 
-Non-critical phases (enrichment, chapters) skip ahead on persistent failure rather than blocking the pipeline.
+**Downstream stages** — real work, currently statusless (measured 2026-08-08 over
+19,465 live books; see #3756 §A for the coverage table):
 
----
+- **Embeddings** — Supabase workers fill `page_translations`, `book_embeddings`,
+  `artwork_embeddings`, `gallery_text_embeddings`, `clip_embeddings` (see `embeddings.md`).
+  Paid; to be dial-gated when enrolled as phases (#3756 A2).
+- **Identity** — `work_id` (#3260) and `edition_key` (#3710) are ~99% covered and
+  maintained by their own sweeps (see invariants `work-identity.md`, `edition-identity.md`).
+- **Discoverability** — collections, galleries, catalog sync to Supabase, ISR warmup.
 
-## OCR (Gemini Batch API on Hetzner)
-
-**Why Hetzner:** 50% cost discount via Batch API, no timeout for hours-long batch waits.
-
-### Flow
-
-1. Phase 2 downloads page images locally from IIIF URLs
-2. Builds JSONL file with OCR prompts + base64 images
-3. File upload for >20 pages (via Gemini File API), inline for <=20 pages
-4. One job per book (was 25 small jobs, changed to avoid 100 concurrent limit)
-5. File-based batches hold ~150 pages per job
-6. API key rotation: `GEMINI_API_KEY_2`, `GEMINI_API_KEY_TIER3`, `GEMINI_API_KEY`
-7. `batch-collector.mjs` polls every 10 min, saves results to `pages.ocr.data`
-
-### Configuration Constants
-
-| Constant | Value |
-|----------|-------|
-| `OCR_INLINE_BATCH_SIZE` | 20 |
-| `OCR_FILE_BATCH_SIZE` | 150 |
-| `MAX_ACTIVE_BATCH_OCR` | 500 |
-| Model | `gemini-3-flash-preview` |
-
-### Cost
-
-$0.0017/page (measured from `gemini_usage`: $354 / 211K pages over 7 days)
+Books enter mid-line all the time (already-OCR'd imports, re-translations); phases
+select on *predicates* (what's missing), not on history.
 
 ---
 
-## Translation (Hetzner Inline Worker)
+## The one door: translate-core
 
-**Why not Batch API:** Cross-page context continuity. Each page must see the previous page's translation to maintain coherent output. The Batch API returns results in arbitrary order -- this was learned the hard way on Feb 18 when 17K pages got wrong translations.
+Every code path that writes `pages.translation` goes through
+**`scripts/lib/translate-core.mjs`** (issue #3725 — it replaced 13 divergent writers).
+The door enforces:
 
-**Why Hetzner, not Lambda/SQS:** The `translate-worker.mjs` calls Gemini directly, avoiding SQS/Lambda overhead and enabling model routing (flash for BPH, lite for others). Lambda translation still exists for preview and manual jobs.
+1. **Model routing** — `getTranslateModelForBook` (flash for BPH + non-Latin scripts,
+   lite otherwise), never hardcoded.
+2. **Prompts from the DB** — `prompts` collection (`type: 'translation'` /
+   `'english_modernization'`, `is_default: true`); provenance (`prompt_id`, hash,
+   version) stamped on every page.
+3. **Revision before overwrite** — `page_revisions` snapshot inside
+   `writePageTranslation`; callers cannot forget it.
+4. **Counter sync** — `syncBookTranslationCounters` recomputes the canonical
+   visible-pages counters (#3293) and bumps `updated_at` for the Supabase sync.
 
-### Flow (Production)
+Plus the guards: the **human-edit guard** (`source: 'manual'` / `edited_by` is never
+silently overwritten; explicit `overwriteHuman: true` required), the **translatability
+predicate** (`isTranslatablePage` — soft-hidden, skip types, blank-from-OCR,
+recitation/safety blocks), and the **semantic health check** (#3756):
+`assessTranslationHealth(ocrText, translationText)` detects collapsed (body < 800
+chars against real OCR) and runaway (body > 3× OCR body; clears normal CJK expansion,
+#2532) outputs. `writePageTranslation({ refuseUnhealthy: true })` refuses to persist
+an unhealthy result — **opt-in**, used by the repair lane; the production worker's
+behavior is unchanged.
 
-1. Orchestrator Phase 4 creates a `jobs` record, sets book to `translate_submitted`
-2. `translate-worker.mjs` (Hetzner cron, every 2 min) picks up books in `translate_submitted`
-3. Translates pages sequentially per book (previous page's translation as context)
-4. Calls Gemini directly -- model: `gemini-3-flash-preview` (BPH) or `gemini-3.1-flash-lite-preview` (others)
-5. Writes translation directly to `pages` collection
-6. Rotates API keys on rate limits (up to 11 keys)
-7. Concurrency: 15 books simultaneously (tuned for 60-connection budget), 8,000 page cap per run
-
-### Legacy Lambda Path (Fallback)
-
-Lambda translation processor + SQS FIFO queue still work. Used only for:
-- Preview translation (first 25 pages via `preview-translate.ts`)
-- Manual job submission via `/api/jobs/queue-books`
-
-### Special Cases
-
-- **English books** use `ENGLISH_MODERNIZATION_PROMPT` instead of the translation prompt
-
-### Cost
-
-$0.0045/page (measured: $408 / 91K pages over 7 days)
-
----
-
-## Adaptive Limits (Backpressure)
-
-Stored in `system_config._id: 'adaptive_limits'`
-
-| Resource | Min | Default | Max |
-|----------|-----|---------|-----|
-| OCR books/run | 2 | 10 | 20 |
-| OCR Lambda concurrency | 3 | 10 | 20 |
-| Translation books/run | 2 | 20 | 50 |
-| Translation Lambda concurrency | 3 | 15 | 30 |
-| Global active jobs | 5 | 20 | 40 |
-| Image extraction/run | 3 | 10 | 20 |
-
-### Health Signal Responses
-
-| Health State | Action |
-|--------------|--------|
-| Healthy | Ramp up 20% |
-| Degraded | Reduce 50% |
-| Critical | Slam to minimums + cancel pending |
-
-Health signals: DB query latency, active job count, cron duration, SQS depth.
-
-**Override:** `PATCH /api/admin/adaptive-limits` with `locked: true`
+**TS twin** (#3749, in progress): API routes use `src/lib/types/ai-models.ts`
+(routing), `src/lib/prompts.ts` (DB-first prompt fetch, incl. english_modernization
+and the stitch prompt), `src/lib/page-counts.ts` (counters). Parity is pinned by
+`tests/unit/translate-core-parity.test.ts` and `translate-edge-cases.test.ts` — change
+either side and the suite fails. Full route write-through is the remaining #3749 work.
 
 ---
 
-## Emergency Controls
+## The budget dial + spend-guard
 
-| Action | How |
-|--------|-----|
-| Stop all processing | Set `system_config._id: 'processing_control'` -> `paused: true` |
-| Resume processing | `POST /api/admin/emergency-stop?resume=true` |
-| Selective pause | Set `paused_phases: ['ocr','translation','images']` |
+Spend is a **number, not a switch** (`scripts/lib/spend-guard.mjs`, #3737):
 
-**WARNING:** `paused: true` does NOT stop Lambda workers that are already running. You must CANCEL the jobs in MongoDB to actually stop in-flight work.
+- Dial: `system_config.processing_control.daily_budget_usd`.
+- **Default-closed**: unset/null/0 ⇒ no paid dispatch, even with `paused: false`.
+- Orchestrator Phase 2 (OCR submit) and Phase 4 (translation dispatch) call
+  `budgetAllowsDispatch()` each cycle; at the ceiling, dispatch stops. In-flight work
+  always finishes. `--phase N --book=ID` operator runs bypass the dial, like the pause.
+- Spend measured from `gemini_usage` by **ObjectId range** (the `timestamp` field is a
+  string on old rows — Date queries silently return nothing). `cost_usd` is a computed
+  estimate and sometimes absent ⇒ the guard can **undercount**: a brake, not accounting.
+- Every cycle logs `[spend-guard] … spend $X / $Y` — the dial is always visible.
 
----
+Turn-on steps (Derek) are in `memory/pipeline-ops.md` § "The Budget Dial".
 
-## Current Velocity (March 18, 2026)
-
-### Last 24 Hours
-
-| Type | Calls | Pages | Cost |
-|------|-------|-------|------|
-| Translation | 57,893 | 56,475 | $221.51 |
-| Index | 4,012 | 44,568 | $23.57 |
-| Transliteration | 21,160 | -- | $17.92 |
-| OCR | 10,921 | 53,083 | $7.17 |
-| FT verification | 1,046 | -- | $4.93 |
-| Image extraction | 966 | 966 | $1.65 |
-| Summary | 91 | 1,602 | $0.70 |
-| Chapters | 93 | 22,417 | $0.69 |
-| **Total** | -- | -- | **$278.14** |
-
-### Last 7 Days
-
-| Type | Calls | Pages | Cost |
-|------|-------|-------|------|
-| Translation | 106,781 | 91,256 | $407.82 |
-| OCR | 139,013 | 211,327 | $354.30 |
-| Index | 19,138 | 163,258 | $112.20 |
-| Transliteration | 21,160 | -- | $17.92 |
-| FT verification | 2,348 | -- | $13.76 |
-| Other | 1,122 | 23,688 | $8.19 |
-| Chapters | 436 | 86,005 | $3.00 |
-| Summary | 306 | 5,126 | $2.40 |
-| Image extraction | 966 | 966 | $1.65 |
-| **Total** | -- | -- | **$921.24** |
-
-### Projections
-
-- Current run rate: ~$130/day average over 7 days, spiking to $278 today
-- Monthly estimate: **~$3,700-$4,000/month**
-- Remaining backlog: ~20K books with no OCR, ~24K with no translation
-- Full processing of backlog: **~$35K** at current per-page costs
+**Priority within the budget:** `books.processing_priority` (higher first, absent = 0)
+leads every paid candidate sort — Phase 2, Phase 4, translate-worker self-dispatch,
+and the archive crons. Feeder weights (sponsorship 200, reader request 100, fresh
+import 80, curated collection 50): `memory/pipeline-ops.md` § "Priority Ordering".
+So "what will tomorrow's $5 buy" is answerable: the top of that sort.
 
 ---
 
-## Cost per Page (Measured)
+## The collector cron
 
-| Phase | $/page | Per 300-page book |
-|-------|--------|-------------------|
-| OCR (batch) | $0.0017 | $0.51 |
-| Translation (realtime) | $0.0045 | $1.35 |
-| Index generation | $0.0007 | $0.21 |
-| Image extraction | $0.0017 | $0.51 |
-| Transliteration | ~$0.001 | $0.30 |
-| **Full pipeline** | **~$0.009** | **~$2.70** |
+Submitting a Gemini batch is half a transaction — **collection is the other half**,
+and it must always be scheduled, or paid results rot uncollected (the 2026-08 acute
+failure: `process-batches` was archived with no replacement; 22 zombie jobs lost).
 
----
-
-## Archiving to Cloudflare R2
-
-Scripts: `archive-ocr.mjs` (every 30 min), `archive-bulk.mjs` (every 10 min), `archive-erara.mjs` (Mac local, every 30 min)
-
-### Flow
-
-1. Finds pages with `photo` set but no `archived_photo` (no OCR required — archiving is a prerequisite for OCR)
-2. Downloads from source IIIF URL
-3. Uploads to `https://images.sourcelibrary.org/archived/{bookId}/{pageNumber}.jpg`
-4. Stores `archive_metadata.archived_at`, `source_url`, `bytes`
-
-### R2 Cost
-
-- Storage: $0.015/GB/month
-- Writes: $4.50/M operations
-- Egress: Free within Cloudflare
+- **Live:** `scripts/batch/collect-batch-results.mjs` on Hetzner every 30 min
+  (#3713/#3717; `--limit 200 --abandon-stale=7`, log `collect-batch.log`). Collects
+  results for the express-lane routes and any other Batch API submitter.
+- `scripts/workers/batch-collector.mjs` is the orchestrated-era collector (every
+  10 min under the scheduler); returns with the scheduler when the line restarts.
+- **Key rule:** batch jobs are visible only to their creating API key — any collector
+  must hold a **superset** of every submitting key (Vercel/Hetzner key drift caused
+  348 false "failed" jobs, 2026-06-05).
+- **Verify semantically:** `pages_ocr`/`pages_translated` moving is success; a clean
+  collector log is not (`batch_jobs` counters lie by omission — the silent-success
+  incident class).
 
 ---
 
-## Known Bugs & Gotchas
+## The lanes
 
-1. **`gemini_usage.timestamp` is a string, not Date.** Date-range queries with Date objects return nothing. Use ObjectId range filtering as a workaround.
-
-2. **Hetzner crontab is local, not in git.** If the server dies, cron config is lost. Must recreate manually from the table in this document.
-
-3. **`paused: true` doesn't stop running Lambdas.** Must cancel jobs in MongoDB to stop in-flight work.
-
-4. **MongoDB saturates at ~40 concurrent Lambda jobs.** Adaptive limits prevent this, but be aware when adjusting limits manually.
-
-5. **Gemini Batch API files are key-scoped.** Must use the same API key for file upload AND job creation. A different key cannot see the uploaded file.
-
-6. **Stale Vercel connection pools after DB recovery.** After any MongoDB outage or failover, redeploy Vercel to reset connection pools.
+| Lane | Entry | Dial-gated? | Notes |
+|------|-------|-------------|-------|
+| **Orchestrated** | scheduler → `pipeline-orchestrator.mjs` phases → `translate-worker.mjs` | **Yes** (Phases 2 & 4) | Bulk. Sequential translation with cross-page context. Currently dormant (below). |
+| **Express** (one-off books) | `POST /api/books/[id]/batch-ocr-async` / `batch-translate-async`; `/batch-translate` skill; `translating-a-book.md` | No (human-initiated, small) | Spend still logs to `gemini_usage` (counts toward the measured total). Batch-API translation = no cross-page context: sanctioned per-book, banned for bulk. Owed: route dedup against pending `batch_jobs` (double-submit = double-charge, #3756 §D) + TS-door write-through (#3749). |
+| **Preview** | Phase 1.5 preview OCR (first 25 pages, inline); Lambda `preview-translate` via SQS FIFO | Via orchestrator | Gets metadata/classification before full OCR; fast reader preview. |
+| **Repair** | `retranslate-pages.mjs`, `retranslate-stale.mjs`, collapse/loop detectors | No (targeted, paid, `--dry-run` default) | Writes through the door with `refuseUnhealthy: true` — never replaces a bad translation with another bad one. |
+| **Human** | Reader/editor PATCH routes, hand-corrections in Mongo | n/a | Marked `source: 'manual'` / `edited_by`; the door's human-edit guard makes them unoverwritable by every AI lane. |
 
 ---
 
-## Batch API Failure History
+## Machine topology (verified 2026-08-08)
 
-| Date | Issue | Root Cause | Fix |
-|------|-------|-----------|-----|
-| Feb 18 | 17K pages got wrong translations | Batch results return in arbitrary order; code used array index to match | Match by `metadata.key` instead |
-| Feb 19-20 | 553 orphan jobs in DB | DB records created before Gemini submission; submission failed silently | Atomic insert + submit |
-| Feb 28 | File upload key mismatch | Uploaded with Key 1, created job with Key 0 (files are key-scoped) | Use same key for upload + create |
-| Mar 17 | 700 inline jobs exceeded limit | Many small books -> >100 concurrent batch jobs | One job per book via file upload |
+**Hetzner** (`root@46.224.122.120`, auto-pulls `main` ~5 min; crontab source of truth:
+`infrastructure/hetzner-crontab`, orchestrated-era reference `scripts/workers/crontab.production`):
 
----
+| What | Schedule | State |
+|------|----------|-------|
+| Scheduler / main orchestrator loop | (`*/2` when enabled) | **DORMANT** — not in the live crontab; returns when Derek sets the dial + unpauses + re-adds the scheduler line |
+| `translate-worker.mjs`, `enrich-worker.mjs` | (scheduler-managed) | **DORMANT** with the line paused (since 2026-06-08) |
+| Finalize tail — `pipeline-orchestrator.mjs --phase 9` (runs 8.9 + 9) | every 15 min | **LIVE** — completes books whose pages arrive via any lane |
+| `collect-batch-results.mjs` | every 30 min | **LIVE** (#3717) |
+| Archiving + acquisition crons, archiving-watchdog, daily health alert | various | **LIVE** — books keep piling at `archive_complete`; looks like an outage, isn't |
 
-## How to Switch Back to Vercel
+**Local Mac (launchd):** `archive-{erara,harvard,gallica}.mjs` every 30 min — those
+hosts block datacenter IPs. The e-rara warehouse backlog is Mac-only.
 
-All pipeline code still exists in the codebase. To re-enable Vercel-based orchestration:
+**Lambda (eu-central-1):** preview + manual translation (SQS FIFO), image extraction
+(SQS standard). Deprecated for bulk translation.
 
-### Steps
-
-1. Add crons back to `vercel.json`:
-```json
-{ "path": "/api/cron/post-import-pipeline", "schedule": "*/10 * * * *" },
-{ "path": "/api/cron/process-batches", "schedule": "*/2 * * * *" },
-{ "path": "/api/cron/submit-batch-ocr", "schedule": "*/10 * * * *" },
-{ "path": "/api/cron/enrich-books", "schedule": "*/10 * * * *" }
-```
-
-2. Disable Hetzner crons (comment out in crontab on `46.224.122.120`)
-
-3. Test that 300s timeout is sufficient -- the March 17 bounded-query optimizations (50 books/cycle) should keep cycles under 300s
-
-4. Cost impact: +$195/month on Vercel plan
-
-### Key Files
-
-| File | Purpose |
-|------|---------|
-| `vercel.json` | Cron schedule |
-| `src/app/api/cron/post-import-pipeline/route.ts` | Main orchestrator |
-| `src/app/api/cron/process-batches/route.ts` | Batch collector |
-| `src/app/api/cron/submit-batch-ocr/route.ts` | OCR submission |
-| `src/app/api/cron/enrich-books/route.ts` | Enrichment |
-| `src/lib/sqs-client.ts` | SQS queue config |
-| `src/lib/queue-utils.ts` | Job enqueueing |
-| `src/lib/gemini-batch.ts` | Batch API client |
+**Vercel:** the app, the express-lane routes, lightweight crons (social, health,
+daily report). No pipeline orchestration.
 
 ---
 
-## Observability
+## Invariants (read before touching)
 
-### MongoDB Collections for Monitoring
+The scar tissue lives in `.claude/docs/invariants/` — routed from CLAUDE.md by
+subsystem. Most pipeline-relevant: `archive-fetch-failures.md`, `paired-artifacts.md`
+(page images vs OCR must line up), `visibility-and-stats.md`, `quote-and-snippet-integrity.md`,
+`measurement-instruments.md` (job counters lie; measure semantic outputs),
+`request-path-queries.md`. Also: `page_revisions` is a **mixed** corpus — segment by
+`source` before quoting numbers (`data-provenance.md`).
 
-| Collection | Purpose |
-|------------|---------|
-| `cron_runs` | Execution logs per cron (duration, status, actions, errors) |
-| `gemini_usage` | Every AI call (4.22M records), indexed by type/status/book_id/timestamp |
-| `jobs` | Lambda job tracking |
-| `batch_jobs` | Gemini Batch API job tracking |
-| `page_revisions` | Full OCR/translation history per page |
-| `audit_log` | Admin actions |
+Known traps that survived from v1: `gemini_usage.timestamp` is a string (use ObjectId
+ranges); `paused: true` doesn't stop in-flight workers (cancel jobs to actually stop);
+Batch API files/jobs are key-scoped; Mongo saturates near ~40 concurrent Lambda jobs.
 
-### Key API Routes
-
-| Route | Purpose |
-|-------|---------|
-| `GET /api/books/{id}/history` | Chronological timeline (6 data sources) |
-| `GET /api/admin/adaptive-limits` | Current limits + health |
-| `POST /api/admin/emergency-stop` | Pause/resume processing |
-| `GET /api/admin/processing-dashboard` | Metrics overview |
-
----
-
-## Hetzner Server Setup (Disaster Recovery)
-
-If the Hetzner server needs to be recreated from scratch:
-
-1. **Provision:** cax31 (ARM, 8 vCPU, 16GB RAM) -- cheap, plenty for orchestration
-2. **Clone repo:** `git clone <repo-url> /root/sourcelibrary`
-3. **Install runtime:** Node.js 24, then `npm install`
-4. **Environment:** Copy `.env.production.local` from Vercel or local machine
-5. **Set up crontab:** Use entries from the [Hetzner Cron Schedule](#hetzner-cron-schedule) table above
-6. **Create lock directory:** `mkdir -p /root/sourcelibrary/locks`
-7. **Test:** Run `pipeline-orchestrator.mjs --phase 0` manually
-8. **Verify:** Check `cron_runs` collection for successful entries
-
-**WARNING:** There may be local patches on the current server that are not in git. SSH in and check for uncommitted changes before rebuilding from scratch.
+The human-readable layer (explainer + incident record artifacts, #3756 §E) should be
+kept true as phases land.

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -65,6 +65,30 @@ treat the ceiling as a brake, not accounting. The guard logs `spend $X / $Y` eve
 4. Watch `/var/log/sourcelibrary/scheduler.log` + `pipeline.log` for the `[spend-guard]` lines; first candidates processed should be `loop_quarantine_hold` books once those are re-enrolled.
 5. Failure at step 4 = no `[spend-guard]` line at all → the box hasn't pulled main yet (auto-pull ~5 min) or the crontab line didn't take (`crontab -l | grep scheduler`).
 
+## Priority Ordering (#3756)
+
+One field decides who gets processed first: **`books.processing_priority`** (number;
+absent = 0; **higher first**). It is the LEADING sort key in every paid candidate
+query — orchestrator Phase 2 (OCR submit, both passes), Phase 4 (translation
+dispatch, fresh + gap-fill), and translate-worker self-dispatch (fresh + partial) —
+with each query's previous ordering (BPH boost, first-translation flag, speed tier)
+kept as the tiebreak. The archive crons already honored the same field
+(`image-storage-architecture.md`), so one number now moves a book up the whole line.
+
+Feeder sources and their conventional weights (writers stamp the field; also record
+why in `processing_priority_breakdown`):
+
+| Source | Weight |
+|--------|--------|
+| Sponsorship (paid, promised to a donor) | 200 |
+| Reader request (feedback translation-requests) | 100 |
+| Fresh imports (existing import-script default) | 80 |
+| Curated collection membership | 50 |
+
+Legacy note: Phase 2's aggregations also honor an older `pipeline_priority` (≥1 = manual
+boost) inside their computed `_priority` — it now acts as a tiebreak below
+`processing_priority`. Prefer `processing_priority` for anything new.
+
 ## Emergency Controls
 
 - **Stop all:** Set `system_config._id: 'processing_control'` → `paused: true`

--- a/scripts/lib/spend-guard.mjs
+++ b/scripts/lib/spend-guard.mjs
@@ -15,7 +15,7 @@
  * Spend is measured from `gemini_usage`. Two deliberate choices:
  *   - Rows are selected by **ObjectId time range**, not the `timestamp` field —
  *     old rows store timestamp as a string, and Date-range queries silently
- *     return nothing (known trap, pipeline-architecture "Known Bugs" #1).
+ *     return nothing (known trap, pipeline-architecture "Known traps").
  *   - `cost_usd` is a computed estimate, not billed truth, and some writers
  *     omit it. Missing costs count as 0, so the guard can UNDERCOUNT — treat
  *     the ceiling as a strong brake, not an accounting system. The costless

--- a/scripts/lib/translate-core.mjs
+++ b/scripts/lib/translate-core.mjs
@@ -195,6 +195,69 @@ export const contentHash = (t) =>
   createHash('sha256').update(t || '').digest('hex').slice(0, 16);
 
 // ────────────────────────────────────────────────────────────────────────────
+// Semantic health (issue #3756): collapse / runaway detection at the door.
+// Extracted verbatim from scripts/maintenance/retranslate-pages.mjs (which
+// mirrored detect-translation-collapse.mjs) so every writer can ask "is this
+// translation plausibly real?" instead of only the repair script knowing.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Editorial wrapper tags stripped before measuring the translation BODY.
+ * A page whose output is only <summary>/<keywords>/<note> wrappers has no
+ * actual translation, however long the raw string is.
+ */
+export const BLOCK_TAGS = ['meta','image-desc','vocab','summary','keywords','warning','note',
+  'scan-quality','language','page-type','page-num','header','sig','insert','columns','script'];
+const blockRe = new RegExp(`<(${BLOCK_TAGS.join('|')})\\b[^>]*>[\\s\\S]*?</\\1>`, 'gi');
+const looseRe = new RegExp(`</?(${BLOCK_TAGS.join('|')})\\b[^>]*>`, 'gi');
+
+/** Length of the prose body after stripping wrappers, tags, and whitespace. */
+export function bodyLen(text) {
+  if (!text) return 0;
+  return String(text).replace(blockRe, ' ').replace(looseRe, ' ')
+    .replace(/<[^>]+>/g, ' ').replace(/->|<-/g, ' ').replace(/\s+/g, ' ').trim().length;
+}
+
+/**
+ * Collapse = the translation BODY is genuinely short in absolute terms (empty
+ * or a sliver). The absolute cap is essential: dense pages and pages with
+ * huge/artifact-inflated OCR have a low body RATIO but a perfectly adequate
+ * translation — they are NOT collapses. (Verified 2026-06-16: ratio-only
+ * flagged ~20% false positives from oversized OCR denominators.)
+ */
+export const COLLAPSE_ABS_CAP = 800;
+export const isCollapsed = (ocr, tr) => {
+  const ob = bodyLen(ocr), tb = bodyLen(tr);
+  if (ob < 400) return false;
+  if (tb >= COLLAPSE_ABS_CAP) return false;
+  return tb / ob < 0.3 || (/continued from previous page/i.test(tr || '') && tb < 60);
+};
+
+/**
+ * Runaway / repetition loop: translation body far longer than its own OCR
+ * body. Body-based to avoid false positives on low-OCR pages (headers,
+ * image-only). The 3× ratio deliberately clears normal CJK→English expansion
+ * (~3× in chars — #2532 found length-ratio runaway flags were ~97% false
+ * positives on CJK; real loops need a repetition metric, this only catches
+ * the gross ones).
+ */
+export const isExcess = (ocr, tr) => {
+  if ((tr || '').length > 20000) return true;
+  const ob = bodyLen(ocr), tb = bodyLen(tr);
+  return ob >= 300 && tb > ob * 3;
+};
+
+/**
+ * THE semantic health check for a freshly generated translation.
+ * @returns {{healthy: boolean, reason: 'collapsed'|'runaway'|null}}
+ */
+export function assessTranslationHealth(ocrText, translationText) {
+  if (isCollapsed(ocrText, translationText)) return { healthy: false, reason: 'collapsed' };
+  if (isExcess(ocrText, translationText)) return { healthy: false, reason: 'runaway' };
+  return { healthy: true, reason: null };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Edge cases (issue #3734): one definition of "is this page translatable",
 // replacing ~10 forked skip-lists across writers, and the blank-from-OCR
 // detection that previously lived only inside translate-worker.
@@ -273,12 +336,27 @@ export function translatablePageFilter({ extraSkipTypes = [] } = {}) {
  * @param {object} [args.extraSet] extra top-level page fields to $set in the same write
  *                                (e.g. detected_terms) — never translation.* keys
  * @param {boolean} [args.overwriteHuman=false] bypass the human-edit guard
- * @returns {{written: boolean, protected: boolean, text: string}} — when
- *   protected, `text` is the EXISTING human translation (use it for
+ * @param {boolean} [args.refuseUnhealthy=false] OPT-IN semantic health gate:
+ *   assess the new text against the page's OCR (assessTranslationHealth) and
+ *   refuse to write a collapsed/runaway result, returning
+ *   {written:false, unhealthy:true, reason}. Deliberately NOT default-on —
+ *   the production worker's behavior must not change silently (#3756).
+ * @returns {{written: boolean, protected: boolean, unhealthy?: boolean, reason?: string, text: string}}
+ *   — when protected, `text` is the EXISTING human translation (use it for
  *   previous-page continuity); when written, it is the sanitized new text.
  */
-export async function writePageTranslation(db, { page, book, text, promptRef, model, jobId, note, extraSet, overwriteHuman = false }) {
+export async function writePageTranslation(db, { page, book, text, promptRef, model, jobId, note, extraSet, overwriteHuman = false, refuseUnhealthy = false }) {
   const clean = sanitizeTranslationTags(text);
+
+  // Opt-in semantic health gate (#3756): never persist an obviously collapsed
+  // or runaway translation. Checked before any DB access — an unhealthy result
+  // must leave no trace (no revision snapshot, no write).
+  if (refuseUnhealthy) {
+    const health = assessTranslationHealth(page?.ocr?.data, clean);
+    if (!health.healthy) {
+      return { written: false, protected: false, unhealthy: true, reason: health.reason, text: clean };
+    }
+  }
 
   // Human-edit guard (#3734): a translation a person wrote or corrected by
   // hand (source: 'manual', or edited_by set) must never be silently replaced

--- a/scripts/maintenance/retranslate-pages.mjs
+++ b/scripts/maintenance/retranslate-pages.mjs
@@ -55,6 +55,8 @@ import {
   buildTranslationPrompt,
   writePageTranslation,
   syncBookTranslationCounters,
+  assessTranslationHealth,
+  bodyLen,
 } from '../lib/translate-core.mjs';
 
 function getModelForBook(book) {
@@ -76,36 +78,11 @@ const aiClient = () => new GoogleGenerativeAI(API_KEYS[keyIdx++ % API_KEYS.lengt
 
 import { sanitizeTranslationTags } from '../lib/translate-core.mjs';
 
-// ── collapse-guard body measurement (mirror of detect-translation-collapse.mjs) ──
-const BLOCK_TAGS = ['meta','image-desc','vocab','summary','keywords','warning','note',
-  'scan-quality','language','page-type','page-num','header','sig','insert','columns','script'];
-const blockRe = new RegExp(`<(${BLOCK_TAGS.join('|')})\\b[^>]*>[\\s\\S]*?</\\1>`, 'gi');
-const looseRe = new RegExp(`</?(${BLOCK_TAGS.join('|')})\\b[^>]*>`, 'gi');
-function bodyLen(text) {
-  if (!text) return 0;
-  return String(text).replace(blockRe, ' ').replace(looseRe, ' ')
-    .replace(/<[^>]+>/g, ' ').replace(/->|<-/g, ' ').replace(/\s+/g, ' ').trim().length;
-}
-// Collapse = the translation BODY is genuinely short in absolute terms (empty or
-// a sliver). The absolute cap is essential: dense pages and pages with huge/
-// artifact-inflated OCR have a low body RATIO but a perfectly adequate translation
-// — they are NOT collapses. (Verified 2026-06-16: ratio-only flagged ~20% false
-// positives from oversized OCR denominators.)
-const COLLAPSE_ABS_CAP = 800;
-const isCollapsed = (ocr, tr) => {
-  const ob = bodyLen(ocr), tb = bodyLen(tr);
-  if (ob < 400) return false;
-  if (tb >= COLLAPSE_ABS_CAP) return false;
-  return tb / ob < 0.3 || (/continued from previous page/i.test(tr || '') && tb < 60);
-};
-// Runaway / repetition loop: translation body far longer than its own OCR body.
-// Body-based to avoid false positives on low-OCR pages (headers, image-only).
-const isExcess = (ocr, tr) => {
-  if ((tr || '').length > 20000) return true;
-  const ob = bodyLen(ocr), tb = bodyLen(tr);
-  return ob >= 300 && tb > ob * 3;
-};
-const isBad = (ocr, tr) => isCollapsed(ocr, tr) || isExcess(ocr, tr);
+// ── collapse/runaway detection now lives in translate-core (#3756) ──
+// The local copies this file carried were extracted into
+// assessTranslationHealth(ocrText, translationText) so every writer shares
+// one definition of "is this translation plausibly real?".
+const isBad = (ocr, tr) => !assessTranslationHealth(ocr, tr).healthy;
 // Smaller = healthier. 0 when translation body ≈ OCR body.
 const badnessScore = (ocr, tr) => {
   const ob = bodyLen(ocr) || 1, tb = bodyLen(tr) || 1;
@@ -196,12 +173,16 @@ await withMongo(async (db) => {
     // a non-Latin page where flash also loops/collapses), keep the existing text —
     // replacing a bad translation with another bad one wastes tokens and gains
     // nothing. These pages need a benchmark, not a blind re-run.
+    // (refuseUnhealthy below makes the door itself enforce this too.)
     if (isBad(page.ocr.data, best.text)) { stillBad++; return; }
 
-    // The one door: revision snapshot + provenance-stamped write (translate-core).
+    // The one door: revision snapshot + provenance-stamped write (translate-core),
+    // with the semantic health gate armed (#3756).
     const w = await writePageTranslation(db, {
       page, book, text: best.text, promptRef: best.promptRef, model, note: 'anomaly-fix',
+      refuseUnhealthy: true,
     });
+    if (w.unhealthy) { stillBad++; return; }
     if (w.protected) {
       // Human-edited page — the door refused (correctly). Never count as fixed.
       console.log(`  ⛨ ${book.id} p${t.page_number}: human-edited, left untouched`);

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3864,7 +3864,9 @@ Rules:
                 },
               },
             }},
-            { $sort: { _priority: 1, hidden: 1 } },
+            // processing_priority (#3756): explicit queue weight, higher first
+            // (absent sorts last under -1). Existing ordering kept as tiebreak.
+            { $sort: { processing_priority: -1, _priority: 1, hidden: 1 } },
             { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.split_checked': 1 } },
             { $limit: ocrLimit },
           ])
@@ -3969,7 +3971,8 @@ Rules:
               },
             },
           }},
-          { $sort: { _priority: 1, hidden: 1 } },
+          // processing_priority (#3756): explicit queue weight, higher first.
+          { $sort: { processing_priority: -1, _priority: 1, hidden: 1 } },
           { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.recitation_retry_lite': 1, 'pipeline_auto.split_checked': 1 } },
           { $limit: ocrLimit },
         ])
@@ -4499,8 +4502,9 @@ Rules:
           }}}},
           { $addFields: { _bigBook: { $cond: [{ $gte: ['$pages_count', 200] }, 0, 1] } } },
           { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
-          // BPH priority until backlog cleared, then first translations, then speed tier
-          { $sort: { _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
+          // processing_priority (#3756) leads: explicit queue weight, higher first.
+          // Then BPH priority until backlog cleared, then first translations, then speed tier
+          { $sort: { processing_priority: -1, _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
           { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
@@ -4520,9 +4524,11 @@ Rules:
             }},
             { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
             { $match: { _denominator: { $gt: 0 }, $expr: { $lt: [{ $divide: [{ $ifNull: ['$pages_translated', 0] }, '$_denominator'] }, 0.9] } } },
-            { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+            // processing_priority + pages_translated must survive the projection
+            // for the sort below to see them (#3756).
+            { $project: { id: 1, title: 1, pages_count: 1, pages_translated: 1, processing_priority: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
             { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
-            { $sort: { _isBph: 1, pages_translated: -1 } },
+            { $sort: { processing_priority: -1, _isBph: 1, pages_translated: -1 } },
             { $limit: effectiveLimit },
           ]).toArray();
           if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1 });

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -1027,8 +1027,11 @@ async function selfDispatch(db, limit) {
     // Books with ≥200 pages fill the full 200-page cap and finish together.
     // Small books finish early, leaving idle slots. Dispatch big books first.
     { $addFields: { _bigBook: { $cond: [{ $gte: ['$pages_count', 200] }, 0, 1] } } },
-    // First translations prioritized above speed tier — clear untranslated backlog first
-    { $sort: { is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
+    // processing_priority (#3756) leads: explicit queue weight, higher first
+    // (reader requests / sponsorships / curated collections — see
+    // memory/pipeline-ops.md "Priority Ordering"). Then first translations
+    // above speed tier — clear untranslated backlog first.
+    { $sort: { processing_priority: -1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
     { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'image_source.provider': 1 } },
     { $limit: limit },
   ]).toArray();
@@ -1045,8 +1048,10 @@ async function selfDispatch(db, limit) {
       } },
       { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
       { $match: { _denominator: { $gt: 0 }, $expr: { $gte: [{ $divide: ['$pages_translated', '$_denominator'] }, 0] } } },
-      { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'image_source.provider': 1 } },
-      { $sort: { pages_translated: -1 } }, // most-translated first — finish fastest
+      // processing_priority + pages_translated must survive the projection for
+      // the sort below to see them (#3756).
+      { $project: { id: 1, title: 1, pages_count: 1, pages_translated: 1, processing_priority: 1, language: 1, 'image_source.provider': 1 } },
+      { $sort: { processing_priority: -1, pages_translated: -1 } }, // explicit priority first, then most-translated — finish fastest
       { $limit: limit },
     ]).toArray();
     if (candidates.length > 0) {

--- a/src/app/api/books/[id]/stitch-translations/route.ts
+++ b/src/app/api/books/[id]/stitch-translations/route.ts
@@ -32,6 +32,31 @@ const STITCH_PROMPT = `You are reviewing a scholarly translation for continuity 
 If change needed: Return ONLY the smoothed opening paragraph (first 1-3 sentences), followed by "..." to indicate the rest continues unchanged.
 If no change needed: Return exactly "NO_CHANGE_NEEDED"`;
 
+/**
+ * DB-first stitch prompt (#3756), mirroring the english_modernization pattern
+ * in src/lib/prompts.ts getTranslationPrompt: the prompts collection (type:
+ * 'stitch', is_default: true) is the source of truth so the prompt can be
+ * improved without a deploy; the hardcoded constant remains only as a
+ * fallback so stitching never fails closed on a DB hiccup. Not seeded here —
+ * until a 'stitch' prompt row exists, the constant is used.
+ */
+async function getStitchPrompt(
+  db: Awaited<ReturnType<typeof getDb>>
+): Promise<{ text: string; version: string }> {
+  try {
+    const doc = await db.collection('prompts').findOne(
+      { type: 'stitch', is_default: true },
+      { sort: { version: -1 } }
+    );
+    if (doc?.content) {
+      return { text: doc.content as string, version: `stitch-db-v${doc.version ?? 1}` };
+    }
+  } catch (error) {
+    console.error('[stitch] Error fetching stitch prompt from DB:', error);
+  }
+  return { text: STITCH_PROMPT, version: 'stitch-inline-2026-05' };
+}
+
 function calculateCost(inputTokens: number, outputTokens: number, model: string): number {
   const pricing = MODEL_PRICING[model] || MODEL_PRICING['default'];
   const inputCost = (inputTokens / 1_000_000) * pricing.input;
@@ -100,6 +125,8 @@ export const POST = withAuth(async (request, session, context) => {
 
     console.log(`[stitch] Processing ${pages.length} pages for book ${bookId}`);
 
+    const stitchPrompt = await getStitchPrompt(db);
+
     const genAI = getGeminiClient();
     const model = genAI.getGenerativeModel({ model: modelId });
 
@@ -130,7 +157,7 @@ export const POST = withAuth(async (request, session, context) => {
       // Use last 1500 chars of previous page
       const prevEnding = prevTranslation.slice(-1500);
 
-      const prompt = STITCH_PROMPT
+      const prompt = stitchPrompt.text
         .replace('{prev_translation}', prevEnding)
         .replace('{curr_translation}', currTranslation.slice(0, 3000));
 
@@ -223,7 +250,7 @@ export const POST = withAuth(async (request, session, context) => {
         input_tokens: totalInputTokens,
         output_tokens: totalOutputTokens,
         status: 'success',
-        prompt_version: 'stitch-inline-2026-05',
+        prompt_version: stitchPrompt.version,
         endpoint: '/api/books/stitch-translations',
         triggered_by: triggeredBy,
       });

--- a/tests/unit/translation-health.test.ts
+++ b/tests/unit/translation-health.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Semantic health checks at the translation door (issue #3756).
+ *
+ * assessTranslationHealth was extracted from retranslate-pages.mjs; these
+ * fixtures pin the thresholds EXACTLY as ported (COLLAPSE_ABS_CAP 800, the
+ * 0.3 collapse ratio behind a 400-char OCR floor, the 3× runaway ratio, the
+ * 20k raw cap) so a drift in the shared copy fails loudly. The CJK fixture is
+ * the #2532 lesson: length-ratio runaway flags were ~97% false positives on
+ * CJK (which legitimately expands ~3× in chars) — normal expansion must NOT
+ * be flagged.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assessTranslationHealth,
+  bodyLen,
+  isCollapsed,
+  isExcess,
+  COLLAPSE_ABS_CAP,
+  BLOCK_TAGS,
+  writePageTranslation,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/translate-core.mjs';
+
+const latinOcr = 'x'.repeat(2000); // a substantial page (body 2000)
+
+describe('threshold constants (ported exactly from retranslate-pages)', () => {
+  it('COLLAPSE_ABS_CAP is 800', () => {
+    expect(COLLAPSE_ABS_CAP).toBe(800);
+  });
+  it('BLOCK_TAGS carries the editorial-wrapper list', () => {
+    expect(BLOCK_TAGS).toEqual(['meta','image-desc','vocab','summary','keywords','warning','note',
+      'scan-quality','language','page-type','page-num','header','sig','insert','columns','script']);
+  });
+});
+
+describe('bodyLen', () => {
+  it('strips editorial block wrappers before measuring', () => {
+    const tr = `<summary>${'s'.repeat(600)}</summary> ${'x'.repeat(100)}`;
+    expect(bodyLen(tr)).toBe(100);
+  });
+  it('handles null/empty', () => {
+    expect(bodyLen(null)).toBe(0);
+    expect(bodyLen('')).toBe(0);
+  });
+});
+
+describe('collapsed page', () => {
+  it('a wrapper-only sliver against real OCR is collapsed', () => {
+    const tr = `<summary>${'s'.repeat(600)}</summary> ${'x'.repeat(100)}`;
+    expect(isCollapsed(latinOcr, tr)).toBe(true);
+    expect(assessTranslationHealth(latinOcr, tr)).toEqual({ healthy: false, reason: 'collapsed' });
+  });
+
+  it('"continued from previous page" stub under 60 chars is collapsed', () => {
+    const tr = 'Continued from previous page.';
+    expect(assessTranslationHealth('x'.repeat(500), tr)).toEqual({ healthy: false, reason: 'collapsed' });
+  });
+
+  it('dense page: low ratio but body >= 800 is NOT a collapse (absolute cap)', () => {
+    // Ratio-only flagged ~20% false positives from oversized OCR denominators.
+    const tr = 'x'.repeat(800);
+    expect(assessTranslationHealth('x'.repeat(10000), tr).healthy).toBe(true);
+    // one char below the cap with the same low ratio IS a collapse
+    expect(assessTranslationHealth('x'.repeat(10000), 'x'.repeat(799)))
+      .toEqual({ healthy: false, reason: 'collapsed' });
+  });
+
+  it('short OCR (< 400 body) never counts as collapsed', () => {
+    expect(assessTranslationHealth('x'.repeat(399), 'x'.repeat(20)).healthy).toBe(true);
+  });
+});
+
+describe('runaway page', () => {
+  it('translation body > 3x OCR body (OCR >= 300) is a runaway', () => {
+    expect(isExcess('x'.repeat(500), 'x'.repeat(2000))).toBe(true);
+    expect(assessTranslationHealth('x'.repeat(500), 'x'.repeat(2000)))
+      .toEqual({ healthy: false, reason: 'runaway' });
+  });
+
+  it('the 3x ratio is strict: exactly 3x is NOT a runaway', () => {
+    expect(assessTranslationHealth('x'.repeat(300), 'x'.repeat(900)).healthy).toBe(true);
+    expect(assessTranslationHealth('x'.repeat(300), 'x'.repeat(901)).healthy).toBe(false);
+  });
+
+  it('raw length > 20000 is always a runaway, regardless of OCR', () => {
+    expect(assessTranslationHealth('', 'x'.repeat(20001)))
+      .toEqual({ healthy: false, reason: 'runaway' });
+  });
+
+  it('low-OCR pages (headers, image-only) are exempt from the ratio', () => {
+    expect(assessTranslationHealth('x'.repeat(299), 'x'.repeat(5000)).healthy).toBe(true);
+  });
+});
+
+describe('healthy page', () => {
+  it('an ordinary translation of an ordinary page is healthy', () => {
+    expect(assessTranslationHealth(latinOcr, 'x'.repeat(1800)))
+      .toEqual({ healthy: true, reason: null });
+  });
+});
+
+describe('CJK expansion (#2532: NOT a runaway)', () => {
+  it('a ~2.8x char expansion of a CJK page is healthy', () => {
+    const cjkOcr = '道'.repeat(1000); // body 1000
+    const english = 'x'.repeat(2800); // ~2.8x — normal CJK-to-English expansion
+    expect(assessTranslationHealth(cjkOcr, english)).toEqual({ healthy: true, reason: null });
+  });
+});
+
+// ── refuseUnhealthy mode of writePageTranslation ───────────────────────────
+function makeDbStub() {
+  const calls: { updates: unknown[]; revisions: unknown[] } = { updates: [], revisions: [] };
+  const pageDoc = { id: 'p1', book_id: 'b1', translation: { data: 'old ai', source: 'ai' } };
+  const db = {
+    collection(name: string) {
+      return {
+        findOne: async () => pageDoc,
+        find: () => ({ toArray: async () => [pageDoc] }),
+        updateOne: async (...args: unknown[]) => { if (name === 'pages') calls.updates.push(args); return { modifiedCount: 1 }; },
+        insertMany: async (docs: unknown[]) => { if (name === 'page_revisions') calls.revisions.push(...docs); return {}; },
+        aggregate: () => ({ toArray: async () => [] }),
+      };
+    },
+  };
+  return { db, calls };
+}
+
+const baseArgs = {
+  page: { id: 'p1', book_id: 'b1', ocr: { data: latinOcr } },
+  book: { language: 'latin' },
+  promptRef: { id: 'x', name: 'Standard Translation', version: 12 },
+};
+
+describe('writePageTranslation refuseUnhealthy', () => {
+  it('refuses a collapsed result: no write, no revision, reason surfaced', async () => {
+    const { db, calls } = makeDbStub();
+    const r = await writePageTranslation(db, { ...baseArgs, text: 'tiny.', refuseUnhealthy: true });
+    expect(r).toMatchObject({ written: false, unhealthy: true, reason: 'collapsed' });
+    expect(calls.updates.length).toBe(0);
+    expect(calls.revisions.length).toBe(0);
+  });
+
+  it('refuses a runaway result', async () => {
+    const { db, calls } = makeDbStub();
+    const r = await writePageTranslation(db, { ...baseArgs, text: 'x'.repeat(20001), refuseUnhealthy: true });
+    expect(r).toMatchObject({ written: false, unhealthy: true, reason: 'runaway' });
+    expect(calls.updates.length).toBe(0);
+  });
+
+  it('writes a healthy result normally', async () => {
+    const { db, calls } = makeDbStub();
+    const r = await writePageTranslation(db, { ...baseArgs, text: 'x'.repeat(1800), refuseUnhealthy: true });
+    expect(r.written).toBe(true);
+    expect(calls.updates.length).toBe(1);
+  });
+
+  it('is OPT-IN: without the flag an unhealthy result still writes (worker behavior unchanged)', async () => {
+    const { db, calls } = makeDbStub();
+    const r = await writePageTranslation(db, { ...baseArgs, text: 'tiny.' });
+    expect(r.written).toBe(true);
+    expect(r.unhealthy).toBeUndefined();
+    expect(calls.updates.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Implements sections **C**, **D-doc**, and **E** of #3756, plus two door-hardening items from the #3725 lineage.

## In scope

**C — Prioritization as a mechanism.** `books.processing_priority` (number, absent = 0, **higher first**) is now the LEADING sort key in every paid candidate query: orchestrator Phase 2 (OCR submit, preview + full passes), Phase 4 (translation dispatch, fresh + gap-fill), and translate-worker self-dispatch (fresh + partial). Each query's previous ordering (BPH boost, `is_first_translation`, speed tier, `pipeline_priority`) is kept as the tiebreak. Two partial-books pipelines projected away the fields their own `$sort` needed (`pages_translated`, and now `processing_priority`) — the projections now carry them so the sorts are real. Convention + feeder weights (sponsorship 200, reader request 100, fresh import 80, curated collection 50) documented in `memory/pipeline-ops.md` § "Priority Ordering". The archive crons already honored the same field, so one number now moves a book up the whole line.

**Semantic health in the door.** The collapse/runaway detection lived only in `retranslate-pages.mjs`; it's extracted **verbatim** (BLOCK_TAGS, `bodyLen`, `COLLAPSE_ABS_CAP = 800`, the 0.3 ratio behind a 400-char OCR floor, the strict 3× runaway ratio, the 20k raw cap) into `scripts/lib/translate-core.mjs` as `assessTranslationHealth(ocrText, translationText) → {healthy, reason: 'collapsed'|'runaway'|null}`. `writePageTranslation` gains an **opt-in** `refuseUnhealthy: true` mode that returns `{written:false, unhealthy:true, reason}` without writing (checked before the revision snapshot, so a refused result leaves no trace). Deliberately NOT default-on — the production worker's behavior is unchanged. `retranslate-pages.mjs` now imports the shared functions (local copies deleted) and arms `refuseUnhealthy` at its write.

**Stitch prompt DB-first.** `stitch-translations/route.ts` now tries `prompts` (`type: 'stitch'`, `is_default: true`, latest version) and falls back to the hardcoded constant, mirroring the `english_modernization` pattern in `src/lib/prompts.ts`. `prompt_version` logged to `gemini_usage` reflects which source was used. The DB is **not** seeded — until a `stitch` row exists, behavior is byte-identical.

**E — Docs.** `.claude/docs/pipeline-architecture.md` rewritten as the v2 document (181 lines): the seven-stage line + downstream stages (embeddings, identity, discoverability), the one door + TS twin (#3749), the budget dial + spend-guard (#3737), the collector cron (#3717), the five lanes (orchestrated/express/preview/repair/human), machine topology verified 2026-08-08 (orchestrator dormant pending dial enable; `collect-batch-results` live every 30 min; finalize tail every 15 min), and a link-out to the invariants. The v1 doc is archived **verbatim** at `.claude/docs/archive/pipeline-architecture-v1-2026-04.md`; the living filename is unchanged, so all inbound references (`spend-guard.mjs`, system-map pages, `pipeline.md`, `pipeline-ops.md`, `pipeline-diagram.html` — grep-verified) survive.

**Tests.** `tests/unit/translation-health.test.ts` pins the ported thresholds exactly — collapsed page, runaway page, healthy page, dense-page absolute-cap protection, and the **#2532 CJK fixture** (a ~2.8× char expansion must NOT flag as runaway; length-ratio runaway flags were ~97% false positives on CJK). Plus the `refuseUnhealthy` contract incl. a negative control that WITHOUT the flag an unhealthy result still writes.

## Out of scope (deliberately)

- Making `refuseUnhealthy` default-on for translate-worker — a behavior change for the production worker that deserves its own PR + observation window.
- Seeding the `stitch` prompt row (the task said don't).
- Feeder automation that *writes* `processing_priority` (boarding, #3750 — this PR is the consumer side).
- Express-lane `batch_jobs` dedup (#3756 §D) and the TS-door route write-through (#3749).

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 2,363/2,364 green; the 1 failure was in an untouched file and passed on full re-run (flaky); the three translation suites (`translation-health`, `translate-edge-cases`, `translate-core-parity`, 168 tests) green
- `node --check` on all touched `.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx