### PR TITLE
feat(pipeline): boarding mechanism + stall-timeout rollout (#3750)

### DIFF
--- a/scripts/lib/fetch-stall-timeout.mjs
+++ b/scripts/lib/fetch-stall-timeout.mjs
@@ -28,6 +28,9 @@
  * double-page plates this function exists to rescue.
  */
 
+import { createWriteStream } from 'node:fs';
+import { pipeline as streamPipeline } from 'node:stream/promises';
+
 /**
  * @param {string} url
  * @param {object} [opts]
@@ -88,6 +91,78 @@ export async function fetchWithStallTimeout(url, opts = {}) {
     cleanup();
     // Surface WHY it aborted. A bare "This operation was aborted" is what made
     // the original failure read as rate-limiting for two debugging passes.
+    if (abortReason) throw new Error(`fetch aborted: ${abortReason} (${url})`);
+    throw err;
+  }
+}
+
+/**
+ * Same stall semantics, but streamed to a file instead of buffered in memory —
+ * for the archive-bulk / archive-erara whole-book downloads (IA _jp2.zip and
+ * e-rara PDFs run hundreds of MB to GB; buffering them would trade a timeout
+ * bug for an OOM). The stall timer re-arms per chunk while `pipeline()`
+ * preserves backpressure to disk.
+ *
+ * On a non-2xx response nothing is written and `bytes` is 0 — the caller
+ * inspects `res.status`, exactly like fetchWithStallTimeout. On abort the
+ * partial file is left for the caller's tmp-dir cleanup.
+ *
+ * @param {string} url
+ * @param {string} destPath
+ * @param {object} [opts]
+ * @param {number} [opts.stallMs=60000]  Abort if no bytes arrive for this long.
+ * @param {number} [opts.maxMs=900000]   Absolute backstop for a trickling connection.
+ * @param {Record<string,string>} [opts.headers]
+ * @returns {Promise<{ res: Response, bytes: number }>}
+ */
+export async function fetchToFileWithStallTimeout(url, destPath, opts = {}) {
+  const stallMs = opts.stallMs ?? 60_000;
+  const maxMs = opts.maxMs ?? 15 * 60_000;
+  const headers = opts.headers ?? {};
+
+  const controller = new AbortController();
+  let abortReason = null;
+  let stallTimer = null;
+
+  const armStall = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      abortReason = `stalled — no data for ${Math.round(stallMs / 1000)}s`;
+      controller.abort();
+    }, stallMs);
+  };
+  const hardTimer = setTimeout(() => {
+    abortReason = `exceeded absolute cap of ${Math.round(maxMs / 1000)}s`;
+    controller.abort();
+  }, maxMs);
+
+  const cleanup = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    clearTimeout(hardTimer);
+  };
+
+  armStall();
+  try {
+    const res = await fetch(url, { signal: controller.signal, headers });
+    if (!res.ok || !res.body) {
+      cleanup();
+      return { res, bytes: 0 };
+    }
+
+    let bytes = 0;
+    const body = res.body;
+    async function* rearmedChunks() {
+      for await (const chunk of body) {
+        bytes += chunk.length;
+        armStall();
+        yield chunk;
+      }
+    }
+    await streamPipeline(rearmedChunks(), createWriteStream(destPath));
+    cleanup();
+    return { res, bytes };
+  } catch (err) {
+    cleanup();
     if (abortReason) throw new Error(`fetch aborted: ${abortReason} (${url})`);
     throw err;
   }

--- a/scripts/lib/reenroll-eligibility.mjs
+++ b/scripts/lib/reenroll-eligibility.mjs
@@ -1,0 +1,61 @@
+/**
+ * Eligibility predicate for re-enrolling loop-quarantined books (#3750).
+ *
+ * Books at `pipeline_auto.status: 'loop_quarantine_hold'` had recitation-loop
+ * translation garbage cleared by fix-translation-loops.mjs (translations
+ * $unset, pages_translated decremented) and were then parked in a status the
+ * orchestrator never picks up. Re-enrollment resets them to 'ocr_complete' so
+ * Phase 4 dispatches translation again.
+ *
+ * Pure function over the book document so the exclusion rules — above all the
+ * takedown rule — can be unit-tested without a database
+ * (tests/unit/reenroll-eligibility.test.ts).
+ *
+ * Rules, in order:
+ *  1. hidden_reason set (any truthy value) → NEVER re-enter. Takedowns and
+ *     copyright holds must not be resurrected by bulk sweeps — repo lesson
+ *     #3099 (bulk flips must respect hidden_reason). This also covers the
+ *     visible:false + hidden_reason case by construction.
+ *  2. status must still be 'loop_quarantine_hold' (guards races with other
+ *     sessions between the candidate query and the write).
+ *  3. pages_ocr > 0 — 'ocr_complete' is only a truthful re-entry point for a
+ *     book that actually has OCR for Phase 4 to translate.
+ *  4. pages_translated < pages_ocr — the earlier clear decremented the
+ *     counter, so a "fully translated" quarantined book means either the
+ *     garbage was never cleared or the counters are wrong; skip and report
+ *     rather than re-enroll on bad premises.
+ */
+
+export const QUARANTINE_STATUS = 'loop_quarantine_hold';
+export const REENTRY_STATUS = 'ocr_complete';
+
+/**
+ * @param {object} book — needs hidden_reason, pipeline_auto.status,
+ *                        pages_ocr, pages_translated
+ * @returns {{ eligible: boolean, reason: string }}
+ *   reason is 'ok' when eligible, else the exclusion:
+ *   'missing_book' | 'hidden_reason' | 'wrong_status' | 'no_ocr' | 'fully_translated'
+ */
+export function evaluateReenrollment(book) {
+  if (!book) return { eligible: false, reason: 'missing_book' };
+
+  // Rule 1: takedowns never re-enter (#3099). ANY truthy hidden_reason —
+  // including a whitespace-only string or an unexpected shape — excludes.
+  // Fail closed: only absent / null / '' (no takedown recorded) passes.
+  if (book.hidden_reason) {
+    return { eligible: false, reason: 'hidden_reason' };
+  }
+
+  // Rule 2: still quarantined.
+  if (book.pipeline_auto?.status !== QUARANTINE_STATUS) {
+    return { eligible: false, reason: 'wrong_status' };
+  }
+
+  // Rules 3–4: there must be OCR'd pages left untranslated.
+  const ocr = Number(book.pages_ocr) || 0;
+  if (ocr <= 0) return { eligible: false, reason: 'no_ocr' };
+  const translated = Number(book.pages_translated) || 0;
+  if (translated >= ocr) return { eligible: false, reason: 'fully_translated' };
+
+  return { eligible: true, reason: 'ok' };
+}

--- a/scripts/maintenance/board-reader-requests.mjs
+++ b/scripts/maintenance/board-reader-requests.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Board reader-requested books at the head of the line (#3750, queue #3087).
+ *
+ * Gathers book ids from BOTH places reader translation requests live:
+ *   (a) the manual checklist in GitHub issue #3087 (fetched via `gh issue
+ *       view` at runtime — every open request carries a /book/<id> link), and
+ *   (b) the Mongo `feedback` collection, matching the same translation-request
+ *       classifier the /feedback triage uses (the reader widget writes
+ *       "Translation requested for …" messages; see
+ *       scripts/analytics/feedback-triage.mjs CLASSIFIERS).
+ *
+ * …then sets `processing_priority: 100` on those books.
+ *
+ * PRIORITY CONVENTION — `books.processing_priority`: a 0–100 number, HIGHER =
+ * SOONER. This field already exists (scored by src/lib/processing-priority.ts,
+ * viewable at /api/admin/processing-priority; imports seed 80 for fresh
+ * batches; the orchestrator's dispatch sorts read it descending). Reader
+ * requests get 100 — the ceiling — because a human asked for this specific
+ * book; nothing algorithmic should outrank them. Written with $max so an
+ * existing score is only ever raised, and provenance goes in
+ * `processing_priority_breakdown.reader_request` (the breakdown-map convention
+ * the import scripts use).
+ *
+ * Boarding ≠ spending: the budget dial (#3737) still gates dispatch; this only
+ * decides who goes first when the dial allows.
+ *
+ * DRY-RUN BY DEFAULT — writes nothing without --apply. Logs every id it found,
+ * where it came from, and whether it resolved to a book.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/board-reader-requests.mjs            # dry run
+ *   node scripts/maintenance/board-reader-requests.mjs --apply
+ *   node scripts/maintenance/board-reader-requests.mjs --skip-issue   # feedback only (no gh)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { MongoClient, ObjectId } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const SKIP_ISSUE = process.argv.includes('--skip-issue');
+const ISSUE = '3087';
+const PRIORITY = 100;
+
+// Same classifier the feedback triage uses (feedback-triage.mjs) — keep in sync.
+const TRANSLATION_REQUEST_RE = /translation requested for|needs? translation|not (yet )?translated|please translate|translation\?/i;
+const BOOK_ID_RE = /\/book\/([a-f0-9]{24})/g;
+
+const toOid = (id) => { try { return new ObjectId(String(id)); } catch { return null; } };
+
+// ── Source (a): the #3087 checklist ─────────────────────────────────────────
+// id -> Set of provenance notes
+const found = new Map();
+const note = (id, src) => {
+  if (!found.has(id)) found.set(id, new Set());
+  found.get(id).add(src);
+};
+
+if (!SKIP_ISSUE) {
+  try {
+    const body = execFileSync('gh', ['issue', 'view', ISSUE, '--json', 'body', '-q', '.body'], { encoding: 'utf8' });
+    let m; let n = 0;
+    while ((m = BOOK_ID_RE.exec(body)) !== null) { note(m[1], `issue #${ISSUE}`); n++; }
+    console.log(`Issue #${ISSUE}: ${n} /book/ links, ${found.size} unique book ids.`);
+  } catch (err) {
+    console.error(`WARN: could not fetch issue #${ISSUE} via gh (${err.message?.split('\n')[0]}). Continuing with feedback only; use --skip-issue to silence.`);
+  }
+}
+
+// ── Source (b): the feedback collection ─────────────────────────────────────
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
+if (!uri) { console.error('Missing MONGODB_URI'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+
+const fbRows = await db.collection('feedback')
+  .find({ message: TRANSLATION_REQUEST_RE }, { projection: { message: 1, page: 1, created_at: 1 } })
+  .toArray();
+let fbWithBook = 0;
+for (const r of fbRows) {
+  // The reader widget stores the page path (e.g. /book/<id>/page/7); the
+  // message itself names the title, not the id — so the id comes from `page`.
+  const hay = `${r.page || ''} ${r.message || ''}`;
+  let m; let hit = false;
+  BOOK_ID_RE.lastIndex = 0;
+  while ((m = BOOK_ID_RE.exec(hay)) !== null) { note(m[1], `feedback ${String(r._id).slice(-6)}`); hit = true; }
+  if (hit) fbWithBook++;
+}
+console.log(`Feedback: ${fbRows.length} translation-request rows, ${fbWithBook} with a resolvable /book/ id.`);
+console.log(`\n${found.size} unique candidate book ids.\n`);
+
+// ── Resolve + write ─────────────────────────────────────────────────────────
+// Book URLs may carry either the string `id` field or the Mongo _id hex —
+// resolve both (books `id` ≠ `_id` is a known trap).
+let boarded = 0, already = 0, unresolved = 0;
+for (const [rawId, sources] of [...found.entries()].sort()) {
+  const or = [{ id: rawId }];
+  const oid = toOid(rawId);
+  if (oid) or.push({ _id: oid });
+  const book = await db.collection('books').findOne({ $or: or }, {
+    projection: { id: 1, title: 1, display_title: 1, processing_priority: 1, hidden_reason: 1 },
+  });
+  const src = [...sources].join(', ');
+  if (!book) {
+    unresolved++;
+    console.log(`  UNRESOLVED ${rawId}  (${src})`);
+    continue;
+  }
+  const label = `${rawId}  ${(book.display_title || book.title || '?').slice(0, 55)}`;
+  if ((book.processing_priority ?? 0) >= PRIORITY) {
+    already++;
+    console.log(`  ALREADY ${PRIORITY} ${label}`);
+    continue;
+  }
+  console.log(`  ${APPLY ? 'BOARD' : 'WOULD BOARD'} ${label}  (priority ${book.processing_priority ?? 'unset'} -> ${PRIORITY}; ${src})` +
+    (book.hidden_reason ? '  [note: hidden_reason set — prioritized but hidden-book gates still apply]' : ''));
+  boarded++;
+  if (!APPLY) continue;
+  await db.collection('books').updateOne(
+    { _id: book._id },
+    {
+      $max: { processing_priority: PRIORITY },
+      $set: {
+        'processing_priority_breakdown.reader_request': `reader translation request (${src}) — boarded by board-reader-requests.mjs`,
+        updated_at: new Date(),
+      },
+    },
+  );
+}
+
+console.log(`\n=== SUMMARY ===  ${APPLY ? 'boarded' : 'would board'}: ${boarded}, already at ${PRIORITY}: ${already}, unresolved: ${unresolved}`);
+if (!APPLY) console.log('DRY RUN — no writes. Re-run with --apply.');
+await client.close();
+process.exit(0);

--- a/scripts/maintenance/reenroll-quarantined.mjs
+++ b/scripts/maintenance/reenroll-quarantined.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Re-enroll loop-quarantined books into the pipeline (#3750).
+ *
+ * BACKGROUND. fix-translation-loops.mjs cleared recitation-loop translation
+ * garbage (translation.data $unset, pages_translated decremented) and the
+ * affected books were parked at `pipeline_auto.status: 'loop_quarantine_hold'`
+ * — a status the orchestrator never picks up, so they sit outside the line
+ * (~1,393 books). This script boards them again: reset to 'ocr_complete', the
+ * exact status orchestrator Phase 4 reads its fresh-translation candidates
+ * from (pipeline-orchestrator.mjs, `'pipeline_auto.status': { $in:
+ * ['ocr_complete'] }`). Phase 3.1's spread guard and Phase 4's budget dial
+ * (#3737) still apply — re-enrolling puts a book in line, it does not spend.
+ *
+ * PER-BOOK CHECKS (see scripts/lib/reenroll-eligibility.mjs for the pure
+ * predicate, unit-tested in tests/unit/reenroll-eligibility.test.ts):
+ *   - hidden_reason set → NEVER re-enrolled. Takedowns/copyright holds must
+ *     not re-enter via bulk sweeps (repo lesson #3099).
+ *   - counters: pages_ocr > 0 and pages_translated < pages_ocr.
+ *   - actuals (DB, not counters): the book still has OCR'd-but-untranslated
+ *     pages, and no page still carries BOTH the loop-quarantine marker and a
+ *     translation.data — i.e. the earlier clear really happened.
+ *
+ * DRY-RUN BY DEFAULT — writes nothing without --apply. Every decision is
+ * logged. Each re-enrolled book gets a permanent book_events record
+ * (type: 'loop_quarantine_reenroll') — that collection is durable history,
+ * never pruned (see ensure-indexes.mjs).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/reenroll-quarantined.mjs                # dry run, first 100
+ *   node scripts/maintenance/reenroll-quarantined.mjs --limit=500    # dry run, more
+ *   node scripts/maintenance/reenroll-quarantined.mjs --book=<id>    # one book
+ *   node scripts/maintenance/reenroll-quarantined.mjs --apply        # write (bounded by --limit)
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import { evaluateReenrollment, QUARANTINE_STATUS, REENTRY_STATUS } from '../lib/reenroll-eligibility.mjs';
+
+const arg = (name, def) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : def;
+};
+const APPLY = process.argv.includes('--apply');
+const LIMIT = parseInt(arg('limit', '100'), 10);
+const ONE_BOOK = arg('book', null);
+
+const toOid = (id) => { try { return new ObjectId(String(id)); } catch { return null; } };
+
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
+if (!uri) { console.error('Missing MONGODB_URI'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+const pages = db.collection('pages');
+
+console.log(`Re-enroll quarantined books — ${APPLY ? '\x1b[31mAPPLY (writing)\x1b[0m' : 'DRY RUN (no writes)'}`);
+console.log(`  ${QUARANTINE_STATUS} -> ${REENTRY_STATUS}, batch limit ${LIMIT}${ONE_BOOK ? `, scope: book ${ONE_BOOK}` : ''}`);
+
+const query = { 'pipeline_auto.status': QUARANTINE_STATUS };
+if (ONE_BOOK) query.$or = [{ id: ONE_BOOK }, { _id: toOid(ONE_BOOK) }].filter((c) => c.id || c._id);
+
+const total = await books.countDocuments(query);
+const candidates = await books.find(query, {
+  projection: {
+    id: 1, title: 1, display_title: 1, language: 1, hidden_reason: 1, visible: 1,
+    pages_ocr: 1, pages_translated: 1, pages_count: 1, 'pipeline_auto.status': 1,
+  },
+}).limit(LIMIT).toArray();
+console.log(`\n${total.toLocaleString()} books at ${QUARANTINE_STATUS}; examining ${candidates.length} this run.\n`);
+
+const tally = new Map();
+const bump = (reason) => tally.set(reason, (tally.get(reason) || 0) + 1);
+let reenrolled = 0;
+
+for (const book of candidates) {
+  const label = `${book.id || book._id}  ${(book.display_title || book.title || '?').slice(0, 60)}`;
+
+  // Pure predicate over the book doc (counters + hidden_reason + status).
+  const verdict = evaluateReenrollment(book);
+  if (!verdict.eligible) {
+    bump(verdict.reason);
+    console.log(`  SKIP [${verdict.reason}] ${label}` +
+      (verdict.reason === 'hidden_reason' ? `  (hidden_reason: ${JSON.stringify(book.hidden_reason).slice(0, 80)})` : ''));
+    continue;
+  }
+
+  // Actuals, not counters: pages.book_id is a string id — match either the
+  // books.id field or the stringified _id (both conventions exist in the DB).
+  const bookIdKeys = [...new Set([book.id, String(book._id)].filter(Boolean))];
+  const pageScope = { book_id: { $in: bookIdKeys } };
+  const [ocrActual, translatedActual, loopResidue] = await Promise.all([
+    pages.countDocuments({ ...pageScope, 'ocr.data': { $type: 'string' } }),
+    pages.countDocuments({ ...pageScope, 'translation.data': { $type: 'string' } }),
+    // A page that still has BOTH the quarantine marker and translation text
+    // means the loop garbage was never actually cleared for this book.
+    pages.countDocuments({ ...pageScope, 'translation.loop_quarantined_at': { $exists: true }, 'translation.data': { $type: 'string' } }),
+  ]);
+
+  if (loopResidue > 0) {
+    bump('loop_garbage_present');
+    console.log(`  SKIP [loop_garbage_present] ${label}  (${loopResidue} pages still hold quarantined translation text — needs fix-translation-loops.mjs first)`);
+    continue;
+  }
+  if (ocrActual <= 0 || translatedActual >= ocrActual) {
+    bump('no_untranslated_pages_actual');
+    console.log(`  SKIP [no_untranslated_pages_actual] ${label}  (actual ocr=${ocrActual}, translated=${translatedActual}; counters said ${book.pages_ocr}/${book.pages_translated})`);
+    continue;
+  }
+
+  const drift = (Number(book.pages_translated) || 0) !== translatedActual || (Number(book.pages_ocr) || 0) !== ocrActual;
+  console.log(`  ${APPLY ? 'REENROLL' : 'WOULD REENROLL'} ${label}  (${ocrActual - translatedActual} pages to translate` +
+    (drift ? `; counter drift: book says ocr=${book.pages_ocr}/tr=${book.pages_translated}, actual ${ocrActual}/${translatedActual}` : '') + ')');
+  bump('reenrolled');
+
+  if (!APPLY) continue;
+
+  const now = new Date();
+  // Guard on status in the filter so a concurrent write elsewhere loses cleanly.
+  const res = await books.updateOne(
+    { _id: book._id, 'pipeline_auto.status': QUARANTINE_STATUS },
+    {
+      $set: { 'pipeline_auto.status': REENTRY_STATUS, 'pipeline_auto.last_updated': now, updated_at: now },
+      $unset: { job: '' },
+    },
+  );
+  if (res.modifiedCount !== 1) {
+    console.log(`    !! status changed under us — not re-enrolled (modifiedCount=${res.modifiedCount})`);
+    bump('lost_race');
+    continue;
+  }
+  reenrolled++;
+  // Durable provenance — book_events is permanent (never in prune-telemetry).
+  await db.collection('book_events').insertOne({
+    book_id: book.id || String(book._id),
+    type: 'loop_quarantine_reenroll',
+    at: now,
+    source: 'reenroll-quarantined',
+    details: {
+      from_status: QUARANTINE_STATUS,
+      to_status: REENTRY_STATUS,
+      pages_ocr_counter: book.pages_ocr ?? null,
+      pages_translated_counter: book.pages_translated ?? null,
+      pages_ocr_actual: ocrActual,
+      pages_translated_actual: translatedActual,
+      untranslated: ocrActual - translatedActual,
+    },
+  });
+}
+
+console.log('\n=== SUMMARY ===');
+for (const [reason, n] of [...tally.entries()].sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${reason.padEnd(30)} ${String(n).padStart(6)}`);
+}
+if (APPLY) {
+  console.log(`\nRe-enrolled ${reenrolled} books to ${REENTRY_STATUS}. Orchestrator Phase 4 dispatches them when the budget dial allows (#3737).`);
+  if (total > candidates.length) console.log(`${(total - candidates.length).toLocaleString()} books remain quarantined — re-run to process the next batch.`);
+} else {
+  console.log('\nDRY RUN — no writes. Re-run with --apply to re-enroll (bounded by --limit).');
+}
+await client.close();
+process.exit(0);

--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -25,13 +25,12 @@ const execFileAsync = promisify(execFileCb);
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { pipeline } from 'stream/promises';
-import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 import { fetchAccessLeaves, indexJp2FilesByLeaf } from '../lib/ia-access-leaves.mjs';
 import { hashBuffer, hammingHex, HASH_MATCH } from '../lib/page-alignment.mjs';
+import { fetchToFileWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 // CLI args
 const args = process.argv.slice(2);
@@ -147,19 +146,19 @@ async function uploadToR2(key, buffer, contentType = 'image/jpeg') {
   return `${R2_PUBLIC_URL}/${key}`;
 }
 
+// Stall timeout, not a total-duration cap (#3477): a multi-GB _jp2.zip on a
+// slow link legitimately outlives a fixed clock. The old 600s total survives
+// as the absolute backstop; the abort now asks "is data still arriving?".
+const FETCH_STALL_MS = parseInt(process.env.ARCHIVE_STALL_TIMEOUT_MS || '60000', 10);
+
 async function downloadToFile(url, destPath, timeoutMs = 600000) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, { signal: controller.signal, headers: { 'User-Agent': USER_AGENT } });
-    clearTimeout(timeoutId);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    await pipeline(res.body, createWriteStream(destPath));
-    return fs.statSync(destPath).size;
-  } catch (err) {
-    clearTimeout(timeoutId);
-    throw err;
-  }
+  const { res, bytes } = await fetchToFileWithStallTimeout(url, destPath, {
+    stallMs: FETCH_STALL_MS,
+    maxMs: timeoutMs,
+    headers: { 'User-Agent': USER_AGENT },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return bytes;
 }
 
 async function resolveDownloadUrl(iaId) {

--- a/scripts/workers/archive-eap.mjs
+++ b/scripts/workers/archive-eap.mjs
@@ -33,6 +33,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { fetchIiifInfo, fetchIiifNativeRes, shouldTileStitch } from '../lib/iiif-utils.mjs';
+import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -73,17 +74,18 @@ async function uploadToR2(key, buffer, contentType = 'image/jpeg') {
   return `${R2_PUBLIC_URL}/${key}`;
 }
 
+// Stall timeout, not a total-duration cap (#3477): the old 30s-from-start abort
+// selected for the largest page in a book. The old 30s becomes the stall
+// window; the lib's 15-min maxMs is the backstop.
+const FETCH_STALL_MS = parseInt(process.env.ARCHIVE_STALL_TIMEOUT_MS || '30000', 10);
+
 async function downloadImage(url, maxRetries = 3) {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
     try {
-      const res = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeout);
+      const { res, buffer } = await fetchWithStallTimeout(url, { stallMs: FETCH_STALL_MS });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      return Buffer.from(await res.arrayBuffer());
+      return buffer;
     } catch (err) {
-      clearTimeout(timeout);
       if (attempt === maxRetries) throw err;
       await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
     }

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -22,10 +22,9 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { pipeline } from 'stream/promises';
-import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { fetchToFileWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 // CLI args
 const args = process.argv.slice(2);
@@ -78,22 +77,19 @@ async function uploadToR2(key, buffer, contentType = 'image/jpeg') {
   return `${R2_PUBLIC_URL}/${key}`;
 }
 
+// Stall timeout, not a total-duration cap (#3477): a whole-book PDF on a slow
+// link legitimately outlives a fixed clock. The old 600s total survives as the
+// absolute backstop; the abort now asks "is data still arriving?".
+const FETCH_STALL_MS = parseInt(process.env.ARCHIVE_STALL_TIMEOUT_MS || '60000', 10);
+
 async function downloadPdf(url, destPath, timeoutMs = 600000) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: { 'User-Agent': USER_AGENT },
-    });
-    clearTimeout(timeoutId);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    await pipeline(res.body, createWriteStream(destPath));
-    return fs.statSync(destPath).size;
-  } catch (err) {
-    clearTimeout(timeoutId);
-    throw err;
-  }
+  const { res, bytes } = await fetchToFileWithStallTimeout(url, destPath, {
+    stallMs: FETCH_STALL_MS,
+    maxMs: timeoutMs,
+    headers: { 'User-Agent': USER_AGENT },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return bytes;
 }
 
 function extractEraraId(book) {

--- a/scripts/workers/archive-harvard.mjs
+++ b/scripts/workers/archive-harvard.mjs
@@ -21,6 +21,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -81,17 +82,19 @@ async function waitForToken() {
   }
 }
 
+// Stall timeout, not a total-duration cap (#3477): the old 60s-from-start abort
+// selected for the largest page in a book — the foldout, the map, the plate.
+// The old 60s becomes the stall window; the lib's 15-min maxMs is the backstop.
+const FETCH_STALL_MS = parseInt(process.env.ARCHIVE_STALL_TIMEOUT_MS || '60000', 10);
+
 async function downloadImage(url, maxRetries = 4) {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60_000);
     try {
-      const res = await fetch(url, {
-        signal: controller.signal,
+      const { res, buffer } = await fetchWithStallTimeout(url, {
+        stallMs: FETCH_STALL_MS,
         headers: { 'User-Agent': USER_AGENT },
       });
       if (res.status === 429) {
-        clearTimeout(timeout);
         const backoff = 5000 * Math.pow(2, attempt); // 5s, 10s, 20s, 40s
         if (attempt < maxRetries) {
           await new Promise(r => setTimeout(r, backoff));
@@ -100,10 +103,8 @@ async function downloadImage(url, maxRetries = 4) {
         throw new Error(`HTTP 429 after ${maxRetries + 1} attempts`);
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const buffer = Buffer.from(await res.arrayBuffer());
       return buffer;
     } catch (err) {
-      clearTimeout(timeout);
       if (attempt === maxRetries || !err.message?.includes('429')) throw err;
     }
   }

--- a/scripts/workers/archive-iiif-local.mjs
+++ b/scripts/workers/archive-iiif-local.mjs
@@ -49,6 +49,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -134,22 +135,25 @@ async function waitForToken() {
   }
 }
 
+// Stall timeout, not a total-duration cap (#3477): the old TIMEOUT_MS-from-start
+// abort selected for the largest page in a book. --timeout now sets the stall
+// window; the lib's 15-min maxMs is the backstop.
 async function downloadImage(url, maxRetries = 3) {
   for (let attempt = 0; ; attempt++) {
-    const ctrl = new AbortController();
-    const timeout = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
     try {
-      const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT }, signal: ctrl.signal });
-      clearTimeout(timeout);
+      const { res, buffer } = await fetchWithStallTimeout(url, {
+        stallMs: TIMEOUT_MS,
+        headers: { 'User-Agent': USER_AGENT },
+      });
       if (res.status === 429 || res.status >= 500) {
         if (attempt < maxRetries) { await new Promise(r => setTimeout(r, 4000 * Math.pow(2, attempt))); continue; }
         throw new Error(`HTTP ${res.status} after ${maxRetries + 1} attempts`);
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      return Buffer.from(await res.arrayBuffer());
+      return buffer;
     } catch (err) {
-      clearTimeout(timeout);
-      const transient = err.name === 'AbortError' || /ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket|network/i.test(err.message || '');
+      // 'fetch aborted' is the stall/backstop abort — retried, as AbortError was before.
+      const transient = err.name === 'AbortError' || /fetch aborted|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket|network/i.test(err.message || '');
       if (attempt < maxRetries && transient) { await new Promise(r => setTimeout(r, 4000 * Math.pow(2, attempt))); continue; }
       throw err;
     }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -4499,8 +4499,10 @@ Rules:
           }}}},
           { $addFields: { _bigBook: { $cond: [{ $gte: ['$pages_count', 200] }, 0, 1] } } },
           { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
-          // BPH priority until backlog cleared, then first translations, then speed tier
-          { $sort: { _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
+          // Reader requests first (processing_priority 100, board-reader-requests.mjs #3750),
+          // then BPH priority until backlog cleared, then first translations, then speed tier.
+          // Descending sort puts books without the field last — no $addFields needed.
+          { $sort: { processing_priority: -1, _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
           { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
@@ -4520,9 +4522,10 @@ Rules:
             }},
             { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
             { $match: { _denominator: { $gt: 0 }, $expr: { $lt: [{ $divide: [{ $ifNull: ['$pages_translated', 0] }, '$_denominator'] }, 0.9] } } },
-            { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+            { $project: { id: 1, title: 1, pages_count: 1, language: 1, pages_translated: 1, processing_priority: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
             { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
-            { $sort: { _isBph: 1, pages_translated: -1 } },
+            // Reader requests first (#3750) — see the fresh-books sort above.
+            { $sort: { processing_priority: -1, _isBph: 1, pages_translated: -1 } },
             { $limit: effectiveLimit },
           ]).toArray();
           if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1 });

--- a/tests/unit/reenroll-eligibility.test.ts
+++ b/tests/unit/reenroll-eligibility.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Re-enrollment eligibility for loop-quarantined books (#3750).
+ *
+ * The rule that must never regress: a book with hidden_reason set — a takedown
+ * or copyright hold — must NEVER be re-enrolled by a bulk sweep (repo lesson
+ * #3099). The predicate is pure so this is testable without a database.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateReenrollment,
+  QUARANTINE_STATUS,
+  REENTRY_STATUS,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/reenroll-eligibility.mjs';
+
+function quarantinedBook(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'abc123',
+    pipeline_auto: { status: QUARANTINE_STATUS },
+    pages_ocr: 100,
+    pages_translated: 40,
+    visible: true,
+    ...overrides,
+  };
+}
+
+describe('evaluateReenrollment', () => {
+  it('re-enrolls a clean quarantined book with untranslated OCR pages', () => {
+    expect(evaluateReenrollment(quarantinedBook())).toEqual({ eligible: true, reason: 'ok' });
+  });
+
+  it('constants match the orchestrator contract', () => {
+    // Phase 4 reads fresh candidates from ocr_complete; the quarantine status
+    // is the one the orchestrator never picks up.
+    expect(QUARANTINE_STATUS).toBe('loop_quarantine_hold');
+    expect(REENTRY_STATUS).toBe('ocr_complete');
+  });
+
+  describe('hidden_reason exclusion (#3099 — takedowns never re-enter)', () => {
+    it('excludes a takedown string', () => {
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: 'kloss-takedown-2026-06' })))
+        .toEqual({ eligible: false, reason: 'hidden_reason' });
+    });
+
+    it('excludes visible:false + hidden_reason', () => {
+      expect(evaluateReenrollment(quarantinedBook({ visible: false, hidden_reason: 'copyright hold' })))
+        .toEqual({ eligible: false, reason: 'hidden_reason' });
+    });
+
+    it('excludes a non-string truthy hidden_reason (unknown shapes fail closed)', () => {
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: { code: 'takedown' } })).eligible).toBe(false);
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: true })).eligible).toBe(false);
+    });
+
+    it('a whitespace-only hidden_reason blocks (fail closed on weird data)', () => {
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: '  ' })).eligible).toBe(false);
+    });
+
+    it('empty string / null / absent hidden_reason does not block', () => {
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: '' })).eligible).toBe(true);
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: null })).eligible).toBe(true);
+      expect(evaluateReenrollment(quarantinedBook()).eligible).toBe(true);
+    });
+
+    it('hidden_reason wins over every other outcome (checked first)', () => {
+      // Even a book that would be excluded for another reason reports the
+      // takedown, so a log reader sees the strongest exclusion.
+      expect(evaluateReenrollment(quarantinedBook({ hidden_reason: 'takedown', pages_ocr: 0 })))
+        .toEqual({ eligible: false, reason: 'hidden_reason' });
+    });
+
+    it('visible:false alone (hidden import, no takedown) is still eligible', () => {
+      expect(evaluateReenrollment(quarantinedBook({ visible: false })).eligible).toBe(true);
+    });
+  });
+
+  describe('status guard', () => {
+    it('excludes books not at the quarantine status (race protection)', () => {
+      for (const status of [REENTRY_STATUS, 'complete', 'translate_submitted', undefined]) {
+        expect(evaluateReenrollment(quarantinedBook({ pipeline_auto: { status } })))
+          .toEqual({ eligible: false, reason: 'wrong_status' });
+      }
+      expect(evaluateReenrollment(quarantinedBook({ pipeline_auto: undefined })).reason).toBe('wrong_status');
+    });
+  });
+
+  describe('counter checks', () => {
+    it('excludes books without OCR (ocr_complete would be a lie)', () => {
+      expect(evaluateReenrollment(quarantinedBook({ pages_ocr: 0 }))).toEqual({ eligible: false, reason: 'no_ocr' });
+      expect(evaluateReenrollment(quarantinedBook({ pages_ocr: undefined })).reason).toBe('no_ocr');
+    });
+
+    it('excludes fully-translated books (nothing for Phase 4; clear may not have happened)', () => {
+      expect(evaluateReenrollment(quarantinedBook({ pages_translated: 100 })))
+        .toEqual({ eligible: false, reason: 'fully_translated' });
+      expect(evaluateReenrollment(quarantinedBook({ pages_translated: 150 })).reason).toBe('fully_translated');
+    });
+
+    it('treats missing pages_translated as 0 (fully untranslated is the common cleared case)', () => {
+      expect(evaluateReenrollment(quarantinedBook({ pages_translated: undefined })).eligible).toBe(true);
+    });
+  });
+
+  it('handles a missing book', () => {
+    expect(evaluateReenrollment(null)).toEqual({ eligible: false, reason: 'missing_book' });
+  });
+});


### PR DESCRIPTION
Built by the boarding builder for #3750; pushed by the integrator (the builder's typecheck starved behind five parallel compilations — all other verification green in-worktree: node --check all touched files, 14 new unit tests, full unit suite 2,260 green; no dependency files touched, CI arbitrates tsc).

## In scope
- `scripts/maintenance/reenroll-quarantined.mjs` — re-enroll `loop_quarantine_hold` books: dry-run default, `--apply` gate, excludes `hidden_reason` (#3099), verifies cleared translations, bounded batches, book_events records, resets to the Phase-4 re-entry status.
- `scripts/maintenance/board-reader-requests.mjs` — reader-request boarding from issue #3087 + feedback translation-requests → `processing_priority: 100` (dry-run default).
- Stall-timeout rollout (#3477 class): `fetchWithStallTimeout` applied to the archivers still on a total-duration cap — the size-limit-in-costume that silently dropped the largest plates.

Nothing was run against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx