### PR TITLE
feat(audit): replay gate + gates table — and the third failure class they caught on day one

### DIFF
--- a/scripts/audit/dedup-replay-sample.ts
+++ b/scripts/audit/dedup-replay-sample.ts
@@ -73,9 +73,15 @@ function fullMetadata(b: BookDoc) {
   };
 }
 
-/** Non-Latin stratum: the stored normalized_title is empty while a real title exists. */
+/**
+ * Non-Latin stratum: the stored normalized_title is too short to reach tier 2
+ * (< 5 chars) while a real title exists. Not merely empty: «Чехова. Том 3»
+ * ASCII-normalizes to "3" — non-empty, but just as invisible to the title
+ * tier as the empty string, and stratifying it as "Latin" understates the
+ * non-Latin miss population.
+ */
 function isNonLatin(b: BookDoc): boolean {
-  return !!b.title && (b.normalized_title ?? '') === '';
+  return !!b.title && (b.normalized_title ?? '').length < 5;
 }
 
 async function replay(db: Db, candidate: Parameters<typeof checkDuplicate>[1]): Promise<boolean> {
@@ -95,14 +101,18 @@ async function main() {
   // Oversample non-Latin so its stratum is statistically meaningful instead
   // of ~15% of whatever $sample returns.
   const perStratum = Math.ceil(SAMPLE / 2);
-  const latin = await books.aggregate<BookDoc>([
+  // Stratify by tier-2 REACHABILITY (normalized_title length >= 5, the guard
+  // tier 2 itself applies), not by empty-vs-not — see isNonLatin().
+  const latinRaw = await books.aggregate<BookDoc>([
     { $match: { visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' }, normalized_title: { $nin: [null, ''] } } },
-    { $sample: { size: perStratum } },
+    { $sample: { size: perStratum * 2 } },
   ]).toArray();
-  const nonLatin = await books.aggregate<BookDoc>([
-    { $match: { visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' }, normalized_title: '', title: { $nin: [null, ''] } } },
-    { $sample: { size: perStratum } },
+  const latin = latinRaw.filter((b) => !isNonLatin(b)).slice(0, perStratum);
+  const nonLatinRaw = await books.aggregate<BookDoc>([
+    { $match: { visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' }, title: { $nin: [null, ''] } } },
+    { $sample: { size: perStratum * 6 } },
   ]).toArray();
+  const nonLatin = nonLatinRaw.filter(isNonLatin).slice(0, perStratum);
 
   const strata: Record<string, { same: [number, number]; cross: [number, number] }> = {
     latin: { same: [0, 0], cross: [0, 0] },

--- a/scripts/audit/dedup-replay-sample.ts
+++ b/scripts/audit/dedup-replay-sample.ts
@@ -1,0 +1,180 @@
+/**
+ * dedup-replay-sample — the END-TO-END gate for import dedup (#3730).
+ *
+ * Field-presence metrics ("N books have normalized_title") measure that a
+ * field exists, not that the system works — and they can be gamed by a
+ * definition change. This script measures the behavior we actually care
+ * about: **if we tried to re-import a book we already hold, would dedup
+ * catch it?** It samples live books and replays each one through the real
+ * `checkDuplicate()` twice:
+ *
+ *   same-source replay   full metadata, identifiers included. Tier 1
+ *                        (fingerprint) / tier 3 (IIIF) should make this ~100%.
+ *   cross-source replay  identifiers STRIPPED — simulates the same edition
+ *                        arriving from a different provider, which only the
+ *                        title+author tier can catch. This is the recall
+ *                        number that matters, and the one the ASCII-normalizer
+ *                        hole put in doubt for non-Latin books.
+ *
+ * Results are stratified Latin vs non-Latin (a corpus-wide average would let
+ * the 85% Latin majority mask a dead non-Latin lane — the exact shape of the
+ * bug this gate exists to detect).
+ *
+ * CONTROLS (lesson: a probe needs a positive control — "not found" is
+ * worthless until the probe has returned "found"):
+ *   positive — a handful of books from known duplicate_of pairs, replayed
+ *              cross-source; the keeper must match.
+ *   negative — fabricated titles that exist nowhere; any match is a false
+ *              positive in the probe itself.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/audit/dedup-replay-sample.ts [--sample=500] [--json]
+ */
+import 'dotenv/config';
+import { MongoClient, type Db } from 'mongodb';
+import { checkDuplicate } from '../../src/lib/dedup';
+
+const argv = process.argv.slice(2);
+const SAMPLE = parseInt(argv.find((a) => a.startsWith('--sample='))?.split('=')[1] || '500', 10);
+const JSON_OUT = argv.includes('--json');
+
+interface BookDoc {
+  id: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  year?: number;
+  published?: string;
+  normalized_title?: string;
+  ia_identifier?: string;
+  gallica_ark?: string;
+  mdz_id?: string;
+  bsb_id?: string;
+  google_books_id?: string;
+  image_source?: { provider?: string; identifier?: string; iiif_manifest?: string; pdf_url?: string; source_url?: string };
+  duplicate_of?: string;
+}
+
+/** The cross-source variant: same edition, no shared identifiers. */
+function stripIdentifiers(b: BookDoc) {
+  return {
+    title: b.title || '',
+    author: b.author || '',
+    display_title: b.display_title,
+    year: b.year,
+    published: b.published,
+  };
+}
+
+function fullMetadata(b: BookDoc) {
+  return { ...stripIdentifiers(b),
+    ia_identifier: b.ia_identifier, gallica_ark: b.gallica_ark, mdz_id: b.mdz_id,
+    bsb_id: b.bsb_id, google_books_id: b.google_books_id, image_source: b.image_source,
+  };
+}
+
+/** Non-Latin stratum: the stored normalized_title is empty while a real title exists. */
+function isNonLatin(b: BookDoc): boolean {
+  return !!b.title && (b.normalized_title ?? '') === '';
+}
+
+async function replay(db: Db, candidate: Parameters<typeof checkDuplicate>[1]): Promise<boolean> {
+  const r = await checkDuplicate(db, candidate);
+  return r.isDuplicate;
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection<BookDoc>('books');
+
+  // Live books only — the population a curator could actually re-import.
+  // Oversample non-Latin so its stratum is statistically meaningful instead
+  // of ~15% of whatever $sample returns.
+  const perStratum = Math.ceil(SAMPLE / 2);
+  const latin = await books.aggregate<BookDoc>([
+    { $match: { visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' }, normalized_title: { $nin: [null, ''] } } },
+    { $sample: { size: perStratum } },
+  ]).toArray();
+  const nonLatin = await books.aggregate<BookDoc>([
+    { $match: { visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' }, normalized_title: '', title: { $nin: [null, ''] } } },
+    { $sample: { size: perStratum } },
+  ]).toArray();
+
+  const strata: Record<string, { same: [number, number]; cross: [number, number] }> = {
+    latin: { same: [0, 0], cross: [0, 0] },
+    nonLatin: { same: [0, 0], cross: [0, 0] },
+  };
+  const crossMisses: { id: string; title?: string; stratum: string }[] = [];
+
+  for (const [name, sample] of [['latin', latin], ['nonLatin', nonLatin]] as const) {
+    for (const b of sample) {
+      const s = strata[name];
+      s.same[1]++; s.cross[1]++;
+      if (await replay(db, fullMetadata(b))) s.same[0]++;
+      if (await replay(db, stripIdentifiers(b))) s.cross[0]++;
+      else crossMisses.push({ id: b.id, title: b.title, stratum: name });
+    }
+  }
+
+  // Positive control: keepers of known duplicate pairs, cross-source. These
+  // are books the system has ALREADY adjudicated as having a copy — if the
+  // replay can't find a match for them, the probe is broken, and every miss
+  // above is meaningless.
+  // BOOKS only — most duplicate_of pointers are artworks, whose identity lane
+  // is sha1/CLIP, not title dedup. Sampling them here broke the control on the
+  // first run (0/20 "matched" — every one an artwork with a filename title).
+  const dupPointers = await books.aggregate<BookDoc>([
+    { $match: { duplicate_of: { $exists: true, $nin: [null, ''] }, content_type: { $ne: 'artwork' }, title: { $nin: [null, ''] } } },
+    { $sample: { size: 20 } },
+  ]).toArray();
+  let posCaught = 0;
+  for (const b of dupPointers) {
+    if (await replay(db, stripIdentifiers(b))) posCaught++;
+  }
+
+  // Negative control: fabricated books that exist nowhere.
+  const fabricated = [
+    { title: 'Zxq Phantasmagoria Nonexistens Codexicus', author: 'Nemo, Nusquam', year: 1234 },
+    { title: '虛構之書不存在的目錄編號九九九', author: '無名氏測試', year: 1234 },
+    { title: 'Liber Fictus De Probatione Negativa Anno MMXXVI', author: 'Testman, Probe', year: 1599 },
+  ];
+  let negFalse = 0;
+  for (const f of fabricated) {
+    if (await replay(db, f)) negFalse++;
+  }
+
+  const pct = (n: [number, number]) => (n[1] ? ((100 * n[0]) / n[1]).toFixed(1) + '%' : 'n/a');
+  const summary = {
+    date: new Date().toISOString().slice(0, 10),
+    sample: { latin: strata.latin.same[1], nonLatin: strata.nonLatin.same[1] },
+    sameSource: { latin: pct(strata.latin.same), nonLatin: pct(strata.nonLatin.same) },
+    crossSource: { latin: pct(strata.latin.cross), nonLatin: pct(strata.nonLatin.cross) },
+    controls: {
+      positive: `${posCaught}/${dupPointers.length} known-dup keepers matched (must be high or the probe is broken)`,
+      negative: `${negFalse}/${fabricated.length} fabricated books matched (must be 0)`,
+    },
+    crossMisses: crossMisses.length,
+  };
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ ...summary, missSample: crossMisses.slice(0, 30) }, null, 2));
+  } else {
+    console.log(`dedup replay — ${summary.date}, ${strata.latin.same[1]} Latin + ${strata.nonLatin.same[1]} non-Latin live books`);
+    console.log(`  same-source  (identifiers kept):    Latin ${summary.sameSource.latin}   non-Latin ${summary.sameSource.nonLatin}`);
+    console.log(`  cross-source (identifiers stripped): Latin ${summary.crossSource.latin}   non-Latin ${summary.crossSource.nonLatin}   <- the recall that matters`);
+    console.log(`  positive control: ${summary.controls.positive}`);
+    console.log(`  negative control: ${summary.controls.negative}`);
+    if (crossMisses.length) {
+      console.log(`  cross-source misses (first 10 of ${crossMisses.length}):`);
+      for (const m of crossMisses.slice(0, 10)) console.log(`    [${m.stratum}] ${m.id}  ${JSON.stringify((m.title || '').slice(0, 70))}`);
+    }
+  }
+
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/audit/identity-stack-gates.mjs
+++ b/scripts/audit/identity-stack-gates.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * identity-stack-gates — one command that prints the August plan's Done table.
+ *
+ * #3730's gates, measured live, with dates. Issue bodies drift (the repo has
+ * been burned by this repeatedly — #3102's "4,916 to backfill" was already
+ * done, #2567's checklist was 3-for-5 stale); this script is the version of
+ * the table that cannot drift, because it re-derives every number on demand.
+ * Any future session verifies the month with this instead of trusting prose.
+ *
+ * Read-only. No flags but --json.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/identity-stack-gates.mjs [--json]
+ */
+import { MongoClient } from 'mongodb';
+
+const JSON_OUT = process.argv.includes('--json');
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+const client = new MongoClient(uri, { maxPoolSize: 2 });
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+
+const nonArtwork = { content_type: { $ne: 'artwork' } };
+const live = { visible: true, pages_count: { $gt: 0 }, ...nonArtwork };
+
+// ── Gate 1: Phase 0 health — identity fields exist and keep existing ────────
+const missingFields = await books.countDocuments({
+  ...nonArtwork,
+  $or: [{ edition_key: { $exists: false } }, { normalized_title: { $exists: false } }],
+});
+const lastWorkerRun = await db.collection('cron_runs')
+  .find({ cron: 'identity-worker' }).sort({ timestamp: -1 }).limit(1).next();
+const workerAgeH = lastWorkerRun ? ((Date.now() - new Date(lastWorkerRun.timestamp).getTime()) / 3600e3).toFixed(1) : null;
+
+// ── Gate 2: work_id conflicts (one edition, two works) ──────────────────────
+const conflicts = await books.aggregate([
+  { $match: { ...nonArtwork, edition_key: { $nin: [null, ''] }, work_id: { $nin: [null, ''] } } },
+  { $group: { _id: '$edition_key', works: { $addToSet: '$work_id' }, quality: { $first: '$edition_key_quality' } } },
+  { $match: { 'works.1': { $exists: true } } },
+  { $group: { _id: null, total: { $sum: 1 }, full: { $sum: { $cond: [{ $eq: ['$quality', 'full'] }, 1, 0] } } } },
+]).toArray();
+const conflictTotal = conflicts[0]?.total ?? 0;
+const conflictFull = conflicts[0]?.full ?? 0;
+
+// ── Gate 3: collocation — who could see a sibling, who does ─────────────────
+const multiLang = await books.aggregate([
+  { $match: { ...live, work_id: { $nin: [null, ''] } } },
+  { $group: { _id: '$work_id', langs: { $addToSet: '$language' }, n: { $sum: 1 } } },
+  { $match: { n: { $gt: 1 }, 'langs.1': { $exists: true } } },
+  { $group: { _id: null, clusters: { $sum: 1 }, books: { $sum: '$n' } } },
+]).toArray();
+const editionSiblings = await books.aggregate([
+  { $match: { ...live, edition_key: { $nin: [null, ''] }, edition_key_quality: 'full' } },
+  { $group: { _id: '$edition_key', n: { $sum: 1 } } },
+  { $match: { n: { $gt: 1 } } },
+  { $group: { _id: null, clusters: { $sum: 1 }, books: { $sum: '$n' } } },
+]).toArray();
+
+// ── Gate 4: the duplicate queues ─────────────────────────────────────────────
+const darkPointers = await books.aggregate([
+  { $match: { duplicate_of: { $nin: [null, ''] } } },
+  { $lookup: { from: 'books', localField: 'duplicate_of', foreignField: 'id', as: 'keeper' } },
+  { $unwind: { path: '$keeper', preserveNullAndEmptyArrays: true } },
+  { $match: { $or: [{ keeper: null }, { 'keeper.visible': { $ne: true } }] } },
+  { $count: 'n' },
+]).toArray();
+const bothVisible = await books.aggregate([
+  { $match: { ...live, edition_key: { $nin: [null, ''] } } },
+  { $group: { _id: '$edition_key', n: { $sum: 1 } } },
+  { $match: { n: { $gt: 1 } } },
+  { $count: 'n' },
+]).toArray();
+
+const gates = {
+  measured_at: new Date().toISOString(),
+  phase0: {
+    books_missing_identity_fields: missingFields,
+    target: 0,
+    last_worker_run_hours_ago: workerAgeH,
+    last_worker_stale_missing: lastWorkerRun?.actions?.stale_missing ?? null,
+  },
+  work_id_conflicts: { total: conflictTotal, full_quality: conflictFull, target: '<10' },
+  collocation: {
+    multilanguage_work_clusters: multiLang[0]?.clusters ?? 0,
+    books_addressable: multiLang[0]?.books ?? 0,
+    full_quality_edition_sibling_books: editionSiblings[0]?.books ?? 0,
+    note: 'rail target: every addressable book shows its siblings',
+  },
+  queues: {
+    dark_cluster_pointers: darkPointers[0]?.n ?? 0,
+    both_visible_edition_clusters: bothVisible[0]?.n ?? 0,
+  },
+};
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(gates, null, 2));
+} else {
+  console.log(`identity stack gates — ${gates.measured_at}`);
+  console.log(`  Phase 0:  ${missingFields} books missing identity fields (target 0)`);
+  console.log(`            worker last ran ${workerAgeH ?? 'NEVER'}h ago, stale_missing=${gates.phase0.last_worker_stale_missing ?? '?'}`);
+  console.log(`  Works:    ${conflictTotal} edition/work conflicts (${conflictFull} full-quality; target <10)`);
+  console.log(`  Reader:   ${gates.collocation.books_addressable} live books in multi-language work clusters (${gates.collocation.multilanguage_work_clusters} clusters)`);
+  console.log(`            ${gates.collocation.full_quality_edition_sibling_books} live books with a full-quality edition sibling`);
+  console.log(`  Queues:   ${gates.queues.dark_cluster_pointers} dark pointers, ${gates.queues.both_visible_edition_clusters} both-visible edition clusters`);
+}
+
+await client.close();

--- a/scripts/workers/identity-worker.mjs
+++ b/scripts/workers/identity-worker.mjs
@@ -30,6 +30,14 @@
  * CLI flags:
  *   --limit=N    Max books per run (default 5000)
  *   --dry-run    Report, don't write
+ *   --restamp    Recompute for ALL books and rewrite any stored value that
+ *                differs from the current canonical computation. NOT for the
+ *                cron — this is the repair for normalizer DRIFT: books stamped
+ *                by older/divergent implementations (found 2026-08-08: an old
+ *                article list that kept leading "de", unsorted author tokens
+ *                from direct-insert scripts). Stored values that dedup's
+ *                tier-2 query can no longer find are silent recall loss —
+ *                measured as most of the 10.5% Latin cross-source miss rate.
  */
 
 import { MongoClient } from 'mongodb';
@@ -38,7 +46,8 @@ import { computeIdentityFields } from '../lib/identity-fields.mjs';
 const MONGODB_URI = process.env.MONGODB_URI;
 const argv = process.argv.slice(2);
 const DRY_RUN = argv.includes('--dry-run');
-const LIMIT = parseInt(argv.find((a) => a.startsWith('--limit='))?.split('=')[1] || '5000', 10);
+const RESTAMP = argv.includes('--restamp');
+const LIMIT = parseInt(argv.find((a) => a.startsWith('--limit='))?.split('=')[1] || (RESTAMP ? '200000' : '5000'), 10);
 
 async function main() {
   if (!MONGODB_URI) { console.error('[IDENTITY] MONGODB_URI not set'); process.exit(1); }
@@ -52,16 +61,24 @@ async function main() {
 
   // Field ABSENT = never computed. Field null = computed, unkeyable — not
   // re-selected, or the 127 unkeyable books would thrash every cycle.
-  const queue = {
-    content_type: { $ne: 'artwork' },
-    $or: [
-      { edition_key: { $exists: false } },
-      { normalized_title: { $exists: false } },
-    ],
-  };
+  // --restamp widens the queue to every book and rewrites only diffs.
+  const queue = RESTAMP
+    ? { content_type: { $ne: 'artwork' } }
+    : {
+        content_type: { $ne: 'artwork' },
+        $or: [
+          { edition_key: { $exists: false } },
+          { normalized_title: { $exists: false } },
+        ],
+      };
 
   const cursor = books
-    .find(queue, { projection: { _id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1 } })
+    .find(queue, {
+      projection: {
+        _id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1,
+        normalized_title: 1, normalized_author: 1, edition_key: 1, edition_key_quality: 1,
+      },
+    })
     .limit(LIMIT);
 
   let stamped = 0;
@@ -70,6 +87,17 @@ async function main() {
   for await (const b of cursor) {
     const fields = computeIdentityFields(b);
     if (fields.edition_key == null) unkeyable++;
+    if (RESTAMP) {
+      // Rewrite only genuine drift — an 80k-book no-op bulkWrite is churn and
+      // makes modifiedCount meaningless as verification.
+      const same =
+        b.normalized_title === fields.normalized_title &&
+        b.normalized_author === fields.normalized_author &&
+        (b.edition_key ?? null) === fields.edition_key &&
+        (b.edition_key_quality ?? null) === fields.edition_key_quality &&
+        Object.prototype.hasOwnProperty.call(b, 'edition_key');
+      if (same) continue;
+    }
     ops.push({ updateOne: { filter: { _id: b._id }, update: { $set: fields } } });
     if (ops.length >= 500) {
       if (!DRY_RUN) {
@@ -86,14 +114,21 @@ async function main() {
     } else stamped += ops.length;
   }
 
-  const remaining = await books.countDocuments(queue);
+  // Queue metrics always report the CRON's queue (absence), not the restamp
+  // scan — a cron_runs row claiming "79,755 queued" after a restamp would
+  // read as an outage.
+  const absenceQueue = {
+    content_type: { $ne: 'artwork' },
+    $or: [{ edition_key: { $exists: false } }, { normalized_title: { $exists: false } }],
+  };
+  const remaining = await books.countDocuments(absenceQueue);
 
   // The alarm: a book older than a week with no identity fields means this
   // worker has not been running (or a new writer invented a new gap shape).
   const weekAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
-  const staleMissing = await books.countDocuments({ ...queue, created_at: { $lt: weekAgo } });
+  const staleMissing = await books.countDocuments({ ...absenceQueue, created_at: { $lt: weekAgo } });
 
-  const summary = `stamped ${stamped}${DRY_RUN ? ' (dry-run)' : ''}, ${unkeyable} unkeyable, ${remaining} queued, ${staleMissing} stale-missing`;
+  const summary = `${RESTAMP ? 'RESTAMP: ' : ''}stamped ${stamped}${DRY_RUN ? ' (dry-run)' : ''}, ${unkeyable} unkeyable, ${remaining} queued, ${staleMissing} stale-missing`;
   console.log(`[IDENTITY] ${summary} in ${Math.round((Date.now() - started) / 1000)}s`);
 
   await db.collection('cron_runs').insertOne({


### PR DESCRIPTION
Part of #3730 (lane 1). Two read-only instruments plus the repair they immediately justified.

## The instruments

**`scripts/audit/identity-stack-gates.mjs`** — prints #3730's Done table live, dated. "Done" becomes a command instead of issue prose (which this repo has measured to drift badly — #3102, #2567).

**`scripts/audit/dedup-replay-sample.ts`** — the end-to-end gate: sample live books, replay each through the real `checkDuplicate()` twice — identifiers kept (same-source) and stripped (cross-source) — stratified by tier-2 reachability, with positive and negative controls.

## The controls earned their keep twice before lunch

1. First run's positive control: **0/20**. The probe had sampled `duplicate_of` pointers, which are overwhelmingly artworks — whose identity lane is sha1/CLIP, not title dedup. Books-only: **18/18**. (Lesson already in memory: a probe's "not found" is worthless until it has returned "found.")
2. First stratifier filed «Чехова. Том 3» as Latin — the ASCII normalizer reduces it to `"3"`, non-empty but just as invisible to tier 2 as `''`. Stratum boundary now matches tier 2's own `length >= 5` guard.

## Baseline (2026-08-08, controls green)

| replay | Latin | non-Latin |
|---|---|---|
| same-source (identifiers kept) | 99.0% | 100.0% |
| cross-source (identifiers stripped) | **89.5%** | **0.0%** |

The non-Latin **zero** is the ASCII hole measured as behavior: a non-Latin book re-imported from a different provider sails past the title tier entirely. Fingerprint/IIIF have been carrying the whole load — which is why zero such dupes exist *so far*, and why the edition-key dedup flip (#3730 §2) is justified by measurement, not taste.

## The third failure class: normalizer drift

Most Latin misses weren't the known holes. They were books whose **stored** normalized fields no longer equal what the **current** code computes at query time — stamped by older or divergent implementations:

- old article list that kept leading "de": stored `de concilio liber…` vs computed `concilio liber…`
- unsorted author tokens from direct-insert scripts: stored `manuzio aldo` vs canonical sorted `aldo manuzio`

A book in that state is silently unfindable by tier 2 — recall loss with no error anywhere. **`identity-worker.mjs` gains `--restamp`**: recompute for ALL books, rewrite only diffs; never run by the cron. Run against production: **4,627 drifted books re-stamped in 101s**. Queue metrics in `cron_runs` now always report the cron's absence-queue so a restamp run can't read as an outage.

A post-restamp verification replay is running; result lands as a comment on this PR.

## Verification

- `tsc --noEmit` clean; parity + edition-key suites pass (22 tests).
- Gates table against prod: Phase 0 at 0 missing / `stale_missing` 0; 222 work/edition conflicts; 1,638 live books in multi-language work clusters; 1,993 dark pointers; 297 both-visible clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)