### PR TITLE
fix(ft): rung-2 skeptic fails closed on ungrounded responses — two-phase prose-then-format (#3778)

### DIFF
--- a/scripts/eval/ft-ladder.ts
+++ b/scripts/eval/ft-ladder.ts
@@ -1,0 +1,376 @@
+/**
+ * ft-ladder.ts — the FT verification escalation ladder (#3778).
+ *
+ * Runs each queued book up the cheapest rung that can settle it:
+ *
+ *   rung 0  history      — the attempt ledger already answers → skip (free)
+ *   rung 1  registry     — deterministic tier-0 catalog match → log it (free)
+ *   rung 2  skeptic      — grounded Gemini refutation attempt (~$0.005–0.03/book)
+ *   rung 3  claude queue — hard classes + rung-2 residue, emitted as a queue
+ *                          file for the ft-verify skill (NOT executed here)
+ *   rung 4  human queue  — policy holds (practitioner PDFs etc.), emitted
+ *
+ * ACTUATION (#3776): with --apply this script writes to
+ * `first_translation_attempts`, which the 05:30 nightly derive+reconcile reads.
+ * Every row written here carries a method that resolves to tier1_catalog or
+ * tier0_linked — resolvers the reconcile valve (--resolver=tier2_agent,human)
+ * does NOT admit — so nothing this script writes can move a public badge.
+ * The badge-moving tier is rung 3+ (ft-verify → ingest-ft-verify-results.mjs)
+ * and stays behind Derek's sign-off. Pinned by tests/unit/ft-skeptic.test.ts.
+ *
+ * QUEUE CLAIM (#3778 non-negotiable): before launching a paid run over a shared
+ * queue, claim it with a comment on the tracking issue — two sessions running
+ * the same queue duplicate spend and collide in the ledger (the 08-08 lesson).
+ *
+ * SAFE/COST: free and read-only by default. --run performs the paid rung-2
+ * searches (requires --budget-usd, hard cap). --apply persists ledger rows +
+ * transcripts. Never flips a badge, never writes a verdict.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/eval/ft-ladder.ts --limit=50                 # free: rungs 0-1 + routing report
+ *   npx tsx scripts/eval/ft-ladder.ts --limit=50 --apply         # also log rung-1 registry hits
+ *   npx tsx scripts/eval/ft-ladder.ts --limit=50 --run --apply --budget-usd=1
+ *   npx tsx scripts/eval/ft-ladder.ts --queue=contradictions --run --apply --budget-usd=2
+ *   npx tsx scripts/eval/ft-ladder.ts --ids=abc123,def456 --run --apply --budget-usd=0.50
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { GoogleGenAI } from '@google/genai';
+import { getDb } from '@/lib/mongodb';
+import { makeTier0Catalog, type CatalogPrior, type CatalogLookup } from '@/lib/first-translation/tier0-catalog';
+import type { ResolvableBook } from '@/lib/first-translation/resolve';
+import { appendAttempt, makeAttemptId, type FirstTranslationAttempt, type PriorTranslation } from '@/lib/first-translation/attempt-log';
+import { renderRubric, routeBook, postSearchRoute } from '@/lib/first-translation/casebook';
+import {
+  SKEPTIC_PROMPT_VERSION, buildSkepticPrompt, parseSkepticResponse,
+  normalizeSkepticAttempt, type SkepticBook, type SkepticDirection,
+} from '@/lib/first-translation/skeptic';
+// @ts-expect-error — plain .mjs modules without type declarations (tsx resolves them)
+import { screenDemoteCandidate } from '../lib/ft-demote-screen.mjs';
+// @ts-expect-error — plain .mjs module without type declarations
+import { costOf } from '../lib/model-pricing.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const DATE = new Date().toISOString().slice(0, 10);
+const RUN_DATE = new Date().toISOString();
+
+const arg = (name: string) => process.argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
+const RUN = process.argv.includes('--run');
+const APPLY = process.argv.includes('--apply');
+const QUEUE = arg('queue') ?? 'badged-weak';
+const IDS = arg('ids')?.split(',').map((s) => s.trim()).filter(Boolean);
+const LIMIT = parseInt(arg('limit') ?? '0', 10);
+const MODEL = arg('model') ?? 'gemini-3.1-flash-lite';
+const BUDGET = parseFloat(arg('budget-usd') ?? '0');
+const CONC = parseInt(arg('concurrency') ?? '4', 10);
+const TRANSCRIPTS = 'first_translation_transcripts'; // pure archive: no automated job reads it (#3778)
+
+if (RUN && !(BUDGET > 0)) {
+  console.error('--run is a paid operation and requires an explicit --budget-usd=<cap>.');
+  process.exit(1);
+}
+
+const keys: string[] = [];
+if (process.env.GEMINI_API_KEY) keys.push(process.env.GEMINI_API_KEY);
+for (let i = 2; i <= 7; i++) { const k = process.env[`GEMINI_API_KEY_${i}`]; if (k) keys.push(k); }
+let keyIdx = 0;
+const nextKey = () => keys[(keyIdx++) % keys.length];
+
+interface LadderRow {
+  id: string;
+  title?: string;
+  author?: string;
+  language?: string;
+  rung: 0 | 1 | 2 | 3 | 4;
+  outcome: string;
+  reasons: string[];
+  skeptic_result?: string;
+  cost_usd?: number;
+}
+
+async function main() {
+  if (RUN && keys.length === 0) { console.error('No GEMINI_API_KEY in env.'); process.exit(1); }
+  const db = await getDb();
+  const books = db.collection('books');
+  const attemptsCol = db.collection('first_translation_attempts');
+
+  /* ---------- queue selection ---------- */
+  const NOT_ENGLISH = { $nin: [null, 'en', 'eng', 'English', 'english'] };
+  let query: Record<string, unknown>;
+  if (IDS?.length) {
+    query = { id: { $in: IDS } };
+  } else if (QUEUE === 'contradictions') {
+    // The #3687 shape: publicly badged first while our own verdict says not_first.
+    query = { is_first_translation: true, visible: true, 'first_translation.verdict': 'not_first' };
+  } else if (QUEUE === 'badged-weak') {
+    // The mass: badged books whose verdict rests on weak evidence (the shim) or none.
+    query = {
+      is_first_translation: true, visible: true, language: NOT_ENGLISH,
+      $or: [
+        { 'first_translation.evidence_strength': 'weak' },
+        { first_translation: { $exists: false } },
+      ],
+    };
+  } else {
+    console.error(`Unknown --queue=${QUEUE} (badged-weak | contradictions)`); process.exit(1); return;
+  }
+
+  const cursor = books.find(query, {
+    projection: {
+      _id: 0, id: 1, title: 1, author: 1, language: 1, original_language: 1, work_id: 1,
+      text_role: 1, first_translation: 1, 'translation_verification.translations_found': 1,
+    },
+  }).sort({ id: 1 });
+  if (LIMIT) cursor.limit(LIMIT);
+  const queue = await cursor.toArray();
+  console.log(`queue=${IDS ? `ids(${IDS.length})` : QUEUE} → ${queue.length} book(s)  [run=${RUN} apply=${APPLY} model=${MODEL} budget=$${BUDGET || 0}]`);
+
+  /* ---------- rung-1 registry index (loaded once) ---------- */
+  const norm = (s?: string) =>
+    (s || '').toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+  const surnameOf = (author?: string) => {
+    const a = norm(author);
+    if (!a) return '';
+    return a.includes(',') ? a.split(',')[0].trim() : a.split(' ').slice(-1)[0];
+  };
+  const tokens = (s?: string) => new Set(norm(s).split(' ').filter((t) => t.length > 3));
+  const overlap = (a: Set<string>, b: Set<string>) => {
+    if (!a.size || !b.size) return 0;
+    let n = 0; for (const t of a) if (b.has(t)) n++;
+    return n / Math.min(a.size, b.size);
+  };
+  const completeRows = await db.collection('translation_catalogs')
+    .find({ completeness: 'complete' }, {
+      projection: {
+        _id: 0, author_surname: 1, canonical_author_normalized: 1, canonical_work_normalized: 1,
+        english_title: 1, english_title_normalized: 1, translator: 1, pub_year: 1,
+        completeness: 1, source_language: 1, source_url: 1, source: 1,
+      },
+    }).toArray();
+  const bySurname = new Map<string, typeof completeRows>();
+  for (const r of completeRows) {
+    const sn = (r.author_surname && norm(r.author_surname)) || surnameOf(r.canonical_author_normalized);
+    if (!sn) continue;
+    (bySurname.get(sn) ?? bySurname.set(sn, []).get(sn)!).push(r);
+  }
+  const lookup: CatalogLookup = async (book) => {
+    const rows = bySurname.get(surnameOf(book.author));
+    if (!rows) return [];
+    const wt = tokens(book.title);
+    const out: CatalogPrior[] = [];
+    for (const r of rows) {
+      const ov = Math.max(overlap(wt, tokens(r.canonical_work_normalized)), overlap(wt, tokens(r.english_title_normalized)));
+      if (ov >= 0.6) {
+        out.push({
+          english_title: r.english_title, translator: r.translator, pub_year: r.pub_year,
+          completeness: r.completeness, source_language: r.source_language, source_url: r.source_url,
+          source: r.source, matched_by: 'author_title',
+        });
+      }
+    }
+    return out;
+  };
+  const tier0 = makeTier0Catalog(lookup);
+  console.log(`registry: ${completeRows.length} complete catalog rows across ${bySurname.size} surnames`);
+
+  /* ---------- the ladder ---------- */
+  const rows: LadderRow[] = [];
+  const rung3Queue: Array<Record<string, unknown>> = [];
+  const rung4Queue: Array<Record<string, unknown>> = [];
+  let spent = 0;
+  let rung1Applied = 0, rung2Logged = 0;
+
+  async function skepticCall(prompt: string): Promise<{ text: string; queries: string[]; sources: string[]; chunks: Array<{ uri?: string; title?: string }>; cost: number } | { error: string }> {
+    for (let attempt = 0; attempt <= 2; attempt++) {
+      try {
+        const ai = new GoogleGenAI({ apiKey: nextKey() });
+        const resp = await ai.models.generateContent({
+          model: MODEL, contents: prompt,
+          config: { tools: [{ googleSearch: {} }], temperature: 0.1 },
+        });
+        const gm = (resp.candidates?.[0] as { groundingMetadata?: { webSearchQueries?: string[]; groundingChunks?: Array<{ web?: { uri?: string; title?: string } }> } })?.groundingMetadata ?? {};
+        const u = resp.usageMetadata ?? {};
+        const cost = costOf(MODEL, u.promptTokenCount ?? 0, (u.candidatesTokenCount ?? 0) + ((u as { thoughtsTokenCount?: number }).thoughtsTokenCount ?? 0));
+        return {
+          text: resp.text ?? '',
+          queries: Array.isArray(gm.webSearchQueries) ? gm.webSearchQueries : [],
+          sources: [...new Set((gm.groundingChunks ?? []).map((c) => c?.web?.title || c?.web?.uri).filter((s): s is string => !!s))],
+          chunks: (gm.groundingChunks ?? []).map((c) => ({ uri: c?.web?.uri, title: c?.web?.title })),
+          cost,
+        };
+      } catch (err) {
+        const msg = String((err as Error).message ?? err);
+        if (attempt < 2 && /fetch failed|ECONNRESET|timeout|503|500|overloaded|RESOURCE_EXHAUSTED|429/i.test(msg)) {
+          await new Promise((r) => setTimeout(r, (attempt + 1) * 2500)); continue;
+        }
+        return { error: msg.slice(0, 200) };
+      }
+    }
+    return { error: 'retries_exhausted' };
+  }
+
+  const work = [...queue];
+  async function worker() {
+    while (work.length) {
+      const b = work.shift()!;
+      const row: LadderRow = { id: b.id, title: b.title, author: b.author, language: b.language, rung: 0, outcome: '', reasons: [] };
+      rows.push(row);
+
+      /* rung 0 — history */
+      const stored = b.first_translation as { resolver?: string; verdict?: string } | undefined;
+      if (stored?.resolver === 'tier2_agent' || stored?.resolver === 'human') {
+        row.outcome = `resolved:${stored.verdict} (resolver=${stored.resolver})`; continue;
+      }
+      const attempts = await attemptsCol.find({ book_id: b.id }).sort({ date: -1 }).limit(20).toArray();
+      if (attempts.some((a) => a.prompt_version === SKEPTIC_PROMPT_VERSION)) {
+        row.outcome = 'already_searched_this_prompt_version'; continue;
+      }
+
+      /* rung 1 — registry */
+      const outcome = await tier0(b as unknown as ResolvableBook, { now: RUN_DATE });
+      if (outcome.terminal && outcome.verdict) {
+        row.rung = 1;
+        const p = outcome.attempt.priors?.[0];
+        row.outcome = `registry_prior:${p?.english_title ?? '?'} (${p?.translator ?? '?'}, ${p?.pub_year ?? '?'})`;
+        if (APPLY) { await appendAttempt(db, outcome.attempt); rung1Applied++; }
+        continue;
+      }
+
+      /* routing — hard classes skip the paid rung */
+      const priors: PriorTranslation[] = [];
+      for (const a of attempts) for (const p of (a.priors ?? [])) if (p.english_title) priors.push(p);
+      for (const p of (b.translation_verification?.translations_found ?? [])) if (p.english_title) priors.push(p);
+      const screen = screenDemoteCandidate(b, priors) as { signals: Array<{ code: string }> };
+      const pre = routeBook(b, screen.signals.map((s) => s.code));
+      if (pre.route === 'claude') {
+        row.rung = 3; row.outcome = 'hard_class'; row.reasons = pre.reasons;
+        rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: QUEUE === 'contradictions' ? 'demote' : 'promote', reasons: pre.reasons });
+        continue;
+      }
+
+      /* rung 2 — grounded skeptic */
+      if (!RUN) { row.rung = 2; row.outcome = 'skeptic_pending (--run to execute)'; continue; }
+      if (spent >= BUDGET) { row.rung = 2; row.outcome = 'skeptic_skipped:budget_exhausted'; continue; }
+
+      const direction: SkepticDirection = QUEUE === 'contradictions' && priors.length
+        ? { kind: 'verify_prior', claimedPriors: priors.slice(0, 6) }
+        : { kind: 'refute_first' };
+      const prompt = buildSkepticPrompt(b as SkepticBook, renderRubric(b), direction);
+      const res = await skepticCall(prompt);
+      if ('error' in res) {
+        row.rung = 3; row.outcome = `skeptic_error:${res.error}`; row.reasons = ['rung2_error'];
+        rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: direction.kind, reasons: [`rung2_error:${res.error}`] });
+        continue;
+      }
+      spent += res.cost;
+      row.cost_usd = res.cost;
+
+      const attemptId = makeAttemptId(b.id, 'gemini_grounded_search', RUN_DATE);
+      // Only reference a transcript that was actually persisted.
+      const transcriptRef = APPLY ? attemptId : undefined;
+      if (APPLY) {
+        // Transcript first (a pure archive — nothing automated reads it), so the
+        // ledger row can reference it even if parsing below fails.
+        await db.collection(TRANSCRIPTS).insertOne({
+          attempt_id: attemptId, book_id: b.id, date: RUN_DATE, rung: 2,
+          prompt_version: SKEPTIC_PROMPT_VERSION, model: MODEL, prompt,
+          raw_response: res.text, grounding: { queries: res.queries, chunks: res.chunks },
+          cost_usd: res.cost,
+        });
+        await db.collection('gemini_usage').insertOne({
+          timestamp: new Date(), type: 'ft_ladder_skeptic', model: MODEL, book_id: b.id,
+          cost_usd: res.cost, status: 'ok', endpoint: 'script/ft-ladder',
+        });
+      }
+
+      const parsed = parseSkepticResponse(res.text);
+      if (!parsed) {
+        row.rung = 3; row.outcome = 'skeptic_unparseable'; row.reasons = ['rung2_parse_failed'];
+        rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: direction.kind, reasons: ["rung2_parse_failed"], transcript_ref: transcriptRef });
+        continue;
+      }
+      const normed = normalizeSkepticAttempt(parsed, { queries: res.queries, sources: res.sources });
+      row.rung = 2;
+      row.skeptic_result = parsed.result;
+      row.outcome = `skeptic:${parsed.result}`;
+      row.reasons = normed.problems;
+
+      if (APPLY) {
+        const attempt: FirstTranslationAttempt = {
+          attempt_id: attemptId, book_id: b.id, work_id: b.work_id ?? null, date: RUN_DATE,
+          ...normed.attempt,
+          sources_checked: res.sources, queries: res.queries,
+          model: MODEL, cost_usd: res.cost,
+          prompt_version: SKEPTIC_PROMPT_VERSION, transcript_ref: transcriptRef,
+          notes: `[ft-ladder rung2 ${SKEPTIC_PROMPT_VERSION}] ${direction.kind}; ${parsed.reasoning ?? ''}`.slice(0, 480),
+        };
+        await appendAttempt(db, attempt);
+        rung2Logged++;
+      }
+
+      /* post-search routing */
+      const post = postSearchRoute(normed.attempt.priors ?? []);
+      const badged = QUEUE !== 'unbadged';
+      const escalate: string[] = [...normed.problems];
+      if (post.route === 'human') {
+        row.rung = 4; row.reasons = post.reasons;
+        rung4Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, reasons: post.reasons, transcript_ref: transcriptRef });
+        continue;
+      }
+      if (parsed.result === 'uncertain') escalate.push('rung2_uncertain');
+      if (parsed.scope_flags?.container || parsed.scope_flags?.witness) escalate.push('rung2_scope_flag');
+      // A complete prior found against a live badge is a DEMOTE candidate — only
+      // rung 3+ may earn the resolver tier that moves the badge.
+      if (badged && parsed.result === 'complete_prior_found') escalate.push('demote_candidate_needs_tier2');
+      if (escalate.length) {
+        row.rung = 3; row.reasons = escalate;
+        rung3Queue.push({
+          book_id: b.id, work: b.title, author: b.author, lang: b.language,
+          direction: parsed.result === 'complete_prior_found' ? 'demote' : direction.kind,
+          claimed_priors: normed.attempt.priors, reasons: escalate, transcript_ref: transcriptRef,
+        });
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.max(1, Math.min(CONC, work.length)) }, () => worker()));
+
+  /* ---------- report ---------- */
+  const byOutcome = new Map<string, number>();
+  for (const r of rows) {
+    const k = `rung${r.rung}:${r.outcome.split(':')[0]}`;
+    byOutcome.set(k, (byOutcome.get(k) ?? 0) + 1);
+  }
+  console.log('\n── ladder summary ──');
+  for (const [k, v] of [...byOutcome.entries()].sort()) console.log(`  ${k.padEnd(40)} ${String(v).padStart(4)}`);
+  console.log(`  rung-3 (claude) queue: ${rung3Queue.length} | rung-4 (human) queue: ${rung4Queue.length}`);
+  if (RUN) console.log(`  rung-2 spend: $${spent.toFixed(4)} of $${BUDGET} budget${spent >= BUDGET ? '  ← BUDGET EXHAUSTED, queue truncated' : ''}`);
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const reportPath = path.join(OUT_DIR, `ft-ladder-${DATE}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({ date: RUN_DATE, queue: QUEUE, model: MODEL, prompt_version: SKEPTIC_PROMPT_VERSION, spent_usd: spent, rows }, null, 1));
+  console.log(`\nWrote ${reportPath}`);
+  if (rung3Queue.length) {
+    const p = path.join(OUT_DIR, `ft-ladder-rung3-queue-${DATE}.json`);
+    fs.writeFileSync(p, JSON.stringify(rung3Queue, null, 1));
+    console.log(`Wrote ${p} — feed to the ft-verify skill (Claude subagents).`);
+  }
+  if (rung4Queue.length) {
+    const p = path.join(OUT_DIR, `ft-ladder-rung4-human-${DATE}.json`);
+    fs.writeFileSync(p, JSON.stringify(rung4Queue, null, 1));
+    console.log(`Wrote ${p} — policy holds for Derek.`);
+  }
+
+  if (APPLY && (rung1Applied || rung2Logged)) {
+    console.log(`\n⚠ ACTUATION NOTICE: ingested ${rung1Applied + rung2Logged} row(s) into first_translation_attempts `
+      + `(${rung1Applied} registry, ${rung2Logged} skeptic). The 05:30 derive will read them and may update `
+      + `book.first_translation verdicts. The reconcile valve (--resolver=tier2_agent,human) excludes every `
+      + `resolver these rows can produce, so NO public badge can move from this run.`);
+  } else if (!APPLY) {
+    console.log('\nDry evidence run — nothing persisted. Re-run with --apply to write ledger rows + transcripts.');
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/eval/ft-ladder.ts
+++ b/scripts/eval/ft-ladder.ts
@@ -44,7 +44,7 @@ import type { ResolvableBook } from '@/lib/first-translation/resolve';
 import { appendAttempt, makeAttemptId, type FirstTranslationAttempt, type PriorTranslation } from '@/lib/first-translation/attempt-log';
 import { renderRubric, routeBook, postSearchRoute } from '@/lib/first-translation/casebook';
 import {
-  SKEPTIC_PROMPT_VERSION, buildSkepticPrompt, parseSkepticResponse,
+  SKEPTIC_PROMPT_VERSION, buildSkepticPrompt, buildFormatPrompt, parseSkepticResponse,
   normalizeSkepticAttempt, type SkepticBook, type SkepticDirection,
 } from '@/lib/first-translation/skeptic';
 // @ts-expect-error — plain .mjs modules without type declarations (tsx resolves them)
@@ -64,6 +64,9 @@ const QUEUE = arg('queue') ?? 'badged-weak';
 const IDS = arg('ids')?.split(',').map((s) => s.trim()).filter(Boolean);
 const LIMIT = parseInt(arg('limit') ?? '0', 10);
 const MODEL = arg('model') ?? 'gemini-3.1-flash-lite';
+// Retry model for responses the primary returns UNGROUNDED (zero API-level
+// grounding metadata). --fallback-model=none disables the retry.
+const FALLBACK = arg('fallback-model') ?? 'gemini-3-flash-preview';
 const BUDGET = parseFloat(arg('budget-usd') ?? '0');
 const CONC = parseInt(arg('concurrency') ?? '4', 10);
 const TRANSCRIPTS = 'first_translation_transcripts'; // pure archive: no automated job reads it (#3778)
@@ -183,17 +186,17 @@ async function main() {
   let spent = 0;
   let rung1Applied = 0, rung2Logged = 0;
 
-  async function skepticCall(prompt: string): Promise<{ text: string; queries: string[]; sources: string[]; chunks: Array<{ uri?: string; title?: string }>; cost: number } | { error: string }> {
+  async function skepticCall(prompt: string, model: string): Promise<{ text: string; queries: string[]; sources: string[]; chunks: Array<{ uri?: string; title?: string }>; cost: number } | { error: string }> {
     for (let attempt = 0; attempt <= 2; attempt++) {
       try {
         const ai = new GoogleGenAI({ apiKey: nextKey() });
         const resp = await ai.models.generateContent({
-          model: MODEL, contents: prompt,
+          model, contents: prompt,
           config: { tools: [{ googleSearch: {} }], temperature: 0.1 },
         });
         const gm = (resp.candidates?.[0] as { groundingMetadata?: { webSearchQueries?: string[]; groundingChunks?: Array<{ web?: { uri?: string; title?: string } }> } })?.groundingMetadata ?? {};
         const u = resp.usageMetadata ?? {};
-        const cost = costOf(MODEL, u.promptTokenCount ?? 0, (u.candidatesTokenCount ?? 0) + ((u as { thoughtsTokenCount?: number }).thoughtsTokenCount ?? 0));
+        const cost = costOf(model, u.promptTokenCount ?? 0, (u.candidatesTokenCount ?? 0) + ((u as { thoughtsTokenCount?: number }).thoughtsTokenCount ?? 0));
         return {
           text: resp.text ?? '',
           queries: Array.isArray(gm.webSearchQueries) ? gm.webSearchQueries : [],
@@ -212,12 +215,44 @@ async function main() {
     return { error: 'retries_exhausted' };
   }
 
+  /** Phase-2 formatter: NO tools (the JSON demand suppresses grounding). */
+  async function formatCall(prompt: string): Promise<{ text: string; cost: number } | { error: string }> {
+    for (let attempt = 0; attempt <= 2; attempt++) {
+      try {
+        const ai = new GoogleGenAI({ apiKey: nextKey() });
+        const resp = await ai.models.generateContent({ model: MODEL, contents: prompt, config: { temperature: 0 } });
+        const u = resp.usageMetadata ?? {};
+        return {
+          text: resp.text ?? '',
+          cost: costOf(MODEL, u.promptTokenCount ?? 0, (u.candidatesTokenCount ?? 0) + ((u as { thoughtsTokenCount?: number }).thoughtsTokenCount ?? 0)),
+        };
+      } catch (err) {
+        const msg = String((err as Error).message ?? err);
+        if (attempt < 2 && /fetch failed|ECONNRESET|timeout|503|500|overloaded|RESOURCE_EXHAUSTED|429/i.test(msg)) {
+          await new Promise((r) => setTimeout(r, (attempt + 1) * 2500)); continue;
+        }
+        return { error: msg.slice(0, 200) };
+      }
+    }
+    return { error: 'retries_exhausted' };
+  }
+
   const work = [...queue];
+  let processed = 0;
+  const progress = (row: LadderRow) => {
+    processed++;
+    // Every book on paid runs (the log is the live progress file for a
+    // multi-hour job); every 100th on free passes.
+    if (RUN || processed % 100 === 0) {
+      console.log(`[${processed}/${queue.length}] rung${row.rung} ${row.outcome} $${spent.toFixed(4)} ${row.id} ${(row.title ?? '').slice(0, 48)}`);
+    }
+  };
   async function worker() {
     while (work.length) {
       const b = work.shift()!;
       const row: LadderRow = { id: b.id, title: b.title, author: b.author, language: b.language, rung: 0, outcome: '', reasons: [] };
       rows.push(row);
+      try {
 
       /* rung 0 — history */
       const stored = b.first_translation as { resolver?: string; verdict?: string } | undefined;
@@ -259,14 +294,43 @@ async function main() {
         ? { kind: 'verify_prior', claimedPriors: priors.slice(0, 6) }
         : { kind: 'refute_first' };
       const prompt = buildSkepticPrompt(b as SkepticBook, renderRubric(b), direction);
-      const res = await skepticCall(prompt);
+      // FAIL-CLOSED ESCALATION (run-1 lesson): a response with zero API-level
+      // grounding is model memory wearing a search costume. Grounding on the
+      // primary model is STOCHASTIC (~2/3 per call, measured 2026-08-09), so
+      // retry the cheap rung up to 2 more times before the fallback model —
+      // the ladder's own logic applied to a single call.
+      const isUngrounded = (r: Awaited<ReturnType<typeof skepticCall>>) =>
+        !('error' in r) && r.queries.length === 0 && r.sources.length === 0;
+      let res = await skepticCall(prompt, MODEL);
+      let usedModel = MODEL;
+      let searchCost = 'error' in res ? 0 : res.cost;
+      if (!('error' in res)) spent += res.cost;
+      for (let retry = 0; retry < 2 && isUngrounded(res) && spent < BUDGET; retry++) {
+        const r2 = await skepticCall(prompt, MODEL);
+        if ('error' in r2) break;
+        searchCost += r2.cost; spent += r2.cost;
+        res = r2;
+      }
+      const primaryUngrounded = isUngrounded(res);
+      if (primaryUngrounded && FALLBACK !== 'none' && spent < BUDGET) {
+        const r3 = await skepticCall(prompt, FALLBACK);
+        if (!('error' in r3)) { searchCost += r3.cost; spent += r3.cost; res = r3; usedModel = FALLBACK; }
+      }
       if ('error' in res) {
         row.rung = 3; row.outcome = `skeptic_error:${res.error}`; row.reasons = ['rung2_error'];
         rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: direction.kind, reasons: [`rung2_error:${res.error}`] });
         continue;
       }
-      spent += res.cost;
-      row.cost_usd = res.cost;
+
+      // Phase 2: prose → JSON contract, tools off, adds nothing.
+      const fmt = await formatCall(buildFormatPrompt(res.text));
+      if ('error' in fmt) {
+        row.rung = 3; row.outcome = `skeptic_error:format:${fmt.error}`; row.reasons = ['rung2_format_error'];
+        rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: direction.kind, reasons: [`rung2_format_error:${fmt.error}`] });
+        continue;
+      }
+      spent += fmt.cost;
+      row.cost_usd = searchCost + fmt.cost;
 
       const attemptId = makeAttemptId(b.id, 'gemini_grounded_search', RUN_DATE);
       // Only reference a transcript that was actually persisted.
@@ -276,17 +340,19 @@ async function main() {
         // ledger row can reference it even if parsing below fails.
         await db.collection(TRANSCRIPTS).insertOne({
           attempt_id: attemptId, book_id: b.id, date: RUN_DATE, rung: 2,
-          prompt_version: SKEPTIC_PROMPT_VERSION, model: MODEL, prompt,
-          raw_response: res.text, grounding: { queries: res.queries, chunks: res.chunks },
-          cost_usd: res.cost,
+          prompt_version: SKEPTIC_PROMPT_VERSION, model: usedModel, prompt,
+          primary_model: MODEL, fallback_used: usedModel !== MODEL, primary_ungrounded: primaryUngrounded,
+          raw_search: res.text, raw_response: fmt.text,
+          grounding: { queries: res.queries, chunks: res.chunks },
+          cost_usd: searchCost + fmt.cost,
         });
         await db.collection('gemini_usage').insertOne({
-          timestamp: new Date(), type: 'ft_ladder_skeptic', model: MODEL, book_id: b.id,
-          cost_usd: res.cost, status: 'ok', endpoint: 'script/ft-ladder',
+          timestamp: new Date(), type: 'ft_ladder_skeptic', model: usedModel, book_id: b.id,
+          cost_usd: searchCost + fmt.cost, status: 'ok', endpoint: 'script/ft-ladder',
         });
       }
 
-      const parsed = parseSkepticResponse(res.text);
+      const parsed = parseSkepticResponse(fmt.text);
       if (!parsed) {
         row.rung = 3; row.outcome = 'skeptic_unparseable'; row.reasons = ['rung2_parse_failed'];
         rung3Queue.push({ book_id: b.id, work: b.title, author: b.author, lang: b.language, direction: direction.kind, reasons: ["rung2_parse_failed"], transcript_ref: transcriptRef });
@@ -303,7 +369,7 @@ async function main() {
           attempt_id: attemptId, book_id: b.id, work_id: b.work_id ?? null, date: RUN_DATE,
           ...normed.attempt,
           sources_checked: res.sources, queries: res.queries,
-          model: MODEL, cost_usd: res.cost,
+          model: usedModel, cost_usd: searchCost + fmt.cost,
           prompt_version: SKEPTIC_PROMPT_VERSION, transcript_ref: transcriptRef,
           notes: `[ft-ladder rung2 ${SKEPTIC_PROMPT_VERSION}] ${direction.kind}; ${parsed.reasoning ?? ''}`.slice(0, 480),
         };
@@ -333,6 +399,7 @@ async function main() {
           claimed_priors: normed.attempt.priors, reasons: escalate, transcript_ref: transcriptRef,
         });
       }
+      } finally { progress(row); }
     }
   }
   await Promise.all(Array.from({ length: Math.max(1, Math.min(CONC, work.length)) }, () => worker()));

--- a/scripts/eval/ft-search-unexamined.mjs
+++ b/scripts/eval/ft-search-unexamined.mjs
@@ -142,10 +142,18 @@ async function main() {
         if (APPLY) {
           const ok = await appendAttempt(db, {
           attempt_id: `${b.id}:ft_search_unexamined:${PROMPT_VERSION}`,
-          book_id: b.id, work_id: b.work_id || null, date: RUN_DATE, method: 'gemini_grounded_search', match_key: 'work_search',
+          // match_key/result MUST be legal enum values (attempt-log.ts): the
+          // original 'work_search'/'not_found' were off-enum, so every absence
+          // this script logged was invisible to deriveVerdictFromAttempts and
+          // ranked as NaN in strongestAttempt (#3778). Historical rows keep the
+          // old values; only new runs write legal ones.
+          book_id: b.id, work_id: b.work_id || null, date: RUN_DATE, method: 'gemini_grounded_search', match_key: 'author_title',
           prompt_version: PROMPT_VERSION, prompt: buildPrompt(b), model: MODEL, raw_response: v.raw || null,
           sources_checked: v.sources_checked || [], queries: v.queries || [],
-          result: priorFound ? 'found' : (v.verdict === 'not_applicable' ? 'not_applicable' : 'not_found'),
+          result: priorFound ? 'found' : (v.verdict === 'not_applicable' ? 'not_applicable' : 'none'),
+          // "Could not tell" must never count as an absence vote: derive
+          // excludes verdict:'uncertain' rows from absence/refute counting.
+          verdict: (v.verdict === 'unverifiable' || v.verdict === 'needs_review') ? 'uncertain' : v.verdict,
           found_refs: [],
           priors: priors.map((p) => ({ english_title: p.english_title || undefined, translator: p.translator || undefined, pub_year: p.pub_year != null ? String(p.pub_year) : undefined, completeness: p.completeness || undefined, source_url: p.source_url || undefined })),
           adjudication: { verdict: v.verdict, our_completeness: v.our_completeness, confidence: v.confidence },

--- a/src/lib/first-translation/attempt-log.ts
+++ b/src/lib/first-translation/attempt-log.ts
@@ -81,6 +81,19 @@ export interface FirstTranslationAttempt {
   cost_usd?: number;
   notes?: string;
   /**
+   * Version tag of the prompt that produced this attempt (e.g.
+   * 'ft-ladder-skeptic/v1-2026-08-08'). Required on every automated
+   * instrument's rows (#3778): without it a search result cannot be reproduced
+   * or superseded when the prompt changes — the July replicability gap.
+   */
+  prompt_version?: string;
+  /**
+   * Pointer into `first_translation_transcripts` (the attempt_id doubles as the
+   * key) when the full prompt + raw response + grounding metadata were
+   * persisted separately. The ledger row stays lean; the transcript endures.
+   */
+  transcript_ref?: string;
+  /**
    * The verifier's raw result string, preserved by the ingest
    * (ingest-ft-verify-results.mjs) alongside the coarse `result`. For a
    * demote-direction Tier-2 check, `'not_found'` means the agent went looking

--- a/src/lib/first-translation/casebook.ts
+++ b/src/lib/first-translation/casebook.ts
@@ -1,0 +1,263 @@
+/**
+ * The FT verification CASEBOOK (#3778) — the fourth memory-bank layer.
+ *
+ * Three layers already exist as data: verified positives (`translation_catalogs`),
+ * catalogue absence (`reference_translations`), and search history
+ * (`first_translation_attempts`). The fourth — the failure-mode detectors, the
+ * policy rules, and the tradition-specific rules — lived only as prose in
+ * `.claude/docs/invariants/first-translation-claims.md`, readable by humans and
+ * Claude sessions but invisible to the cheap Gemini instruments that do most of
+ * the searching. This module makes it machine-readable so every rung of the
+ * escalation ladder injects the SAME rubric and routes on the SAME hard classes.
+ *
+ * Two exports matter:
+ *  - `renderRubric(book)` — the rubric block injected into rung-2/3 prompts.
+ *  - `routeBook(book, screenSignals)` / `postSearchRoute(priors)` — the routing
+ *    function: which rung is allowed to settle this book.
+ *
+ * Pure data + string assembly. No I/O, no model calls. Every rule carries its
+ * provenance so a future session can re-verify it instead of trusting it.
+ */
+
+import type { PriorTranslation } from './attempt-log';
+
+export interface CasebookRule {
+  id: string;
+  kind: 'failure_mode' | 'policy' | 'tradition';
+  /** Imperative instruction, written to be injected into a verifier prompt. */
+  rule: string;
+  /** Where this rule was learned — issue/PR/doc, so it can be re-verified. */
+  provenance: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Failure modes — the fabrication shapes observed in real Stage-1/2   */
+/* output. ~63% of early Stage-1 "a prior exists" claims were          */
+/* fabricated; these are the shapes they took.                         */
+/* ------------------------------------------------------------------ */
+
+export const FAILURE_MODES: CasebookRule[] = [
+  {
+    id: 'no_named_translator',
+    kind: 'failure_mode',
+    rule: 'A claimed prior with no named translator ("anonymous", "various", or an empty field) is the signature of a fabricated citation. Do not accept it without locating the actual edition in a library catalogue.',
+    provenance: '#3687 screen; first-translation-claims.md §fabricated priors',
+  },
+  {
+    id: 'amalgamated_citation',
+    kind: 'failure_mode',
+    rule: 'A translator field containing a disjunction ("Hadock (or Gibbons)") usually fuses two real translators of two DIFFERENT works into one citation. Split and verify each name against its own work.',
+    provenance: 'first-translation-claims.md §fabricated priors',
+  },
+  {
+    id: 'study_as_translation',
+    kind: 'failure_mode',
+    rule: 'A scholarly STUDY of a text (a monograph that quotes, summarizes, or analyses it) is not a translation of it. Check how the holding library itself catalogues the item (e.g. the NLM files Savage-Smith as a work ABOUT the treatise).',
+    provenance: 'first-translation-claims.md §fabricated priors',
+  },
+  {
+    id: 'real_scholar_nonexistent_work',
+    kind: 'failure_mode',
+    rule: 'A real scholar\'s name attached to a nonexistent work ("Deitz and Monfasani 1997") defeats every structural check. Confirm the work exists in the scholar\'s own bibliography or a library catalogue, not merely that the scholar exists.',
+    provenance: 'first-translation-claims.md §fabricated priors',
+  },
+  {
+    id: 'fabrication_beside_genuine',
+    kind: 'failure_mode',
+    rule: 'A fabricated prior can sit BESIDE a genuine defeater in the same answer. Finding one fabrication does not clear the book; verify every cited prior independently.',
+    provenance: 'first-translation-claims.md §fabricated priors',
+  },
+  {
+    id: 'wrong_date',
+    kind: 'failure_mode',
+    rule: 'Dates drift in fabricated citations (Read 1946 cited as "1936"). The year decides the first_modern grade, so verify it against the edition itself, never against the model\'s memory.',
+    provenance: 'first-translation-claims.md §fabricated priors; ft-verify SKILL first_modern note',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* Policy rules — what defeats a claim and what does not.              */
+/* ------------------------------------------------------------------ */
+
+export const POLICY_RULES: CasebookRule[] = [
+  {
+    id: 'complete_same_text_defeats',
+    kind: 'policy',
+    rule: 'A prior defeats a first-translation claim ONLY if it is COMPLETE and renders the SAME text. Report every prior\'s completeness explicitly: complete | partial | excerpt | unknown.',
+    provenance: '#3753; derive-from-evidence.ts priorDefeatsClaim',
+  },
+  {
+    id: 'different_source_language_no_defeat',
+    kind: 'policy',
+    rule: 'If OUR item is itself a translation (a witness), a prior rendered from a DIFFERENT source language or witness does not defeat a first-from-source claim. Report relationship: different_source_language.',
+    provenance: 'POLICY 2; types.ts PriorRelationship',
+  },
+  {
+    id: 'all_partial_first_complete',
+    kind: 'policy',
+    rule: 'If every prior you can find is partial or an excerpt, that is a POSITIVE finding (the claim grades first_complete), not a defeat. Say so; do not round it to "a prior exists".',
+    provenance: 'first-translation-claims.md §"All fragments" vs "could not tell"',
+  },
+  {
+    id: 'unknown_completeness_needs_review',
+    kind: 'policy',
+    rule: '"All priors are fragments" and "I could not determine completeness" are DIFFERENT verdicts. If any prior\'s completeness is unknown, mark it unknown — never guess complete or partial.',
+    provenance: 'first-translation-claims.md §"All fragments" vs "could not tell"',
+  },
+  {
+    id: 'pre1900_first_modern',
+    kind: 'policy',
+    rule: 'A complete prior that is pre-1900 does NOT defeat the claim outright — it grades the text "first modern translation". The publication YEAR of every prior is therefore mandatory, as a number, in a structured field.',
+    provenance: 'ft-verify SKILL §first_modern (Whittington 1547 mis-grade)',
+  },
+  {
+    id: 'container_partial_no_defeat',
+    kind: 'policy',
+    rule: 'If OUR item is a multi-work container, a multi-volume work, or text-plus-commentary, a prior covering only PART of it (one constituent, one volume, the base text without the apparatus) does not defeat it. Scope the claim before grading.',
+    provenance: '#3687 verified outcomes (Hagakure vol. 2, one juan of 106); ft-demote-screen container_title/work_plus_apparatus',
+  },
+  {
+    id: 'absence_is_bounded',
+    kind: 'policy',
+    rule: 'You cannot prove no prior exists — only report the bounded search you ran. Record every query verbatim and what each source showed. "I could not search this tradition" must be reported as uncertain, never as none_found.',
+    provenance: '#3459; first-translation-claims.md header',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* Tradition rules — keyed by source language.                         */
+/* ------------------------------------------------------------------ */
+
+export interface TraditionRule extends CasebookRule {
+  /** Case-insensitive test against the book's (original_)language string. */
+  appliesTo: RegExp;
+}
+
+export const TRADITION_RULES: TraditionRule[] = [
+  {
+    id: 'latin_greek_modern_imprints',
+    kind: 'tradition',
+    appliesTo: /latin|greek|grc|\bla\b/i,
+    rule: 'Prior English translations of Latin/Greek works are usually POST-1950 scholarly imprints (Loeb, Brill, university presses) — 80.8% of known priors. Early-modern catalogues (ESTC, Wing) cannot see them; search modern scholarly publishing and WorldCat, not just antiquarian sources.',
+    provenance: 'first-translation-claims.md §recall (ESTC covers 1473–1800)',
+  },
+  {
+    id: 'cjk_catalogue_blind',
+    kind: 'tradition',
+    appliesTo: /chin|japan|korea|cjk/i,
+    rule: 'Western catalogues are nearly blind to CJK works (romanization varies, MARC 880 coverage is 2.3%). Search ctext.org, romanized AND native-script titles, and sinological/japanological scholarship. Beware the container trap: one translated juan/fascicle of a large work is a partial, not a defeat.',
+    provenance: 'first-translation-claims.md §depth-vs-reachability; #3687 Sancai Tuhui / one juan of 106',
+  },
+  {
+    id: 'hebrew_title_collisions',
+    kind: 'tradition',
+    appliesTo: /hebrew|aramaic|judeo/i,
+    rule: 'Kabbalistic and rabbinic titles collide: multiple UNRELATED works share a title (Shaʿarei Ẓedek vs Shaʿarei Orah vs a third unrelated same-title text). Establish WHICH work by author and incipit before accepting any prior. Sefaria hosts community translations — report them, but flag them as practitioner/community sources for policy review.',
+    provenance: '#3687 verified outcomes; practitioner-PDF policy held for human (project_ft_v2_state)',
+  },
+  {
+    id: 'tibetan_practitioner_pdfs',
+    kind: 'tradition',
+    appliesTo: /tibet|dzongkha/i,
+    rule: 'Search 84000, BDRC, and Lotsawa House. Practitioner/dharma-community PDFs may exist without appearing in any catalogue — report them with URLs but flag as practitioner sources; whether they count as priors is a HUMAN policy decision, not yours.',
+    provenance: 'project_ft_v2_state practitioner-PDF hold (Kunzang Gongdü)',
+  },
+  {
+    id: 'arabic_syriac_series',
+    kind: 'tradition',
+    appliesTo: /arab|syriac|persian|farsi|ottoman|turkish/i,
+    rule: 'Check the standard translation series (Brill, Gibb Memorial, Bibliotheca Persica, JAOS scholarship) and both transliteration schemes for the title/author. Many "priors" are partial editions of long works — completeness is the usual failure point, not existence.',
+    provenance: '#3687 al-Jāḥiẓ class (every English rendering a fragment)',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* Routing — which rung may settle a book.                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Screen-signal codes (scripts/lib/ft-demote-screen.mjs) that mark a book as a
+ * HARD class: the question is work identity or scope, which the cheap grounded
+ * skeptic reliably gets wrong. These route to rung 3 (Claude) without paying
+ * for rung 2 first. Measured basis: the five detectors predicted 13/16 verified
+ * outcomes with zero searches (#3778); every rung-3 case was an identity
+ * question (#3778 addendum).
+ */
+export const HARD_CLASS_SIGNALS = new Set([
+  'container_title',
+  'work_plus_apparatus',
+  'item_is_a_witness',
+  'amalgamated_translator',
+]);
+
+/** Domains whose priors raise a POLICY question only a human may settle. */
+export const POLICY_HOLD_DOMAINS = [/sefaria\.org/i, /lotsawahouse\.org/i];
+
+export interface RouteDecision {
+  route: 'gemini' | 'claude' | 'human';
+  reasons: string[];
+}
+
+/**
+ * Pre-search routing: decide the cheapest rung allowed to settle this book.
+ * `screenSignalCodes` are the codes from `screenDemoteCandidate(book, priors)`.
+ */
+export function routeBook(
+  book: { title?: string; author?: string; language?: string | null },
+  screenSignalCodes: string[],
+): RouteDecision {
+  const hard = screenSignalCodes.filter((c) => HARD_CLASS_SIGNALS.has(c));
+  if (hard.length > 0) {
+    return { route: 'claude', reasons: hard.map((c) => `hard_class:${c}`) };
+  }
+  return { route: 'gemini', reasons: [] };
+}
+
+/**
+ * Post-search routing: after rung 2 returns, escalate anything it is not
+ * allowed to settle. `uncertain` and disagreement escalation live in the
+ * driver (they need the stored verdict); this handles the policy holds.
+ */
+export function postSearchRoute(priors: PriorTranslation[]): RouteDecision {
+  const policyHits = priors.filter((p) =>
+    POLICY_HOLD_DOMAINS.some((d) => d.test(p.source_url ?? '')));
+  if (policyHits.length > 0) {
+    return {
+      route: 'human',
+      reasons: policyHits.map((p) => `policy_hold:practitioner_source:${p.source_url}`),
+    };
+  }
+  return { route: 'gemini', reasons: [] };
+}
+
+/* ------------------------------------------------------------------ */
+/* Rubric rendering                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Tradition rules applicable to a book's source language. */
+export function traditionRulesFor(language?: string | null): TraditionRule[] {
+  const l = String(language ?? '');
+  return TRADITION_RULES.filter((r) => r.appliesTo.test(l));
+}
+
+/**
+ * Render the casebook as a rubric block for injection into a verifier prompt
+ * (rung 2 and rung 3 get the SAME rubric — the point is that hard-won rules
+ * stop living only in prose no instrument reads).
+ */
+export function renderRubric(book: { language?: string | null; original_language?: string | null }): string {
+  const lang = book.original_language ?? book.language;
+  const lines: string[] = [];
+  lines.push('KNOWN FAILURE MODES (each observed in real verification output — check your own answer against every one):');
+  for (const r of FAILURE_MODES) lines.push(`- ${r.rule}`);
+  lines.push('');
+  lines.push('POLICY RULES (what defeats a first-translation claim and what does not):');
+  for (const r of POLICY_RULES) lines.push(`- ${r.rule}`);
+  const trad = traditionRulesFor(lang);
+  if (trad.length > 0) {
+    lines.push('');
+    lines.push(`TRADITION-SPECIFIC RULES for this book's source language (${lang}):`);
+    for (const r of trad) lines.push(`- ${r.rule}`);
+  }
+  return lines.join('\n');
+}

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -166,6 +166,18 @@ function hasSearchCoverage(a: FirstTranslationAttempt): boolean {
   return (a.sources_checked?.length ?? 0) > 0 || (a.queries?.length ?? 0) > 0;
 }
 
+/**
+ * "We asked and could not tell" is not "we asked and found nothing" (#3778).
+ * The rung-2 skeptic records an unsettleable question as result:'none' (no
+ * priors surfaced) with verdict:'uncertain'; counting that row as an absence
+ * vote — or letting it refute a found — would turn an unrun check into a
+ * confident negative, the single most common way this system lies. Excluding
+ * it is strictly conservative: fewer absence votes, fewer refutes.
+ */
+function isUncertain(a: FirstTranslationAttempt): boolean {
+  return a.verdict === 'uncertain';
+}
+
 /** A prior is *locatable* when it carries a resolvable http(s) grounding link. */
 function hasResolvableUrl(p: NonNullable<FirstTranslationAttempt['priors']>[number]): boolean {
   const u = p.source_url;
@@ -242,7 +254,7 @@ export function deriveVerdictFromAttempts(
     const strongest = strongestAttempt(trustFound)!;
     const maxFoundTier = Math.max(...trustFound.map(familyTier));
     const refutes = attempts.filter(
-      (a) => a.result === 'none' && !isNotApplicable(a) && hasSearchCoverage(a),
+      (a) => a.result === 'none' && !isNotApplicable(a) && !isUncertain(a) && hasSearchCoverage(a),
     );
     const maxRefuteTier = refutes.length ? Math.max(...refutes.map(familyTier)) : -1;
     if (maxRefuteTier >= 2 && maxRefuteTier > maxFoundTier) {
@@ -352,7 +364,7 @@ export function deriveVerdictFromAttempts(
   //    exclude not_applicable rows (not absence votes) and rows with no recorded
   //    search coverage (an undocumented "none" is not evidence of absence).
   const absences = attempts.filter(
-    (a) => a.result === 'none' && !isNotApplicable(a) && hasSearchCoverage(a),
+    (a) => a.result === 'none' && !isNotApplicable(a) && !isUncertain(a) && hasSearchCoverage(a),
   );
   if (absences.length === 0) return null;
   const families = new Set(absences.map(attemptFamily)).size;

--- a/src/lib/first-translation/skeptic.ts
+++ b/src/lib/first-translation/skeptic.ts
@@ -1,0 +1,241 @@
+/**
+ * Rung-2 grounded skeptic — the CONTRACT layer (#3778).
+ *
+ * The escalation ladder's cheap tier: a Google-Search-grounded Gemini call that
+ * tries to REFUTE the position under test. This module is pure (prompt assembly
+ * + response parsing/normalization); the API call and all I/O live in the
+ * driver (`scripts/eval/ft-ladder.ts`), so the contract is unit-testable.
+ *
+ * The invariants this layer enforces mechanically, because every one was
+ * violated by an earlier instrument:
+ *
+ *  1. LEGAL ENUMS ONLY. `ft-search-unexamined.mjs` wrote `result:'not_found'`
+ *     and `match_key:'work_search'` — both off-enum, so every absence it logged
+ *     was invisible to `deriveVerdictFromAttempts` and its rank lookups did NaN
+ *     comparisons. The normalizer here can only emit legal values.
+ *  2. UNCERTAIN IS NOT ABSENCE. "We asked and could not tell" must never count
+ *     as an absence vote. Uncertain rows keep `verdict:'uncertain'`, which the
+ *     derive step excludes from absence/refute counting.
+ *  3. YEAR IS LOAD-BEARING. A prior without a parseable year cannot be graded
+ *     (the first_modern rule turns on it), so its attempt is clamped to
+ *     `weak` — below the trust gate — and flagged for escalation.
+ *  4. A SINGLE INSTRUMENT IS NEVER 'strong'. Evidence strength is computed
+ *     here from what the search documented, capped at `moderate`. Independence
+ *     comes from families, not from one model's self-confidence.
+ *  5. CATALOG-TIER TRUST. The method is always `gemini_grounded_search`, which
+ *     `methodToResolver` maps to `tier1_catalog` — a resolver the nightly
+ *     reconcile valve (`--resolver=tier2_agent,human`) does not admit. Rung-2
+ *     output can therefore never move a public badge on its own (#3776:
+ *     ingest is actuation — this is the structural guarantee, pinned by
+ *     tests/unit/ft-skeptic.test.ts).
+ */
+
+import type { FirstTranslationAttempt, PriorTranslation } from './attempt-log';
+import type { PriorRelationship } from './types';
+
+export const SKEPTIC_PROMPT_VERSION = 'ft-ladder-skeptic/v1-2026-08-08';
+
+/** The model's response contract. Kept in sync with the prompt below. */
+export interface SkepticResponse {
+  result: 'complete_prior_found' | 'only_partial_exists' | 'none_found' | 'not_applicable' | 'uncertain';
+  priors: Array<{
+    translator?: string;
+    year?: number | string;
+    english_title?: string;
+    completeness?: string;
+    relationship?: string;
+    source_url?: string;
+    publisher?: string;
+  }>;
+  queries_run: string[];
+  sources_consulted: Array<{ url?: string; found?: string }>;
+  scope_flags?: { container?: boolean; witness?: boolean };
+  reasoning?: string;
+}
+
+export interface SkepticDirection {
+  /**
+   * 'refute_first'  — the book is badged/claimed first; try to FIND a prior.
+   * 'verify_prior'  — a prior has been claimed; verify it is real and complete.
+   */
+  kind: 'refute_first' | 'verify_prior';
+  /** For verify_prior: the claimed priors under test. */
+  claimedPriors?: PriorTranslation[];
+}
+
+const RESULT_VALUES = new Set([
+  'complete_prior_found', 'only_partial_exists', 'none_found', 'not_applicable', 'uncertain',
+]);
+
+const LEGAL_RELATIONSHIPS = new Set<PriorRelationship>([
+  'same_text', 'same_work_diff_edition', 'different_source_language',
+  'related_distinct_work', 'partial', 'adaptation',
+]);
+
+export interface SkepticBook {
+  id: string;
+  title?: string;
+  author?: string;
+  language?: string | null;
+  original_language?: string | null;
+  work_id?: string | null;
+}
+
+/* ------------------------------------------------------------------ */
+/* Prompt                                                              */
+/* ------------------------------------------------------------------ */
+
+function describeClaimed(priors: PriorTranslation[]): string {
+  return priors
+    .map((p) => `- "${p.english_title ?? '?'}" — ${p.translator ?? 'NO TRANSLATOR NAMED'}, ${p.pub_year ?? 'NO YEAR'} (${p.completeness ?? 'completeness unknown'})`)
+    .join('\n');
+}
+
+export function buildSkepticPrompt(
+  book: SkepticBook,
+  rubric: string,
+  direction: SkepticDirection,
+): string {
+  const lang = book.original_language ?? book.language ?? 'unknown';
+  const mission =
+    direction.kind === 'verify_prior'
+      ? `Stage 1 claims a PRIOR English translation of this work exists. BE SKEPTICAL — AI invents plausible translators and years. Verify whether EACH claimed prior below actually exists, and whether it is COMPLETE or only partial/excerpt, by locating the actual edition.\n\nCLAIMED PRIOR(S) UNDER TEST:\n${describeClaimed(direction.claimedPriors ?? [])}`
+      : `We are about to claim this book is a FIRST English translation — that NO complete prior English translation exists. BE SKEPTICAL: try to REFUTE the claim by FINDING a prior English translation. AI tends to wrongly assume "no prior" — fight that.`;
+
+  return `You are a skeptical bibliographic verifier for a library's "first English translation" audit. Use Google Search to do REAL research, then report the search you actually ran.
+
+WORK UNDER TEST:
+- Title: ${book.title ?? '?'}
+- Author: ${book.author ?? '?'}
+- Source language: ${lang}
+
+${mission}
+
+${rubric}
+
+METHOD:
+1. Identify the work precisely; separate it from parent/sibling/derivative works, other same-title works, and other editions. A translation of a DIFFERENT work does not count.
+2. Search library catalogues (WorldCat), archive.org, Google Books, HathiTrust, publishers, and the tradition-appropriate sources named above. Weight library catalogues and scholarly publishers; distrust aggregator/forum/AI-mirror sites.
+3. For EVERY prior you find or verify: record translator, publication year (a number — mandatory), exact English title, completeness (complete|partial|excerpt|unknown), its relationship to OUR text (same_text|same_work_diff_edition|different_source_language|related_distinct_work|partial|adaptation), and a real URL.
+4. If you cannot settle the question (sources unreachable, identity unresolved, tradition catalogue-blind), the answer is "uncertain" — never round it to none_found.
+
+Respond with ONLY JSON (\`\`\`json fences allowed):
+{"result":"complete_prior_found|only_partial_exists|none_found|not_applicable|uncertain","priors":[{"translator":"","year":0,"english_title":"","completeness":"complete|partial|excerpt|unknown","relationship":"same_text|same_work_diff_edition|different_source_language|related_distinct_work|partial|adaptation","source_url":"","publisher":""}],"queries_run":["every query, verbatim"],"sources_consulted":[{"url":"...","found":"<one line: what it showed>"}],"scope_flags":{"container":false,"witness":false},"reasoning":"<2-3 sentences>"}
+"not_applicable" only if our item is visual art, a plain scripture manuscript, or itself already in English.`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Parsing + normalization                                             */
+/* ------------------------------------------------------------------ */
+
+/** Extract the JSON payload from a model response; null when unparseable. */
+export function parseSkepticResponse(text: string): SkepticResponse | null {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidates = [fenced?.[1], text, text.match(/\{[\s\S]*\}/)?.[0]];
+  for (const c of candidates) {
+    if (!c) continue;
+    try {
+      const parsed = JSON.parse(c.trim());
+      if (parsed && typeof parsed === 'object' && RESULT_VALUES.has(parsed.result)) {
+        return {
+          result: parsed.result,
+          priors: Array.isArray(parsed.priors) ? parsed.priors : [],
+          queries_run: Array.isArray(parsed.queries_run) ? parsed.queries_run.filter((q: unknown) => typeof q === 'string') : [],
+          sources_consulted: Array.isArray(parsed.sources_consulted) ? parsed.sources_consulted : [],
+          scope_flags: parsed.scope_flags,
+          reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : undefined,
+        };
+      }
+    } catch { /* try next candidate */ }
+  }
+  return null;
+}
+
+export interface NormalizedSkepticAttempt {
+  /** Legal-enum fields, ready to spread into a FirstTranslationAttempt. */
+  attempt: Pick<
+    FirstTranslationAttempt,
+    'method' | 'match_key' | 'result' | 'priors' | 'evidence_strength' | 'verdict' | 'independence_score'
+  >;
+  /** Contract problems found while normalizing — each one escalates. */
+  problems: string[];
+}
+
+/** Parse a 4-digit year out of the model's year field. */
+function parseYear(y: number | string | undefined): number | null {
+  const m = String(y ?? '').match(/\b(1[2-9]\d{2}|20\d{2})\b/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Normalize a parsed skeptic response into legal attempt-ledger fields.
+ * Deterministic; every judgement here is a rule, not a model opinion.
+ */
+export function normalizeSkepticAttempt(
+  resp: SkepticResponse,
+  grounding: { queries: string[]; sources: string[] },
+): NormalizedSkepticAttempt {
+  const problems: string[] = [];
+
+  const priors: PriorTranslation[] = [];
+  let yearless = 0;
+  for (const p of resp.priors) {
+    if (!p.english_title && !p.translator) continue;
+    const year = parseYear(p.year);
+    if (year === null) { yearless++; problems.push(`prior_without_year:${p.english_title ?? p.translator}`); }
+    const rel = LEGAL_RELATIONSHIPS.has(p.relationship as PriorRelationship)
+      ? (p.relationship as PriorRelationship)
+      : undefined;
+    if (p.relationship && !rel) problems.push(`illegal_relationship:${p.relationship}`);
+    priors.push({
+      english_title: p.english_title || undefined,
+      translator: p.translator || undefined,
+      pub_year: year !== null ? String(year) : undefined,
+      publisher: p.publisher || undefined,
+      completeness: p.completeness || undefined,
+      source_url: p.source_url || undefined,
+      // relationship is read by priorDefeatsClaim via a structural cast; carry
+      // ONLY legal values (an illegal value would default to defeating).
+      ...(rel ? { relationship: rel } : {}),
+    } as PriorTranslation);
+  }
+
+  // result → the three legal ledger values. `uncertain` maps by whether the
+  // model surfaced prior hints, and ALWAYS keeps verdict:'uncertain' so derive
+  // excludes it from absence/refute votes.
+  const result: FirstTranslationAttempt['result'] =
+    resp.result === 'not_applicable' ? 'not_applicable'
+    : (resp.result === 'complete_prior_found' || resp.result === 'only_partial_exists' || priors.length > 0) ? 'found'
+    : 'none';
+
+  // Evidence strength is COMPUTED, never model-reported, and capped at
+  // moderate (a single instrument cannot be 'strong').
+  const documented = grounding.queries.length >= 3 && grounding.sources.length >= 2;
+  let evidence_strength: FirstTranslationAttempt['evidence_strength'] = 'weak';
+  if (resp.result === 'uncertain') {
+    evidence_strength = 'weak';
+  } else if (result === 'found') {
+    const gradeable = priors.length > 0 && yearless === 0
+      && priors.every((p) => p.source_url && /^https?:\/\//.test(p.source_url));
+    evidence_strength = gradeable ? 'moderate' : 'weak';
+  } else if (result === 'none') {
+    evidence_strength = documented ? 'moderate' : 'weak';
+  } else {
+    evidence_strength = 'moderate'; // not_applicable with a documented look
+  }
+
+  if (result === 'none' && !documented) problems.push('absence_without_documented_search');
+
+  return {
+    attempt: {
+      method: 'gemini_grounded_search',
+      match_key: 'author_title',
+      result,
+      priors: priors.length ? priors : undefined,
+      evidence_strength,
+      verdict: resp.result,
+      independence_score: 0.3,
+    },
+    problems,
+  };
+}

--- a/src/lib/first-translation/skeptic.ts
+++ b/src/lib/first-translation/skeptic.ts
@@ -33,7 +33,20 @@
 import type { FirstTranslationAttempt, PriorTranslation } from './attempt-log';
 import type { PriorRelationship } from './types';
 
-export const SKEPTIC_PROMPT_VERSION = 'ft-ladder-skeptic/v1-2026-08-08';
+/**
+ * v3 (2026-08-09): TWO-PHASE. Run 1 (v1) proved gemini-3.1-flash-lite silently
+ * skips the googleSearch tool and fabricates queries_run when the prompt
+ * demands strict-JSON output — 634/634 responses ungrounded (rows deleted;
+ * backup in scripts/output/ft-ladder-run1-attempts-backup-*.json). v2's
+ * explicit search mandate changed nothing (10/10 still ungrounded); a matrix
+ * probe isolated the cause: the JSON contract itself suppresses tool use, and
+ * the same model grounds 3/3 with 11-13 chunks when asked for PROSE. So v3
+ * splits the rung: phase 1 is a grounded prose research call (tools on, no
+ * format demand), phase 2 converts that prose to the JSON contract (tools
+ * off). Grounding provenance always comes from phase 1's API metadata;
+ * normalizeSkepticAttempt still fails closed when it is empty.
+ */
+export const SKEPTIC_PROMPT_VERSION = 'ft-ladder-skeptic/v3-2026-08-09';
 
 /** The model's response contract. Kept in sync with the prompt below. */
 export interface SkepticResponse {
@@ -102,7 +115,7 @@ export function buildSkepticPrompt(
       ? `Stage 1 claims a PRIOR English translation of this work exists. BE SKEPTICAL — AI invents plausible translators and years. Verify whether EACH claimed prior below actually exists, and whether it is COMPLETE or only partial/excerpt, by locating the actual edition.\n\nCLAIMED PRIOR(S) UNDER TEST:\n${describeClaimed(direction.claimedPriors ?? [])}`
       : `We are about to claim this book is a FIRST English translation — that NO complete prior English translation exists. BE SKEPTICAL: try to REFUTE the claim by FINDING a prior English translation. AI tends to wrongly assume "no prior" — fight that.`;
 
-  return `You are a skeptical bibliographic verifier for a library's "first English translation" audit. Use Google Search to do REAL research, then report the search you actually ran.
+  return `You are a skeptical bibliographic verifier for a library's "first English translation" audit. Use Google Search to do REAL research, then report what your searches actually showed.
 
 WORK UNDER TEST:
 - Title: ${book.title ?? '?'}
@@ -114,14 +127,25 @@ ${mission}
 ${rubric}
 
 METHOD:
-1. Identify the work precisely; separate it from parent/sibling/derivative works, other same-title works, and other editions. A translation of a DIFFERENT work does not count.
-2. Search library catalogues (WorldCat), archive.org, Google Books, HathiTrust, publishers, and the tradition-appropriate sources named above. Weight library catalogues and scholarly publishers; distrust aggregator/forum/AI-mirror sites.
-3. For EVERY prior you find or verify: record translator, publication year (a number — mandatory), exact English title, completeness (complete|partial|excerpt|unknown), its relationship to OUR text (same_text|same_work_diff_edition|different_source_language|related_distinct_work|partial|adaptation), and a real URL.
-4. If you cannot settle the question (sources unreachable, identity unresolved, tradition catalogue-blind), the answer is "uncertain" — never round it to none_found.
+1. Execute at least 3 Google Search queries. Search library catalogues (WorldCat), archive.org, Google Books, HathiTrust, publishers, and the tradition-appropriate sources named above. Weight library catalogues and scholarly publishers; distrust aggregator/forum/AI-mirror sites. Do not report anything your searches did not just show you.
+2. Identify the work precisely; separate it from parent/sibling/derivative works, other same-title works, and other editions. A translation of a DIFFERENT work does not count.
+3. Report in PLAIN PROSE (no JSON): for EVERY prior translation you found, give the translator, publication year, exact English title, completeness (complete, partial, or excerpt), its relationship to OUR text (same text? same work in a different edition? a different source language? a related but distinct work?), and the URL where your search showed it. If your searches found no prior, say so and say where you looked. If you could not settle the question (sources unreachable, identity unresolved, tradition catalogue-blind), say you are uncertain — never round that to "none". Also note if our item is a multi-work container, carries a commentary, is itself a translation, is visual art, plain scripture, or already in English.`;
+}
+
+/**
+ * Phase 2: convert the phase-1 prose research report into the JSON contract.
+ * Runs WITHOUT tools (the JSON demand is what suppressed grounding in v1/v2),
+ * so it must add nothing: it is a formatter, not a second opinion.
+ */
+export function buildFormatPrompt(prose: string): string {
+  return `Below is a bibliographic research report. Convert it to JSON. Include ONLY facts the report explicitly states — do not add, infer, or complete anything from your own knowledge. If the report does not state a field, leave it empty.
+
+REPORT:
+${prose}
 
 Respond with ONLY JSON (\`\`\`json fences allowed):
-{"result":"complete_prior_found|only_partial_exists|none_found|not_applicable|uncertain","priors":[{"translator":"","year":0,"english_title":"","completeness":"complete|partial|excerpt|unknown","relationship":"same_text|same_work_diff_edition|different_source_language|related_distinct_work|partial|adaptation","source_url":"","publisher":""}],"queries_run":["every query, verbatim"],"sources_consulted":[{"url":"...","found":"<one line: what it showed>"}],"scope_flags":{"container":false,"witness":false},"reasoning":"<2-3 sentences>"}
-"not_applicable" only if our item is visual art, a plain scripture manuscript, or itself already in English.`;
+{"result":"complete_prior_found|only_partial_exists|none_found|not_applicable|uncertain","priors":[{"translator":"","year":0,"english_title":"","completeness":"complete|partial|excerpt|unknown","relationship":"same_text|same_work_diff_edition|different_source_language|related_distinct_work|partial|adaptation","source_url":"","publisher":""}],"queries_run":["queries the report says were run"],"sources_consulted":[{"url":"...","found":"<one line: what the report says it showed>"}],"scope_flags":{"container":false,"witness":false},"reasoning":"<2-3 sentences summarizing the report>"}
+result rules: complete_prior_found only if the report affirms a COMPLETE prior exists; only_partial_exists if every prior is partial/excerpt; none_found only if the report says the searches found no prior; not_applicable if the report says the item is visual art, plain scripture, or already English; uncertain if the report expresses uncertainty or could not settle the question.`;
 }
 
 /* ------------------------------------------------------------------ */
@@ -208,11 +232,20 @@ export function normalizeSkepticAttempt(
     : (resp.result === 'complete_prior_found' || resp.result === 'only_partial_exists' || priors.length > 0) ? 'found'
     : 'none';
 
+  // GROUNDING IS THE PROVENANCE, and it comes from the API's metadata, never
+  // the model's self-report. Run 1 (2026-08-08) proved a model can emit
+  // plausible queries_run and cited URLs while executing ZERO searches — so an
+  // ungrounded response is MODEL KNOWLEDGE and must be recorded as such:
+  // method 'gemini_verifier' (whose family without queries is model_knowledge),
+  // strength weak, flagged. Without grounding, a URL is just another token.
+  const grounded = grounding.queries.length > 0 || grounding.sources.length > 0;
+  if (!grounded) problems.push('ungrounded_response');
+
   // Evidence strength is COMPUTED, never model-reported, and capped at
   // moderate (a single instrument cannot be 'strong').
   const documented = grounding.queries.length >= 3 && grounding.sources.length >= 2;
   let evidence_strength: FirstTranslationAttempt['evidence_strength'] = 'weak';
-  if (resp.result === 'uncertain') {
+  if (!grounded || resp.result === 'uncertain') {
     evidence_strength = 'weak';
   } else if (result === 'found') {
     const gradeable = priors.length > 0 && yearless === 0
@@ -228,7 +261,7 @@ export function normalizeSkepticAttempt(
 
   return {
     attempt: {
-      method: 'gemini_grounded_search',
+      method: grounded ? 'gemini_grounded_search' : 'gemini_verifier',
       match_key: 'author_title',
       result,
       priors: priors.length ? priors : undefined,

--- a/tests/unit/ft-casebook.test.ts
+++ b/tests/unit/ft-casebook.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderRubric, routeBook, postSearchRoute, traditionRulesFor,
+  FAILURE_MODES, POLICY_RULES, HARD_CLASS_SIGNALS,
+} from '@/lib/first-translation/casebook';
+
+describe('casebook rubric (#3778 — the fourth memory-bank layer)', () => {
+  it('always carries every failure mode and policy rule', () => {
+    const r = renderRubric({ language: 'Latin' });
+    for (const rule of FAILURE_MODES) expect(r).toContain(rule.rule);
+    for (const rule of POLICY_RULES) expect(r).toContain(rule.rule);
+  });
+
+  it('selects tradition rules by source language', () => {
+    expect(traditionRulesFor('Chinese').map((r) => r.id)).toContain('cjk_catalogue_blind');
+    expect(traditionRulesFor('Tibetan').map((r) => r.id)).toContain('tibetan_practitioner_pdfs');
+    expect(traditionRulesFor('Latin').map((r) => r.id)).toContain('latin_greek_modern_imprints');
+    expect(traditionRulesFor('Chinese').map((r) => r.id)).not.toContain('tibetan_practitioner_pdfs');
+  });
+
+  it('original_language wins over the edition language for the rubric', () => {
+    // books.language is the language of the WORK we hold, not necessarily the
+    // source tradition — original_language is the tradition when present.
+    const r = renderRubric({ language: 'German', original_language: 'Hebrew' });
+    expect(r).toContain('Kabbalistic and rabbinic titles collide');
+  });
+});
+
+describe('casebook routing — hard classes never pay for rung 2', () => {
+  it('routes hard-class screen signals to claude', () => {
+    const d = routeBook({ title: 'Opera omnia' }, ['container_title']);
+    expect(d.route).toBe('claude');
+    expect(d.reasons).toEqual(['hard_class:container_title']);
+  });
+
+  it('every hard-class signal is a real detector code', () => {
+    // Guards against drift between the casebook and ft-demote-screen.mjs.
+    const known = new Set([
+      'item_is_a_witness', 'work_plus_apparatus', 'container_title', 'no_named_translator',
+      'amalgamated_translator', 'prior_is_a_study', 'prior_without_year',
+      'no_complete_prior_claimed', 'first_modern_candidate',
+    ]);
+    for (const s of HARD_CLASS_SIGNALS) expect(known.has(s)).toBe(true);
+  });
+
+  it('clean screen → gemini', () => {
+    expect(routeBook({ title: 'A single work' }, []).route).toBe('gemini');
+    // Prior-shaped signals (fabrication signatures) stay at gemini — verifying
+    // whether a citation exists is exactly what rung 2 is for.
+    expect(routeBook({ title: 'X' }, ['no_named_translator']).route).toBe('gemini');
+  });
+
+  it('practitioner-source priors are a HUMAN policy hold, not a verdict', () => {
+    const d = postSearchRoute([
+      { english_title: 'Gates of Light', source_url: 'https://www.sefaria.org/Shaarei_Orah' },
+    ]);
+    expect(d.route).toBe('human');
+    expect(d.reasons[0]).toContain('practitioner_source');
+    expect(postSearchRoute([{ english_title: 'X', source_url: 'https://archive.org/x' }]).route).toBe('gemini');
+  });
+});

--- a/tests/unit/ft-skeptic.test.ts
+++ b/tests/unit/ft-skeptic.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSkepticResponse, normalizeSkepticAttempt, buildSkepticPrompt,
+  SKEPTIC_PROMPT_VERSION, type SkepticResponse,
+} from '@/lib/first-translation/skeptic';
+import { deriveVerdictFromAttempts } from '@/lib/first-translation/derive-from-evidence';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+import type { FirstTranslationBook } from '@/lib/first-translation/types';
+
+const BOOK: FirstTranslationBook = {
+  title: 'De occulta philosophia', author: 'Agrippa von Nettesheim', language: 'Latin',
+  visible: true, pages_translated: 10,
+} as FirstTranslationBook;
+
+const GROUNDED = { queries: ['q1', 'q2', 'q3'], sources: ['WorldCat', 'archive.org'] };
+
+const resp = (over: Partial<SkepticResponse>): SkepticResponse => ({
+  result: 'none_found', priors: [], queries_run: ['q1'], sources_consulted: [], ...over,
+});
+
+/** Build a full ledger row from a normalized skeptic result, as the driver does. */
+const toRow = (r: SkepticResponse, grounded = GROUNDED): FirstTranslationAttempt => ({
+  attempt_id: 'a', book_id: 'b', date: '2026-08-08T00:00:00Z',
+  sources_checked: grounded.sources, queries: grounded.queries,
+  prompt_version: SKEPTIC_PROMPT_VERSION,
+  ...normalizeSkepticAttempt(r, grounded).attempt,
+});
+
+describe('parseSkepticResponse', () => {
+  it('parses fenced and bare JSON, rejects garbage and off-enum results', () => {
+    const json = '{"result":"none_found","priors":[],"queries_run":["a"],"sources_consulted":[]}';
+    expect(parseSkepticResponse('```json\n' + json + '\n```')?.result).toBe('none_found');
+    expect(parseSkepticResponse('prose then ' + json)?.result).toBe('none_found');
+    expect(parseSkepticResponse('no json at all')).toBeNull();
+    expect(parseSkepticResponse('{"result":"not_found"}')).toBeNull(); // off-contract value
+  });
+});
+
+describe('normalizeSkepticAttempt — legal enums only (the ft-search-unexamined lesson)', () => {
+  it('emits only legal result/match_key/method values', () => {
+    for (const r of ['complete_prior_found', 'only_partial_exists', 'none_found', 'not_applicable', 'uncertain'] as const) {
+      const { attempt } = normalizeSkepticAttempt(resp({ result: r }), GROUNDED);
+      expect(['found', 'none', 'not_applicable']).toContain(attempt.result);
+      expect(attempt.match_key).toBe('author_title');
+      expect(attempt.method).toBe('gemini_grounded_search');
+    }
+  });
+
+  it('a fully-documented complete prior → found/moderate, relationship carried', () => {
+    const { attempt, problems } = normalizeSkepticAttempt(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'J. Freake', year: 1651, english_title: 'Three Books of Occult Philosophy', completeness: 'complete', relationship: 'same_text', source_url: 'https://archive.org/x' }],
+    }), GROUNDED);
+    expect(attempt.result).toBe('found');
+    expect(attempt.evidence_strength).toBe('moderate');
+    expect(problems).toEqual([]);
+    expect((attempt.priors?.[0] as { relationship?: string }).relationship).toBe('same_text');
+    expect(attempt.priors?.[0].pub_year).toBe('1651');
+  });
+
+  it('a prior without a parseable year clamps to weak and flags (first_modern rule)', () => {
+    const { attempt, problems } = normalizeSkepticAttempt(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'Someone', english_title: 'X', completeness: 'complete', source_url: 'https://a/x' }],
+    }), GROUNDED);
+    expect(attempt.evidence_strength).toBe('weak');
+    expect(problems.some((p) => p.startsWith('prior_without_year'))).toBe(true);
+  });
+
+  it('an illegal relationship value is dropped, never carried (it would default to defeating)', () => {
+    const { attempt, problems } = normalizeSkepticAttempt(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'T', year: 1980, english_title: 'X', completeness: 'complete', relationship: 'sameish', source_url: 'https://a/x' }],
+    }), GROUNDED);
+    expect((attempt.priors?.[0] as { relationship?: string }).relationship).toBeUndefined();
+    expect(problems).toContain('illegal_relationship:sameish');
+  });
+
+  it('strength is computed, never model-reported, and never strong', () => {
+    // Even a perfect documented absence caps at moderate: one instrument is one family.
+    const documented = normalizeSkepticAttempt(resp({ result: 'none_found' }), GROUNDED);
+    expect(documented.attempt.evidence_strength).toBe('moderate');
+    const undocumented = normalizeSkepticAttempt(resp({ result: 'none_found' }), { queries: [], sources: [] });
+    expect(undocumented.attempt.evidence_strength).toBe('weak');
+    expect(undocumented.problems).toContain('absence_without_documented_search');
+  });
+
+  it('uncertain keeps verdict:"uncertain" — "could not tell" is not "found nothing"', () => {
+    const { attempt } = normalizeSkepticAttempt(resp({ result: 'uncertain' }), GROUNDED);
+    expect(attempt.result).toBe('none');
+    expect(attempt.verdict).toBe('uncertain');
+    expect(attempt.evidence_strength).toBe('weak');
+  });
+});
+
+describe('actuation pins (#3776 — rung 2 can never move a badge)', () => {
+  // The nightly cron (scripts/workers/crontab.production) runs the reconcile with
+  // --resolver=tier2_agent,human. These tests pin the OTHER half of that valve:
+  // every verdict a rung-2-only ledger can produce carries a resolver outside
+  // that set. If methodToResolver ever maps a gemini method into the admitted
+  // set, this fails. (The crontab itself is not readable from a unit test —
+  // changing the cron's --resolver list is a reviewed change by convention.)
+  const CRON_VALVE_ADMITS = new Set(['tier2_agent', 'human']);
+
+  it('a rung-2-only demote verdict resolves to tier1_catalog — outside the valve', () => {
+    const row = toRow(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'V. Perrone Compagni', year: 1992, english_title: 'De occulta philosophia libri tres (English)', completeness: 'complete', relationship: 'same_text', source_url: 'https://brill.com/x' }],
+    }));
+    const ft = deriveVerdictFromAttempts([row], BOOK);
+    expect(ft?.verdict).toBe('not_first');
+    expect(ft?.resolver).toBe('tier1_catalog');
+    expect(CRON_VALVE_ADMITS.has(ft!.resolver)).toBe(false);
+  });
+
+  it('a rung-2-only absence promotes nothing above weak first_no_prior, resolver outside the valve', () => {
+    const ft = deriveVerdictFromAttempts([toRow(resp({ result: 'none_found' }))], BOOK);
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('weak'); // one family, never more
+    expect(CRON_VALVE_ADMITS.has(ft!.resolver)).toBe(false);
+  });
+});
+
+describe('derive excludes uncertain rows from absence and refute votes', () => {
+  const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
+    attempt_id: 'a', book_id: 'b', date: '2026-06-29T00:00:00Z',
+    method: 'tier1_catalog', match_key: 'author_title',
+    sources_checked: ['search_local_catalogs'],
+    result: 'none', evidence_strength: 'moderate', ...over,
+  });
+
+  it('an uncertain row alone derives nothing', () => {
+    expect(deriveVerdictFromAttempts([toRow(resp({ result: 'uncertain' }))], BOOK)).toBeNull();
+  });
+
+  it('an agent-family uncertain row does not add an absence family', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({}), // one real catalog absence
+      at({ method: 'claude_subagent_verify', verdict: 'uncertain', queries: ['q'] }),
+    ], BOOK);
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('weak'); // still ONE family — uncertain excluded
+  });
+
+  it('an agent-family uncertain row does not refute a trustworthy found', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ result: 'found', found_refs: ['cat:1'], priors: [{ english_title: 'X', source_url: 'https://a/x' }] }),
+      at({ method: 'claude_subagent_verify', verdict: 'uncertain', queries: ['q'] }),
+    ], BOOK);
+    // Without the exclusion this graded needs_review (a fake §17 refute).
+    expect(ft?.verdict).toBe('not_first');
+  });
+});
+
+describe('buildSkepticPrompt', () => {
+  it('refute-frames the promote direction and lists claimed priors in the demote direction', () => {
+    const rubric = 'RUBRIC-MARKER';
+    const promote = buildSkepticPrompt({ id: 'x', title: 'T', author: 'A', language: 'Latin' }, rubric, { kind: 'refute_first' });
+    expect(promote).toContain('REFUTE');
+    expect(promote).toContain('RUBRIC-MARKER');
+    const demote = buildSkepticPrompt({ id: 'x', title: 'T', author: 'A', language: 'Latin' }, rubric,
+      { kind: 'verify_prior', claimedPriors: [{ english_title: 'Old Version', translator: 'N. N.', pub_year: '1900' }] });
+    expect(demote).toContain('CLAIMED PRIOR(S) UNDER TEST');
+    expect(demote).toContain('Old Version');
+  });
+});

--- a/tests/unit/ft-skeptic.test.ts
+++ b/tests/unit/ft-skeptic.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  parseSkepticResponse, normalizeSkepticAttempt, buildSkepticPrompt,
+  parseSkepticResponse, normalizeSkepticAttempt, buildSkepticPrompt, buildFormatPrompt,
   SKEPTIC_PROMPT_VERSION, type SkepticResponse,
 } from '@/lib/first-translation/skeptic';
 import { deriveVerdictFromAttempts } from '@/lib/first-translation/derive-from-evidence';
@@ -90,6 +90,44 @@ describe('normalizeSkepticAttempt — legal enums only (the ft-search-unexamined
     expect(attempt.result).toBe('none');
     expect(attempt.verdict).toBe('uncertain');
     expect(attempt.evidence_strength).toBe('weak');
+  });
+});
+
+describe('ungrounded responses fail closed (run-1: 634/634 rows had zero API grounding)', () => {
+  const UNGROUNDED = { queries: [], sources: [] };
+
+  it('an ungrounded found — even with perfect-looking priors — is model knowledge: gemini_verifier, weak, flagged', () => {
+    // Run 1 proved the model self-reports plausible queries_run and real-looking
+    // URLs while executing ZERO searches. Without grounding, a URL is a token.
+    const { attempt, problems } = normalizeSkepticAttempt(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'J. Freake', year: 1651, english_title: 'Three Books of Occult Philosophy', completeness: 'complete', relationship: 'same_text', source_url: 'https://archive.org/x' }],
+    }), UNGROUNDED);
+    expect(attempt.method).toBe('gemini_verifier');
+    expect(attempt.evidence_strength).toBe('weak');
+    expect(problems).toContain('ungrounded_response');
+  });
+
+  it('actuation pin: an ungrounded-found-only ledger derives NOTHING (weak hint defers)', () => {
+    const row = toRow(resp({
+      result: 'complete_prior_found',
+      priors: [{ translator: 'T', year: 1992, english_title: 'X', completeness: 'complete', relationship: 'same_text', source_url: 'https://a/x' }],
+    }), UNGROUNDED);
+    expect(deriveVerdictFromAttempts([row], BOOK)).toBeNull();
+  });
+
+  it('v3 is two-phase: the search prompt asks for PROSE, never JSON (JSON suppresses grounding)', () => {
+    expect(SKEPTIC_PROMPT_VERSION).toMatch(/\/v3-/);
+    const p = buildSkepticPrompt({ id: 'x', title: 'T', author: 'A', language: 'Latin' }, 'R', { kind: 'refute_first' });
+    expect(p).toContain('PLAIN PROSE');
+    expect(p).not.toContain('Respond with ONLY JSON');
+  });
+
+  it('the phase-2 formatter is a formatter, not a second opinion', () => {
+    const f = buildFormatPrompt('Research report text.');
+    expect(f).toContain('ONLY facts the report explicitly states');
+    expect(f).toContain('Respond with ONLY JSON');
+    expect(f).toContain('Research report text.');
   });
 });
 


### PR DESCRIPTION
Follow-up to #3783, from the first at-scale ladder run (Derek-approved $10 budget).

## What run 1 found

634 books in, every attempt row had **zero API-level grounding metadata** while the model's JSON self-reported plausible `queries_run` — `gemini-3.1-flash-lite` was answering from memory and inventing the search trail. The run was halted; all 634 rows were deleted with Derek's approval (backup: `scripts/output/ft-ladder-run1-attempts-backup-2026-08-08.json`; transcripts and usage rows kept as the true record). The one thing that contained the damage: the contract computes coverage from API metadata, never the model's self-report, so 498 of the bogus absences were already inert to derive. The remaining hole — 109 "found" rows graded moderate because their priors carried year+URL — is exactly what this PR closes.

## Diagnosis (measured, not theorized)

- v2 added an explicit "you MUST search" mandate: **0/10 grounded**. Not an instruction problem.
- Matrix probe: compact prompt 0/3, search-first imperative 0/3, **prose output 3/3** (11–13 grounding chunks). The strict-JSON output demand itself suppresses tool use on lite.
- Preview model grounds 10/10 but costs ~$0.113/book (thinking tokens) — $590 for the queue.
- Lite prose grounding is stochastic: 8/12 per call. Two cheap retries → ~96%.

## The fix

- **Skeptic v3 is two-phase**: a grounded prose research call (tools on, no format demand), then a tools-off formatter into the JSON contract, instructed to add nothing.
- **Fail closed**: a response with zero grounding is recorded as `gemini_verifier` (model-knowledge family), weak, flagged `ungrounded_response` — never as a grounded search. Without grounding, a URL is just another token.
- **Retry the cheap rung**: up to 2 primary-model retries before any fallback model.
- Tests pin both: the ungrounded fail-closed mapping, and that an ungrounded-found-only ledger derives nothing.

Full run relaunched under this code (v3 prompt stamp, $8 cap, fallback off — the ~4% residual fails closed into the free rung-3 Claude queue). Projected ≈$4 for all ~5.2K books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)