### PR TITLE
feat(monitoring): nightly snapshot pushes ntfy on the batch/stall failure classes

### DIFF
--- a/scripts/workers/stage-coverage-snapshot.mjs
+++ b/scripts/workers/stage-coverage-snapshot.mjs
@@ -29,6 +29,27 @@ import { measureAllStages, computeStageDeltas, findStalled } from '../lib/stage-
 import { getTodaySpendUsd, readDailyBudgetUsd } from '../lib/spend-guard.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
+const NO_PUSH = process.argv.includes('--no-push');
+
+// Same ntfy topic as traffic-anomaly / uptime — the channel Derek actually
+// reads. Deliberately NOT email: the gemini_key_drift alarm emailed itself
+// daily for weeks unread. An alert nobody sees is a dead instrument (the
+// archaeology's core finding: zero expensive incidents were caught by
+// monitoring).
+const NTFY_TOPIC = 'https://ntfy.sh/sourcelibrary-uptime';
+async function pushNtfy(title, message, priority = 'high') {
+  if (NO_PUSH || DRY_RUN) return;
+  try {
+    await fetch(NTFY_TOPIC, {
+      method: 'POST',
+      headers: { Title: title, Priority: priority, Tags: 'factory' },
+      body: message,
+    });
+    console.log('[stage-coverage] ntfy push sent: ' + title);
+  } catch (err) {
+    console.error('[stage-coverage] ntfy push failed: ' + err.message);
+  }
+}
 
 /** Latest cron_runs row for the batch collector, whichever writer named it. */
 async function getCollectorLastRun(db) {
@@ -66,8 +87,21 @@ await withMongo(async (db) => {
   const stages = computeStageDeltas(rawStages, previous?.stages);
   const stalled = findStalled(stages);
 
+  // The two failure classes with the worst history (submit/collect asymmetry;
+  // see incident record class 3): a dead collector, and paid batches aging
+  // toward Gemini's ~2-day output discard while uncollected.
+  const staleBatchCutoff = new Date(Date.now() - 24 * 3600 * 1000);
+  const agingUncollected = await db.collection('batch_jobs').countDocuments({
+    child_job_ids: { $exists: false },
+    collection_abandoned: { $ne: true },
+    results_collected: { $ne: true },
+    status: { $in: ['pending', 'processing', 'completed', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING', 'JOB_STATE_SUCCEEDED'] },
+    created_at: { $lt: staleBatchCutoff },
+  }, { maxTimeMS: 60_000 }).catch(() => null);
+
   const doc = {
     timestamp: new Date(),
+    aging_uncollected_batches: agingUncollected,
     stages,
     stalled,
     dial: {
@@ -87,11 +121,24 @@ await withMongo(async (db) => {
     await db.collection('stage_coverage_snapshots').insertOne(doc);
   }
 
+  // ── Alerts: push only what someone would act on ──
+  const alerts = [];
+  const broken = stages.filter((s) => s.status === 'probe_broken').map((s) => s.stage);
+  if (stalled.length) alerts.push(`STALLED (queue>0, no progress since last snapshot): ${stalled.join(', ')}`);
+  if (broken.length) alerts.push(`PROBE BROKEN (do not trust these rows): ${broken.join(', ')}`);
+  const collectorAgeMs = collectorLastRun?.timestamp ? Date.now() - new Date(collectorLastRun.timestamp).getTime() : Infinity;
+  if (collectorAgeMs > 2 * 3600 * 1000) alerts.push(`Batch collector last ran ${collectorLastRun?.timestamp ? Math.round(collectorAgeMs / 3600000) + 'h ago' : 'NEVER'} (cron is every 30min)`);
+  if (typeof agingUncollected === 'number' && agingUncollected > 0) alerts.push(`${agingUncollected} paid batch job(s) uncollected >24h — Gemini discards output at ~2 days`);
+  if (alerts.length) {
+    await pushNtfy('Pipeline line: ' + (stalled.length + broken.length + (agingUncollected || 0)) + ' issue(s)',
+      alerts.join('\n') + '\n\nsourcelibrary.org/platform/admin/line', 'high');
+  }
+
   // One-line human summary — this is what the cron log shows.
   const pct = (s) =>
     s.status !== 'ok' ? 'BROKEN' : s.total ? `${((100 * s.covered) / s.total).toFixed(1)}%` : '—';
   const parts = stages.map((s) => `${s.stage} ${pct(s)}`);
-  const broken = stages.filter((s) => s.status === 'probe_broken').map((s) => s.stage);
+  
   console.log(
     `[stage-coverage] ${parts.join(' | ')} | stalled: ${stalled.length ? stalled.join(',') : 'none'}` +
       `${broken.length ? ` | PROBE BROKEN: ${broken.join(',')}` : ''}` +


### PR DESCRIPTION
Alerts on exactly what history says goes silently wrong: stalled stages, broken probes, dead collector (>2h), paid batches uncollected >24h (Gemini ~2-day discard window). Same ntfy topic as traffic-anomaly — the channel that gets read; deliberately not email (the key-drift alarm precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx