### PR TITLE
feat(pipeline): the TS-side door — human-edit guard everywhere + batch-route dedup (#3749)

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -9,6 +9,7 @@
 
 import { MongoClient } from 'mongodb';
 import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -225,6 +226,13 @@ async function processOneJob(db, job) {
       }
     }
 
+    // Human-edit guard (#3749): pages whose ocr/translation was written or
+    // corrected by a person (source 'manual' or edited_by) are protected —
+    // batch results submitted before the edit must not clobber them.
+    const guardField = job.type === 'ocr' ? 'ocr' : 'translation';
+    const humanEditedIds = await findHumanEditedPageIds(db, pageResults.map(r => r.pageId), guardField);
+    let protectedCount = 0;
+
     // First pass: fix null ocr/translation subdocuments
     const nullFixOps = [];
     for (const { pageId } of pageResults) {
@@ -241,6 +249,11 @@ async function processOneJob(db, job) {
     // Second pass: save results
     const bulkOps = [];
     for (const { pageId, text, usage } of pageResults) {
+      if (humanEditedIds.has(pageId)) {
+        console.log(`  PROTECTED: page ${pageId} has a human-edited ${guardField} — skipping (#3749)`);
+        protectedCount++;
+        continue;
+      }
       if (text.length > 25000) { failCount++; continue; }
 
       if (job.type === 'ocr') {
@@ -319,6 +332,7 @@ async function processOneJob(db, job) {
           gemini_state: 'JOB_STATE_SUCCEEDED',
           completed_pages: successCount,
           failed_pages: failCount,
+          ...(protectedCount > 0 && { protected_pages: protectedCount }),
           results_collected: true,
           completed_at: now,
           updated_at: now,

--- a/scripts/lib/translate-core.mjs
+++ b/scripts/lib/translate-core.mjs
@@ -323,6 +323,30 @@ export async function writePageTranslation(db, { page, book, text, promptRef, mo
 }
 
 /**
+ * Bulk form of the human-edit guard, for batch collectors that write many
+ * pages at once: which of these pages have a human-edited `field`
+ * ('translation' | 'ocr')? Returns the Set of protected page ids — batch
+ * results for those pages must be skipped, not written. Same predicate as
+ * writePageTranslation's guard (source 'manual' or edited_by set); manual
+ * edits stamp the identical convention on both fields (/api/pages/[id]).
+ * TS twin: findHumanEditedPageIds in src/lib/translate-write.ts.
+ */
+export async function findHumanEditedPageIds(db, pageIds, field = 'translation') {
+  if (!pageIds || pageIds.length === 0) return new Set();
+  const docs = await db.collection('pages').find(
+    {
+      id: { $in: pageIds },
+      $or: [
+        { [`${field}.source`]: 'manual' },
+        { [`${field}.edited_by`]: { $exists: true, $nin: [null, ''] } },
+      ],
+    },
+    { projection: { id: 1 } }
+  ).toArray();
+  return new Set(docs.map(d => d.id));
+}
+
+/**
  * Recompute the book's cached page counters with the canonical visible-pages
  * convention (#3293) and bump updated_at (which the Supabase catalog sync
  * keys on — a counter write without updated_at is invisible downstream).

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -24,6 +24,7 @@ import { syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { hasScope } from './lib/selective-unpause.mjs';
 import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
+import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 
 /**
  * Save current page content as a revision before overwriting.
@@ -472,22 +473,32 @@ async function processOneJob(db, job) {
       }
     }
 
+    // Human-edit guard (#3749): pages whose ocr/translation was written or
+    // corrected by a person (source 'manual' or edited_by) are protected —
+    // batch results submitted before the edit must not clobber them.
+    let humanEditedIds = new Set();
+    let protectedCount = 0;
+
     // First pass: fix null ocr/translation subdocuments (skip for image_extraction)
     if (job.type !== 'image_extraction') {
-      const nullFixOps = pageResults.map(({ pageId }) => ({
-        updateOne: {
-          filter: { id: pageId, [job.type === 'ocr' ? 'ocr' : 'translation']: null },
-          update: { $set: { [job.type === 'ocr' ? 'ocr' : 'translation']: {} } },
-        },
-      }));
+      const field = job.type === 'ocr' ? 'ocr' : 'translation';
+      humanEditedIds = await findHumanEditedPageIds(db, pageResults.map(r => r.pageId), field);
+
+      const nullFixOps = pageResults
+        .filter(({ pageId }) => !humanEditedIds.has(pageId))
+        .map(({ pageId }) => ({
+          updateOne: {
+            filter: { id: pageId, [job.type === 'ocr' ? 'ocr' : 'translation']: null },
+            update: { $set: { [job.type === 'ocr' ? 'ocr' : 'translation']: {} } },
+          },
+        }));
       if (nullFixOps.length > 0) {
         await db.collection('pages').bulkWrite(nullFixOps, { ordered: false });
       }
 
       // Save revisions for pages that already have content (non-blocking, parallel)
-      const field = job.type === 'ocr' ? 'ocr' : 'translation';
       const revisionPromises = pageResults
-        .filter(r => r.text.length <= HALLUCINATION_LIMIT)
+        .filter(r => r.text.length <= HALLUCINATION_LIMIT && !humanEditedIds.has(r.pageId))
         .map(r => saveRevisionBeforeOverwrite(db, r.pageId, field, jobIdStr));
       await Promise.allSettled(revisionPromises);
     }
@@ -504,6 +515,11 @@ async function processOneJob(db, job) {
 
     for (const { pageId, text, usage } of pageResults) {
       if (staleDropPages?.has(pageId)) { continue; } // generation guard (#2449)
+      if (humanEditedIds.has(pageId)) {
+        console.log(`  PROTECTED: page ${pageId} has a human-edited ${job.type === 'ocr' ? 'ocr' : 'translation'} — skipping (#3749)`);
+        protectedCount++;
+        continue;
+      }
       if (text.length > HALLUCINATION_LIMIT) { failCount++; continue; }
 
       // Per-page stamp only — the job totals are summed per response above.
@@ -693,10 +709,12 @@ async function processOneJob(db, job) {
     }
 
     // Update batch_jobs status — mark as 'failed' if zero pages saved
-    const finalStatus = successCount > 0 ? 'saved' : 'failed';
-    const errorDetail = successCount === 0 && recitationCount > 0
-      ? `All ${recitationCount} pages blocked by RECITATION filter`
-      : successCount === 0 ? `All ${failCount} pages failed` : undefined;
+    // (pages skipped by the human-edit guard count as handled, not failed)
+    const finalStatus = successCount > 0 || protectedCount > 0 ? 'saved' : 'failed';
+    const errorDetail = finalStatus !== 'failed' ? undefined
+      : recitationCount > 0
+        ? `All ${recitationCount} pages blocked by RECITATION filter`
+        : `All ${failCount} pages failed`;
 
     const costUsd = calculateCost(job.model, totalInputTokens, totalOutputTokens);
 
@@ -708,6 +726,7 @@ async function processOneJob(db, job) {
           gemini_state: 'JOB_STATE_SUCCEEDED',
           completed_pages: successCount,
           failed_pages: failCount,
+          ...(protectedCount > 0 && { protected_pages: protectedCount }),
           results_collected: true,
           completed_at: now,
           updated_at: now,

--- a/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
@@ -8,6 +8,7 @@ import { images } from '@/lib/api-client';
 import { PROMPT_VERSION, extractPageType, extractColumns, parseDetectedImages, parseMultiPageOcr } from '@/lib/types/prompts/defaults';
 import { withAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
+import { findPendingBatchJob } from '@/lib/translate-write';
 import { contentHash } from '@/lib/steganographia';
 import { nanoid } from 'nanoid';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -159,6 +160,7 @@ export const POST = withAuth(async (request, session, context) => {
       force = false, // When true, include pages that already have OCR (for re-processing)
       pagesPerRequest = 1, // >1 enables multi-page mode: N images per Gemini request (saves quota)
       apiKeyIndex, // Optional: rotate between available API keys (0, 1, 2)
+      resubmit = false, // When true, bypass the pending-job double-submit guard
     } = body;
 
     // Use key-specific client if requested (for quota rotation)
@@ -175,6 +177,20 @@ export const POST = withAuth(async (request, session, context) => {
     const book = await db.collection('books').findOne({ id: bookId, tenantId });
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Double-submit guard (#3749, archaeology I68): a pending OCR batch for
+    // this book means submitting again pays Gemini twice for the same pages.
+    // 409 with the existing job; pass resubmit: true to bypass.
+    if (!resubmit) {
+      const pending = await findPendingBatchJob(db, { bookId, type: 'ocr', tenantId });
+      if (pending) {
+        return NextResponse.json({
+          error: 'batch_job_already_pending',
+          message: `An OCR batch job for this book is already pending (submitted ${pending.createdAt?.toISOString?.() || pending.createdAt}). Collect it or pass resubmit: true to force a new submission.`,
+          existingJob: pending,
+        }, { status: 409 });
+      }
     }
 
     // Find pages to OCR

--- a/src/app/api/[tenant]/books/[id]/batch-translate-async/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-translate-async/route.ts
@@ -6,6 +6,7 @@ import { getTriggerSource } from '@/lib/cron-auth';
 import { getTranslationPrompt } from '@/lib/prompts';
 import { PROMPT_VERSION, SKIP_TRANSLATION_PAGE_TYPES } from '@/lib/types/prompts/defaults';
 import { createRevision } from '@/lib/page-revisions';
+import { findHumanEditedPageIds, findPendingBatchJob } from '@/lib/translate-write';
 import { withAuth } from '@/lib/auth-helpers';
 import { VISIBLE_PAGE_MATCH } from '@/lib/page-counts';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -50,6 +51,7 @@ export const POST = withAuth(async (request, session, context) => {
       model = process.env.GEMINI_BATCH_MODEL || 'gemini-3-flash-preview',
       force = false, // When true, include pages that already have translation (for re-processing)
       staleOnly = false, // When true, only retranslate pages where translation model differs from OCR model
+      resubmit = false, // When true, bypass the pending-job double-submit guard
     } = body;
 
     const db = await getDb();
@@ -63,6 +65,20 @@ export const POST = withAuth(async (request, session, context) => {
     const book = await db.collection('books').findOne({ id: bookId, tenantId });
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Double-submit guard (#3749, archaeology I68): a pending translation
+    // batch for this book means submitting again pays Gemini twice for the
+    // same pages. 409 with the existing job; pass resubmit: true to bypass.
+    if (!resubmit) {
+      const pending = await findPendingBatchJob(db, { bookId, type: 'translation', tenantId });
+      if (pending) {
+        return NextResponse.json({
+          error: 'batch_job_already_pending',
+          message: `A translation batch job for this book is already pending (submitted ${pending.createdAt?.toISOString?.() || pending.createdAt}). Collect it or pass resubmit: true to force a new submission.`,
+          existingJob: pending,
+        }, { status: 409 });
+      }
     }
 
     // Find pages to translate (or modernize for English books)
@@ -313,8 +329,14 @@ export const GET = withAuth(async (request, session, context) => {
         const validPageIdSet = new Set(pageIds as string[]);
         const responses = batchJob.dest.inlinedResponses;
 
+        // Human-edit guard (#3749): pages whose translation was written or
+        // corrected by a person (source 'manual' or edited_by) are protected —
+        // batch results submitted before the edit must not clobber it.
+        const protectedPageIds = await findHumanEditedPageIds(db, pageIds as string[], 'translation');
+
         let successCount = 0;
         let failCount = 0;
+        let protectedCount = 0;
         const now = new Date().toISOString();
 
         for (let i = 0; i < responses.length; i++) {
@@ -327,6 +349,12 @@ export const GET = withAuth(async (request, session, context) => {
           if (!pageId || !validPageIdSet.has(pageId)) {
             console.warn(`[batch-translate] Result idx ${i} has invalid pageId: ${pageId}`);
             failCount++;
+            continue;
+          }
+
+          if (protectedPageIds.has(pageId)) {
+            console.log(`[batch-translate] Skipping page ${pageId} — translation is human-edited; refusing to overwrite (#3749)`);
+            protectedCount++;
             continue;
           }
 
@@ -372,6 +400,7 @@ export const GET = withAuth(async (request, session, context) => {
               results_collected: true,
               success_count: successCount,
               fail_count: failCount,
+              ...(protectedCount > 0 && { protected_count: protectedCount }),
               completed_at: new Date()
             }
           }
@@ -433,7 +462,8 @@ export const GET = withAuth(async (request, session, context) => {
           resultsCollected: true,
           successCount,
           failCount,
-          message: `Collected ${successCount} translations`
+          ...(protectedCount > 0 && { protectedCount }),
+          message: `Collected ${successCount} translations${protectedCount > 0 ? ` (${protectedCount} skipped: human-edited)` : ''}`
         });
       }
     }

--- a/src/app/api/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/books/[id]/batch-ocr-async/route.ts
@@ -8,6 +8,7 @@ import { images } from '@/lib/api-client';
 import { PROMPT_VERSION, extractPageType, extractColumns, parseDetectedImages, parseMultiPageOcr } from '@/lib/types/prompts/defaults';
 import { withAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
+import { findPendingBatchJob } from '@/lib/translate-write';
 import { contentHash } from '@/lib/steganographia';
 import { nanoid } from 'nanoid';
 
@@ -158,6 +159,7 @@ export const POST = withAuth(async (request, session, context) => {
       force = false, // When true, include pages that already have OCR (for re-processing)
       pagesPerRequest = 1, // >1 enables multi-page mode: N images per Gemini request (saves quota)
       apiKeyIndex, // Optional: rotate between available API keys (0, 1, 2)
+      resubmit = false, // When true, bypass the pending-job double-submit guard
     } = body;
 
     // Use key-specific client if requested (for quota rotation)
@@ -169,6 +171,20 @@ export const POST = withAuth(async (request, session, context) => {
     const book = await db.collection('books').findOne({ id: bookId });
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Double-submit guard (#3749, archaeology I68): a pending OCR batch for
+    // this book means submitting again pays Gemini twice for the same pages.
+    // 409 with the existing job; pass resubmit: true to bypass.
+    if (!resubmit) {
+      const pending = await findPendingBatchJob(db, { bookId, type: 'ocr' });
+      if (pending) {
+        return NextResponse.json({
+          error: 'batch_job_already_pending',
+          message: `An OCR batch job for this book is already pending (submitted ${pending.createdAt?.toISOString?.() || pending.createdAt}). Collect it or pass resubmit: true to force a new submission.`,
+          existingJob: pending,
+        }, { status: 409 });
+      }
     }
 
     // Find pages to OCR

--- a/src/app/api/books/[id]/batch-translate-async/route.ts
+++ b/src/app/api/books/[id]/batch-translate-async/route.ts
@@ -6,6 +6,7 @@ import { getTriggerSource } from '@/lib/cron-auth';
 import { getTranslationPrompt } from '@/lib/prompts';
 import { PROMPT_VERSION, SKIP_TRANSLATION_PAGE_TYPES } from '@/lib/types/prompts/defaults';
 import { createRevision } from '@/lib/page-revisions';
+import { findHumanEditedPageIds, findPendingBatchJob } from '@/lib/translate-write';
 import { withAuth } from '@/lib/auth-helpers';
 import { buildVisiblePageCountPipeline } from '@/lib/page-counts';
 
@@ -49,6 +50,7 @@ export const POST = withAuth(async (request, session, context) => {
       model = process.env.GEMINI_BATCH_MODEL || 'gemini-3-flash-preview',
       force = false, // When true, include pages that already have translation (for re-processing)
       staleOnly = false, // When true, only retranslate pages where translation model differs from OCR model
+      resubmit = false, // When true, bypass the pending-job double-submit guard
     } = body;
 
     const db = await getDb();
@@ -57,6 +59,21 @@ export const POST = withAuth(async (request, session, context) => {
     const book = await db.collection('books').findOne({ id: bookId });
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Double-submit guard (#3749, archaeology I68): a pending translation
+    // batch for this book means submitting again pays Gemini twice for the
+    // same pages. 409 with the existing job; pass resubmit: true to bypass
+    // (e.g. a job Gemini lost track of).
+    if (!resubmit) {
+      const pending = await findPendingBatchJob(db, { bookId, type: 'translation' });
+      if (pending) {
+        return NextResponse.json({
+          error: 'batch_job_already_pending',
+          message: `A translation batch job for this book is already pending (submitted ${pending.createdAt?.toISOString?.() || pending.createdAt}). Collect it or pass resubmit: true to force a new submission.`,
+          existingJob: pending,
+        }, { status: 409 });
+      }
     }
 
     // Find pages to translate (or modernize for English books)
@@ -298,8 +315,14 @@ export const GET = withAuth(async (request, session, context) => {
         const validPageIdSet = new Set(pageIds as string[]);
         const responses = batchJob.dest.inlinedResponses;
 
+        // Human-edit guard (#3749): pages whose translation was written or
+        // corrected by a person (source 'manual' or edited_by) are protected —
+        // batch results submitted before the edit must not clobber it.
+        const protectedPageIds = await findHumanEditedPageIds(db, pageIds as string[], 'translation');
+
         let successCount = 0;
         let failCount = 0;
+        let protectedCount = 0;
         const now = new Date().toISOString();
 
         for (let i = 0; i < responses.length; i++) {
@@ -312,6 +335,12 @@ export const GET = withAuth(async (request, session, context) => {
           if (!pageId || !validPageIdSet.has(pageId)) {
             console.warn(`[batch-translate] Result idx ${i} has invalid pageId: ${pageId}`);
             failCount++;
+            continue;
+          }
+
+          if (protectedPageIds.has(pageId)) {
+            console.log(`[batch-translate] Skipping page ${pageId} — translation is human-edited; refusing to overwrite (#3749)`);
+            protectedCount++;
             continue;
           }
 
@@ -357,6 +386,7 @@ export const GET = withAuth(async (request, session, context) => {
               results_collected: true,
               success_count: successCount,
               fail_count: failCount,
+              ...(protectedCount > 0 && { protected_count: protectedCount }),
               completed_at: new Date()
             }
           }
@@ -418,7 +448,8 @@ export const GET = withAuth(async (request, session, context) => {
           resultsCollected: true,
           successCount,
           failCount,
-          message: `Collected ${successCount} translations`
+          ...(protectedCount > 0 && { protectedCount }),
+          message: `Collected ${successCount} translations${protectedCount > 0 ? ` (${protectedCount} skipped: human-edited)` : ''}`
         });
       }
     }

--- a/src/app/api/process/route.ts
+++ b/src/app/api/process/route.ts
@@ -5,6 +5,7 @@ import { performOCR, performOCRWithBuffer, performTranslation, generateSummary, 
 import { getOcrPrompt, getTranslationPrompt, getSummaryPrompt, type PromptLookupResult } from '@/lib/prompts';
 import { withAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
+import { isHumanEditedTranslation } from '@/lib/translate-write';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
 import { DEFAULT_MODEL, PROMPT_VERSION, extractPageType, extractColumns } from '@/lib/types';
@@ -52,7 +53,8 @@ export const POST = withAuth(async (request: NextRequest) => {
       customPrompts,
       autoSave = true,
       model = DEFAULT_MODEL,
-      promptInfo // { ocr?: string, translation?: string, summary?: string } - prompt names
+      promptInfo, // { ocr?: string, translation?: string, summary?: string } - prompt names
+      overwriteHuman = false // Explicit bypass of the human-edit guard (#3749)
     } = body;
 
     const { id: tenantId } = getTenantContextFromRequest(request);
@@ -110,12 +112,28 @@ export const POST = withAuth(async (request: NextRequest) => {
       });
     }
 
+    // Human-edit guard (#3749): a translation a person wrote or corrected by
+    // hand (source: 'manual', or edited_by set) must not be silently replaced
+    // by AI output. The generation still runs (the caller may want a preview),
+    // but the save is refused unless overwriteHuman: true is passed.
+    let translationProtected = false;
+    if (pageId && autoSave && !overwriteHuman && (action === 'translation' || action === 'all')) {
+      const existingPage = await db.collection('pages').findOne(
+        { id: pageId, tenantId },
+        { projection: { 'translation.source': 1, 'translation.edited_by': 1 } }
+      );
+      translationProtected = isHumanEditedTranslation(existingPage?.translation);
+      if (translationProtected) {
+        console.log(`[process] Page ${pageId}: translation is human-edited — will not overwrite (pass overwriteHuman: true to bypass)`);
+      }
+    }
+
     // Create revisions of existing content before overwriting
     if (pageId && autoSave) {
       if (action === 'ocr' || action === 'all') {
         await createRevision(pageId, 'ocr');
       }
-      if (action === 'translation' || action === 'all') {
+      if ((action === 'translation' || action === 'all') && !translationProtected) {
         await createRevision(pageId, 'translation');
       }
     }
@@ -374,7 +392,7 @@ export const POST = withAuth(async (request: NextRequest) => {
         }
       }
 
-      if (results.translation && promptRefs.translation) {
+      if (results.translation && promptRefs.translation && !translationProtected) {
         const translationPromptRef = promptRefs.translation.reference;
         updateData['translation'] = {
           data: results.translation,
@@ -420,7 +438,7 @@ export const POST = withAuth(async (request: NextRequest) => {
       );
 
       // Update book counts if translation was processed
-      if (results.translation) {
+      if (results.translation && !translationProtected) {
         const page = await db.collection('pages').findOne({ id: pageId, tenantId });
         if (page?.book_id) {
           const bookId = page.book_id;
@@ -469,7 +487,11 @@ export const POST = withAuth(async (request: NextRequest) => {
       });
     }
 
-    return NextResponse.json({ ...results, usage: totalUsage });
+    return NextResponse.json({
+      ...results,
+      usage: totalUsage,
+      ...(translationProtected && { translationProtected: true }),
+    });
   } catch (error) {
     console.error('Error processing:', error);
     const errorMessage = error instanceof Error ? error.message : 'Processing failed';

--- a/src/lib/translate-write.ts
+++ b/src/lib/translate-write.ts
@@ -1,0 +1,216 @@
+/**
+ * translate-write — the TS-side door for writing a page translation (#3749).
+ *
+ * TypeScript twin of scripts/lib/translate-core.mjs `writePageTranslation`.
+ * The script lanes got a human-edit guard in #3725/#3734; until this module,
+ * the TS writers (Lambda worker, batch-async collectors, /api/process) wrote
+ * translations with NO guard, so "no automated process can overwrite a human
+ * edit" was only true for scripts.
+ *
+ * The promises this door enforces:
+ *   1. HUMAN-EDIT GUARD — a translation a person wrote or corrected by hand
+ *      (`source: 'manual'`, or `edited_by` set) is never silently replaced by
+ *      AI output. Refuse by default; a caller that REALLY means it passes
+ *      `overwriteHuman: true`.
+ *   2. REVISION BEFORE OVERWRITE — existing content is snapshotted into
+ *      `page_revisions` via createRevision() before the write (non-fatal on
+ *      failure, matching long-standing worker behavior).
+ *   3. PROVENANCE — prompt_id / prompt_hash / prompt_name / prompt_version are
+ *      stamped when provided.
+ *
+ * Existing call sites keep their bespoke write payloads and wire the guard in
+ * via the primitives (`isHumanEditedTranslation`, `findHumanEditedPageIds`);
+ * NEW TS writers should go through `writePageTranslation` directly.
+ *
+ * Parity with the .mjs door is pinned by tests/unit/translate-write-guard.test.ts.
+ */
+import type { Db } from 'mongodb';
+import { getDb } from './mongodb';
+import { createRevision } from './page-revisions';
+import { contentHash } from './steganographia';
+
+/** Shape of an existing `translation` (or `ocr`) subdocument for guard checks. */
+export interface HumanEditableField {
+  source?: string;
+  edited_by?: string | null;
+  data?: string;
+}
+
+/**
+ * THE human-edit predicate — one definition on the TS side, mirroring the
+ * check inside scripts/lib/translate-core.mjs writePageTranslation:
+ * `source === 'manual' || !!edited_by`.
+ *
+ * Works for both `translation` and `ocr` subdocuments — manual edits stamp
+ * the same convention on both (see /api/pages/[id]: `ocr.source = 'manual'`,
+ * `ocr.edited_by` / `translation.edited_by`).
+ */
+export function isHumanEditedField(existing: HumanEditableField | null | undefined): boolean {
+  if (!existing) return false;
+  return existing.source === 'manual' || !!existing.edited_by;
+}
+
+/** Alias making translation-guard call sites read naturally. */
+export const isHumanEditedTranslation = isHumanEditedField;
+
+/**
+ * Bulk form of the guard for batch collectors: which of these pages have a
+ * human-edited `field` (translation | ocr)? Returns the Set of protected page
+ * ids — batch results for those pages must be skipped, not written.
+ */
+export async function findHumanEditedPageIds(
+  db: Db,
+  pageIds: string[],
+  field: 'translation' | 'ocr' = 'translation'
+): Promise<Set<string>> {
+  if (!pageIds || pageIds.length === 0) return new Set();
+  const docs = await db.collection('pages').find(
+    {
+      id: { $in: pageIds },
+      $or: [
+        { [`${field}.source`]: 'manual' },
+        { [`${field}.edited_by`]: { $exists: true, $nin: [null, ''] } },
+      ],
+    },
+    { projection: { id: 1 } }
+  ).toArray();
+  return new Set(docs.map(d => d.id as string));
+}
+
+export interface TranslationPromptRef {
+  id?: string;
+  name?: string;
+  version?: number | string;
+  content_hash?: string;
+}
+
+export interface WritePageTranslationArgs {
+  pageId: string;
+  /** The new translation text. */
+  text: string;
+  /** Model that produced the text (stamped on the subdocument). */
+  model?: string;
+  /** Provenance of the writing lane. Defaults to 'ai'. */
+  source?: string;
+  /** Target language. Defaults to 'English'. */
+  language?: string;
+  /** Prompt provenance — stamped as prompt_id/hash/name/version when provided. */
+  promptRef?: TranslationPromptRef;
+  /** Job identifier, recorded on the revision row. */
+  jobId?: string;
+  /** Extra fields merged INTO the translation subdocument (e.g. batch_job_id, token counts). */
+  extraTranslationFields?: Record<string, unknown>;
+  /** Extra TOP-LEVEL page fields to $set in the same write — never translation.* keys. */
+  extraSet?: Record<string, unknown>;
+  /** Bypass the human-edit guard. Only for callers acting on explicit human intent. */
+  overwriteHuman?: boolean;
+}
+
+export interface WritePageTranslationResult {
+  written: boolean;
+  protected: boolean;
+  /**
+   * When protected, the EXISTING human translation (use it for previous-page
+   * continuity); when written, the new text.
+   */
+  text: string;
+}
+
+/**
+ * Guard + revision + write, mirroring scripts/lib/translate-core.mjs
+ * writePageTranslation. Refuses (written:false, protected:true) if the page's
+ * current translation is human-edited and `overwriteHuman` was not passed.
+ */
+export async function writePageTranslation(
+  args: WritePageTranslationArgs
+): Promise<WritePageTranslationResult> {
+  const {
+    pageId, text, model, source = 'ai', language = 'English',
+    promptRef, jobId, extraTranslationFields, extraSet, overwriteHuman = false,
+  } = args;
+
+  const db = await getDb();
+
+  // Promise 1: the human-edit guard.
+  const current = await db.collection('pages').findOne(
+    { id: pageId },
+    { projection: { 'translation.source': 1, 'translation.edited_by': 1, 'translation.data': 1 } }
+  );
+  const existing = current?.translation as HumanEditableField | undefined;
+  if (isHumanEditedField(existing) && !overwriteHuman) {
+    return { written: false, protected: true, text: existing?.data ?? '' };
+  }
+
+  // Promise 2: snapshot existing content first (non-fatal — createRevision
+  // catches its own errors and never blocks the write path).
+  await createRevision(pageId, 'translation', jobId);
+
+  // Promise 3: provenance-stamped write.
+  const now = new Date();
+  await db.collection('pages').updateOne(
+    { id: pageId },
+    {
+      $set: {
+        translation: {
+          data: text,
+          content_hash: contentHash(text),
+          language,
+          ...(model && { model }),
+          updated_at: now,
+          source,
+          ...(promptRef && {
+            prompt_version: String(promptRef.version ?? ''),
+            ...(promptRef.id && { prompt_id: promptRef.id }),
+            ...(promptRef.content_hash && { prompt_hash: promptRef.content_hash }),
+            ...(promptRef.name && { prompt_name: promptRef.name }),
+          }),
+          ...(extraTranslationFields || {}),
+        },
+        ...(extraSet || {}),
+        updated_at: now,
+      },
+    }
+  );
+  return { written: true, protected: false, text };
+}
+
+/**
+ * Double-submit guard for the batch-async submit routes (archaeology I68):
+ * find a still-pending batch job for the same book + type, created within the
+ * last 48h, whose results have not been collected. Submitting again while one
+ * is pending pays Gemini twice for the same pages — the routes return 409
+ * with this job's info instead (bypass with `resubmit: true`).
+ */
+export async function findPendingBatchJob(
+  db: Db,
+  opts: { bookId: string; type: 'translation' | 'ocr'; tenantId?: string; windowHours?: number }
+): Promise<{ jobName?: string; status?: string; pageCount?: number; createdAt?: Date } | null> {
+  const windowMs = (opts.windowHours ?? 48) * 60 * 60 * 1000;
+  const doc = await db.collection('batch_jobs').findOne(
+    {
+      book_id: opts.bookId,
+      type: opts.type,
+      ...(opts.tenantId && { tenantId: opts.tenantId }),
+      // "Pending" = not failed/cancelled/expired (raw Gemini states included —
+      // the GET collectors write raw JOB_STATE_* strings, scripts write
+      // 'failed') and results not yet collected.
+      status: {
+        $nin: [
+          'failed', 'cancelled', 'expired',
+          'JOB_STATE_FAILED', 'JOB_STATE_CANCELLED', 'JOB_STATE_EXPIRED',
+          'BATCH_STATE_FAILED', 'BATCH_STATE_CANCELLED',
+        ],
+      },
+      results_collected: { $ne: true },
+      created_at: { $gte: new Date(Date.now() - windowMs) },
+    },
+    { sort: { created_at: -1 }, projection: { job_name: 1, status: 1, page_count: 1, created_at: 1 } }
+  );
+  if (!doc) return null;
+  return {
+    jobName: doc.job_name,
+    status: doc.status,
+    pageCount: doc.page_count,
+    createdAt: doc.created_at,
+  };
+}

--- a/src/workers/translation-processor-logic.ts
+++ b/src/workers/translation-processor-logic.ts
@@ -7,6 +7,7 @@ import { SKIP_TRANSLATION_PAGE_TYPES, extractPageType } from '@/lib/types/prompt
 import { classifyError } from '@/lib/errors';
 import { extractTranslationMetadata, propagateOcrWarnings } from '@/lib/translation-metadata';
 import { createRevision } from '@/lib/page-revisions';
+import { isHumanEditedTranslation } from '@/lib/translate-write';
 import { sendWriteResult } from '@/lib/sqs-client';
 import { retryDbWrite } from '@/lib/retry-utils';
 import { contentHash } from '@/lib/steganographia';
@@ -131,6 +132,22 @@ export async function processTranslationPage(message: PageProcessingMessage) {
       timestamp: new Date().toISOString(),
       failed: true,
       error: { message: 'No OCR data on page', category: 'no_data' },
+    });
+    return;
+  }
+
+  // Human-edit guard (#3749): a translation a person wrote or corrected by
+  // hand (source: 'manual', or edited_by set) must never be silently replaced
+  // by automated output — that includes the blank-marker write below, so this
+  // check comes first. Refuse before spending the AI call; a job that REALLY
+  // means it sets config.overwriteHuman. Mirrors scripts/lib/translate-core.mjs.
+  if (isHumanEditedTranslation(page.translation) && !job.config?.overwriteHuman) {
+    console.log(`[TRANS] Skipping page ${pageId} — translation is human-edited (source: ${page.translation?.source || 'n/a'}, edited_by: ${page.translation?.edited_by || 'n/a'}); refusing to overwrite`);
+    await sendWriteResult({
+      type: 'translation',
+      bookId, pageId, jobId, targetPageIds,
+      timestamp: new Date().toISOString(),
+      failed: false,
     });
     return;
   }

--- a/tests/unit/translate-write-guard.test.ts
+++ b/tests/unit/translate-write-guard.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The TS-side translation door (src/lib/translate-write.ts, issue #3749) —
+ * guard tests mirroring tests/unit/translate-edge-cases.test.ts's guard suite
+ * for the .mjs door, plus a parity assertion importing BOTH doors.
+ *
+ * Negative control: the human-edit tests assert updateOne is NOT called,
+ * which cannot pass if the guard is deleted.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Stub DB behind getDb() ─────────────────────────────────────────────────
+// Both translate-write.ts and page-revisions.ts (createRevision) resolve
+// their db through '@/lib/mongodb' getDb — one mock covers guard read,
+// revision snapshot, and final write.
+const state = vi.hoisted(() => ({
+  pageDoc: null as Record<string, unknown> | null,
+  updates: [] as Array<[unknown, unknown]>,
+  revisions: [] as unknown[],
+  findFilters: [] as unknown[],
+  findResults: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => makeDb()),
+}));
+
+function makeDb() {
+  return {
+    collection(name: string) {
+      return {
+        findOne: async () => state.pageDoc,
+        find: (filter: unknown) => {
+          state.findFilters.push(filter);
+          return { toArray: async () => state.findResults };
+        },
+        updateOne: async (filter: unknown, update: unknown) => {
+          if (name === 'pages') state.updates.push([filter, update]);
+          return { matchedCount: 1, modifiedCount: 1 };
+        },
+        insertOne: async (doc: unknown) => {
+          if (name === 'page_revisions') state.revisions.push(doc);
+          return { insertedId: 'rev1' };
+        },
+        // The .mjs door's revision helper uses insertMany
+        insertMany: async (docs: unknown[]) => {
+          if (name === 'page_revisions') state.revisions.push(...docs);
+          return {};
+        },
+      };
+    },
+  };
+}
+
+import {
+  writePageTranslation,
+  isHumanEditedTranslation,
+  isHumanEditedField,
+  findHumanEditedPageIds,
+} from '@/lib/translate-write';
+import {
+  writePageTranslation as writePageTranslationMjs,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/translate-core.mjs';
+
+function setPage(translation: Record<string, unknown> | null) {
+  state.pageDoc = translation === null
+    ? { id: 'p1', book_id: 'b1' }
+    : { id: 'p1', book_id: 'b1', translation };
+}
+
+beforeEach(() => {
+  state.pageDoc = null;
+  state.updates = [];
+  state.revisions = [];
+  state.findFilters = [];
+  state.findResults = [];
+});
+
+const writeArgs = {
+  pageId: 'p1',
+  text: 'New AI translation.',
+  model: 'gemini-3.1-flash-lite',
+  promptRef: { id: 'x', name: 'Standard Translation', version: 12, content_hash: 'abc123' },
+};
+
+describe('writePageTranslation (TS door) human-edit guard', () => {
+  it('refuses to overwrite a manual translation (negative control: no updateOne)', async () => {
+    setPage({ data: 'HAND-CORRECTED TEXT', source: 'manual' });
+    const r = await writePageTranslation(writeArgs);
+    expect(r.written).toBe(false);
+    expect(r.protected).toBe(true);
+    expect(r.text).toBe('HAND-CORRECTED TEXT'); // returns human text for continuity
+    expect(state.updates.length).toBe(0);
+    expect(state.revisions.length).toBe(0);
+  });
+
+  it('refuses when edited_by is set even if source is ai', async () => {
+    setPage({ data: 'EDITED', source: 'ai', edited_by: 'derek' });
+    const r = await writePageTranslation(writeArgs);
+    expect(r.written).toBe(false);
+    expect(r.protected).toBe(true);
+    expect(state.updates.length).toBe(0);
+  });
+
+  it('overwriteHuman: true bypasses the guard AND still writes a revision first', async () => {
+    setPage({ data: 'HAND', source: 'manual' });
+    const r = await writePageTranslation({ ...writeArgs, overwriteHuman: true });
+    expect(r.written).toBe(true);
+    expect(state.updates.length).toBe(1);
+    expect(state.revisions.length).toBe(1); // the human text is preserved as a revision
+    expect((state.revisions[0] as { data: string }).data).toBe('HAND');
+  });
+
+  it('writes normally over AI text, with provenance stamped', async () => {
+    setPage({ data: 'old ai', source: 'ai' });
+    const r = await writePageTranslation(writeArgs);
+    expect(r.written).toBe(true);
+    expect(r.text).toBe('New AI translation.');
+    expect(state.updates.length).toBe(1);
+    expect(state.revisions.length).toBe(1);
+    const [, update] = state.updates[0];
+    const set = (update as { $set: Record<string, unknown> }).$set;
+    const t = set.translation as Record<string, unknown>;
+    expect(t.data).toBe('New AI translation.');
+    expect(t.source).toBe('ai');
+    expect(t.model).toBe('gemini-3.1-flash-lite');
+    // Provenance (#3749 promise 3)
+    expect(t.prompt_version).toBe('12');
+    expect(t.prompt_id).toBe('x');
+    expect(t.prompt_hash).toBe('abc123');
+    expect(t.prompt_name).toBe('Standard Translation');
+    expect(typeof t.content_hash).toBe('string');
+  });
+
+  it('writes normally on first translation (no existing → no revision)', async () => {
+    setPage(null);
+    const r = await writePageTranslation(writeArgs);
+    expect(r.written).toBe(true);
+    expect(state.updates.length).toBe(1);
+    expect(state.revisions.length).toBe(0); // nothing to snapshot
+  });
+
+  it('extraTranslationFields and extraSet ride along in the same write', async () => {
+    setPage(null);
+    await writePageTranslation({
+      ...writeArgs,
+      extraTranslationFields: { batch_job_id: 'job9' },
+      extraSet: { detected_terms: ['azoth'] },
+    });
+    const [, update] = state.updates[0];
+    const set = (update as { $set: Record<string, unknown> }).$set;
+    expect((set.translation as Record<string, unknown>).batch_job_id).toBe('job9');
+    expect(set.detected_terms).toEqual(['azoth']);
+  });
+});
+
+describe('isHumanEditedTranslation predicate', () => {
+  it('matches the door: manual OR edited_by; ai/empty pass', () => {
+    expect(isHumanEditedTranslation({ source: 'manual' })).toBe(true);
+    expect(isHumanEditedTranslation({ source: 'ai', edited_by: 'derek' })).toBe(true);
+    expect(isHumanEditedTranslation({ source: 'ai' })).toBe(false);
+    expect(isHumanEditedTranslation({ source: 'batch_api' })).toBe(false);
+    expect(isHumanEditedTranslation(null)).toBe(false);
+    expect(isHumanEditedTranslation(undefined)).toBe(false);
+    // works for ocr subdocuments too (same convention, /api/pages/[id])
+    expect(isHumanEditedField({ source: 'manual', data: 'ocr text' })).toBe(true);
+  });
+});
+
+describe('findHumanEditedPageIds (bulk guard for collectors)', () => {
+  it('returns the protected id set and queries by manual-or-edited_by', async () => {
+    state.findResults = [{ id: 'p2' }, { id: 'p5' }];
+    const db = makeDb();
+    const ids = await findHumanEditedPageIds(db as never, ['p1', 'p2', 'p5'], 'translation');
+    expect(ids).toEqual(new Set(['p2', 'p5']));
+    const filter = state.findFilters[0] as Record<string, unknown>;
+    expect(filter.id).toEqual({ $in: ['p1', 'p2', 'p5'] });
+    expect(filter.$or).toEqual([
+      { 'translation.source': 'manual' },
+      { 'translation.edited_by': { $exists: true, $nin: [null, ''] } },
+    ]);
+  });
+
+  it('empty input short-circuits without a query', async () => {
+    const db = makeDb();
+    const ids = await findHumanEditedPageIds(db as never, [], 'ocr');
+    expect(ids.size).toBe(0);
+    expect(state.findFilters.length).toBe(0);
+  });
+});
+
+// ── Parity: the TS door and the .mjs door make the same refusal decision ──
+describe('TS/.mjs door parity', () => {
+  const mjsArgs = {
+    page: { id: 'p1', book_id: 'b1' },
+    book: { language: 'latin' },
+    text: 'New AI translation.',
+    promptRef: { id: 'x', name: 'Standard Translation', version: 12 },
+  };
+
+  it('both doors refuse the same manual fixture', async () => {
+    setPage({ data: 'HAND', source: 'manual' });
+    const ts = await writePageTranslation(writeArgs);
+    const mjs = await writePageTranslationMjs(makeDb(), mjsArgs);
+    expect(ts.written).toBe(false);
+    expect(mjs.written).toBe(false);
+    expect(ts.protected).toBe(true);
+    expect(mjs.protected).toBe(true);
+    expect(state.updates.length).toBe(0); // neither door touched pages
+  });
+
+  it('both doors refuse the same edited_by fixture', async () => {
+    setPage({ data: 'EDITED', source: 'batch_api', edited_by: 'derek' });
+    const ts = await writePageTranslation(writeArgs);
+    const mjs = await writePageTranslationMjs(makeDb(), mjsArgs);
+    expect(ts.written).toBe(false);
+    expect(mjs.written).toBe(false);
+  });
+
+  it('both doors write over plain AI text', async () => {
+    setPage({ data: 'old ai', source: 'ai' });
+    const ts = await writePageTranslation(writeArgs);
+    expect(ts.written).toBe(true);
+    setPage({ data: 'old ai', source: 'ai' });
+    const mjs = await writePageTranslationMjs(makeDb(), mjsArgs);
+    expect(mjs.written).toBe(true);
+  });
+});


### PR DESCRIPTION
Completes #3749 (built by the TS-door builder, finished by the integrator after the builder hit the session limit mid-typecheck; typecheck now clean, full suite 2,305 green post-merge-with-main).

## In scope
- **`src/lib/translate-write.ts`** — the TS twin of the scripts-side door: a translation with `source:'manual'`/`edited_by` is never overwritten by default (returns the human text for continuity); `overwriteHuman:true` bypasses and still snapshots via `createRevision` first.
- Wired into the **Lambda processor**, **/api/process**, both **batch-translate-async** GET collectors, and both script collectors — the last writers that could silently replace a hand-corrected page. 'No automated process overwrites a human edit' is now true in BOTH runtimes.
- **Route dedup** (archaeology I68): both `batch-translate-async` and `batch-ocr-async` POST twins refuse with 409 when a pending uncollected `batch_jobs` row exists for the same book+type — re-calls no longer double-submit and double-charge.
- `tests/unit/translate-write-guard.test.ts` — stub-db guard tests with negative controls (no updateOne when protected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx