### PR TITLE
docs: writing to a store an automated job reads is actuation, not recording

### DIFF
--- a/.claude/docs/invariants/first-translation-claims.md
+++ b/.claude/docs/invariants/first-translation-claims.md
@@ -54,6 +54,47 @@ resolved to "we badged it": the very claim it existed to qualify. Same family as
 name being a claim about its denominator. When a state promises "earned by evidence", the
 gate must read evidence.
 
+**A prior only defeats a claim if it is COMPLETE and of the SAME text — and the grader
+checked neither** (2026-08-08, #3753). `deriveVerdictFromEvidence` graded the defeat
+branch on a found sighting and the priors' *years alone*. So an `excerpt` defeated a
+claim exactly as a complete edition did, and `prior_relationship` — documented in
+`types.ts` as the field that "determines whether the candidate defeats first" — was
+**hardcoded to `same_text`**, the value that always defeats, while the ingest dropped the
+verifier's actual judgement. Of 429 books graded `not_first`, **31 had no complete prior
+anywhere** (7 already demoted) and **44 had priors of unknown completeness** (36 already
+demoted). Three books verified hours earlier as *badge stands* were demoted overnight.
+
+Two rules follow, and both are about registers, not facts:
+
+- **Judgement must be a field or it does not exist.** Forty verification rounds concluded
+  "this prior does not defeat the claim" — in `notes`, as prose, where no grader can read
+  it. Record the *relationship* (`different_source_language`, `related_distinct_work`),
+  not just the citation. Absent relationship still defaults to defeating, deliberately:
+  most rows predate the field and reversing them silently would be its own mass rewrite.
+- **"All fragments" and "we could not tell" are different verdicts.** Every prior known
+  partial → `first_complete`, a *badgeable* first-family claim (ours may be the first
+  complete edition). Any completeness unknown → `needs_review`. Collapsing them repeats
+  the error one level up.
+
+**A verification queue built from "obvious" over-claims is mostly correct badges.** 39 of
+59 verified by independent subagents, each chosen *because* it looked like a certain
+demote: **25 badges stood, 6 demotes held.** Not one failure was a search failure — every
+one was *which text is this exactly*: Boethius **plus Waleys**, Coornhert's **Dutch**
+Odyssey, Traversari's **Latin** Diogenes, volume 2 **of** the Hagakure, one juan **of** a
+106-juan encyclopedia, *usuras* vs *cambios*, *Shaʿarei Ẓedek* vs *Orah* (and a third
+unrelated text of the same title). Screen before verifying —
+`scripts/audit/ft-demote-queue-screen.mjs` cut 59 to 2 for free, and both its "no signal"
+cases were genuine badge-removals.
+
+**Fabricated priors are the norm here, and the hardest shape is well-formed.** Six
+observed: no named translator; an amalgam ("Hadock **(or** Gibbons)" — two real
+translators of two different works); a *study* counted as a translation (the NLM's own
+catalogue files Savage-Smith as a work *about* the treatise); a wrong date (Read
+1946→"1936"); **a real scholar attached to a nonexistent work** ("Deitz and Monfasani
+1997", "Del Soldato 2010" — absent from their own bibliographies), which defeats every
+structural detector; and a fabrication sitting *beside* a genuine defeater, so finding
+one fabrication does not clear a book.
+
 **Every bug in this area fails toward a confident clean negative.** Fourteen defects in one session, not one of which produced a false positive. A null is the cheap answer at every layer: an inverted year comparison, a capped fallback threshold, a throttled endpoint returning HTTP 200 with HTML, a schema mismatch between two extractors. The only thing that caught them was the **recorded reason on each rejected candidate** — a system that logs only what it found cannot be debugged.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,23 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 - **Judge a worktree by occupancy, never by a global session count.** `reap-worktrees.mjs` keeps a worktree iff a live process has its cwd inside it (`lsof -d cwd`), its git lock names a running pid, or it holds real uncommitted work. Everything else is an orphan. Asked per worktree the question is exact, so reaping is safe with other sessions open — which is what lets `/gnite` reap one window at a time. The old `ps | grep -i claude` count reported **34 sessions on a machine running 3** (it matched the desktop app, the dashboard, and MCP helpers), so `--apply` always refused and the habit became `--force` — the one genuinely dangerous flag. A noisy safety check doesn't fail closed; it trains people to bypass it.
 - **`git worktree remove --force` refuses a *locked* worktree** — git wants `-f -f`. Don't force twice. `EnterWorktree` writes its session pid into the lock reason, so a dead pid means a stale lock (unlock, then reap) and a live pid means someone is working (keep). Locking is a deliberate "don't touch" signal; the reaper honors it.
 
+## Writing to a store an automated job reads is ACTUATION, not recording — CRITICAL
+A ledger, queue or evidence log that a cron or worker consumes is not a notebook; it is
+the input to a writer you are not watching. On 2026-08-08 a first-translation
+verification round wrote 40 rows to an append-only evidence ledger and reported "Sink B
+untouched, no flag written" — true of the ingest, false of the pipeline. Seven hours
+later the nightly loop read that evidence and **removed three public badges**, including
+books the same session had just verified as correct. The rows even carried
+`resolver: tier2_agent`, which is exactly what the loop's safety valve
+(`--resolver=tier2_agent,human`) admits — the evidence unlocked the gate it was meant to
+pass. **Before writing to any such store, ask what reads it and when it next runs**, and
+say so in the report: "ingested N rows; the 05:30 job will act on them." A sign-off that
+sits two hops downstream of the decision is not a sign-off. Prefer a shape where the
+human reviews the *diff* at the point the change becomes visible (see #3726 Tier 3 for
+the pattern). Corollary: **a valve that only removes claims can never undo its own
+error** — `--only-demotions` is right for an unattended job, and it means every mistake
+it makes needs a person. Related: `.claude/docs/invariants/first-translation-claims.md`.
+
 ## Data Protection — CRITICAL
 - **NEVER** delete books, pages, or source material without explicit confirmation
 - **NEVER** batch delete — list items first, wait for approval


### PR DESCRIPTION
The lesson from 2026-08-08, both tiers.

## CLAUDE.md — the unconditional half

A verification round wrote 40 rows to an append-only evidence ledger and reported *"Sink B untouched, no flag written"* — true of the ingest, false of the pipeline. Seven hours later the nightly loop read that evidence and **removed three public badges**, including books the same session had just verified as correct.

The rows carried `resolver: tier2_agent`, which is exactly what the loop's safety valve (`--resolver=tier2_agent,human`) admits. **The evidence unlocked the gate it was meant to pass.**

Goes in CLAUDE.md rather than an invariant because the trigger cannot be named as a subsystem — it is *any* store with a downstream automated reader — and the consequence was a public claim changing overnight with nobody watching. Adds the corollary too: **a valve that only removes claims can never undo its own error.** `--only-demotions` is right for an unattended job, and it means every mistake it makes needs a person.

205 → 222 lines, inside the ~250 budget. Nothing demoted; nothing in the file turned out stale this session.

## The FT invariant — the subsystem half

- **A prior defeats a claim only if COMPLETE and of the SAME text**, and the grader checked neither. `prior_relationship` is documented in `types.ts` as the field that *"determines whether the candidate defeats first"* and was hardcoded to the always-defeating value. Blast radius: of 429 books graded `not_first`, **31 had no complete prior** (7 demoted) and **44 unknown completeness** (36 demoted).
- **Judgement must be a field or it does not exist.** Forty rounds concluded "this prior does not defeat the claim" — in `notes`, as prose, where no grader can read it.
- **"All fragments" ≠ "we could not tell."** All-known-partial → `first_complete` (badgeable); any-unknown → `needs_review`.
- **A queue of "obvious" over-claims is mostly correct badges** — 25 of 39 stood, and not one failure was a search failure.
- **Six fabricated-prior shapes**, the hardest being a real scholar attached to a nonexistent work, which defeats every structural detector.

Plus the session handoff.

Related: #3753, #3763, #3764, #3687, #3726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)