### PR TITLE
feat(versioning): everything versions — config trail, dial lever, R2 preservation

### DIFF
--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -61,6 +61,13 @@ spend counts toward the measured total, and its volume is downstream of gated ph
 `cost_usd` is a computed estimate and some rows lack it → the guard can UNDERCOUNT;
 treat the ceiling as a brake, not accounting. The guard logs `spend $X / $Y` every cycle.
 
+**Change the dial ONLY via `scripts/maintenance/set-dial.mjs`** (`--budget N --by "why"`,
+`--pause/--resume`, `--history`) — it snapshots the prior state to
+`system_config_revisions` (everything versions; raw one-liner \$sets on
+`processing_control` are how scopes got clobbered). `unpause-scope.mjs` writes are
+versioned the same way. Repair scripts that overwrite R2 images preserve the prior
+object under `versions/<key>.<ts>` via `scripts/lib/r2-version.mjs`.
+
 **To turn the line on (Derek):**
 1. Set the dial: `db.system_config.updateOne({_id:'processing_control'}, {$set:{daily_budget_usd: 5}})` — start at $5/day.
 2. Unpause: `{$set:{paused:false}}` (same doc).

--- a/scripts/lib/r2-version.mjs
+++ b/scripts/lib/r2-version.mjs
@@ -1,0 +1,39 @@
+/**
+ * r2-version — application-level object versioning for R2 (#3756 "everything
+ * versions").
+ *
+ * R2 has no S3-style bucket versioning, so an overwrite is a destruction.
+ * That's usually fine for the pipeline's forward writes (the source library
+ * still holds the original), but REPAIR paths overwrite images we may want
+ * to compare against later — and the photo_original lesson says never
+ * overwrite an archive without keeping a way back.
+ *
+ * preserveObjectVersion() copies the current object to
+ *   versions/<original-key>.<unix-ts>
+ * before an overwrite. NoSuchKey (first write) is silently fine. Failures
+ * WARN and return false but never block the write — versioning must not make
+ * repairs fragile; the caller decides whether to proceed.
+ *
+ * Adopt in: repair scripts that overwrite archived/* or pages/* objects.
+ * Not wired into bulk forward-archiving (doubling writes on 19M pages is a
+ * cost decision, and the source still holds those originals).
+ */
+
+import { CopyObjectCommand } from '@aws-sdk/client-s3';
+
+export async function preserveObjectVersion(s3, bucket, key) {
+  const versionKey = `versions/${key}.${Math.floor(Date.now() / 1000)}`;
+  try {
+    await s3.send(new CopyObjectCommand({
+      Bucket: bucket,
+      CopySource: `${bucket}/${encodeURIComponent(key).replace(/%2F/g, '/')}`,
+      Key: versionKey,
+    }));
+    return versionKey;
+  } catch (err) {
+    const code = err?.name || err?.Code || '';
+    if (/NoSuchKey|NotFound/i.test(String(code))) return null; // first write — nothing to version
+    console.warn(`  [r2-version] could not preserve ${key}: ${String(err?.message || err).slice(0, 100)}`);
+    return false;
+  }
+}

--- a/scripts/lib/versioned-config.mjs
+++ b/scripts/lib/versioned-config.mjs
@@ -1,0 +1,45 @@
+/**
+ * versioned-config — a revision trail for `system_config` (#3756 "everything
+ * versions").
+ *
+ * `processing_control` is shared mutable production state with a documented
+ * history of being clobbered by concurrent sessions (the June scope-stomp
+ * lost a 47-book batch unrecoverably; the relight found seven stale scopes
+ * nobody could date). Pages got `page_revisions`; books got book revisions;
+ * config had nothing — this closes that.
+ *
+ * Every write through here snapshots the PRIOR doc to
+ * `system_config_revisions` first: { config_id, prior, changed_by, change,
+ * created_at }. Reverting = read the snapshot, write it back (through here,
+ * so the revert is itself versioned).
+ *
+ * This is a door, not a wall: raw $set from a session still works and is
+ * still wrong. The nightly stage-coverage snapshot provides the safety net —
+ * it records dial/pause state every night, so side-door changes are at least
+ * observable day-over-day.
+ */
+
+/**
+ * Versioned update of one system_config doc.
+ * @param {import('mongodb').Db} db
+ * @param {string} configId    e.g. 'processing_control'
+ * @param {object} update      full Mongo update doc ({ $set, $unset, ... })
+ * @param {string} changedBy   who/what/why — REQUIRED, shows in the trail
+ */
+export async function updateConfigVersioned(db, configId, update, changedBy) {
+  if (!changedBy) throw new Error('updateConfigVersioned: changedBy is required — the trail is the point');
+  const prior = await db.collection('system_config').findOne({ _id: configId });
+  await db.collection('system_config_revisions').insertOne({
+    config_id: configId,
+    prior: prior ?? null,
+    change: JSON.parse(JSON.stringify(update)),
+    changed_by: changedBy,
+    created_at: new Date(),
+  });
+  return db.collection('system_config').updateOne({ _id: configId }, update, { upsert: true });
+}
+
+/** Convenience: versioned $set of top-level fields on processing_control. */
+export function setProcessingControl(db, fields, changedBy) {
+  return updateConfigVersioned(db, 'processing_control', { $set: { ...fields } }, changedBy);
+}

--- a/scripts/maintenance/repair-bulk-jp2-offset.mjs
+++ b/scripts/maintenance/repair-bulk-jp2-offset.mjs
@@ -38,6 +38,7 @@ import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { uploadPageVariants } from '../workers/lib/display-image.mjs';
+import { preserveObjectVersion } from '../lib/r2-version.mjs';
 import { checkAlignment, hashBuffer, readerVisibleShift } from '../lib/page-alignment.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -187,6 +188,8 @@ async function repairBook(db, bookId) {
       const p = targets[idx++];
       try {
         const buf = await fetchBuf(fullRes(p.photo_original || p.photo));
+        // Everything versions (#3756): keep the pre-repair object reachable
+        await preserveObjectVersion(s3, process.env.R2_BUCKET_NAME, `archived/${bookId}/${p.page_number}.jpg`);
         await uploadPageVariants(buf, bookId, p.page_number, uploadToR2);
         done++;
         if (done % 25 === 0) console.log(`    … ${done}/${targets.length}`);

--- a/scripts/maintenance/set-dial.mjs
+++ b/scripts/maintenance/set-dial.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * set-dial — THE versioned lever for the pipeline's spend/pause state.
+ *
+ * Replaces raw one-liner $sets on processing_control (which have a history of
+ * clobbering concurrent state and leaving no trail). Every change snapshots
+ * the prior doc to system_config_revisions via versioned-config.mjs.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/set-dial.mjs --show
+ *   node --env-file=.env.production.local scripts/maintenance/set-dial.mjs --budget 15 --by "derek: scale up"
+ *   node --env-file=.env.production.local scripts/maintenance/set-dial.mjs --pause  --by "reason"
+ *   node --env-file=.env.production.local scripts/maintenance/set-dial.mjs --resume --by "reason"
+ *   node --env-file=.env.production.local scripts/maintenance/set-dial.mjs --history        # last 10 changes
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+import { setProcessingControl } from '../lib/versioned-config.mjs';
+
+const args = process.argv.slice(2);
+const flag = (n) => args.includes(`--${n}`);
+const val = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : null; };
+
+await withMongo(async (db) => {
+  if (flag('history')) {
+    const rows = await db.collection('system_config_revisions')
+      .find({ config_id: 'processing_control' }).sort({ created_at: -1 }).limit(10).toArray();
+    for (const r of rows) {
+      console.log(`${r.created_at.toISOString()}  by ${r.changed_by}`);
+      console.log(`  change: ${JSON.stringify(r.change)}`);
+      console.log(`  prior:  paused=${r.prior?.paused} budget=$${r.prior?.daily_budget_usd ?? 'unset'}`);
+    }
+    return;
+  }
+
+  const show = async (label) => {
+    const c = await db.collection('system_config').findOne({ _id: 'processing_control' });
+    console.log(`${label}: paused=${c?.paused} daily_budget_usd=$${c?.daily_budget_usd ?? 'unset'}`);
+  };
+
+  if (flag('show')) return show('current');
+
+  const by = val('by');
+  if (!by) { console.error('--by "who/why" is required for any change (the trail is the point)'); process.exit(1); }
+
+  const fields = {};
+  if (val('budget') != null) {
+    const b = Number(val('budget'));
+    if (!Number.isFinite(b) || b < 0) { console.error('--budget must be a number >= 0'); process.exit(1); }
+    fields.daily_budget_usd = b;
+  }
+  if (flag('pause')) fields.paused = true;
+  if (flag('resume')) fields.paused = false;
+  if (Object.keys(fields).length === 0) { console.error('nothing to change — pass --budget/--pause/--resume'); process.exit(1); }
+
+  await show('before');
+  await setProcessingControl(db, fields, by);
+  await show('after ');
+  console.log('(prior state snapshotted to system_config_revisions — see --history)');
+});

--- a/scripts/maintenance/unpause-scope.mjs
+++ b/scripts/maintenance/unpause-scope.mjs
@@ -62,17 +62,17 @@ if (cmd === 'list') {
   const books = list(flag('--books'));
   const reason = flag('--reason') || `selective-unpause: ${tag}`;
   if (!collections.length && !books.length) { console.error('provide --collections and/or --books'); process.exit(1); }
-  await cfg.updateOne(CTRL, {
+  await updateConfigVersioned(db, 'processing_control', {
     $set: {
       [`allow_scopes.${tag}`]: { book_ids: books, collections, reason, set_at: new Date(), set_by: process.env.USER || 'claude-session' },
       updated_at: new Date(),
     },
-  }, { upsert: true });
+  }, `unpause-scope add ${tag}`);
   console.log(`✓ added/updated scope "${tag}" (books=${books.length}, collections=${collections.length}) — did NOT touch other scopes`);
   await show();
 } else if (cmd === 'remove') {
   if (!tag) { console.error('remove requires a <tag>'); process.exit(1); }
-  await cfg.updateOne(CTRL, { $unset: { [`allow_scopes.${tag}`]: '' }, $set: { updated_at: new Date() } });
+  await updateConfigVersioned(db, 'processing_control', { $unset: { [`allow_scopes.${tag}`]: '' }, $set: { updated_at: new Date() } }, `unpause-scope remove ${tag}`);
   console.log(`✓ removed scope "${tag}"`);
   await show();
 } else {


### PR DESCRIPTION
Closes the versioning holes from the Wikipedia-comparison review: system_config_revisions trail (versioned-config helper; unpause-scope wired; set-dial.mjs as THE lever with --history), and R2 prior-object preservation on repair overwrites (r2-version.mjs). Doors not walls; nightly snapshot remains the observational net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx