### PR TITLE
feat(dedup): tier 2 IS the edition key — the flip (#3730 §2)

### DIFF
--- a/.claude/docs/invariants/edition-identity.md
+++ b/.claude/docs/invariants/edition-identity.md
@@ -58,16 +58,22 @@ write partial identity. The worker's `stale_missing` count in `cron_runs` is
 the alarm: a book >7 days old with no identity fields means the worker is not
 running. The integrity script proves stored == computed.
 
-**Dedup's edition-key tier runs in SHADOW (since 2026-08-08).** Every real
-`checkDuplicate()` call logs the edition-key tier's would-be verdict next to
-the live tier-2 verdict in `dedup_shadow_decisions` (`agree` compares tier 2
-only — fingerprint/IIIF are untouched by the flip). Read it with
-`scripts/audit/dedup-shadow-agreement.mjs`; the flip criterion is a week of
-agreement on real traffic (offline baseline: 99.94% over 20,326, PR #3787).
-Audit scripts replaying books already in the DB must pass
-`{ shadowLog: false }` or their self-matches pollute the stats. The shadow
-block is fenced — it must never fail or slow an import materially, and it
-DECIDES nothing until the flip PR swaps tier 2's implementation.
+**Dedup tier 2 IS the edition key (flipped 2026-08-08, #3730 §2).**
+`checkDuplicate()`'s tier 2 is `editionKeyTierMatches()` — stored-key prefix
+lookup, year/volume as a both-sides veto, a missing year non-distinguishing
+(the safe error is "assume duplicate"). It replaced the ASCII title+author
+match on Derek's call after the offline replay (99.94% agreement over 20,326
+real candidates, 0 regressions — PR #3787) rather than after the planned week
+of shadow traffic. The retired title+author tier still runs as the POST-FLIP
+shadow: both verdicts land in `dedup_shadow_decisions` (`regime:
+'edition_live'`), where a shadow-only row now means the OLD tier caught
+something the new one lets through — the regression signature. Read with
+`scripts/audit/dedup-shadow-agreement.mjs`; a clean week means the shadow
+block and `titleAuthorTierMatches()` get deleted. Audit scripts replaying
+books already in the DB must pass `{ shadowLog: false }`. The shadow block is
+fenced — it must never fail an import. Corollary of the flip: dedup recall now
+DEPENDS on Phase 0 stamping both `books` and `books_warehouse` — an unstamped
+row is invisible to tier 2 (tiers 1/3 still catch same-source re-imports).
 
 ## `edition_key_quality` is not decoration — gate on it
 

--- a/scripts/audit/dedup-shadow-agreement.mjs
+++ b/scripts/audit/dedup-shadow-agreement.mjs
@@ -2,13 +2,19 @@
 /**
  * dedup-shadow-agreement — reads the flip criterion for #3730 §2.
  *
- * `checkDuplicate()` logs the edition-key tier's would-be verdict next to the
- * live tier-2 verdict on every real dedup decision (`dedup_shadow_decisions`).
- * This prints the per-day agreement so the flip ("a week of agreement") is a
- * measurement, not a feeling. Disagreements are listed newest-first — read
- * them: a shadow-only catch is usually the point of the flip (non-Latin,
- * author form, volume window; see PR #3787), a live-only catch is a potential
- * regression and blocks it.
+ * `checkDuplicate()` logs the live tier-2 verdict next to a shadow matcher's
+ * on every real dedup decision (`dedup_shadow_decisions`). Rows carry a
+ * `regime`:
+ *
+ *   (absent)         pre-flip — live was title+author, shadow was edition-key.
+ *                    A shadow-only row is usually the point of the flip
+ *                    (non-Latin, author form, volume window; PR #3787).
+ *   'edition_live'   post-flip (2026-08-08) — live IS the edition tier, shadow
+ *                    is the retired title+author tier. Here the signature
+ *                    flips too: a SHADOW-ONLY row means the old tier caught
+ *                    something the new one lets through — the regression to
+ *                    read carefully. A week clean means the shadow block and
+ *                    titleAuthorTierMatches() can be deleted.
  *
  *   set -a; source .env.production.local; set +a
  *   node scripts/audit/dedup-shadow-agreement.mjs [--days=14]
@@ -26,13 +32,16 @@ const since = new Date(Date.now() - DAYS * 24 * 3600 * 1000);
 const daily = await coll.aggregate([
   { $match: { at: { $gte: since } } },
   { $group: {
-    _id: { $dateToString: { format: '%Y-%m-%d', date: '$at' } },
+    _id: {
+      day: { $dateToString: { format: '%Y-%m-%d', date: '$at' } },
+      regime: { $ifNull: ['$regime', 'pre_flip'] },
+    },
     total: { $sum: 1 },
     agree: { $sum: { $cond: ['$agree', 1, 0] } },
     shadowOnly: { $sum: { $cond: [{ $and: [{ $eq: [{ $size: '$live_tier2' }, 0] }, { $gt: [{ $size: '$shadow' }, 0] }] }, 1, 0] } },
     liveOnly: { $sum: { $cond: [{ $and: [{ $gt: [{ $size: '$live_tier2' }, 0] }, { $eq: [{ $size: '$shadow' }, 0] }] }, 1, 0] } },
   } },
-  { $sort: { _id: 1 } },
+  { $sort: { '_id.day': 1, '_id.regime': 1 } },
 ]).toArray();
 
 console.log(`dedup shadow agreement — last ${DAYS} days`);
@@ -41,18 +50,23 @@ if (!daily.length) {
 } else {
   for (const d of daily) {
     const pct = ((100 * d.agree) / d.total).toFixed(2);
-    console.log(`  ${d._id}  ${String(d.total).padStart(6)} decisions  ${pct}% agree  (shadow-only ${d.shadowOnly}, live-only ${d.liveOnly})`);
+    console.log(`  ${d._id.day} [${d._id.regime}]  ${String(d.total).padStart(6)} decisions  ${pct}% agree  (shadow-only ${d.shadowOnly}, live-only ${d.liveOnly})`);
   }
-  const totals = daily.reduce((a, d) => ({ total: a.total + d.total, agree: a.agree + d.agree, liveOnly: a.liveOnly + d.liveOnly }), { total: 0, agree: 0, liveOnly: 0 });
-  console.log(`  overall: ${((100 * totals.agree) / totals.total).toFixed(2)}% over ${totals.total}; live-only (potential regressions): ${totals.liveOnly}`);
+  const post = daily.filter((d) => d._id.regime === 'edition_live');
+  const totals = post.reduce((a, d) => ({ total: a.total + d.total, agree: a.agree + d.agree, shadowOnly: a.shadowOnly + d.shadowOnly }), { total: 0, agree: 0, shadowOnly: 0 });
+  if (totals.total) {
+    console.log(`  post-flip: ${((100 * totals.agree) / totals.total).toFixed(2)}% over ${totals.total}; shadow-only (old tier caught, new one didn't — the regression class): ${totals.shadowOnly}`);
+  }
 }
 
 const disagreements = await coll.find({ agree: false, at: { $gte: since } }).sort({ at: -1 }).limit(20).toArray();
 if (disagreements.length) {
   console.log(`  latest disagreements (${disagreements.length} shown):`);
   for (const d of disagreements) {
-    const kind = d.live_tier2.length ? 'LIVE-ONLY' : 'shadow-only';
-    console.log(`    ${d.at.toISOString().slice(0, 10)} [${kind}] ${JSON.stringify((d.title || '').slice(0, 70))} — ${d.author || '?'}, ${d.year ?? '?'}  live→[${d.live_tier2}] shadow→[${d.shadow}]`);
+    // Post-flip, shadow-only is the regression class; pre-flip it was live-only.
+    const kind = d.live_tier2.length ? 'live-only' : 'shadow-only';
+    const flag = (d.regime === 'edition_live') === (kind === 'shadow-only') ? ' <- REGRESSION CLASS' : '';
+    console.log(`    ${d.at.toISOString().slice(0, 10)} [${d.regime || 'pre_flip'}|${kind}] ${JSON.stringify((d.title || '').slice(0, 70))} — ${d.author || '?'}, ${d.year ?? '?'}  live→[${d.live_tier2}] shadow→[${d.shadow}]${flag}`);
   }
 }
 

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -281,21 +281,82 @@ export async function editionKeyTierMatches(
 }
 
 /**
+ * The RETIRED tier 2 — normalized title+author with year/volume veto. Kept
+ * (not deleted) for one release cycle as the post-flip shadow: it runs on
+ * every real decision and its would-be verdict is logged next to the edition
+ * tier's, so a regression in the flip shows up in `dedup_shadow_decisions`
+ * as a LIVE-ONLY-inverted row instead of as silently re-acquired duplicates.
+ * Remove together with the shadow block once the post-flip week is clean.
+ *
+ * Known, measured weaknesses (why it lost the tier-2 slot — PR #3787):
+ * ASCII-blind to non-Latin titles, whole-name author matching splits
+ * catalogue name variants, and the 5-row window goes blind on multi-volume
+ * sets. See `editionKeyTierMatches()` above.
+ */
+export async function titleAuthorTierMatches(
+  db: Db,
+  book: { title: string; author: string; display_title?: string; year?: number; published?: string }
+): Promise<DedupMatch[]> {
+  const normTitle = normalizeTitle(book.title);
+  const normAuthor = normalizeAuthor(book.author);
+  const candYear = editionYear(book);
+  const candVol = extractVolume(book.display_title) ?? extractVolume(book.title);
+  const matches: DedupMatch[] = [];
+
+  if (normTitle.length < 5) return matches;
+  for (const cn of COLLECTIONS) {
+    const titleMatches = await db.collection(cn).find(
+      {
+        normalized_title: normTitle,
+        normalized_author: normAuthor,
+      },
+      { projection: VIS_PROJ }
+    ).limit(5).toArray();
+
+    for (const tm of titleMatches) {
+      const id = tm.id || tm._id.toString();
+      if (matches.some(m => m.matchedBookId === id)) continue;
+
+      // Different edition? Only conclude so when BOTH sides carry the signal —
+      // a missing year/volume can't distinguish editions, so fall back to
+      // treating the title+author collision as a duplicate (the safe error).
+      const tmYear = editionYear(tm as { year?: number | null; published?: string | null });
+      const tmVol = extractVolume(tm.display_title) ?? extractVolume(tm.title);
+      const differentYear = candYear != null && tmYear != null && candYear !== tmYear;
+      const differentVolume = candVol != null && tmVol != null && candVol !== tmVol;
+      if (differentYear || differentVolume) continue;
+
+      matches.push({
+        matchedBookId: id,
+        matchedTitle: tm.title,
+        matchType: 'title_author',
+        confidence: 'high',
+        matchedVisible: tm.visible === true,
+        matchedCollection: cn,
+      });
+    }
+  }
+  return matches;
+}
+
+/**
  * Check if a book is a duplicate before importing.
  *
  * Runs three tiers of matching:
  *   1. Source fingerprint — exact match on provider-specific IDs
- *   2. Title+Author — normalized fuzzy match
+ *   2. Edition key — stored-identity match (FLIPPED 2026-08-08, #3730 §2;
+ *      replaced the normalized title+author match after an offline replay of
+ *      20,326 real candidates showed 99.94% agreement and 0 regressions)
  *   3. IIIF manifest URL — exact match
  *
  * Returns all matches found (caller decides whether to block import).
  *
- * Plus a SHADOW pass (#3730 §2): the edition-key tier's would-be verdict is
- * computed alongside tier 2's and recorded to `dedup_shadow_decisions` —
- * never affecting the returned result. Flip criterion: a week of agreement,
- * read by scripts/audit/dedup-shadow-agreement.mjs. Callers replaying books
- * that are ALREADY in the database (audit scripts) must pass
- * `{ shadowLog: false }` or every replay self-match pollutes the stats.
+ * Plus a SHADOW pass: the RETIRED title+author tier still runs on every real
+ * call and both verdicts land in `dedup_shadow_decisions` (`regime:
+ * 'edition_live'`) — the rollback trigger for the flip, read by
+ * scripts/audit/dedup-shadow-agreement.mjs. Callers replaying books that are
+ * ALREADY in the database (audit scripts) must pass `{ shadowLog: false }` or
+ * every replay self-match pollutes the stats.
  */
 export async function checkDuplicate(
   db: Db,
@@ -352,53 +413,14 @@ export async function checkDuplicate(
     }
   }
 
-  // Tier 2: Normalized title+author match (high)
-  //
-  // Holding multiple EDITIONS of one work is a first-class case here (the
-  // work_id / original_edition_id / text_role layers exist for exactly this).
-  // A normalized title+author collision is therefore only a duplicate when the
-  // candidate and the match are the SAME edition. Two records that differ in
-  // publication year — or in volume, which normalizeTitle() strips out — are
-  // distinct editions and must be allowed through. (Tiers 1 and 3 still
-  // hard-block a true same-item re-import regardless of year.)
-  const normTitle = normalizeTitle(book.title);
-  const normAuthor = normalizeAuthor(book.author);
-  const candYear = editionYear(book);
-  const candVol = extractVolume(book.display_title) ?? extractVolume(book.title);
-
-  if (normTitle.length >= 5) {
-    for (const cn of COLLECTIONS) {
-      const titleMatches = await db.collection(cn).find(
-        {
-          normalized_title: normTitle,
-          normalized_author: normAuthor,
-        },
-        { projection: VIS_PROJ }
-      ).limit(5).toArray();
-
-      for (const tm of titleMatches) {
-        const id = tm.id || tm._id.toString();
-        if (seen(id)) continue;
-
-        // Different edition? Only conclude so when BOTH sides carry the signal —
-        // a missing year/volume can't distinguish editions, so fall back to
-        // treating the title+author collision as a duplicate (the safe error).
-        const tmYear = editionYear(tm as { year?: number | null; published?: string | null });
-        const tmVol = extractVolume(tm.display_title) ?? extractVolume(tm.title);
-        const differentYear = candYear != null && tmYear != null && candYear !== tmYear;
-        const differentVolume = candVol != null && tmVol != null && candVol !== tmVol;
-        if (differentYear || differentVolume) continue;
-
-        matches.push({
-          matchedBookId: id,
-          matchedTitle: tm.title,
-          matchType: 'title_author',
-          confidence: 'high',
-          matchedVisible: tm.visible === true,
-          matchedCollection: cn,
-        });
-      }
-    }
+  // Tier 2: Edition-key match (high) — the identity layer deciding, not a
+  // string heuristic. Holding multiple EDITIONS of one work stays first-class:
+  // the key carries year and volume, and a both-sides difference in either
+  // means distinct editions, allowed through; a MISSING year/volume stays
+  // non-distinguishing (the safe error is "assume duplicate"). Tiers 1 and 3
+  // still hard-block a true same-item re-import regardless of year.
+  for (const em of await editionKeyTierMatches(db, book)) {
+    if (!seen(em.matchedBookId)) matches.push(em);
   }
 
   // Tier 3: IIIF manifest URL match (exact)
@@ -424,23 +446,27 @@ export async function checkDuplicate(
     }
   }
 
-  // SHADOW pass — logs, never decides. Awaited (fire-and-forget dies with the
-  // serverless invocation) but fully fenced: no failure here may affect the
-  // import verdict.
+  // SHADOW pass — logs, never decides. Roles are SWAPPED since the flip: the
+  // edition tier is live, the retired title+author tier is the shadow. A
+  // shadow-only row here means the OLD tier would have flagged something the
+  // NEW one lets through — the regression signature to watch for a week.
+  // Awaited (fire-and-forget dies with the serverless invocation) but fully
+  // fenced: no failure here may affect the import verdict.
   if (opts.shadowLog !== false) {
     try {
-      const shadow = await editionKeyTierMatches(db, book);
-      const liveTier2 = matches.filter(m => m.matchType === 'title_author');
+      const shadow = await titleAuthorTierMatches(db, book);
+      const liveTier2 = matches.filter(m => m.matchType === 'edition_key');
       await db.collection('dedup_shadow_decisions').insertOne({
         at: new Date(),
+        regime: 'edition_live',
         title: String(book.title || '').slice(0, 200),
         author: String(book.author || '').slice(0, 120),
         year: editionYear(book),
         live_tier2: liveTier2.map(m => m.matchedBookId),
-        live_other_tiers: matches.filter(m => m.matchType !== 'title_author').map(m => m.matchedBookId),
+        live_other_tiers: matches.filter(m => m.matchType !== 'edition_key').map(m => m.matchedBookId),
         shadow: shadow.map(m => m.matchedBookId),
-        // The flip criterion compares the tier being REPLACED, not the
-        // fingerprint/IIIF tiers, which are untouched by it.
+        // Compares the flipped tier against the tier it replaced —
+        // fingerprint/IIIF are untouched by the flip.
         agree: (liveTier2.length > 0) === (shadow.length > 0),
       });
     } catch {

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -256,6 +256,9 @@ export async function editionKeyTierMatches(
       { projection: VIS_PROJ }
     ).limit(25).toArray();
     for (const doc of rows) {
+      // The regex already guarantees a well-formed key on a real DB; the guard
+      // is for test doubles and any future caller passing a looser query.
+      if (typeof doc.edition_key !== 'string' || !doc.edition_key.includes('|')) continue;
       // Stored key: `title|surname|year|vN`. Normalized parts never contain
       // '|' (normalization strips punctuation), so positional split is safe.
       const segs = String(doc.edition_key).split('|');

--- a/tests/unit/dedup-edition-aware.test.ts
+++ b/tests/unit/dedup-edition-aware.test.ts
@@ -50,7 +50,13 @@ describe('editionYear', () => {
 });
 
 // Minimal fake Mongo Db. Tier 1 (fingerprint) and Tier 3 (iiif) findOne return
-// null; Tier 2 find() returns the canned existing edition(s) for `books`.
+// null; find() returns the canned existing edition(s) for `books` REGARDLESS
+// of the query — so tier 2's server-side edition_key prefix filter does not
+// apply here, and only the client-side year/volume vetoes are exercised.
+// Canned docs therefore carry explicit `edition_key` values (the flipped tier
+// skips docs without a parseable key). The shadow-log insert has no insertOne
+// on this fake and is swallowed by checkDuplicate's fence — itself a useful
+// pin: shadow failures must never affect the verdict.
 function makeDb(titleMatches: Record<string, unknown>[]) {
   const collection = (name: string) => ({
     findOne: async () => null,
@@ -59,8 +65,8 @@ function makeDb(titleMatches: Record<string, unknown>[]) {
   return { collection } as unknown as Parameters<typeof checkDuplicate>[0];
 }
 
-describe('checkDuplicate edition-awareness', () => {
-  const existing1730 = { id: 'b1730', title: 'Summa Astensis', year: 1730 };
+describe('checkDuplicate edition-awareness (edition-key tier, flipped 2026-08-08)', () => {
+  const existing1730 = { id: 'b1730', title: 'Summa Astensis', edition_key: 'summa astensis|ast|1730|v' };
 
   it('does NOT flag a different-year edition as a duplicate', async () => {
     const db = makeDb([existing1730]);
@@ -76,11 +82,11 @@ describe('checkDuplicate edition-awareness', () => {
       title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1730,
     });
     expect(res.isDuplicate).toBe(true);
-    expect(res.matches[0].matchType).toBe('title_author');
+    expect(res.matches[0].matchType).toBe('edition_key');
   });
 
   it('does NOT flag a different-volume set as a duplicate', async () => {
-    const db = makeDb([{ id: 'v1', title: 'Utriusque Cosmi Historia Tomus I', year: 1617 }]);
+    const db = makeDb([{ id: 'v1', title: 'Utriusque Cosmi Historia Tomus I', edition_key: 'utriusque cosmi historia tomus i|fludd|1617|v1' }]);
     const res = await checkDuplicate(db, {
       title: 'Utriusque Cosmi Historia Tomus II', author: 'Robert Fludd', year: 1617,
     });
@@ -88,10 +94,18 @@ describe('checkDuplicate edition-awareness', () => {
   });
 
   it('falls back to flagging when the year is unknown on either side (safe default)', async () => {
-    const db = makeDb([{ id: 'bNoYear', title: 'Summa Astensis' }]);
+    const db = makeDb([{ id: 'bNoYear', title: 'Summa Astensis', edition_key: 'summa astensis|ast||v' }]);
     const res = await checkDuplicate(db, {
       title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1728,
     });
     expect(res.isDuplicate).toBe(true);
+  });
+
+  it('skips stored docs without a parseable edition_key (unstamped rows cannot match)', async () => {
+    const db = makeDb([{ id: 'unstamped', title: 'Summa Astensis' }]);
+    const res = await checkDuplicate(db, {
+      title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1730,
+    });
+    expect(res.isDuplicate).toBe(false);
   });
 });


### PR DESCRIPTION
#3730 §2, final step — tier 2 of import dedup is now the edition-key matcher. Flipped on Derek's call ("tier two") on the strength of the offline replay (PR #3787: 99.94% agreement over 20,326 real candidates, 0 unexplained regressions) instead of waiting out the shadow week started in #3788.

## What changed

- **Tier 2 of `checkDuplicate()` is `editionKeyTierMatches()`**: stored `edition_key` prefix lookup (Unicode title + surname), year/volume as a both-sides veto, missing year non-distinguishing. The identity layer now *decides* imports instead of a parallel string heuristic.
- **The safety net inverts rather than disappears.** The retired title+author matcher (`titleAuthorTierMatches()`, kept) runs as the post-flip shadow on every real call; rows carry `regime: 'edition_live'`. A shadow-only disagreement now means the old tier caught something the new one lets through — the regression signature to watch. `dedup-shadow-agreement.mjs` segments by regime and flags the regression class per row. **A clean week deletes the shadow block and the retired matcher.**
- Fingerprint (tier 1) and IIIF (tier 3) untouched.

## What this buys, per the measurement

- Non-Latin re-imports are caught (the ASCII tier was structurally blind — 0.0% cross-source recall in the replay gate).
- Catalogue author variants unify (Erhard/Erhardus).
- Multi-volume sets stop slipping through the 5-row window (Bacon Vol. 11).

## Verified against prod

- Bacon Vol. 11 re-import: **caught** (`edition_key`) — was missed live before the flip.
- Same title, 1901 printing: passes as a distinct edition (year veto).
- Unheld Vol. 99: clean (volume veto).
- Fabricated book: clean.
- Cyrillic re-import (Rozanov 1894): **caught** — the non-Latin hole closed.
- Post-flip shadow rows log with the swapped roles; smoke rows removed after the test.
- `npx tsc --noEmit` clean.

## Dependency made explicit

Dedup recall now depends on Phase 0 stamping both `books` and `books_warehouse` (done in #3787; the identity worker covers both, and `stale_missing` alarms on either lane). Documented in `edition-identity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
