### PR TITLE
feat(work): edition-conflict merge lane — 24 mechanical one-edition-two-works pairs merged (#3730 §3)

### DIFF
--- a/scripts/lib/work-merge-lib.mjs
+++ b/scripts/lib/work-merge-lib.mjs
@@ -27,10 +27,19 @@ export function rankFormat(w) {
   return 3; // legacy clean slug / cjk / other
 }
 
-export function pickWinner(wids) {
+/**
+ * Optional `inbound` (work_id -> book count) breaks format ties toward the id
+ * more books already carry — fewer rewrites, and the better-established mint
+ * survives (#3730 §3). Without it, behaviour is unchanged.
+ */
+export function pickWinner(wids, inbound) {
   return [...wids].sort((a, b) => {
     const r = rankFormat(a) - rankFormat(b);
     if (r) return r;
+    if (inbound) {
+      const ib = (inbound.get(b) || 0) - (inbound.get(a) || 0);
+      if (ib) return ib;
+    }
     if (a.length !== b.length) return a.length - b.length;
     return a < b ? -1 : 1;
   })[0];
@@ -192,7 +201,49 @@ export function containmentCandidates(reps, opts = {}) {
  * across canon works — that is how an Iliad edition would silently land on the
  * Odyssey page).
  */
-export function unionMergeClusters(clusters, canonSlugByWorkId = new Map()) {
+// ── edition-conflict lane (HIGH, #3730 §3) ──────────────────────────────────
+/**
+ * One edition, two works — the contradiction the edition layer surfaces for
+ * free. Auto-mergeable ONLY in the mechanical shape:
+ *
+ *   - exactly 2 distinct work_ids on one FULL-quality edition_key cluster
+ *     (3+-way clusters are where generic titles bridge genuinely different
+ *     works — e.g. seven "Hasidic discourses|schneersohn|1850" work_ids that
+ *     are different rebbes' discourse collections; always human work);
+ *   - both ids are local mints (a QID pair asserts external identity — queue);
+ *   - every member book carries the SAME non-null author_id;
+ *   - every book under EACH work_id — including books outside this edition
+ *     cluster — shares one normalized title (`titleVariants`, Unicode-aware).
+ *     This is the guard that stops a merge from propagating beyond the
+ *     edition that evidenced it: a work_id with other differently-titled
+ *     books is a broader cluster this edition cannot speak for.
+ *
+ * Typical survivor pair: `local:a:…:curiosa-physica` + `local:n:…:curious-physics`
+ * — one edition minted twice from the original title and its English gloss.
+ *
+ * `clusters`: [{ key, works: string[], authorIds: (string|null)[] }]
+ * `titleVariants`: work_id -> count of distinct normalized titles
+ * `inbound`: work_id -> book count (winner tiebreak after format rank)
+ */
+export function editionConflictClusters(clusters, { titleVariants, inbound }) {
+  const out = [];
+  for (const c of clusters) {
+    const wids = [...new Set(c.works)];
+    if (wids.length !== 2) continue;
+    if (!wids.every((w) => /^local:/.test(w))) continue;
+    const auths = [...new Set(c.authorIds || [])];
+    if (auths.length !== 1 || !auths[0]) continue;
+    if (!wids.every((w) => (titleVariants.get(w) || 0) === 1)) continue;
+    const winner = pickWinner(wids, inbound);
+    out.push({
+      source: 'edition-conflict', key: c.key, ids: wids,
+      winner, losers: wids.filter((w) => w !== winner),
+    });
+  }
+  return out;
+}
+
+export function unionMergeClusters(clusters, canonSlugByWorkId = new Map(), inbound) {
   const parent = new Map();
   const find = (x) => {
     while (parent.get(x) !== x) { parent.set(x, parent.get(parent.get(x))); x = parent.get(x); }
@@ -222,7 +273,7 @@ export function unionMergeClusters(clusters, canonSlugByWorkId = new Map()) {
     if (ids.length < 2) continue;
     const slugs = new Set(ids.map((id) => canonSlugByWorkId.get(id)).filter(Boolean));
     const plan = {
-      ids, winner: pickWinner(ids),
+      ids, winner: pickWinner(ids, inbound),
       sources: [...(sourcesByRoot.get(root) || [])].sort(),
     };
     plan.losers = ids.filter((i) => i !== plan.winner);

--- a/scripts/maintenance/merge-work-clusters.mjs
+++ b/scripts/maintenance/merge-work-clusters.mjs
@@ -13,7 +13,12 @@
  * HIGH (auto-written with backup):
  *   - canon gold seeds: the hand-verified workIds arrays in canon-works.ts
  *     (minus combined-volume ids shared between entries);
- *   - identical-title clusters (author surname + identical normalized title).
+ *   - identical-title clusters (author surname + identical normalized title);
+ *   - edition-conflict pairs (#3730 §3): one FULL-quality edition_key carrying
+ *     exactly two local work_ids, same author_id on every member, and both
+ *     work_ids single-titled across ALL their books (Unicode-aware) so the
+ *     merge cannot reach beyond the edition that evidenced it. QID pairs,
+ *     3+-way clusters and anything title-divergent stay human work.
  * MEDIUM (queued to `work_merge_queue`, status=pending — human review):
  *   - author-anchored title containment (the fit rule between clusters).
  *
@@ -34,12 +39,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   canonGoldClusters, identicalTitleClusters, containmentCandidates,
-  unionMergeClusters,
+  editionConflictClusters, unionMergeClusters,
 } from '../lib/work-merge-lib.mjs';
 import { norm as normTitle } from '../lib/work-identity-util.mjs';
 // Dynamic import: node (24+) type-strips the .ts natively, but a STATIC import
 // from an .mjs mis-detects its module format and drops the named exports.
 const { CANON_WORKS } = await import(new URL('../../src/lib/canon-works.ts', import.meta.url).href);
+const { normalizeEditionTitle } = await import(new URL('../../src/lib/edition-key.ts', import.meta.url).href);
 
 const APPLY = process.argv.includes('--apply');
 const OUT_DIR = path.join(process.cwd(), 'scripts', 'output');
@@ -55,7 +61,7 @@ async function main() {
   // cluster stays split under the surface (and FT priors keep hiding in it).
   const all = await books
     .find({ work_id: { $exists: true, $nin: [null, ''] } })
-    .project({ _id: 0, id: 1, work_id: 1, author: 1, author_id: 1, title: 1, work_title: 1, language: 1, visible: 1 })
+    .project({ _id: 0, id: 1, work_id: 1, author: 1, author_id: 1, title: 1, work_title: 1, language: 1, visible: 1, edition_key: 1, edition_key_quality: 1 })
     .toArray();
 
   // one representative per work_id (prefer a visible book — better titles),
@@ -88,12 +94,38 @@ async function main() {
 
   const identical = identicalTitleClusters(reps);
 
+  // ── edition-conflict lane (#3730 §3): one FULL-quality edition_key, two
+  // work_ids. Guards live in the lib; the two maps here feed them —
+  // Unicode-aware title variants per work_id (util `norm` is ASCII and would
+  // collapse every non-Latin title to '', faking single-variant works) and
+  // inbound book counts for the winner tiebreak.
+  const inbound = new Map();
+  const unicodeVariants = new Map();
+  for (const b of all) {
+    inbound.set(b.work_id, (inbound.get(b.work_id) || 0) + 1);
+    if (!unicodeVariants.has(b.work_id)) unicodeVariants.set(b.work_id, new Set());
+    unicodeVariants.get(b.work_id).add(normalizeEditionTitle(b.title));
+  }
+  const titleVariantsUnicode = new Map([...unicodeVariants].map(([w, s]) => [w, s.size]));
+  const byEditionKey = new Map();
+  for (const b of all) {
+    if (b.edition_key_quality !== 'full' || !b.edition_key) continue;
+    if (!byEditionKey.has(b.edition_key)) byEditionKey.set(b.edition_key, { key: b.edition_key, works: [], authorIds: [] });
+    const c = byEditionKey.get(b.edition_key);
+    c.works.push(b.work_id);
+    c.authorIds.push(b.author_id ?? null);
+  }
+  const editionConflicts = editionConflictClusters(
+    [...byEditionKey.values()].filter((c) => new Set(c.works).size > 1),
+    { titleVariants: titleVariantsUnicode, inbound },
+  );
+
   // cross-canon guard map (shared combined-volume ids resolve first-entry-wins;
   // any union spanning two canon entries is demoted, never auto-merged)
   const canonSlugByWorkId = new Map();
   for (const w of CANON_WORKS) for (const id of w.workIds) if (!canonSlugByWorkId.has(id)) canonSlugByWorkId.set(id, w.slug);
 
-  const { merges, demoted } = unionMergeClusters([...gold, ...identical], canonSlugByWorkId);
+  const { merges, demoted } = unionMergeClusters([...gold, ...identical, ...editionConflicts], canonSlugByWorkId, inbound);
 
   // ── MEDIUM lane (queue) ──
   // Skip pairs already unified by a HIGH merge.
@@ -171,7 +203,8 @@ async function main() {
     await db.collection('work_id_merges').insertMany(merges.map((m) => ({
       winner: m.winner, losers: m.losers, sources: m.sources,
       books_rewritten: affected.filter((a) => a.new_work_id === m.winner).length,
-      issue: 3759, backup: planPath, applied_at: now,
+      issue: m.sources.some((s) => s.startsWith('edition-conflict')) ? 3730 : 3759,
+      backup: planPath, applied_at: now,
     })));
   }
 

--- a/tests/unit/work-merge-lib.test.ts
+++ b/tests/unit/work-merge-lib.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   rankFormat, pickWinner, canonGoldClusters, identicalTitleKey,
   identicalTitleClusters, containmentPair, containmentCandidates,
-  unionMergeClusters,
+  editionConflictClusters, unionMergeClusters,
 } from '../../scripts/lib/work-merge-lib.mjs';
 import { CANON_WORKS, canonWorkForWorkId } from '@/lib/canon-works';
 
@@ -18,6 +18,62 @@ describe('pickWinner', () => {
   it('breaks QID ties by shortest id, deterministically', () => {
     expect(pickWinner(['Q125518202', 'Q16547641'])).toBe('Q16547641');
     expect(pickWinner(['Q16547641', 'Q125518202'])).toBe('Q16547641');
+  });
+  it('breaks same-format ties by inbound book count when a map is given', () => {
+    const inbound = new Map([['local:a:x:aaa-long-id', 5], ['local:a:x:bb', 1]]);
+    expect(pickWinner(['local:a:x:bb', 'local:a:x:aaa-long-id'], inbound)).toBe('local:a:x:aaa-long-id');
+    // format rank still dominates inbound count
+    expect(pickWinner(['local:n:x:popular', 'local:a:x:rare'], new Map([['local:n:x:popular', 9]]))).toBe('local:a:x:rare');
+  });
+});
+
+describe('edition-conflict lane (#3730 §3)', () => {
+  const maps = {
+    titleVariants: new Map([
+      ['local:a:christian-wolff:empirical-psychology', 1],
+      ['local:n:christian-wolff:empirica-psychologia', 1],
+      ['local:a:many-titles:w', 3],
+    ]),
+    inbound: new Map([
+      ['local:a:christian-wolff:empirical-psychology', 2],
+      ['local:n:christian-wolff:empirica-psychologia', 1],
+    ]),
+  };
+  const mech = {
+    key: 'psychologia empirica|wolff|1732|v',
+    works: ['local:a:christian-wolff:empirical-psychology', 'local:n:christian-wolff:empirica-psychologia'],
+    authorIds: ['christian-wolff', 'christian-wolff'],
+  };
+
+  it('merges the mechanical gloss/original pair, a: mint wins', () => {
+    const out = editionConflictClusters([mech], maps);
+    expect(out).toHaveLength(1);
+    expect(out[0].winner).toBe('local:a:christian-wolff:empirical-psychology');
+    expect(out[0].losers).toEqual(['local:n:christian-wolff:empirica-psychologia']);
+    expect(out[0].source).toBe('edition-conflict');
+  });
+
+  it('refuses a QID pair (external identity is not mechanical)', () => {
+    const out = editionConflictClusters([{ ...mech, works: ['Q123', mech.works[1]] }], maps);
+    expect(out).toHaveLength(0);
+  });
+
+  it('refuses 3+-way clusters (generic titles bridge distinct works)', () => {
+    const out = editionConflictClusters([{ ...mech, works: [...mech.works, 'local:a:christian-wolff:third'] }], maps);
+    expect(out).toHaveLength(0);
+  });
+
+  it('refuses when author_id is missing or disagrees', () => {
+    expect(editionConflictClusters([{ ...mech, authorIds: ['christian-wolff', null] }], maps)).toHaveLength(0);
+    expect(editionConflictClusters([{ ...mech, authorIds: ['christian-wolff', 'someone-else'] }], maps)).toHaveLength(0);
+  });
+
+  it('refuses when a work_id carries more than one title across ALL its books', () => {
+    const out = editionConflictClusters(
+      [{ ...mech, works: [mech.works[0], 'local:a:many-titles:w'], authorIds: ['christian-wolff', 'christian-wolff'] }],
+      maps,
+    );
+    expect(out).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
#3730 §3, first queue — the mechanical class of the work_id conflicts (one edition, two works), as a new HIGH lane in the existing #3759 merge machinery.

## The lane (`editionConflictClusters()` in `work-merge-lib.mjs`)

Auto-merges only when ALL of:

- one **full-quality** `edition_key` cluster carries **exactly two** distinct work_ids (3+-way clusters are where generic titles bridge genuinely different works — the probe found seven distinct `hasidic discourses|schneersohn|1850` work_ids that are different rebbes' discourse collections; those stay human);
- both ids are **local mints** (a QID pair asserts external identity — queued, not merged);
- every member book carries the **same non-null `author_id`**;
- each work_id is **single-titled across ALL its books** (Unicode-aware — the ASCII `norm` would collapse every non-Latin title to `''` and fake single-variant works). This is the guard that stops a merge from propagating beyond the edition that evidenced it.

Typical pair it exists for: `local:a:…:curious-physics` + `local:n:…:curiosa-physica` — one edition minted twice from the original title and its English gloss. `pickWinner()` gains an optional inbound-count tiebreak after format rank (fewer rewrites; the established mint survives). Unit tests cover the lane's five refusal/acceptance shapes.

## Applied 2026-08-09 (prod)

Through the existing driver — backup plan file, `work_id_aliases` stamped, provenance rows in `work_id_merges` (tagged issue 3730), union + canon-demotion guards active:

- **24 pairs merged, 27 books rewritten, 0 books left on a loser id**
- full-quality edition/work conflicts: **95 → 71** (the remainder: 22 QID-involved, 2 three-plus-way, rest guard-excluded — the human queue)
- Supabase catalog synced (0 errors); 50 affected `/work` pages revalidated; loser URLs verified 307-redirecting to winners (e.g. Hellwig `curiosa-physica` → `curious-physics`)

Note: the issue's "222 conflicts" predates the #3759/#3774 merge pass another session applied; today's live baseline was 95.

## Out of scope

The 47-cluster human remainder (including the possibility the *edition* layer is wrong in some); the LLM cross-language merge proposals (471 groups, deliberately unapplied pending review); the dark-cluster triage (§3's second queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
