### PR TITLE
feat(work): shrink canon workIds arrays — one survivor per cluster (#3759)

### DIFF
--- a/src/lib/canon-works.ts
+++ b/src/lib/canon-works.ts
@@ -1,10 +1,17 @@
 /**
  * Canon works registry — hand-curated landing slugs for major ancient works.
  *
- * Why this exists: the same work is fragmented across several `books.work_id`
- * values (Wikidata QIDs, minted `local:…` ids, legacy clean slugs — the Iliad
- * alone spans four). A canon slug aggregates those verified clusters into one
- * stable reading address: /work/iliad. See issue #3736.
+ * Why this exists: the same work used to be fragmented across several
+ * `books.work_id` values (Wikidata QIDs, minted `local:…` ids, legacy clean
+ * slugs — the Iliad alone spanned four). A canon slug aggregates verified
+ * clusters into one stable reading address: /work/iliad. See issue #3736.
+ *
+ * Since the #3759 merge (2026-08-08) each fragmented cluster has ONE surviving
+ * work_id; retired ids live in `books.work_id_aliases` and /work/[id] 307s
+ * them to the survivor, so entries here hold a single id unless the extra ids
+ * are genuinely distinct works (combined Iliad+Odyssey volumes). Run
+ * `scripts/maintenance/merge-work-clusters.mjs` before adding a multi-id
+ * entry — the merge is usually the right move, not a longer array.
  *
  * Rules for adding an entry:
  * - Every id in `workIds`/`collectedWorkIds` must be VERIFIED against
@@ -56,7 +63,10 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Homer',
     era: 'c. 8th century BCE',
     originalLanguage: 'Greek',
-    workIds: ['Q125518202', 'Q16547641', 'homer-homer-iliad-odyssey', 'Q19090449'],
+    // Q125518202 merged into Q16547641 (2026-08-08, #3759); the two remaining
+    // extra ids are combined Iliad+Odyssey volumes, shared with the Odyssey
+    // entry on purpose — they are their own work_id, never merged.
+    workIds: ['Q16547641', 'homer-homer-iliad-odyssey', 'Q19090449'],
     collectedWorkIds: HOMER_COLLECTED,
   },
   {
@@ -97,7 +107,7 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Plato',
     era: 'c. 360 BCE',
     originalLanguage: 'Greek',
-    workIds: ['Q371884', 'plato-timaeus'],
+    workIds: ['Q371884'], // plato-timaeus merged in (2026-08-08, #3759)
     collectedWorkIds: PLATO_COLLECTED,
     locus: { system: 'stephanus', workSlug: 'timaeus', example: '29d' },
   },
@@ -169,13 +179,7 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Herodotus',
     era: 'c. 430 BCE',
     originalLanguage: 'Greek',
-    workIds: [
-      'Q746583',
-      'local:n:herodotus:histories',
-      'local:a:herodotus:1-2-persian-wars',
-      'local:a:herodotus:historiae',
-      'local:a:herodotus:histories-works',
-    ],
+    workIds: ['Q746583'], // 4 local fragment ids merged in (2026-08-08, #3759)
   },
   {
     slug: 'meditations',
@@ -193,7 +197,7 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Euclid',
     era: 'c. 300 BCE',
     originalLanguage: 'Greek',
-    workIds: ['Q172891', 'local:a:euclid:elements'],
+    workIds: ['Q172891'], // local:a:euclid:elements merged in (2026-08-08, #3759)
   },
   {
     slug: 'aeneid',
@@ -221,7 +225,7 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Lucretius',
     era: 'c. 55 BCE',
     originalLanguage: 'Latin',
-    workIds: ['Q137592632', 'local:a:titus-lucretius:natura-rerum'],
+    workIds: ['Q137592632'], // local natura-rerum id merged in (2026-08-08, #3759)
   },
   {
     slug: 'consolation-of-philosophy',
@@ -230,7 +234,7 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Boethius',
     era: '524 CE',
     originalLanguage: 'Latin',
-    workIds: ['Q138752489', 'local:n:boethius:consolation-philosophy'],
+    workIds: ['Q138752489'], // local consolation id merged in (2026-08-08, #3759)
   },
   {
     slug: 'epistulae-morales',
@@ -239,10 +243,8 @@ export const CANON_WORKS: CanonWork[] = [
     author: 'Seneca',
     era: 'c. 65 CE',
     originalLanguage: 'Latin',
-    workIds: [
-      'seneca-epistulae-morales',
-      'local:a:seneca:ad-add-buschius-epistolae-hermannus-lucilium-senecae-vita',
-    ],
+    // seneca-epistulae-morales merged in (2026-08-08, #3759)
+    workIds: ['local:a:seneca:ad-add-buschius-epistolae-hermannus-lucilium-senecae-vita'],
   },
 ];
 

--- a/tests/unit/work-merge-lib.test.ts
+++ b/tests/unit/work-merge-lib.test.ts
@@ -22,7 +22,16 @@ describe('pickWinner', () => {
 });
 
 describe('canonGoldClusters', () => {
-  const clusters = canonGoldClusters(CANON_WORKS);
+  // The registry AS IT STOOD before the 2026-08-08 merge run — frozen here so
+  // the extraction rules stay pinned even though the live registry has since
+  // shrunk to single ids (the merge's whole point).
+  const PRE_MERGE_REGISTRY = [
+    { slug: 'iliad', workIds: ['Q125518202', 'Q16547641', 'homer-homer-iliad-odyssey', 'Q19090449'] },
+    { slug: 'odyssey', workIds: ['local:a:homer:dolinghe-odyssea-ulysse-van', 'Q19090449', 'homer-homer-iliad-odyssey'] },
+    { slug: 'republic', workIds: ['plato-republic'], collectedWorkIds: ['Q139619812', 'plato-opera-ficino'] },
+    { slug: 'timaeus', workIds: ['Q371884', 'plato-timaeus'] },
+  ];
+  const clusters = canonGoldClusters(PRE_MERGE_REGISTRY);
 
   it('never includes an id shared between two canon entries (combined volumes)', () => {
     // Q19090449 and homer-homer-iliad-odyssey are Iliad+Odyssey combined
@@ -41,21 +50,25 @@ describe('canonGoldClusters', () => {
     expect(iliad!.winner).toBe('Q16547641');
   });
 
-  it('skips single-id entries (nothing to merge)', () => {
+  it('skips entries left with fewer than two unshared ids', () => {
     expect(clusters.find((c) => c.slug === 'republic')).toBeUndefined();
-    expect(clusters.find((c) => c.slug === 'aeneid')).toBeUndefined();
+    expect(clusters.find((c) => c.slug === 'odyssey')).toBeUndefined();
   });
 
-  it('never touches collectedWorkIds (Opera containers are separate works)', () => {
+  it('prefers the QID winner (timaeus)', () => {
+    expect(clusters.find((c) => c.slug === 'timaeus')!.winner).toBe('Q371884');
+  });
+
+  it('LIVE registry steady state: no mergeable fragmentation remains', () => {
+    // Post-merge every entry holds one id (plus genuinely-shared combined
+    // volumes). If this fails, someone added a multi-id entry — run
+    // merge-work-clusters.mjs instead of growing the array.
+    expect(canonGoldClusters(CANON_WORKS)).toEqual([]);
+  });
+
+  it('LIVE registry never lists a collected id inside workIds', () => {
     const collected = new Set(CANON_WORKS.flatMap((w) => w.collectedWorkIds || []));
-    for (const c of clusters) for (const id of c.ids) expect(collected.has(id)).toBe(false);
-  });
-
-  it('prefers the QID for every cluster that has one', () => {
-    for (const c of clusters) {
-      const qids = c.ids.filter((i: string) => /^Q\d+$/.test(i));
-      if (qids.length) expect(/^Q\d+$/.test(c.winner)).toBe(true);
-    }
+    for (const w of CANON_WORKS) for (const id of w.workIds) expect(collected.has(id)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to #3774. The #3759 merge run has been applied to production (197 clusters, 283 books rewritten, 0 dangling loser ids, backup + `work_id_merges` provenance): every canon fragment cluster now has one surviving work_id, and retired ids 307 via `books.work_id_aliases`. The registry's multi-id arrays are therefore obsolete — this PR shrinks them.

- 7 entries shrink to their surviving id (iliad, timaeus, herodotus-histories, elements, de-rerum-natura, consolation-of-philosophy, epistulae-morales).
- Iliad/Odyssey keep their genuinely-shared combined-volume ids (distinct works, on purpose).
- New steady-state test: `canonGoldClusters(CANON_WORKS)` must stay empty — adding a multi-id entry instead of running `merge-work-clusters.mjs` fails CI. The extraction rules stay pinned against a frozen pre-merge fixture.

## Verified

- Prod spot-tests after the data run: `/work/plato-timaeus` → 307 `/work/timaeus`; `/work/fraternitatis-augsburg-confession` → 307 to its winner; `/work/local:a:herodotus:historiae` → 307 `/work/herodotus-histories`; `/work/iliad` renders with the merged 12th-c. manuscript.
- tsc clean; 2456/2456 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)