### PR TITLE
feat(provenance): write-time sensors + derivation provenance

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -263,6 +263,10 @@ async function processOneJob(db, job) {
 
         const setObj = {
           'ocr.data': text,
+          // The model's own <warning> tag is a quality sensor that went unread
+          // for months (false-split incident) — stamp it at write time so the
+          // nightly snapshot can count it and repair lanes can query it.
+          'ocr.has_warning': /<warning[\s>]/i.test(text),
           'ocr.updated_at': now,
           'ocr.model': job.model,
           'ocr.language': job.language,

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -533,6 +533,7 @@ async function processOneJob(db, job) {
 
         const setObj = {
           'ocr.data': text,
+          'ocr.has_warning': /<warning[\s>]/i.test(text), // write-time sensor (see collect-batch-results)
           'ocr.updated_at': now,
           'ocr.model': job.model,
           'ocr.language': job.language,

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -1112,6 +1112,10 @@ async function enrichBook(db, book) {
       generated_at: new Date(),
       model: LITE_MODEL,
       source: 'ai',
+      // Derivation provenance (Vaughan/Sammelband lesson #3584): record WHICH
+      // pages this summary was derived from, so a wrong description can be
+      // traced to its input instead of trusted as catalog fact.
+      pages_sampled: batchExtractions.map((b) => b.pageRange).filter(Boolean),
     };
   }
 

--- a/scripts/workers/stage-coverage-snapshot.mjs
+++ b/scripts/workers/stage-coverage-snapshot.mjs
@@ -96,6 +96,6 @@ await withMongo(async (db) => {
     `[stage-coverage] ${parts.join(' | ')} | stalled: ${stalled.length ? stalled.join(',') : 'none'}` +
       `${broken.length ? ` | PROBE BROKEN: ${broken.join(',')}` : ''}` +
       ` | dial: ${doc.dial.paused ? 'PAUSED' : 'running'} budget=$${doc.dial.daily_budget_usd ?? 'unset'}` +
-      ` spend=$${doc.spend_today_usd.toFixed(2)} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
+      ` spend=$${doc.spend_today_usd.toFixed(2)} | gate-held=${healthBlocked ?? '?'} warn-pages=${ocrWarnings ?? '?'} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
   );
 }, { timeoutMs: 30 * 60_000, socketTimeoutMs: 15 * 60_000 });


### PR DESCRIPTION
Fills the gaps named in the logging/provenance review: ocr.has_warning stamped at collect (the unread-sensor lesson), summary.pages_sampled derivation provenance (the Sammelband lesson), and a sensors block in the nightly snapshot (gate-held pages, warning pages, derivation adoption). page_read UA gap verified already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx