### PR TITLE
feat(pipeline): completeness pass — finalize unhide guard (live bug), cost ledger, convergence loops

### DIFF
--- a/scripts/maintenance/backfill-ocr-warning-flags.mjs
+++ b/scripts/maintenance/backfill-ocr-warning-flags.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Backfill `ocr.has_warning` over historical pages (#3756 provenance gap).
+ *
+ * Collectors stamp the flag at save time since 2026-08-08; history has years
+ * of OCR whose <warning> tags — the model's own quality sensor, famously
+ * unread through the false-split incident — are invisible to queries. One
+ * bounded sweep makes them queryable.
+ *
+ * Only writes `true` (absent = unknown-or-none, matching the write-time
+ * convention). Idempotent: skips pages already flagged. Dry-run by default.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/backfill-ocr-warning-flags.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/backfill-ocr-warning-flags.mjs --apply
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const BATCH = 5000;
+
+await withMongo(async (db) => {
+  const pages = db.collection('pages');
+  let scanned = 0, flagged = 0, lastId = null;
+
+  for (;;) {
+    const q = {
+      'ocr.data': { $regex: '<warning[\\s>]', $options: 'i' },
+      'ocr.has_warning': { $exists: false },
+    };
+    if (lastId) q._id = { $gt: lastId };
+    const batch = await pages.find(q, { projection: { _id: 1 } })
+      .sort({ _id: 1 }).limit(BATCH).toArray();
+    if (batch.length === 0) break;
+    scanned += batch.length;
+    lastId = batch[batch.length - 1]._id;
+    if (APPLY) {
+      const r = await pages.updateMany(
+        { _id: { $in: batch.map((d) => d._id) } },
+        { $set: { 'ocr.has_warning': true } }
+      );
+      flagged += r.modifiedCount;
+    } else {
+      flagged += batch.length;
+    }
+    process.stderr.write(`\r  ${APPLY ? 'flagged' : 'would flag'}: ${flagged}   `);
+  }
+  process.stderr.write('\n');
+  console.log(`${APPLY ? 'Flagged' : 'DRY RUN — would flag'} ${flagged} pages with <warning> OCR.`);
+  if (!APPLY) console.log('Re-run with --apply to write.');
+}, { timeoutMs: 4 * 3600_000, socketTimeoutMs: 30 * 60_000 });

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -144,3 +144,5 @@
 40 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-identity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/identity-worker.mjs" >> /var/log/sourcelibrary/identity-worker.log 2>&1
 # Stage coverage snapshot — nightly semantic monitoring, coverage from data not job counters (#3756). Supervised runs 2026-08-08; page-level counts need the long socket timeout.
 15 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-stage-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/stage-coverage-snapshot.mjs" >> /var/log/sourcelibrary/stage-coverage.log 2>&1
+# Author canonical-link convergence (#3769/#3756) — link books.author -> authors._id where unambiguous; live-only default (backlog inclusion is the #3780 decision)
+40 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-author-links.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-author-canonical-links.mjs --apply" >> /var/log/sourcelibrary/author-links.log 2>&1

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2589,6 +2589,42 @@ async function run() {
         console.log(`  FT-flagged: ${ftFlagged}/${log.enrolled}`);
       }
       console.log(`  Enrolled: ${log.enrolled}`);
+
+      // Convergence tail (#3756): the 14-day window turned "recent" into a
+      // permanent exclusion — 6,874 books / 2.37M pages could never enter the
+      // pipeline (archaeology I89). Enroll a small OLDEST-first batch each
+      // cycle too; archiving is free and the dial gates all paid phases, so
+      // this converges the stranded backlog at bounded pace with zero
+      // unbudgeted spend.
+      if (!DRY_RUN) {
+        const strays = await db.collection('books')
+          .find({
+            pipeline_auto: { $exists: false },
+            created_at: { $lt: cutoff },
+            'image_source.provider': { $nin: ART_PROVIDERS },
+          })
+          .project({ id: 1, language: 1 })
+          .sort({ created_at: 1 })
+          .limit(25)
+          .toArray();
+        const ENGLISH_VARIANTS_STRAY = ['english', 'eng', 'en'];
+        for (const book of strays) {
+          const lang = (book.language || '').toLowerCase();
+          await db.collection('books').updateOne(
+            { id: book.id },
+            { $set: {
+              pipeline_auto: {
+                status: 'queued', source: 'cron-convergence', queued_at: new Date(),
+                last_updated: new Date(), retry_count: 0,
+                likely_first_translation: !!lang && !ENGLISH_VARIANTS_STRAY.includes(lang),
+              },
+              updated_at: new Date(),
+            } }
+          );
+          log.enrolled++;
+        }
+        if (strays.length) console.log(`  Convergence-enrolled (oldest-first, pre-window): ${strays.length}`);
+      }
     }
 
     // Artwork resource types — these skip the book pipeline entirely (no text to OCR/translate).
@@ -5387,10 +5423,28 @@ Rules:
 
         if (!DRY_RUN) {
           await setPipelineStatus(db, book.id, 'complete', { completed_at: new Date() });
+          // Cost ledger (#3756): stamp what this book actually cost, from the
+          // usage meter — powers sponsor-a-book displays and unit economics.
+          // cost_usd is computed-not-billed; label the field accordingly.
+          try {
+            const [costAgg] = await db.collection('gemini_usage').aggregate([
+              { $match: { book_id: book.id } },
+              { $group: { _id: null, usd: { $sum: { $ifNull: ['$cost_usd', 0] } }, calls: { $sum: 1 } } },
+            ], { maxTimeMS: 30000 }).toArray();
+            if (costAgg) {
+              await db.collection('books').updateOne(
+                { id: book.id },
+                { $set: { processing_cost_usd_estimate: Math.round(costAgg.usd * 100) / 100, processing_cost_stamped_at: new Date() } }
+              );
+            }
+          } catch { /* cost stamp is best-effort — never block finalize */ }
           // Auto-unhide: books that completed the full pipeline should be visible
+          // — UNLESS they are hidden for a stated reason (takedown, copyright,
+          // sponsor hold). A hidden_reason is a human decision; finalize must
+          // never overrule it (#3099 Kloss invariant; guard added at relight).
           await db.collection('books').updateOne(
-            { id: book.id, hidden: true },
-            { $set: { hidden: false, visible: true, updated_at: new Date() }, $unset: { hidden_reason: '' } }
+            { id: book.id, hidden: true, hidden_reason: { $exists: false } },
+            { $set: { hidden: false, visible: true, updated_at: new Date() } }
           );
         }
         log.finalized++;


### PR DESCRIPTION
Contains a LIVE-BUG fix: Phase 9 auto-unhide lacked the hidden_reason guard — takedown/copyright books reaching 'complete' would be force-published with their reason erased (#3099 class, armed every 15 min since the relight). Plus: cost-ledger stamp at finalize, oldest-first enrollment convergence (the stranded 6,874), the author-link nightly cron, and the has_warning history backfill script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx