### PR TITLE
feat(dedup): edition-key tier in shadow — logged on every real decision, deciding nothing (#3730 §2)

### DIFF
--- a/.claude/docs/invariants/edition-identity.md
+++ b/.claude/docs/invariants/edition-identity.md
@@ -58,6 +58,17 @@ write partial identity. The worker's `stale_missing` count in `cron_runs` is
 the alarm: a book >7 days old with no identity fields means the worker is not
 running. The integrity script proves stored == computed.
 
+**Dedup's edition-key tier runs in SHADOW (since 2026-08-08).** Every real
+`checkDuplicate()` call logs the edition-key tier's would-be verdict next to
+the live tier-2 verdict in `dedup_shadow_decisions` (`agree` compares tier 2
+only — fingerprint/IIIF are untouched by the flip). Read it with
+`scripts/audit/dedup-shadow-agreement.mjs`; the flip criterion is a week of
+agreement on real traffic (offline baseline: 99.94% over 20,326, PR #3787).
+Audit scripts replaying books already in the DB must pass
+`{ shadowLog: false }` or their self-matches pollute the stats. The shadow
+block is fenced — it must never fail or slow an import materially, and it
+DECIDES nothing until the flip PR swaps tier 2's implementation.
+
 ## `edition_key_quality` is not decoration — gate on it
 
     full        title + author + year      the ONLY tier a reader-facing surface may trust

--- a/scripts/audit/dedup-replay-sample.ts
+++ b/scripts/audit/dedup-replay-sample.ts
@@ -85,7 +85,9 @@ function isNonLatin(b: BookDoc): boolean {
 }
 
 async function replay(db: Db, candidate: Parameters<typeof checkDuplicate>[1]): Promise<boolean> {
-  const r = await checkDuplicate(db, candidate);
+  // shadowLog off: these are books already in the DB — every replay would log
+  // a self-match "agreement" and pollute the flip criterion's stats.
+  const r = await checkDuplicate(db, candidate, { shadowLog: false });
   return r.isDuplicate;
 }
 

--- a/scripts/audit/dedup-shadow-agreement.mjs
+++ b/scripts/audit/dedup-shadow-agreement.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * dedup-shadow-agreement — reads the flip criterion for #3730 §2.
+ *
+ * `checkDuplicate()` logs the edition-key tier's would-be verdict next to the
+ * live tier-2 verdict on every real dedup decision (`dedup_shadow_decisions`).
+ * This prints the per-day agreement so the flip ("a week of agreement") is a
+ * measurement, not a feeling. Disagreements are listed newest-first — read
+ * them: a shadow-only catch is usually the point of the flip (non-Latin,
+ * author form, volume window; see PR #3787), a live-only catch is a potential
+ * regression and blocks it.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/dedup-shadow-agreement.mjs [--days=14]
+ */
+import { MongoClient } from 'mongodb';
+
+const DAYS = parseInt(process.argv.find((a) => a.startsWith('--days='))?.split('=')[1] || '14', 10);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const coll = db.collection('dedup_shadow_decisions');
+
+const since = new Date(Date.now() - DAYS * 24 * 3600 * 1000);
+const daily = await coll.aggregate([
+  { $match: { at: { $gte: since } } },
+  { $group: {
+    _id: { $dateToString: { format: '%Y-%m-%d', date: '$at' } },
+    total: { $sum: 1 },
+    agree: { $sum: { $cond: ['$agree', 1, 0] } },
+    shadowOnly: { $sum: { $cond: [{ $and: [{ $eq: [{ $size: '$live_tier2' }, 0] }, { $gt: [{ $size: '$shadow' }, 0] }] }, 1, 0] } },
+    liveOnly: { $sum: { $cond: [{ $and: [{ $gt: [{ $size: '$live_tier2' }, 0] }, { $eq: [{ $size: '$shadow' }, 0] }] }, 1, 0] } },
+  } },
+  { $sort: { _id: 1 } },
+]).toArray();
+
+console.log(`dedup shadow agreement — last ${DAYS} days`);
+if (!daily.length) {
+  console.log('  no decisions logged yet (the shadow logs only on real checkDuplicate calls — imports and sweeps)');
+} else {
+  for (const d of daily) {
+    const pct = ((100 * d.agree) / d.total).toFixed(2);
+    console.log(`  ${d._id}  ${String(d.total).padStart(6)} decisions  ${pct}% agree  (shadow-only ${d.shadowOnly}, live-only ${d.liveOnly})`);
+  }
+  const totals = daily.reduce((a, d) => ({ total: a.total + d.total, agree: a.agree + d.agree, liveOnly: a.liveOnly + d.liveOnly }), { total: 0, agree: 0, liveOnly: 0 });
+  console.log(`  overall: ${((100 * totals.agree) / totals.total).toFixed(2)}% over ${totals.total}; live-only (potential regressions): ${totals.liveOnly}`);
+}
+
+const disagreements = await coll.find({ agree: false, at: { $gte: since } }).sort({ at: -1 }).limit(20).toArray();
+if (disagreements.length) {
+  console.log(`  latest disagreements (${disagreements.length} shown):`);
+  for (const d of disagreements) {
+    const kind = d.live_tier2.length ? 'LIVE-ONLY' : 'shadow-only';
+    console.log(`    ${d.at.toISOString().slice(0, 10)} [${kind}] ${JSON.stringify((d.title || '').slice(0, 70))} — ${d.author || '?'}, ${d.year ?? '?'}  live→[${d.live_tier2}] shadow→[${d.shadow}]`);
+  }
+}
+
+await client.close();

--- a/src/app/api/books/check-duplicate/route.ts
+++ b/src/app/api/books/check-duplicate/route.ts
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
     author?: string;
     language?: string;
     year?: number;
-    match_type: 'source_fingerprint' | 'title_author' | 'iiif_manifest' | 'keyword' | 'semantic';
+    match_type: 'source_fingerprint' | 'title_author' | 'iiif_manifest' | 'edition_key' | 'keyword' | 'semantic';
     confidence: 'exact' | 'high' | 'medium' | 'low';
     similarity?: number;
     url: string;

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -11,11 +11,12 @@
  */
 
 import type { Db } from 'mongodb';
+import { buildEditionKey } from './edition-key';
 
 export interface DedupMatch {
   matchedBookId: string;
   matchedTitle: string;
-  matchType: 'source_fingerprint' | 'title_author' | 'iiif_manifest';
+  matchType: 'source_fingerprint' | 'title_author' | 'iiif_manifest' | 'edition_key';
   confidence: 'exact' | 'high' | 'medium';
   /** Whether the already-existing match is public. Hidden matches still count as
    * duplicates — this lets callers/auditors distinguish a live dup from a backlog one. */
@@ -199,6 +200,86 @@ export function sourceFingerprint(book: {
   return null;
 }
 
+// NOTE: dedup does NOT filter on `visible`. A duplicate is a duplicate whether
+// or not the existing copy is public — and imports land hidden, so a
+// visible-only check is blind to the entire hidden backlog (the regime we now
+// import into at volume). We surface the match's visibility instead of hiding it.
+const VIS_PROJ = { id: 1, title: 1, display_title: 1, year: 1, published: 1, visible: 1, hidden: 1, edition_key: 1 };
+
+// Check BOTH the live library and the warehouse. `books_warehouse` holds books
+// we've already acquired + archived that are awaiting promotion to `books`
+// (pipeline Phase 1.95). A duplicate there is still a duplicate — skipping the
+// warehouse re-acquires ~items we already hold. (issue: warehouse dedup gap)
+const COLLECTIONS: Array<'books' | 'books_warehouse'> = ['books', 'books_warehouse'];
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * The edition-key tier (#3730 §2) — the intended REPLACEMENT for tier 2's
+ * normalized title+author match, running in shadow until it earns the flip.
+ *
+ * Matches on the stored `edition_key` (`title|surname|year|vN`, Unicode-aware
+ * — see src/lib/edition-key.ts): every stored key sharing the candidate's
+ * `title|surname|` prefix matches unless BOTH sides state a different year or
+ * volume. A missing year/volume is non-distinguishing — the safe error is
+ * "assume duplicate", exactly tier 2's veto rule. Full-quality vs full-quality
+ * thereby reduces to exact key equality.
+ *
+ * Why it should win (shadow-measured 2026-08-08, PR #3787 — 99.94% agreement
+ * over 20,326 real candidates, 0 unexplained regressions):
+ *   - non-Latin titles: ASCII `normalized_title` is empty/garbage for them;
+ *     the edition key keeps any Unicode letter (6 catches in the sample);
+ *   - author forms: the surname unifies what whole-name matching splits
+ *     (Erhard/Erhardus, Niclaus/Nicolaus);
+ *   - volume window: every volume of a set shares one normalized_title, so
+ *     tier 2's 5-row window fills with wrong volumes and vetoes them all —
+ *     the key carries the volume, so the lookup lands on the right printing.
+ *
+ * The candidate's key is computed on the fly; the stored side was stamped by
+ * Phase 0 (identity-worker covers `books` AND `books_warehouse`).
+ */
+export async function editionKeyTierMatches(
+  db: Db,
+  book: { title?: string | null; display_title?: string | null; author?: string | null; year?: number | null; published?: string | null }
+): Promise<DedupMatch[]> {
+  const ek = buildEditionKey(book);
+  if (!ek.key) return [];
+  const { title, author, year, volume } = ek.parts;
+  const prefix = new RegExp(`^${escapeRegex(`${title}|${author}|`)}`);
+
+  const matches: DedupMatch[] = [];
+  for (const cn of COLLECTIONS) {
+    const rows = await db.collection(cn).find(
+      { edition_key: prefix },
+      { projection: VIS_PROJ }
+    ).limit(25).toArray();
+    for (const doc of rows) {
+      // Stored key: `title|surname|year|vN`. Normalized parts never contain
+      // '|' (normalization strips punctuation), so positional split is safe.
+      const segs = String(doc.edition_key).split('|');
+      const volSeg = segs[segs.length - 1] || '';
+      const yearSeg = segs[segs.length - 2] || '';
+      const tmYear = yearSeg === '' ? null : parseInt(yearSeg, 10);
+      const tmVol = volSeg === 'v' ? null : parseInt(volSeg.slice(1), 10);
+      if (year != null && tmYear != null && year !== tmYear) continue;
+      if (volume != null && tmVol != null && volume !== tmVol) continue;
+      const id = doc.id || doc._id.toString();
+      if (matches.some(m => m.matchedBookId === id)) continue;
+      matches.push({
+        matchedBookId: id,
+        matchedTitle: doc.title,
+        matchType: 'edition_key',
+        confidence: 'high',
+        matchedVisible: doc.visible === true,
+        matchedCollection: cn,
+      });
+    }
+  }
+  return matches;
+}
+
 /**
  * Check if a book is a duplicate before importing.
  *
@@ -208,6 +289,13 @@ export function sourceFingerprint(book: {
  *   3. IIIF manifest URL — exact match
  *
  * Returns all matches found (caller decides whether to block import).
+ *
+ * Plus a SHADOW pass (#3730 §2): the edition-key tier's would-be verdict is
+ * computed alongside tier 2's and recorded to `dedup_shadow_decisions` —
+ * never affecting the returned result. Flip criterion: a week of agreement,
+ * read by scripts/audit/dedup-shadow-agreement.mjs. Callers replaying books
+ * that are ALREADY in the database (audit scripts) must pass
+ * `{ shadowLog: false }` or every replay self-match pollutes the stats.
  */
 export async function checkDuplicate(
   db: Db,
@@ -236,21 +324,10 @@ export async function checkDuplicate(
     dublin_core?: {
       dc_identifier?: string[];
     };
-  }
+  },
+  opts: { shadowLog?: boolean } = {}
 ): Promise<DedupResult> {
   const matches: DedupMatch[] = [];
-
-  // NOTE: dedup does NOT filter on `visible`. A duplicate is a duplicate whether
-  // or not the existing copy is public — and imports land hidden, so a
-  // visible-only check is blind to the entire hidden backlog (the regime we now
-  // import into at volume). We surface the match's visibility instead of hiding it.
-  const VIS_PROJ = { id: 1, title: 1, display_title: 1, year: 1, published: 1, visible: 1, hidden: 1 };
-
-  // Check BOTH the live library and the warehouse. `books_warehouse` holds books
-  // we've already acquired + archived that are awaiting promotion to `books`
-  // (pipeline Phase 1.95). A duplicate there is still a duplicate — skipping the
-  // warehouse re-acquires ~items we already hold. (issue: warehouse dedup gap)
-  const COLLECTIONS: Array<'books' | 'books_warehouse'> = ['books', 'books_warehouse'];
   const seen = (id: string) => matches.some(m => m.matchedBookId === id);
 
   // Tier 1: Source fingerprint match (exact)
@@ -344,6 +421,30 @@ export async function checkDuplicate(
           matchedCollection: cn,
         });
       }
+    }
+  }
+
+  // SHADOW pass — logs, never decides. Awaited (fire-and-forget dies with the
+  // serverless invocation) but fully fenced: no failure here may affect the
+  // import verdict.
+  if (opts.shadowLog !== false) {
+    try {
+      const shadow = await editionKeyTierMatches(db, book);
+      const liveTier2 = matches.filter(m => m.matchType === 'title_author');
+      await db.collection('dedup_shadow_decisions').insertOne({
+        at: new Date(),
+        title: String(book.title || '').slice(0, 200),
+        author: String(book.author || '').slice(0, 120),
+        year: editionYear(book),
+        live_tier2: liveTier2.map(m => m.matchedBookId),
+        live_other_tiers: matches.filter(m => m.matchType !== 'title_author').map(m => m.matchedBookId),
+        shadow: shadow.map(m => m.matchedBookId),
+        // The flip criterion compares the tier being REPLACED, not the
+        // fingerprint/IIIF tiers, which are untouched by it.
+        agree: (liveTier2.length > 0) === (shadow.length > 0),
+      });
+    } catch {
+      // Shadow logging must never fail an import.
     }
   }
 


### PR DESCRIPTION
Part of #3730 §2 — the logging-first deploy. Follows the offline measurement in #3787 (99.94% agreement over 20,326 candidates, 0 unexplained regressions).

## What this does

**`editionKeyTierMatches()`** (`src/lib/dedup.ts`) is the intended replacement for tier 2's normalized title+author match: a prefix lookup on the stored `edition_key` (Unicode title + surname), with year/volume as a both-sides veto — a missing year stays non-distinguishing, per the issue's design ("the safe error is assume duplicate").

**`checkDuplicate()` now runs it in shadow** on every real call: both verdicts land in `dedup_shadow_decisions` (`agree` compares tier 2 only — fingerprint and IIIF tiers are untouched by the eventual flip). The block is fully fenced: it never affects the returned result and a failure inside it can never fail an import. Nothing reads this collection to act — it is a metrics sink, read by humans via:

**`scripts/audit/dedup-shadow-agreement.mjs`** — per-day agreement, shadow-only vs live-only splits, latest disagreements. The flip criterion is a week of agreement on real import traffic.

**Audit scripts opt out**: `checkDuplicate(db, book, { shadowLog: false })` — `dedup-replay-sample.ts` replays books already in the DB, and every self-match would log as fake agreement.

## Verified

- `npx tsc --noEmit` clean.
- Smoke-tested against prod: a "Works of Francis Bacon, Vol. 11" re-import with identifiers stripped is **missed by live tier 2** (the volume-window failure class from the measurement, reproduced live: the 5-row window fills with volumes 1–5 and vetoes them all) and **caught by the edition tier**; both verdicts logged, the disagreement row is correct, smoke rows removed after the test.

## Out of scope

The flip itself — swapping tier 2's implementation for `editionKeyTierMatches()` happens in a later PR, after `dedup-shadow-agreement.mjs` shows a week of agreement. Until then the shadow decides nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
