### PR TITLE
docs(handoff): the merge pass finished — correct the "re-run from scratch" instruction

### DIFF
--- a/.claude/handoffs/2026-08-08-greek-five-acquisition-and-work-identity.md
+++ b/.claude/handoffs/2026-08-08-greek-five-acquisition-and-work-identity.md
@@ -109,12 +109,30 @@ a book is still in the backlog. `--include-backlog` linked **10,101** books
   exactly where junk strings live (#3434, #3770), and a rebuild can reshape existing
   clusters and relink live books.
 - **#3770 — `[object Object]`.** 3,297 books, all hidden, zero visible.
-- **LLM merge pass unfinished.** `llm-verify-work-merges.mjs` was at ~800/1387 authors
-  when the session ended (proposals only, no writes, ~$1 of `gemini-3.1-flash-lite`).
-  It writes `scripts/output/llm-work-merge-proposals.json` **only at the end**, so a
-  killed run leaves nothing — **re-run from scratch**, don't look for partial output.
-  1,387 candidate authors; the 10,101 newly-linked books are what make more of them
-  eligible.
+- **LLM merge pass COMPLETED — do NOT re-run it.** (Corrects an earlier line in this
+  handoff that said to re-run from scratch; that was written while it was still in
+  flight.) `llm-verify-work-merges.mjs` finished all 1,387 candidate authors:
+  **471 groups, 450 HIGH, 1,737 books.** Proposals at
+  `scripts/output/llm-work-merge-proposals.json` (gitignored; backup copy in the
+  session scratchpad as `llm-work-merge-proposals-2026-08-08.json`). **Nothing was
+  applied.**
+
+  Many are the divergent-title cross-language wins the tool exists for — al-Bīrūnī's
+  *Taḥqīq mā li-l-Hind* (Arabic + Sachau), Cagliostro's *Mémoire* (French + English),
+  Avicenna's *Canon* pulling 8 Arabic/Latin items together.
+
+  **Review before applying — roughly 12% sit on shapes the casebook says need
+  judgment.** 41 groups contain a volume/part-marked title, 14 contain a
+  container-ish one. Two concrete suspected mis-merges found by inspection:
+  - `[archimedes] Opera omnia` would fuse a Bodmer manuscript, the 1544 Basel editio
+    princeps, Heiberg Vol. I and "The Works of Archimedes" into one work — a
+    **container merged with its own constituents** (casebook #4).
+  - `[abhinavagupta] Tantrāloka` would absorb "The Essence of Tantra", almost
+    certainly the *Tantrasāra* — a distinct, abridged work by the same author.
+
+  The `hasVolumeConflict` guard catches *conflicting* volume numbers (it correctly
+  kept Libavius's *pars prima* and *pars quarta* apart) but not a volume merged with
+  a non-volume item. Worth strengthening before a bulk apply.
 
 ## 6. Downstream effects to expect
 


### PR DESCRIPTION
One-line-class correction to the handoff merged in #3781.

That handoff said the LLM work-merge pass was unfinished and should be **re-run from scratch**. True when written; wrong now — it completed all 1,387 candidate authors after the session had wrapped. Leaving the instruction would cost the next session a pointless ~$1 re-run of work already done.

**Result: 471 groups, 450 HIGH, 1,737 books. Nothing applied.** Proposals at `scripts/output/llm-work-merge-proposals.json`.

The genuine wins are the divergent-title cross-language ones the tool exists for — al-Bīrūnī's *Taḥqīq mā li-l-Hind* (Arabic + Sachau edition), Cagliostro's *Mémoire* (French + English), Avicenna's *Canon of Medicine* pulling 8 Arabic/Latin items together.

But it should **not** be bulk-applied unreviewed. ~12% of groups sit on shapes the casebook says need judgment — 41 contain a volume/part-marked title, 14 a container-ish one — and inspection found two concrete suspected mis-merges:

- **`[archimedes] Opera omnia`** would fuse a Bodmer manuscript, the 1544 Basel editio princeps, Heiberg Vol. I and "The Works of Archimedes" into one work. That is a **container merged with its own constituents** (casebook #4: a Sammelband gets its own id; the claim belongs to the parts).
- **`[abhinavagupta] Tantrāloka`** would absorb "The Essence of Tantra" — almost certainly the *Tantrasāra*, a distinct abridged work by the same author.

Root cause worth fixing before any bulk apply: `hasVolumeConflict` rejects *conflicting* volume numbers (it correctly kept Libavius's *pars prima* and *pars quarta* apart) but not a volume merged with a non-volume item.

Docs only.