### PR TITLE
feat(work): merge fragmented work_id clusters — detection, aliases, redirects (#3759)

### DIFF
--- a/.claude/docs/invariants/work-identity.md
+++ b/.claude/docs/invariants/work-identity.md
@@ -29,6 +29,18 @@ NOT by the `original_edition_id` link (which is half-filled). Umbrella: #2318.
   + rare-token fallback for anonymous works. HIGH-confidence only is auto-written,
   always with a backup. Resolvers: `resolve-work-ids.mjs` (local `works` catalog —
   Sanskrit) and `resolve-work-ids-wikidata.mjs` (Wikidata P50 — Greek/Latin).
+- **Merging fragmented work_ids (#3759):** `scripts/maintenance/merge-work-clusters.mjs`
+  (run with `node --env-file`; it imports the canon registry). HIGH lanes — canon gold
+  seeds + identical-title — auto-write with backup; the containment fit rule only ever
+  QUEUES to `work_merge_queue` (status=pending, human review). Retired ids are kept on
+  every edition in **`books.work_id_aliases`** (indexed); `/work/[id]` resolves an alias
+  via `src/lib/work-alias.ts` and 307s to the survivor, so old URLs stay citable.
+  Provenance log: `work_id_merges`. Two hazards the tool guards, don't relax them:
+  ids SHARED between canon entries are combined volumes (Iliad+Odyssey), never merged;
+  and a work_id whose books carry >1 distinct title is POLLUTED — its representative
+  can't speak for it (the Ellis Yoruba/Tshi/Ewe case), so it is excluded from auto-merge.
+  After any apply, run `node scripts/workers/sync-books-catalog.mjs` (books_catalog
+  carries work_id).
 - Full design, tool list, per-tradition candidate coverage, and open levers:
   **`.claude/docs/work-identity-coverage.md`**.
 - **Acquiring works we're missing — read FIRST, don't reinvent:**

--- a/scripts/lib/work-merge-lib.mjs
+++ b/scripts/lib/work-merge-lib.mjs
@@ -1,0 +1,233 @@
+/**
+ * work-merge-lib.mjs — pure cluster-detection + merge-planning logic for
+ * work_id consolidation (#3759). No I/O here: everything is unit-testable.
+ *
+ * Three detection lanes, two confidence tiers:
+ *  - canon gold seeds (HIGH): the hand-verified workIds arrays in
+ *    src/lib/canon-works.ts, minus ids shared between entries (combined
+ *    volumes like Iliad+Odyssey are their OWN work, never merged).
+ *  - identical-title (HIGH): same author surname + identical full normalized
+ *    title + matching series key. Same-work by construction. Tibetan and
+ *    volume-marked titles are excluded (pecha / multi-volume grain hazards),
+ *    mirroring merge-duplicate-work-ids.mjs.
+ *  - containment (MEDIUM, queue only): author-anchored title containment —
+ *    the work-coverage fit rule applied between two work_id clusters. Never
+ *    auto-written; a wrong merge poisons FT counting silently.
+ *
+ * Winner per cluster is deterministic: Wikidata QID > local:a: > local:n: >
+ * other; tiebreak shortest, then lexicographic.
+ */
+import { norm, sig, seriesKey, surname } from './work-identity-util.mjs';
+
+// ── winner selection ────────────────────────────────────────────────────────
+export function rankFormat(w) {
+  if (/^Q\d+$/.test(w)) return 0; // Wikidata QID — most canonical
+  if (/^local:a:/.test(w)) return 1; // author-resolved mint
+  if (/^local:n:/.test(w)) return 2; // anon-resolved mint
+  return 3; // legacy clean slug / cjk / other
+}
+
+export function pickWinner(wids) {
+  return [...wids].sort((a, b) => {
+    const r = rankFormat(a) - rankFormat(b);
+    if (r) return r;
+    if (a.length !== b.length) return a.length - b.length;
+    return a < b ? -1 : 1;
+  })[0];
+}
+
+// ── canon gold seeds ────────────────────────────────────────────────────────
+/**
+ * Extract verified merge sets from the canon registry. An id that appears in
+ * MORE THAN ONE entry's workIds is a combined edition (e.g. an Iliad+Odyssey
+ * volume) — it is a distinct work_id on purpose and is excluded from every
+ * merge set. collectedWorkIds (Opera containers) are never touched.
+ */
+export function canonGoldClusters(canonWorks) {
+  const entryCount = new Map();
+  for (const w of canonWorks) {
+    for (const id of new Set(w.workIds)) entryCount.set(id, (entryCount.get(id) || 0) + 1);
+  }
+  const out = [];
+  for (const w of canonWorks) {
+    const ids = [...new Set(w.workIds)].filter((id) => entryCount.get(id) === 1);
+    if (ids.length < 2) continue;
+    const winner = pickWinner(ids);
+    out.push({ source: 'canon-registry', slug: w.slug, ids, winner, losers: ids.filter((i) => i !== winner) });
+  }
+  return out;
+}
+
+// ── identical-title lane ────────────────────────────────────────────────────
+const volRe = /\b(vol|volume|part|tome|band|tomus|tom|pt|bd)\.?\s*[ivxlcdm0-9]/i;
+const cjkVolRe = /[巻卷冊册帙]|第[一二三四五六七八九十百0-9]+|[上中下][巻卷冊]?\s*$/;
+
+/** Reps in Tibetan or with volume markers are never auto-merged (grain policy). */
+export function isMergeSafeRep(rep) {
+  if ((rep.language || '') === 'Tibetan') return false;
+  if (volRe.test(rep.title || '') || cjkVolRe.test(rep.title || '')) return false;
+  return true;
+}
+
+/** Cluster key for the identical-title lane, or null when the rep is unsafe. */
+export function identicalTitleKey(rep) {
+  if (!isMergeSafeRep(rep)) return null;
+  // A representative can only stand for its whole work_id when every book
+  // under that id carries the same title. A POLLUTED id (distinct works filed
+  // together — e.g. Ellis's Yoruba/Tshi/Ewe volumes under one id) would
+  // otherwise be merged wholesale onto whichever work its rep happens to be.
+  if ((rep.titleVariants ?? 1) > 1) return null;
+  const t = norm(rep.title);
+  if (t.split(' ').filter(Boolean).length < 3) return null; // need a substantive title
+  return `${surname(rep.author)}||${t}||${seriesKey(rep.title)}`;
+}
+
+/**
+ * reps: [{ work_id, author, title, language }] — one representative book per
+ * distinct work_id. Returns clusters of ≥2 work_ids with identical keys.
+ */
+export function identicalTitleClusters(reps) {
+  const byKey = new Map();
+  for (const rep of reps) {
+    const k = identicalTitleKey(rep);
+    if (!k) continue;
+    if (!byKey.has(k)) byKey.set(k, { key: k, rep, ids: new Set() });
+    byKey.get(k).ids.add(rep.work_id);
+  }
+  const out = [];
+  for (const { key, rep, ids } of byKey.values()) {
+    if (ids.size < 2) continue;
+    const arr = [...ids];
+    const winner = pickWinner(arr);
+    out.push({
+      source: 'identical-title', key, ids: arr, winner,
+      losers: arr.filter((i) => i !== winner),
+      title: rep.title, author: rep.author,
+    });
+  }
+  return out;
+}
+
+// ── containment lane (MEDIUM — review queue only) ───────────────────────────
+// Generic/container words: a match carried entirely by these proves nothing.
+const GENERIC = new Set([
+  'letters', 'poems', 'poem', 'life', 'lives', 'works', 'fragments', 'fragment',
+  'history', 'hymns', 'odes', 'epistles', 'dialogues', 'treatise', 'commentary',
+  'speeches', 'orations', 'elegies', 'epigrams', 'opera', 'tragoediae',
+  'comoediae', 'fabulae', 'opuscula', 'carmina', 'poetae', 'poetica', 'libri',
+  'liber', 'select', 'selected', 'collected', 'writings',
+]);
+
+/** Preferred comparison title for a work_id: the curated work_title, else the raw title. */
+export function repTitle(rep) {
+  return (rep.work_title || '').trim() || rep.title || '';
+}
+
+/**
+ * Fit-rule comparison between two work_id representatives (assumed already
+ * author-blocked). Returns { cont, inter } when the pair clears every guard,
+ * else null. cont = |A∩B| / |smaller token set|.
+ */
+export function containmentPair(repA, repB, { minCont = 0.8, minInter = 2 } = {}) {
+  if (!isMergeSafeRep(repA) || !isMergeSafeRep(repB)) return null;
+  const ta = repTitle(repA);
+  const tb = repTitle(repB);
+  if (!sameSeriesSafe(ta, tb)) return null;
+  const A = sig(ta);
+  const B = sig(tb);
+  if (!A.length || !B.length) return null;
+  const [small, large] = A.length <= B.length ? [A, B] : [B, A];
+  if (small.every((t) => GENERIC.has(t))) return null; // all-generic anchor proves nothing
+  const largeSet = new Set(large);
+  const inter = small.filter((t) => largeSet.has(t)).length;
+  const cont = inter / small.length;
+  if (cont < minCont || inter < minInter) return null;
+  return { cont: +cont.toFixed(2), inter };
+}
+
+function sameSeriesSafe(a, b) {
+  return seriesKey(a) === seriesKey(b);
+}
+
+/**
+ * reps as above (+ optional author_id, work_title). Blocks by author_id when
+ * both sides have one, else by surname; never compares across blocks. Returns
+ * candidate PAIRS with evidence — the review queue, never auto-merged.
+ */
+export function containmentCandidates(reps, opts = {}) {
+  const blocks = new Map();
+  for (const rep of reps) {
+    const key = rep.author_id ? `aid:${rep.author_id}` : `sn:${surname(rep.author)}`;
+    if (key === 'sn:') continue; // no author anchor → no candidate
+    if (!blocks.has(key)) blocks.set(key, []);
+    blocks.get(key).push(rep);
+  }
+  const out = [];
+  for (const [block, members] of blocks) {
+    if (members.length < 2 || members.length > 200) continue; // degenerate blocks
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const hit = containmentPair(members[i], members[j], opts);
+        if (!hit) continue;
+        out.push({
+          source: 'containment', block,
+          a: members[i].work_id, b: members[j].work_id,
+          titleA: repTitle(members[i]), titleB: repTitle(members[j]),
+          // >1 means the id holds several distinct titles — the rep may not
+          // speak for all of them; reviewers must open the id's book list
+          variantsA: members[i].titleVariants ?? 1, variantsB: members[j].titleVariants ?? 1,
+          author: members[i].author, ...hit,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+// ── cluster union + safety ──────────────────────────────────────────────────
+/**
+ * Union overlapping HIGH clusters (a work_id may sit in both a canon seed and
+ * an identical-title cluster). Returns final merge plans; any union whose ids
+ * span ≥2 canon entries is DEMOTED to the review queue (never auto-merge
+ * across canon works — that is how an Iliad edition would silently land on the
+ * Odyssey page).
+ */
+export function unionMergeClusters(clusters, canonSlugByWorkId = new Map()) {
+  const parent = new Map();
+  const find = (x) => {
+    while (parent.get(x) !== x) { parent.set(x, parent.get(parent.get(x))); x = parent.get(x); }
+    return x;
+  };
+  const union = (a, b) => { const ra = find(a), rb = find(b); if (ra !== rb) parent.set(ra, rb); };
+  for (const c of clusters) for (const id of c.ids) if (!parent.has(id)) parent.set(id, id);
+  for (const c of clusters) for (const id of c.ids.slice(1)) union(c.ids[0], id);
+
+  const groups = new Map();
+  for (const id of parent.keys()) {
+    const root = find(id);
+    if (!groups.has(root)) groups.set(root, new Set());
+    groups.get(root).add(id);
+  }
+  const sourcesByRoot = new Map();
+  for (const c of clusters) {
+    const root = find(c.ids[0]);
+    if (!sourcesByRoot.has(root)) sourcesByRoot.set(root, new Set());
+    sourcesByRoot.get(root).add(c.source + (c.slug ? `:${c.slug}` : ''));
+  }
+
+  const merges = [];
+  const demoted = [];
+  for (const [root, idSet] of groups) {
+    const ids = [...idSet];
+    if (ids.length < 2) continue;
+    const slugs = new Set(ids.map((id) => canonSlugByWorkId.get(id)).filter(Boolean));
+    const plan = {
+      ids, winner: pickWinner(ids),
+      sources: [...(sourcesByRoot.get(root) || [])].sort(),
+    };
+    plan.losers = ids.filter((i) => i !== plan.winner);
+    if (slugs.size >= 2) { demoted.push({ ...plan, reason: `spans canon entries: ${[...slugs].join(', ')}` }); continue; }
+    merges.push(plan);
+  }
+  return { merges, demoted };
+}

--- a/scripts/maintenance/merge-work-clusters.mjs
+++ b/scripts/maintenance/merge-work-clusters.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env npx tsx
+/**
+ * merge-work-clusters.mjs — same-work cluster detection + merge for fragmented
+ * work_ids (#3759). Successor to merge-duplicate-work-ids.mjs: adds the canon
+ * registry as a gold seed, writes work_id_aliases for redirects + provenance,
+ * and queues MEDIUM-confidence candidates for review instead of dropping them.
+ *
+ * Run with tsx (it imports src/lib/canon-works.ts):
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/maintenance/merge-work-clusters.mjs            # dry-run + plan/queue report
+ *   npx tsx scripts/maintenance/merge-work-clusters.mjs --apply    # write HIGH merges (+backup)
+ *
+ * HIGH (auto-written with backup):
+ *   - canon gold seeds: the hand-verified workIds arrays in canon-works.ts
+ *     (minus combined-volume ids shared between entries);
+ *   - identical-title clusters (author surname + identical normalized title).
+ * MEDIUM (queued to `work_merge_queue`, status=pending — human review):
+ *   - author-anchored title containment (the fit rule between clusters).
+ *
+ * Apply writes, per final cluster:
+ *   - books with a loser work_id  → { work_id: winner, updated_at }
+ *   - ALL books in the cluster    → $addToSet work_id_aliases (the loser ids)
+ *     (aliases describe the WORK, so every edition carries them; /work/[id]
+ *     resolves an alias via books.work_id_aliases and 307s to the winner)
+ *   - a provenance doc in `work_id_merges`
+ * plus an index on books.work_id_aliases, and a backup file with every book's
+ * prior work_id (revert = replay the backup).
+ *
+ * After --apply, run the Supabase catalog sync (books_catalog carries work_id):
+ *   node scripts/workers/sync-books-catalog.mjs
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  canonGoldClusters, identicalTitleClusters, containmentCandidates,
+  unionMergeClusters,
+} from '../lib/work-merge-lib.mjs';
+import { norm as normTitle } from '../lib/work-identity-util.mjs';
+// Dynamic import: node (24+) type-strips the .ts natively, but a STATIC import
+// from an .mjs mis-detects its module format and drops the named exports.
+const { CANON_WORKS } = await import(new URL('../../src/lib/canon-works.ts', import.meta.url).href);
+
+const APPLY = process.argv.includes('--apply');
+const OUT_DIR = path.join(process.cwd(), 'scripts', 'output');
+const STAMP = new Date().toISOString().slice(0, 10);
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection('books');
+
+  // Every book carrying a work_id — merges must move hidden books too, or the
+  // cluster stays split under the surface (and FT priors keep hiding in it).
+  const all = await books
+    .find({ work_id: { $exists: true, $nin: [null, ''] } })
+    .project({ _id: 0, id: 1, work_id: 1, author: 1, author_id: 1, title: 1, work_title: 1, language: 1, visible: 1 })
+    .toArray();
+
+  // one representative per work_id (prefer a visible book — better titles),
+  // plus the count of distinct normalized titles under the id: a rep can only
+  // speak for a work_id whose books all share one title (see identicalTitleKey)
+  const repByWid = new Map();
+  const titleVariantsByWid = new Map();
+  for (const b of all) {
+    const cur = repByWid.get(b.work_id);
+    if (!cur || (!cur.visible && b.visible)) repByWid.set(b.work_id, b);
+    if (!titleVariantsByWid.has(b.work_id)) titleVariantsByWid.set(b.work_id, new Set());
+    titleVariantsByWid.get(b.work_id).add(normTitle(b.title));
+  }
+  const reps = [...repByWid.values()].map((b) => ({ ...b, titleVariants: titleVariantsByWid.get(b.work_id).size }));
+  console.log(`${all.length} books across ${repByWid.size} distinct work_ids`);
+
+  // ── HIGH lanes ──
+  const gold = canonGoldClusters(CANON_WORKS)
+    // only ids that exist in the DB can be merged; a canon id with zero books
+    // is stale registry data — report it, don't invent a merge around it.
+    .map((c) => {
+      const present = c.ids.filter((id) => repByWid.has(id));
+      const missing = c.ids.filter((id) => !repByWid.has(id));
+      return { ...c, ids: present, missing };
+    })
+    .filter((c) => c.ids.length >= 2);
+  for (const c of gold.filter((g) => g.missing.length)) {
+    console.log(`  note: canon "${c.slug}" ids not found on any book: ${c.missing.join(', ')}`);
+  }
+
+  const identical = identicalTitleClusters(reps);
+
+  // cross-canon guard map (shared combined-volume ids resolve first-entry-wins;
+  // any union spanning two canon entries is demoted, never auto-merged)
+  const canonSlugByWorkId = new Map();
+  for (const w of CANON_WORKS) for (const id of w.workIds) if (!canonSlugByWorkId.has(id)) canonSlugByWorkId.set(id, w.slug);
+
+  const { merges, demoted } = unionMergeClusters([...gold, ...identical], canonSlugByWorkId);
+
+  // ── MEDIUM lane (queue) ──
+  // Skip pairs already unified by a HIGH merge.
+  const finalRoot = new Map();
+  for (const m of merges) for (const id of m.ids) finalRoot.set(id, m.winner);
+  const candidates = containmentCandidates(reps).filter((p) => {
+    const ra = finalRoot.get(p.a) || p.a;
+    const rb = finalRoot.get(p.b) || p.b;
+    return ra !== rb;
+  });
+
+  // ── plan ──
+  const loserToWinner = new Map();
+  for (const m of merges) for (const l of m.losers) loserToWinner.set(l, m.winner);
+  const affected = all
+    .filter((b) => loserToWinner.has(b.work_id))
+    .map((b) => ({ book_id: b.id, old_work_id: b.work_id, new_work_id: loserToWinner.get(b.work_id), title: b.title }));
+
+  console.log(`\n${APPLY ? 'APPLY' : 'DRY-RUN'} — ${merges.length} HIGH clusters (${loserToWinner.size} ids retired, ${affected.length} books rewritten), ${candidates.length} MEDIUM pairs queued, ${demoted.length} demoted`);
+  for (const m of merges) {
+    const rep = repByWid.get(m.winner);
+    console.log(`  keep ${m.winner}  [${m.sources.join(', ')}]\n    + ${m.losers.join('\n    + ')}   "${(rep?.title || '').slice(0, 48)}"`);
+  }
+  if (demoted.length) {
+    console.log('\nDEMOTED (span ≥2 canon entries — review by hand):');
+    for (const d of demoted) console.log(`  ${d.ids.join(' + ')}  (${d.reason})`);
+  }
+  console.log('\nsample MEDIUM queue pairs:');
+  for (const p of candidates.slice(0, 15)) {
+    console.log(`  ${p.a} ~ ${p.b}  cont=${p.cont} inter=${p.inter}  "${p.titleA.slice(0, 36)}" ~ "${p.titleB.slice(0, 36)}"  (${p.author})`);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const planPath = path.join(OUT_DIR, `work-merge-plan-${STAMP}.json`);
+  fs.writeFileSync(planPath, JSON.stringify({ generated: new Date().toISOString(), apply: APPLY, merges, demoted, affected, queue: candidates }, null, 1));
+  console.log(`\nplan/backup written: ${planPath}`);
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN — pass --apply to write. Review the cluster list above first.');
+    await client.close();
+    return;
+  }
+
+  // ── apply ──
+  // 1. alias lookup index (the /work/[id] 404-path query)
+  await books.createIndex({ work_id_aliases: 1 }, { sparse: true, name: 'work_id_aliases_1' });
+
+  // 2. rewrite losers → winner, and stamp aliases on every book in each cluster
+  const now = new Date();
+  const ops = [];
+  for (const m of merges) {
+    ops.push({
+      updateMany: {
+        filter: { work_id: { $in: m.losers } },
+        update: { $set: { work_id: m.winner, updated_at: now }, $addToSet: { work_id_aliases: { $each: m.losers } } },
+      },
+    });
+    // books already on the winner id get the aliases too (the redirect and the
+    // provenance live on the work's editions, not just the moved ones)
+    ops.push({
+      updateMany: {
+        filter: { work_id: m.winner, work_id_aliases: { $not: { $all: m.losers } } },
+        update: { $set: { updated_at: now }, $addToSet: { work_id_aliases: { $each: m.losers } } },
+      },
+    });
+  }
+  let modified = 0;
+  for (let i = 0; i < ops.length; i += 200) {
+    const res = await books.bulkWrite(ops.slice(i, i + 200), { ordered: false });
+    modified += res.modifiedCount;
+  }
+
+  // 3. provenance log
+  if (merges.length) {
+    await db.collection('work_id_merges').insertMany(merges.map((m) => ({
+      winner: m.winner, losers: m.losers, sources: m.sources,
+      books_rewritten: affected.filter((a) => a.new_work_id === m.winner).length,
+      issue: 3759, backup: planPath, applied_at: now,
+    })));
+  }
+
+  // 4. review queue (upsert; never clobber a reviewed row's status)
+  let queued = 0;
+  for (const p of candidates) {
+    const [a, b] = [p.a, p.b].sort();
+    const r = await db.collection('work_merge_queue').updateOne(
+      { _id: `${a}|${b}` },
+      {
+        $setOnInsert: { a, b, status: 'pending', created_at: now },
+        $set: { evidence: { cont: p.cont, inter: p.inter, titleA: p.titleA, titleB: p.titleB, author: p.author, source: p.source }, updated_at: now },
+      },
+      { upsert: true }
+    );
+    queued += r.upsertedCount;
+  }
+
+  const verifyLosers = await books.countDocuments({ work_id: { $in: [...loserToWinner.keys()] } });
+  console.log(`\nAPPLIED — ${modified} book docs touched; ${verifyLosers} books still on a loser id (must be 0).`);
+  console.log(`queue: ${queued} new pending pairs (${candidates.length - queued} already present).`);
+  console.log('Next: node scripts/workers/sync-books-catalog.mjs  (books_catalog carries work_id)');
+  await client.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/work/[id]/compare/page.tsx
+++ b/src/app/work/[id]/compare/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import CompareClient from './CompareClient';
 import { canonWork, workEditionsFilter } from '@/lib/canon-works';
+import { workAliasTarget } from '@/lib/work-alias';
 
 // Must be a finite number — `false` would cache a bad render forever (same
 // rule as the parent work page; see CLAUDE.md on ISR + fallible fetches).
@@ -116,6 +117,11 @@ export default async function CompareWorkPage({ params }: PageProps) {
   const { id: rawId } = await params;
   const id = decodeURIComponent(rawId);
   const editions = await getEditionsForCompare(id);
+  if (editions.length === 0) {
+    // retired work_id (merged cluster, #3759) — follow the alias, keep old URLs alive
+    const target = await workAliasTarget(await getReadDb(), id);
+    if (target) redirect(`/work/${encodeURIComponent(target)}/compare`);
+  }
   if (editions.length < 2) notFound();
 
   const title = canonWork(id)?.title || workTitleFromEditions(editions, id);

--- a/src/app/work/[id]/compare/page.tsx
+++ b/src/app/work/[id]/compare/page.tsx
@@ -116,12 +116,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function CompareWorkPage({ params }: PageProps) {
   const { id: rawId } = await params;
   const id = decodeURIComponent(rawId);
-  const editions = await getEditionsForCompare(id);
-  if (editions.length === 0) {
-    // retired work_id (merged cluster, #3759) — follow the alias, keep old URLs alive
+  if (!canonWork(id)) {
+    // retired work_id (merged cluster, #3759) — follow the alias, keep old
+    // URLs alive; before the editions query so a legacy work_slug match
+    // can't pin a fragment page (same ordering as the parent work page)
     const target = await workAliasTarget(await getReadDb(), id);
     if (target) redirect(`/work/${encodeURIComponent(target)}/compare`);
   }
+  const editions = await getEditionsForCompare(id);
   if (editions.length < 2) notFound();
 
   const title = canonWork(id)?.title || workTitleFromEditions(editions, id);

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -6,6 +6,7 @@ import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { canonWork, canonWorkForWorkId, workEditionsFilter, type CanonWork } from '@/lib/canon-works';
+import { workAliasTarget } from '@/lib/work-alias';
 import { authorUrl, bookUrl } from '@/lib/slugify';
 import { locusEdition } from '@/lib/locus-editions';
 import { jsonLdHtml } from '@/lib/json-ld';
@@ -234,7 +235,13 @@ export default async function WorkPage({ params }: PageProps) {
   }
 
   const editions = await getWorkEditions(id);
-  if (editions.length === 0) notFound();
+  if (editions.length === 0) {
+    // a retired work_id (merged into another cluster, #3759) redirects to the
+    // surviving id's address instead of 404ing — old URLs stay citable
+    const target = await workAliasTarget(await getReadDb(), id);
+    if (target) redirect(`/work/${encodeURIComponent(target)}`);
+    notFound();
+  }
   const collected = canon ? await getCollectedEditions(canon) : [];
 
   const title = canon ? canon.title : workTitleFromEditions(editions as { work_title?: string | null }[], id);

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -232,16 +232,16 @@ export default async function WorkPage({ params }: PageProps) {
     // a raw work_id that belongs to a canon entry gets one stable address
     const owner = canonWorkForWorkId(id);
     if (owner) redirect(`/work/${owner.slug}`);
+    // a retired work_id (merged into another cluster, #3759) redirects to the
+    // survivor — old URLs stay citable. Checked BEFORE the editions query:
+    // a legacy work_slug equal to the retired id would otherwise keep
+    // rendering a fragment page. Indexed lookup (work_id_aliases_1).
+    const target = await workAliasTarget(await getReadDb(), id);
+    if (target) redirect(`/work/${encodeURIComponent(target)}`);
   }
 
   const editions = await getWorkEditions(id);
-  if (editions.length === 0) {
-    // a retired work_id (merged into another cluster, #3759) redirects to the
-    // surviving id's address instead of 404ing — old URLs stay citable
-    const target = await workAliasTarget(await getReadDb(), id);
-    if (target) redirect(`/work/${encodeURIComponent(target)}`);
-    notFound();
-  }
+  if (editions.length === 0) notFound();
   const collected = canon ? await getCollectedEditions(canon) : [];
 
   const title = canon ? canon.title : workTitleFromEditions(editions as { work_title?: string | null }[], id);

--- a/src/lib/work-alias.ts
+++ b/src/lib/work-alias.ts
@@ -1,0 +1,26 @@
+import type { Db } from 'mongodb';
+import { canonWorkForWorkId } from '@/lib/canon-works';
+
+/**
+ * Resolve a retired work_id to its current address (#3759).
+ *
+ * When work_id clusters are merged, the losing ids are kept on every edition
+ * of the work in `books.work_id_aliases` (indexed). A /work/<old-id> URL then
+ * finds no editions by direct match; this lookup recovers the current
+ * work_id from any book carrying the alias, and prefers the canon slug when
+ * the surviving id belongs to a canon entry — one stable reading address.
+ *
+ * Returns the target route param (slug or work_id) or null when the id is not
+ * a known alias. No visibility filter: even a fully hidden cluster should
+ * redirect rather than 404, so the address stays stable when books resurface.
+ */
+export async function workAliasTarget(db: Db, id: string): Promise<string | null> {
+  if (!id) return null;
+  const holder = await db
+    .collection('books')
+    .findOne({ work_id_aliases: id }, { projection: { work_id: 1 } });
+  const current = holder?.work_id as string | undefined;
+  if (!current || current === id) return null;
+  const canon = canonWorkForWorkId(current);
+  return canon ? canon.slug : current;
+}

--- a/tests/unit/work-merge-lib.test.ts
+++ b/tests/unit/work-merge-lib.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs module, no type declarations
+import {
+  rankFormat, pickWinner, canonGoldClusters, identicalTitleKey,
+  identicalTitleClusters, containmentPair, containmentCandidates,
+  unionMergeClusters,
+} from '../../scripts/lib/work-merge-lib.mjs';
+import { CANON_WORKS, canonWorkForWorkId } from '@/lib/canon-works';
+
+describe('pickWinner', () => {
+  it('prefers a Wikidata QID over minted and legacy ids', () => {
+    expect(pickWinner(['local:a:plato:timaeus', 'Q371884', 'plato-timaeus'])).toBe('Q371884');
+  });
+  it('prefers local:a over local:n over legacy slugs', () => {
+    expect(pickWinner(['plato-timaeus', 'local:n:x:y', 'local:a:x:y'])).toBe('local:a:x:y');
+    expect(rankFormat('seneca-epistulae-morales')).toBe(3);
+  });
+  it('breaks QID ties by shortest id, deterministically', () => {
+    expect(pickWinner(['Q125518202', 'Q16547641'])).toBe('Q16547641');
+    expect(pickWinner(['Q16547641', 'Q125518202'])).toBe('Q16547641');
+  });
+});
+
+describe('canonGoldClusters', () => {
+  const clusters = canonGoldClusters(CANON_WORKS);
+
+  it('never includes an id shared between two canon entries (combined volumes)', () => {
+    // Q19090449 and homer-homer-iliad-odyssey are Iliad+Odyssey combined
+    // volumes, listed in BOTH entries — merging them into either work would
+    // silently pull it off the other's page.
+    for (const c of clusters) {
+      expect(c.ids).not.toContain('Q19090449');
+      expect(c.ids).not.toContain('homer-homer-iliad-odyssey');
+    }
+  });
+
+  it('produces a merge set for the Iliad from its unshared ids only', () => {
+    const iliad = clusters.find((c) => c.slug === 'iliad');
+    expect(iliad).toBeDefined();
+    expect(iliad!.ids.sort()).toEqual(['Q125518202', 'Q16547641']);
+    expect(iliad!.winner).toBe('Q16547641');
+  });
+
+  it('skips single-id entries (nothing to merge)', () => {
+    expect(clusters.find((c) => c.slug === 'republic')).toBeUndefined();
+    expect(clusters.find((c) => c.slug === 'aeneid')).toBeUndefined();
+  });
+
+  it('never touches collectedWorkIds (Opera containers are separate works)', () => {
+    const collected = new Set(CANON_WORKS.flatMap((w) => w.collectedWorkIds || []));
+    for (const c of clusters) for (const id of c.ids) expect(collected.has(id)).toBe(false);
+  });
+
+  it('prefers the QID for every cluster that has one', () => {
+    for (const c of clusters) {
+      const qids = c.ids.filter((i: string) => /^Q\d+$/.test(i));
+      if (qids.length) expect(/^Q\d+$/.test(c.winner)).toBe(true);
+    }
+  });
+});
+
+describe('identical-title lane', () => {
+  const rep = (work_id: string, title: string, author = 'Luca Pacioli', language = 'Latin') =>
+    ({ work_id, title, author, language });
+
+  it('clusters two ids with the same author and identical normalized title', () => {
+    const out = identicalTitleClusters([
+      rep('local:a:pacioli:summa-arithmetica', 'Summa de arithmetica geometria proportioni'),
+      rep('local:n:pacioli:summa-arithmetic', 'Summa de Arithmetica, Geometria, Proportioni'),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].winner).toBe('local:a:pacioli:summa-arithmetica');
+  });
+
+  it('refuses Tibetan and volume-marked titles (grain hazards)', () => {
+    expect(identicalTitleKey(rep('x', 'gsung thor bu spellings here', 'Anon', 'Tibetan'))).toBeNull();
+    expect(identicalTitleKey(rep('x', 'Opera omnia tomus II something'))).toBeNull();
+  });
+
+  it('keeps series siblings apart via the series key', () => {
+    const out = identicalTitleClusters([
+      rep('w1', 'Proverbs collection number 10', 'Anon x'),
+      rep('w2', 'Proverbs collection number 11', 'Anon x'),
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('refuses a rep standing for a polluted id (multiple distinct titles)', () => {
+    // production case: ellis-tshispeaking-peoples-gold-coast held the Yoruba,
+    // Tshi AND Ewe volumes; its rep matched the Yoruba id and the whole
+    // polluted id would have been moved onto the wrong work.
+    const polluted = { ...rep('ellis-tshi', 'The Yoruba-Speaking Peoples of the Slave Coast', 'A. B. Ellis', 'English'), titleVariants: 3 };
+    const clean = { ...rep('local:a:ellis:yoruba', 'The Yoruba-Speaking Peoples of the Slave Coast', 'A. B. Ellis', 'English'), titleVariants: 1 };
+    expect(identicalTitleClusters([polluted, clean])).toHaveLength(0);
+    expect(identicalTitleClusters([{ ...polluted, titleVariants: 1 }, clean])).toHaveLength(1);
+  });
+
+  it('never clusters across authors', () => {
+    const out = identicalTitleClusters([
+      rep('w1', 'De occulta philosophia libri tres', 'Agrippa'),
+      rep('w2', 'De occulta philosophia libri tres', 'Paracelsus'),
+    ]);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('containment lane (MEDIUM queue)', () => {
+  const rep = (work_id: string, title: string, extra: Record<string, unknown> = {}) =>
+    ({ work_id, title, author: 'Homer', author_id: 'a1', language: 'Greek', ...extra });
+
+  it('flags a fit-rule containment pair as a candidate, never a merge', () => {
+    const pairs = containmentCandidates([
+      rep('Q1', 'The Iliad of Homer with notes and a life of the author'),
+      rep('local:a:homer:iliad', 'Iliad Homer'),
+    ]);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].source).toBe('containment');
+    expect(pairs[0].cont).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('rejects an all-generic anchor ("Works", "Fragments")', () => {
+    expect(containmentPair(
+      rep('a', 'Fragments works'),
+      rep('b', 'Collected works and fragments of early poets'),
+    )).toBeNull();
+  });
+
+  it('rejects series-key mismatches', () => {
+    expect(containmentPair(
+      rep('a', 'Histories book 3 of the Persian wars'),
+      rep('b', 'Histories book 4 of the Persian wars'),
+    )).toBeNull();
+  });
+
+  it('requires at least two shared significant tokens', () => {
+    expect(containmentPair(rep('a', 'Odyssey translated'), rep('b', 'Odyssey'))).toBeNull();
+  });
+
+  it('never compares across author blocks', () => {
+    const pairs = containmentCandidates([
+      rep('Q1', 'Iliad of Homer complete text', { author_id: 'a1' }),
+      rep('Q2', 'Iliad of Homer complete text', { author_id: 'a2' }),
+    ]);
+    expect(pairs).toHaveLength(0);
+  });
+});
+
+describe('unionMergeClusters', () => {
+  it('unions overlapping clusters and picks one winner', () => {
+    const { merges } = unionMergeClusters([
+      { source: 'canon-registry', ids: ['Q1', 'local:a:x:y'], winner: 'Q1', losers: ['local:a:x:y'] },
+      { source: 'identical-title', ids: ['local:a:x:y', 'x-legacy'], winner: 'local:a:x:y', losers: ['x-legacy'] },
+    ]);
+    expect(merges).toHaveLength(1);
+    expect(merges[0].winner).toBe('Q1');
+    expect(merges[0].losers.sort()).toEqual(['local:a:x:y', 'x-legacy']);
+    expect(merges[0].sources).toEqual(['canon-registry', 'identical-title']);
+  });
+
+  it('demotes any union spanning two canon entries instead of merging', () => {
+    const canonMap = new Map([['Q1', 'iliad'], ['Q2', 'odyssey']]);
+    const { merges, demoted } = unionMergeClusters(
+      [{ source: 'identical-title', ids: ['Q1', 'Q2'], winner: 'Q2', losers: ['Q1'] }],
+      canonMap,
+    );
+    expect(merges).toHaveLength(0);
+    expect(demoted).toHaveLength(1);
+    expect(demoted[0].reason).toContain('iliad');
+  });
+});
+
+describe('alias redirect target', () => {
+  it('a surviving canon work_id resolves to its canon slug', () => {
+    // mirrors workAliasTarget()'s canon preference without a DB
+    expect(canonWorkForWorkId('Q16547641')?.slug).toBe('iliad');
+    expect(canonWorkForWorkId('Q371884')?.slug).toBe('timaeus');
+    expect(canonWorkForWorkId('some-random-work')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

The canon registry papers over work_id fragmentation by hand (the Iliad spans 4 ids, Herodotus' Histories 5). Fragmentation also corrupts FT counting and dupe detection. This PR builds the detection + merge + redirect machinery from #3759.

## In scope

- **`scripts/lib/work-merge-lib.mjs`** — pure, unit-tested cluster logic:
  - *canon gold seeds* (HIGH): the hand-verified `workIds` arrays in `canon-works.ts`, **minus ids shared between entries** (combined Iliad+Odyssey volumes are their own work — never merged) and never `collectedWorkIds`.
  - *identical-title* (HIGH): author surname + identical full normalized title + series key; Tibetan and volume-marked titles excluded (same discipline as `merge-duplicate-work-ids.mjs`).
  - *containment* (MEDIUM): the fit rule between clusters, author-anchored — **queue only, never auto-written**.
  - Deterministic winner: QID > `local:a:` > `local:n:` > other; cross-canon-entry unions are demoted, never merged.
  - **Polluted-id guard** (found live in the dry-run): `ellis-tshispeaking-peoples-gold-coast` holds the Yoruba, Tshi AND Ewe volumes; its representative title matched the Yoruba id and the whole id would have merged onto the wrong work. A work_id whose books carry >1 distinct normalized title is now excluded from auto-merge (removed 26 of 223 candidate clusters).
- **`scripts/maintenance/merge-work-clusters.mjs`** — dry-run/apply orchestrator. Apply: rewrite losers → winner, stamp `work_id_aliases` on every edition, provenance to `work_id_merges`, MEDIUM pairs to `work_merge_queue` (pending), alias index, revert backup, `updated_at` bump for the Supabase catalog sync.
- **`src/lib/work-alias.ts`** + `/work/[id]` + `/work/[id]/compare` — a retired work_id 307s to the survivor (canon slug preferred) instead of 404ing. Old URLs stay citable.

## Out of scope (follow-up after the data run)

- Shrinking the canon `workIds` arrays — only correct **after** the merge has run against prod, else canon pages lose editions. Separate PR.
- Splitting polluted ids (the Ellis case needs a split, not a merge) and reviewing the ~1.5K-pair queue.

## Verification

- 21 new unit tests; full unit suite 2367/2367 green.
- Dry-run against prod: 197 HIGH clusters (7 canon, 190 identical-title), 283 books, 0 demoted, 1482 queued pairs — cluster list eyeballed, plan JSON archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)