### PR TITLE
fix(reader): notes-off no longer deletes inline term+note translation words (#3811)

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -309,18 +309,25 @@ function preprocessBracketTags(text: string, showNotes: boolean): string {
 }
 
 // Handle <term> vocabulary chips when notes are hidden.
-// A trailing glossary entry is a <term> immediately followed by its defining <note>
+// A trailing glossary entry is a line of nothing but <term>+<note> pairs
 // (e.g. `<term>bite</term> <note>original: "morsus."</note>`). With notes off the
-// <note> renders as null, leaving the term chip dangling with no definition. Remove
-// the whole pair. A <term> followed by a <gloss> is the same shape inline in prose
-// (`(<term>feng hou</term> <gloss>beacon towers</gloss>)`) — there the term IS the
-// transcribed word, so keep it and drop only the AI's rendering of it, otherwise the
-// unwrapped gloss reads as a duplicate. Any remaining <term> is inline within running
-// prose — unwrap it to plain text so the sentence stays intact, minus the chip.
+// <note> renders as null, leaving the term chip dangling with no definition —
+// remove those lines whole. But the same pair also occurs INLINE mid-sentence
+// (`a <term>scheme of roundness</term> <note>original: "schema rotundationis"</note>
+// is produced`), where the term IS the translation of the word: deleting the pair
+// there deletes sentence content (#3811). So only whole glossary lines are dropped;
+// every other <term> is unwrapped to plain text (its <note>, if any, is removed
+// downstream by stripAiAnnotations). A <term> followed by a <gloss> keeps the term
+// and drops only the AI's rendering of it, otherwise the unwrapped gloss reads as
+// a duplicate.
 function preprocessTerms(text: string, showNotes: boolean): string {
   if (showNotes) return text;
+  const pair = '<term>[^\\n]*?<\\/term>\\s*<note>[^\\n]*?<\\/note>';
+  const glossaryLine = new RegExp(`^[\\s*\\->#\\d.]*(?:${pair}[\\s.,;:]*)+[\\s*]*$`, 'i');
   return text
-    .replace(/<term>[\s\S]*?<\/term>\s*<note>[\s\S]*?<\/note>/gi, '')
+    .split('\n')
+    .filter(line => !glossaryLine.test(line))
+    .join('\n')
     .replace(/(<term>[\s\S]*?<\/term>)\s*<gloss>[\s\S]*?<\/gloss>/gi, '$1')
     .replace(/<term>([\s\S]*?)<\/term>/gi, '$1');
 }

--- a/tests/unit/notes-toggle-page-marks.test.ts
+++ b/tests/unit/notes-toggle-page-marks.test.ts
@@ -93,6 +93,45 @@ describe('Notes toggle preserves transcribed page marks', () => {
     expect(isDescriptionOnly).toBe(true);
   });
 
+  it('keeps inline term+note translation words when notes are off (#3811)', () => {
+    // pages/6949af986ef4a68b726b8008 (Ten Books on Architecture, 1522) — the
+    // pre-fix stored translation, verbatim. The old pair-drop deleted the term
+    // content mid-sentence, rendering "how a ** is produced in the body".
+    const VITRUVIUS_PAGE = `<meta>This page continues the discussion of the "perfect" proportions of the human body.</meta>
+
+### BOOK THREE
+
+46
+
+No less than how a **<term>scheme of roundness</term> <note>original: "schema rotundationis"</note> is produced in the body, so too a <term>square arrangement</term> <note>original: "quadrata designatio"</note> is found within it. For if a measurement is taken from the soles of the feet to the very top of the head, the width will be found to be the same as the height.**
+
+**<term>scheme of roundness</term> <note>original: "schema rotundationis"</note>, <term>square arrangement</term> <note>original: "quadrata designatio"</note>, width, height, Vitruvius**
+
+<summary>This page concludes the description of the Vitruvian Man.</summary>
+<keywords>Vitruvian Man, geometry, proportion</keywords>`;
+
+    const { processedText } = prepareNotesMarkdown(VITRUVIUS_PAGE, { showNotes: false });
+    // The inline terms are the translation itself — they must survive
+    expect(processedText).toContain('how a **scheme of roundness');
+    expect(processedText).toContain('so too a square arrangement');
+    // ...while the notes (the AI's "original:" glosses) are gone
+    expect(processedText).not.toContain('schema rotundationis');
+    // The trailing vocab line has stray words, so it is not a pure glossary
+    // line; its pairs unwrap rather than leaving comma-holes (", ,")
+    expect(processedText).not.toMatch(/,\s*,/);
+  });
+
+  it('still drops a whole trailing glossary line when notes are off', () => {
+    const prose = `The dog delivered a sharp bite to the intruder.
+
+<term>bite</term> <note>original: "morsus."</note>`;
+    const { processedText } = prepareNotesMarkdown(prose, { showNotes: false });
+    expect(processedText).toContain('sharp bite to the intruder');
+    // The dangling glossary entry (term + its now-hidden definition) is removed
+    expect(processedText).not.toContain('morsus');
+    expect(processedText.trim().endsWith('intruder.')).toBe(true);
+  });
+
   it('drops a term\'s AI gloss but keeps the transcribed term', () => {
     const { processedText } = prepareNotesMarkdown(DIAGRAM_PAGE, { showNotes: false, pageType: 'diagram' });
     // The <note> that contained this pair is gone entirely here; assert the rule


### PR DESCRIPTION
Fixes #3811.

## What

With Notes off (the reader default), `preprocessTerms` in `NotesRenderer` removed every `<term>X</term> <note>Y</note>` pair whole — term content included. That rule was written for trailing glossary entries, but the same pair occurs inline mid-sentence in legacy translations (~7% of translated pages, per a 3,000-page random sample), where the term IS the translation of the word. Result: sentences with holes — "No less than how a ** is produced in the body, so too a is found within it" (Ten Books on Architecture 1522, p95, the reported page).

## How

`preprocessTerms` now distinguishes by line shape:

- A line consisting of nothing but term+note pairs and separators (a trailing glossary list) is dropped whole — the previous, correct behavior for dangling chips.
- Every other `<term>` unwraps to its plain text; its adjacent `<note>` is removed downstream by `stripAiAnnotations`, mirroring how the existing `<gloss>` rule keeps the term and drops only the AI rendering.

Notes-on rendering is untouched.

## Tests

Two new cases in `tests/unit/notes-toggle-page-marks.test.ts`, following the file's verbatim-fixture pattern: the actual pre-fix stored translation of the reported Vitruvius page (inline pairs must keep their words; the junky bold vocab line must not render ", ," holes), and a trailing-glossary regression guard (the pair-drop still works). Full unit suite: 2,485 pass. `tsc --noEmit` clean.

## Out of scope

- The write-side artifact source (old prompt-v2 translations echoing OCR `*…*` and `<vocab>`) — new writes already sanitize via `translate-core`; legacy pages are healed by this render-side fix without re-translation spend.
- The download/export routes have their own `<term>` handling (`[[TERM_PLACEHOLDER]]`); not audited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)