### PR TITLE
fix(monitoring): long-count socket timeout + activate nightly snapshot

### DIFF
--- a/scripts/lib/mongo.mjs
+++ b/scripts/lib/mongo.mjs
@@ -40,6 +40,7 @@ export async function getScriptClient(opts = {}) {
     maxPoolSize = 1,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     noTimeout = false,
+    socketTimeoutMs = 30_000,
   } = opts;
 
   const uri = process.env.MONGODB_URI;
@@ -53,7 +54,7 @@ export async function getScriptClient(opts = {}) {
     minPoolSize: 0,
     serverSelectionTimeoutMS: 10_000,
     connectTimeoutMS: 10_000,
-    socketTimeoutMS: 30_000,
+    socketTimeoutMS: socketTimeoutMs,
     maxIdleTimeMS: 60_000,
   });
 

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -142,5 +142,5 @@
 17 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-traffic-anomaly.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/traffic-anomaly-alert.mjs" >> /var/log/sourcelibrary/traffic-anomaly.log 2>&1
 # Identity worker — Phase 0: stamps normalized_title/author + edition_key on any book missing them (#3730)
 40 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-identity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/identity-worker.mjs" >> /var/log/sourcelibrary/identity-worker.log 2>&1
-# Stage coverage snapshot — nightly semantic monitoring, coverage from data not job counters (#3756). NOT YET ACTIVE — enable after first supervised run.
-#15 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-stage-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/stage-coverage-snapshot.mjs" >> /var/log/sourcelibrary/stage-coverage.log 2>&1
+# Stage coverage snapshot — nightly semantic monitoring, coverage from data not job counters (#3756). Supervised runs 2026-08-08; page-level counts need the long socket timeout.
+15 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-stage-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/stage-coverage-snapshot.mjs" >> /var/log/sourcelibrary/stage-coverage.log 2>&1

--- a/scripts/workers/stage-coverage-snapshot.mjs
+++ b/scripts/workers/stage-coverage-snapshot.mjs
@@ -98,4 +98,4 @@ await withMongo(async (db) => {
       ` | dial: ${doc.dial.paused ? 'PAUSED' : 'running'} budget=$${doc.dial.daily_budget_usd ?? 'unset'}` +
       ` spend=$${doc.spend_today_usd.toFixed(2)} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
   );
-}, { timeoutMs: 30 * 60_000 });
+}, { timeoutMs: 30 * 60_000, socketTimeoutMs: 15 * 60_000 });


### PR DESCRIPTION
Both supervised runs: pages probes died at the DRIVER (socketTimeoutMS 30s hardcoded in mongo.mjs) before their query budget. withMongo gains an opt-in socketTimeoutMs; snapshot passes 15min. Nightly crontab line activated (04:15). The probe-broken design worked — it refused to fake 0% both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx