### PR TITLE
feat(identity): warehouse joins Phase 0, and the edition-key dedup tier is measured safe (#3730 §2)

### DIFF
--- a/.claude/docs/invariants/edition-identity.md
+++ b/.claude/docs/invariants/edition-identity.md
@@ -46,7 +46,11 @@ Two call sites, and only two:
 - `scripts/workers/identity-worker.mjs`, cron on Hetzner every 2h, which stamps
   any book missing the fields **however it was inserted** — this is what closes
   the 47-direct-insert-scripts hole, and it runs even while the pipeline is
-  paused (zero AI cost; the pause exists to stop paid work).
+  paused (zero AI cost; the pause exists to stop paid work). Since 2026-08-08 it
+  covers `books_warehouse` too (backfilled: 22,542 stamped, 100 unkeyable) —
+  import dedup queries the warehouse alongside the live library, so an unstamped
+  warehouse row is invisible to any identity-keyed tier. `stale_missing` in
+  `cron_runs` is the COMBINED count across both collections.
 
 Field convention: **absent = never computed** (the worker's queue), **null =
 computed, unkeyable** (stub title — a correct terminal state, not a gap). Never

--- a/scripts/audit/edition-key-shadow-measure.ts
+++ b/scripts/audit/edition-key-shadow-measure.ts
@@ -1,0 +1,306 @@
+/**
+ * edition-key-shadow-measure — #3730 §2, the measurement before the flip.
+ *
+ * Import dedup's tier 2 currently matches on `normalized_title` +
+ * `normalized_author` (ASCII, whole-name) with year/volume as a both-sides
+ * veto. The edition layer (#3710) proposes to replace that with the stored
+ * `edition_key` (Unicode title + surname + year + volume). This script runs
+ * BOTH matchers over a real import population and reports where they agree,
+ * where the edition tier catches what the live tier misses, and — the part
+ * that could block the flip — where the live tier catches something the
+ * edition tier would let through.
+ *
+ * Population (per the issue): every non-artwork book imported since
+ * 2026-07-01, plus a 1,000-doc sample of `books_warehouse`. Each is replayed
+ * as a would-be import with identifiers stripped (tiers 1/3 are untouched by
+ * the flip, so only tier-2 behaviour matters), with the candidate itself
+ * excluded from the match sets — at import time it wasn't there yet.
+ *
+ * Shadow matcher semantics (from #3730): edition-key equality when both sides
+ * carry full quality; title+surname with year/volume as a both-sides veto
+ * otherwise. A missing year is NON-distinguishing — the safe error is "assume
+ * duplicate". Implemented as one rule: stored keys sharing the candidate's
+ * `title|surname|` prefix match unless both sides state a different year or
+ * volume. (Full-vs-full then reduces to exact key equality.)
+ *
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/audit/edition-key-shadow-measure.ts [--since=2026-07-01]
+ *     [--warehouse-sample=1000] [--limit=N] [--json]
+ */
+import 'dotenv/config';
+import { MongoClient, type Collection, type Db, type Document } from 'mongodb';
+import { normalizeTitle, normalizeAuthor, editionYear, extractVolume } from '../../src/lib/dedup';
+import { buildEditionKey } from '../../src/lib/edition-key';
+
+const argv = process.argv.slice(2);
+const arg = (name: string, dflt: string) => argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1] || dflt;
+const SINCE = new Date(arg('since', '2026-07-01'));
+const WAREHOUSE_SAMPLE = parseInt(arg('warehouse-sample', '1000'), 10);
+const LIMIT = parseInt(arg('limit', '0'), 10); // 0 = full population
+const JSON_OUT = argv.includes('--json');
+const CONCURRENCY = 8;
+
+interface Candidate {
+  collection: 'books' | 'books_warehouse';
+  id: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  year?: number;
+  published?: string;
+  normalized_title?: string;
+}
+
+interface MatchRef {
+  collection: string; id: string; title?: string; author?: string; year?: number | null;
+  normalized_title?: string; edition_key?: string | null;
+}
+
+const PROJ = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, normalized_title: 1, edition_key: 1 };
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Same reachability heuristic as dedup-replay-sample.ts: the stored ASCII
+ * normalized_title is too short for tier 2 while a real title exists. */
+function isNonLatin(c: Candidate): boolean {
+  return !!c.title && normalizeTitle(c.title).length < 5;
+}
+
+function notSelf(c: Candidate) {
+  return (m: { cn: string; doc: Document }) => !(m.cn === c.collection && (m.doc.id || String(m.doc._id)) === c.id);
+}
+
+function toRef(m: { cn: string; doc: Document }): MatchRef {
+  return {
+    collection: m.cn,
+    id: m.doc.id || String(m.doc._id),
+    title: m.doc.title,
+    author: m.doc.author,
+    year: editionYear(m.doc as { year?: number | null; published?: string | null }),
+    normalized_title: m.doc.normalized_title,
+    edition_key: Object.prototype.hasOwnProperty.call(m.doc, 'edition_key') ? m.doc.edition_key : undefined,
+  };
+}
+
+/** Tier 2 of checkDuplicate(), verbatim semantics, self excluded. */
+async function liveTier2(db: Db, c: Candidate): Promise<MatchRef[]> {
+  const normTitle = normalizeTitle(c.title || '');
+  const normAuthor = normalizeAuthor(c.author || '');
+  if (normTitle.length < 5) return [];
+  const candYear = editionYear(c);
+  const candVol = extractVolume(c.display_title) ?? extractVolume(c.title);
+  const out: { cn: string; doc: Document }[] = [];
+  for (const cn of ['books', 'books_warehouse'] as const) {
+    const rows = await db.collection(cn)
+      .find({ normalized_title: normTitle, normalized_author: normAuthor }, { projection: PROJ })
+      .limit(6).toArray();
+    for (const doc of rows) {
+      const tmYear = editionYear(doc as { year?: number | null; published?: string | null });
+      const tmVol = extractVolume(doc.display_title) ?? extractVolume(doc.title);
+      if (candYear != null && tmYear != null && candYear !== tmYear) continue;
+      if (candVol != null && tmVol != null && candVol !== tmVol) continue;
+      out.push({ cn, doc });
+    }
+  }
+  return out.filter(notSelf(c)).map(toRef);
+}
+
+/** The proposed edition-key tier, self excluded. */
+async function shadowTier(db: Db, c: Candidate): Promise<{ matches: MatchRef[]; blind?: string }> {
+  const ek = buildEditionKey(c);
+  if (!ek.key) return { matches: [], blind: ek.reason || 'unkeyable' };
+  const { title, author, year, volume } = ek.parts;
+  const prefix = new RegExp(`^${escapeRegex(`${title}|${author}|`)}`);
+  const out: { cn: string; doc: Document }[] = [];
+  for (const cn of ['books', 'books_warehouse'] as const) {
+    const rows = await db.collection(cn)
+      .find({ edition_key: prefix }, { projection: PROJ })
+      .limit(25).toArray();
+    for (const doc of rows) {
+      // Stored key: `title|surname|year|vN`. Normalized parts never contain
+      // '|' (normalization strips all punctuation), so a rsplit is safe.
+      const segs = String(doc.edition_key).split('|');
+      const volSeg = segs[segs.length - 1] || '';
+      const yearSeg = segs[segs.length - 2] || '';
+      const tmYear = yearSeg === '' ? null : parseInt(yearSeg, 10);
+      const tmVol = volSeg === 'v' ? null : parseInt(volSeg.slice(1), 10);
+      if (year != null && tmYear != null && year !== tmYear) continue;
+      if (volume != null && tmVol != null && volume !== tmVol) continue;
+      out.push({ cn, doc });
+    }
+  }
+  return { matches: out.filter(notSelf(c)).map(toRef) };
+}
+
+type Verdict =
+  | 'agree_clean' | 'agree_dup'
+  | 'shadow_only_live_blind'   // live tier can't even query (non-Latin / short ASCII title)
+  | 'shadow_only_author_form'  // same ASCII title, but whole-name normalized_author differs — surname caught it
+  | 'shadow_only_other'        // Unicode title matched where the ASCII one didn't, or year/vol wildcard differences
+  | 'live_only_unkeyable'      // candidate has no edition key at all
+  | 'live_only_match_unkeyed'  // the doc live matched carries no stored edition_key (stamping gap, not a matcher gap)
+  | 'live_only_surname_split'  // live matched a doc whose surname differs from candidate's
+  | 'live_only_other';         // the flip would LOSE this catch — must stay ~0
+
+interface Row {
+  collection: string; id: string; title?: string; author?: string; year?: number | null;
+  verdict: Verdict; live: MatchRef[]; shadow: MatchRef[]; nonLatin: boolean;
+}
+
+async function classify(db: Db, c: Candidate): Promise<Row> {
+  const [live, shadow] = [await liveTier2(db, c), await shadowTier(db, c)];
+  const liveDup = live.length > 0;
+  const shadowDup = shadow.matches.length > 0;
+  let verdict: Verdict;
+  if (liveDup === shadowDup) {
+    verdict = liveDup ? 'agree_dup' : 'agree_clean';
+  } else if (shadowDup) {
+    const normTitle = normalizeTitle(c.title || '');
+    if (normTitle.length < 5) verdict = 'shadow_only_live_blind';
+    else {
+      // Same ASCII title on some shadow match => live's query key was the
+      // author; the whole-name sorted form split what the surname unified.
+      const normAuthor = normalizeAuthor(c.author || '');
+      const authorForm = shadow.matches.some(
+        (m) => m.normalized_title === normTitle && normalizeAuthor(m.author || '') !== normAuthor,
+      );
+      verdict = authorForm ? 'shadow_only_author_form' : 'shadow_only_other';
+    }
+  } else {
+    if (shadow.blind) verdict = 'live_only_unkeyable';
+    else if (live.some((m) => m.edition_key == null)) verdict = 'live_only_match_unkeyed';
+    else {
+      const surname = buildEditionKey(c).parts.author;
+      const splitSurname = live.some((m) => buildEditionKey(m as Candidate).parts.author !== surname);
+      verdict = splitSurname ? 'live_only_surname_split' : 'live_only_other';
+    }
+  }
+  return {
+    collection: c.collection, id: c.id, title: c.title, author: c.author,
+    year: editionYear(c), verdict, live, shadow: shadow.matches, nonLatin: isNonLatin(c),
+  };
+}
+
+async function pool<T, R>(items: T[], n: number, fn: (t: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let i = 0;
+  await Promise.all(Array.from({ length: n }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      out[idx] = await fn(items[idx]);
+    }
+  }));
+  return out;
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+  const client = new MongoClient(uri, { maxPoolSize: CONCURRENCY + 2 });
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const recentBooks = await db.collection('books').find(
+    { content_type: { $ne: 'artwork' }, created_at: { $gte: SINCE }, title: { $nin: [null, ''] } },
+    { projection: PROJ },
+  ).toArray();
+  const warehouse = await db.collection('books_warehouse').aggregate<Document>([
+    { $match: { title: { $nin: [null, ''] } } },
+    { $sample: { size: WAREHOUSE_SAMPLE } },
+    { $project: PROJ },
+  ]).toArray();
+
+  let candidates: Candidate[] = [
+    ...recentBooks.map((d) => ({ ...(d as Omit<Candidate, 'collection' | 'id'>), collection: 'books' as const, id: (d.id || String(d._id)) as string })),
+    ...warehouse.map((d) => ({ ...(d as Omit<Candidate, 'collection' | 'id'>), collection: 'books_warehouse' as const, id: (d.id || String(d._id)) as string })),
+  ];
+  if (LIMIT > 0) candidates = candidates.slice(0, LIMIT);
+  console.error(`population: ${recentBooks.length} books since ${SINCE.toISOString().slice(0, 10)} + ${warehouse.length} warehouse sample${LIMIT ? ` (capped ${LIMIT})` : ''}`);
+
+  let done = 0;
+  const rows = await pool(candidates, CONCURRENCY, async (c) => {
+    const r = await classify(db, c);
+    if (++done % 1000 === 0) console.error(`  ...${done}/${candidates.length}`);
+    return r;
+  });
+
+  // Controls (lesson: a probe needs a positive control). Positive: keepers of
+  // adjudicated duplicate pairs — BOTH matchers should flag them; the shadow
+  // tier failing books the live tier catches here would block the flip on its
+  // own. Negative: fabricated books that exist nowhere.
+  const dupPointers = await db.collection('books').aggregate<Document>([
+    { $match: { duplicate_of: { $exists: true, $nin: [null, ''] }, content_type: { $ne: 'artwork' }, title: { $nin: [null, ''] } } },
+    { $sample: { size: 20 } },
+    { $project: PROJ },
+  ]).toArray();
+  let posLive = 0, posShadow = 0;
+  for (const d of dupPointers) {
+    const c: Candidate = { ...(d as Omit<Candidate, 'collection' | 'id'>), collection: 'books', id: (d.id || String(d._id)) as string };
+    if ((await liveTier2(db, c)).length) posLive++;
+    if ((await shadowTier(db, c)).matches.length) posShadow++;
+  }
+  const fabricated: Candidate[] = [
+    { collection: 'books', id: '_neg1', title: 'Zxq Phantasmagoria Nonexistens Codexicus', author: 'Nemo, Nusquam', year: 1234 },
+    { collection: 'books', id: '_neg2', title: '虛構之書不存在的目錄編號九九九', author: '無名氏測試', year: 1234 },
+  ];
+  let negHits = 0;
+  for (const f of fabricated) {
+    if ((await liveTier2(db, f)).length || (await shadowTier(db, f)).matches.length) negHits++;
+  }
+
+  const counts: Record<string, number> = {};
+  for (const r of rows) counts[r.verdict] = (counts[r.verdict] || 0) + 1;
+  const total = rows.length;
+  const agree = (counts.agree_clean || 0) + (counts.agree_dup || 0);
+  const nonLatinRows = rows.filter((r) => r.nonLatin);
+  const nlAgree = nonLatinRows.filter((r) => r.verdict.startsWith('agree')).length;
+  const nlShadowOnly = nonLatinRows.filter((r) => r.verdict.startsWith('shadow_only')).length;
+
+  const sample = (v: Verdict, n = 8) => rows.filter((r) => r.verdict === v).slice(0, n)
+    .map((r) => ({ collection: r.collection, id: r.id, title: (r.title || '').slice(0, 80), author: r.author, year: r.year,
+      live: r.live.slice(0, 3), shadow: r.shadow.slice(0, 3) }));
+
+  const summary = {
+    date: new Date().toISOString().slice(0, 10),
+    population: { books_since: SINCE.toISOString().slice(0, 10), books: recentBooks.length, warehouse: warehouse.length, measured: total },
+    agreement_pct: total ? +((100 * agree) / total).toFixed(2) : null,
+    counts,
+    non_latin: { candidates: nonLatinRows.length, agree: nlAgree, shadow_only_catches: nlShadowOnly },
+    controls: {
+      positive: `live ${posLive}/${dupPointers.length}, shadow ${posShadow}/${dupPointers.length} known-dup keepers flagged`,
+      negative: `${negHits}/${fabricated.length} fabricated books flagged (must be 0)`,
+    },
+    examples: {
+      shadow_only_live_blind: sample('shadow_only_live_blind'),
+      shadow_only_author_form: sample('shadow_only_author_form'),
+      shadow_only_other: sample('shadow_only_other'),
+      live_only_surname_split: sample('live_only_surname_split'),
+      live_only_unkeyable: sample('live_only_unkeyable'),
+      live_only_other: sample('live_only_other', 20),
+    },
+  };
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(`edition-key shadow measure — ${summary.date}, ${total} candidates`);
+    console.log(`  agreement (same isDuplicate verdict): ${summary.agreement_pct}%`);
+    console.log(`  verdicts: ${JSON.stringify(counts)}`);
+    console.log(`  non-Latin stratum: ${nonLatinRows.length} candidates, ${nlShadowOnly} caught ONLY by the edition tier`);
+    console.log(`  positive control: ${summary.controls.positive}`);
+    console.log(`  negative control: ${summary.controls.negative}`);
+    const loss = (counts.live_only_other || 0);
+    console.log(`  regressions (live-only, unexplained): ${loss} ${loss === 0 ? '— safe to proceed to logging-first flip' : '<- READ THE EXAMPLES BEFORE FLIPPING'}`);
+    for (const [k, v] of Object.entries(summary.examples)) {
+      if (!v.length) continue;
+      console.log(`  ${k} (${counts[k as Verdict] || 0}, first ${v.length}):`);
+      for (const e of v) console.log(`    [${e.collection}] ${e.id}  ${JSON.stringify(e.title)} — ${e.author ?? ''}, ${e.year ?? '?'}${e.live.length ? ` live→${e.live.map((m) => m.id).join(',')}` : ''}${e.shadow.length ? ` shadow→${e.shadow.map((m) => m.id).join(',')}` : ''}`);
+    }
+  }
+
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/workers/identity-worker.mjs
+++ b/scripts/workers/identity-worker.mjs
@@ -24,6 +24,12 @@
  * Also the alarm: reports how many books older than 7 days are still missing
  * fields (should be 0 — nonzero means this worker has not been running).
  *
+ * Covers BOTH `books` and `books_warehouse`: import dedup (`checkDuplicate`)
+ * queries the warehouse alongside the live library, so an unstamped warehouse
+ * row is invisible to any identity-keyed tier — the edition-key dedup flip
+ * (#3730 §2) cannot happen against a warehouse with no keys. Measured
+ * 2026-08-08: 22,543 warehouse docs, 0 with edition_key.
+ *
  * Cron: Hetzner, every 2 hours at :40, under flock — the exact line lives in
  * scripts/workers/crontab.production (kept as a snapshot of the live crontab).
  *
@@ -49,30 +55,21 @@ const DRY_RUN = argv.includes('--dry-run');
 const RESTAMP = argv.includes('--restamp');
 const LIMIT = parseInt(argv.find((a) => a.startsWith('--limit='))?.split('=')[1] || (RESTAMP ? '200000' : '5000'), 10);
 
-async function main() {
-  if (!MONGODB_URI) { console.error('[IDENTITY] MONGODB_URI not set'); process.exit(1); }
-  const started = Date.now();
-  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 2 });
-  await client.connect();
-  const db = client.db('bookstore');
-  const books = db.collection('books');
+// Field ABSENT = never computed. Field null = computed, unkeyable — not
+// re-selected, or the 127 unkeyable books would thrash every cycle.
+// --restamp widens the queue to every book and rewrites only diffs.
+const ABSENCE_QUEUE = {
+  content_type: { $ne: 'artwork' },
+  $or: [
+    { edition_key: { $exists: false } },
+    { normalized_title: { $exists: false } },
+  ],
+};
 
-  console.log(`[IDENTITY] ${new Date().toISOString()} — limit=${LIMIT}, dry-run=${DRY_RUN}`);
+async function stampCollection(coll) {
+  const queue = RESTAMP ? { content_type: { $ne: 'artwork' } } : ABSENCE_QUEUE;
 
-  // Field ABSENT = never computed. Field null = computed, unkeyable — not
-  // re-selected, or the 127 unkeyable books would thrash every cycle.
-  // --restamp widens the queue to every book and rewrites only diffs.
-  const queue = RESTAMP
-    ? { content_type: { $ne: 'artwork' } }
-    : {
-        content_type: { $ne: 'artwork' },
-        $or: [
-          { edition_key: { $exists: false } },
-          { normalized_title: { $exists: false } },
-        ],
-      };
-
-  const cursor = books
+  const cursor = coll
     .find(queue, {
       projection: {
         _id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1,
@@ -101,7 +98,7 @@ async function main() {
     ops.push({ updateOne: { filter: { _id: b._id }, update: { $set: fields } } });
     if (ops.length >= 500) {
       if (!DRY_RUN) {
-        const r = await books.bulkWrite(ops, { ordered: false });
+        const r = await coll.bulkWrite(ops, { ordered: false });
         stamped += r.modifiedCount;
       } else stamped += ops.length;
       ops = [];
@@ -109,7 +106,7 @@ async function main() {
   }
   if (ops.length) {
     if (!DRY_RUN) {
-      const r = await books.bulkWrite(ops, { ordered: false });
+      const r = await coll.bulkWrite(ops, { ordered: false });
       stamped += r.modifiedCount;
     } else stamped += ops.length;
   }
@@ -117,16 +114,45 @@ async function main() {
   // Queue metrics always report the CRON's queue (absence), not the restamp
   // scan — a cron_runs row claiming "79,755 queued" after a restamp would
   // read as an outage.
-  const absenceQueue = {
-    content_type: { $ne: 'artwork' },
-    $or: [{ edition_key: { $exists: false } }, { normalized_title: { $exists: false } }],
-  };
-  const remaining = await books.countDocuments(absenceQueue);
+  const remaining = await coll.countDocuments(ABSENCE_QUEUE);
 
   // The alarm: a book older than a week with no identity fields means this
   // worker has not been running (or a new writer invented a new gap shape).
   const weekAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
-  const staleMissing = await books.countDocuments({ ...absenceQueue, created_at: { $lt: weekAgo } });
+  const staleMissing = await coll.countDocuments({ ...ABSENCE_QUEUE, created_at: { $lt: weekAgo } });
+
+  return { stamped, unkeyable, remaining, staleMissing };
+}
+
+async function main() {
+  if (!MONGODB_URI) { console.error('[IDENTITY] MONGODB_URI not set'); process.exit(1); }
+  const started = Date.now();
+  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 2 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log(`[IDENTITY] ${new Date().toISOString()} — limit=${LIMIT}/collection, dry-run=${DRY_RUN}`);
+
+  // The warehouse needs the same index the live collection got in #3710, or
+  // every edition-keyed lookup against it is a collection scan. No-op when it
+  // already exists.
+  if (!DRY_RUN) await db.collection('books_warehouse').createIndex({ edition_key: 1 });
+
+  const perCollection = {};
+  const totals = { stamped: 0, unkeyable: 0, remaining: 0, stale_missing: 0 };
+  for (const name of ['books', 'books_warehouse']) {
+    const r = await stampCollection(db.collection(name));
+    perCollection[name] = r;
+    totals.stamped += r.stamped;
+    totals.unkeyable += r.unkeyable;
+    totals.remaining += r.remaining;
+    totals.stale_missing += r.staleMissing;
+    console.log(`[IDENTITY]   ${name}: stamped ${r.stamped}, ${r.unkeyable} unkeyable, ${r.remaining} queued, ${r.staleMissing} stale-missing`);
+  }
+  const { stamped, unkeyable, remaining } = totals;
+  // stale_missing stays the COMBINED number — the gates table and the alarm
+  // read this one field, and a stalled warehouse lane must trip it too.
+  const staleMissing = totals.stale_missing;
 
   const summary = `${RESTAMP ? 'RESTAMP: ' : ''}stamped ${stamped}${DRY_RUN ? ' (dry-run)' : ''}, ${unkeyable} unkeyable, ${remaining} queued, ${staleMissing} stale-missing`;
   console.log(`[IDENTITY] ${summary} in ${Math.round((Date.now() - started) / 1000)}s`);
@@ -137,7 +163,7 @@ async function main() {
     duration_ms: Date.now() - started,
     status: DRY_RUN ? 'dry-run' : 'success',
     failed: false,
-    actions: { stamped, unkeyable, remaining, stale_missing: staleMissing },
+    actions: { stamped, unkeyable, remaining, stale_missing: staleMissing, by_collection: perCollection },
     errors: [],
     error_count: 0,
     summary,


### PR DESCRIPTION
Part of #3730 §2 — the measurement before the dedup flip.

## What's in scope

**1. The identity worker now stamps `books_warehouse`.** Import dedup queries the warehouse alongside the live library, so an unstamped warehouse row is invisible to any identity-keyed tier — the edition-key flip could not happen against a warehouse with no keys (measured before this PR: 22,543 warehouse docs, 0 with `edition_key`). Backfilled at ship time: **22,542 stamped, 100 unkeyable, queue 0**, `edition_key` index created. `stale_missing` in `cron_runs` stays one field — now the combined count across both collections, so a stalled warehouse lane trips the existing alarm. Per-collection breakdown rides in `actions.by_collection`. No cron change needed; Hetzner auto-pulls.

**2. `scripts/audit/edition-key-shadow-measure.ts`** replays a real import population through the live tier-2 matcher (normalized title + whole-name author, year/volume veto) and the proposed edition-key tier (Unicode title + surname + year + volume; missing year non-distinguishing), self-excluded, with positive and negative controls.

## The measurement (2026-08-08)

Population: all 19,326 non-artwork books imported since 2026-07-01 + 1,000-doc warehouse sample.

| | |
|---|---|
| Agreement (same isDuplicate verdict) | **99.94%** (20,314/20,326) |
| Shadow-only catches | **11** — 6 non-Latin (live tier structurally blind: Russian, Hebrew, Chinese), 2 author-form (*Erhard/Erhardus*, *Niclaus/Nicolaus* — surname unifies what whole-name splits), 3 volume-window (below) |
| Live-only | **1** — title "Fragment", deliberately unkeyable (`UNINFORMATIVE_TITLES`); tier-1 fingerprint still catches a true re-import |
| Unexplained regressions (`live_only_other`) | **0** |
| Controls | negative 0/2 flagged; positive: live 6/18, shadow 6/18 known-dup keepers — the tiers are equal on adjudicated pairs (the other 12 were adjudicated by fingerprint/IIIF/cluster tooling, which the flip doesn't touch) |

**The volume-window finding is new**: tier 2 fetches 5 rows per collection for a normalized title+author, and every volume of a set shares one normalized title — so for "Works of Francis Bacon, Vol. 11" the window fills with volumes 1–5, each vetoed for the wrong volume, and the true duplicate of v11 is never fetched. The edition key carries the volume inside the key, so the prefix lookup lands on exactly the right printing. Same shape caught Kloss's *Schema…* Band 11.

## Out of scope, deliberately

The flip itself. Next step per #3730 is **logging-first**: one deploy that logs the edition-tier verdict next to the live one inside `checkDuplicate()`, flip after a week of agreement. That touches the import request path and belongs in its own PR. Fingerprint and IIIF tiers untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
