### PR TITLE
fix(repair-uri-authors): parse d-nb.info's bare-array JSON-LD

### DIFF
--- a/scripts/catalog-coverage/snapshot-stats.mjs
+++ b/scripts/catalog-coverage/snapshot-stats.mjs
@@ -10,6 +10,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { computeUstcAuthorCoverage } from '../lib/ustc-author-coverage.mjs';
 
 const MONGO_URI = process.env.MONGODB_URI;
 if (!MONGO_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -52,6 +53,23 @@ async function main() {
   const enrichSnap = await db.collection('system_config').findOne({ _id: 'enrichment_snapshot' });
   const slOver90 = enrichSnap?.milestones?.over_90_pct || 0;
 
+  // Author coverage vs the USTC census — "we hold >=1 book by N of the census's
+  // distinct authors". Streams a 2.4M-row group; ~1-2 min, fine at 4:30am.
+  // exact = floor, cluster = estimate; see scripts/lib/ustc-author-coverage.mjs.
+  let authorCoverage = null;
+  try {
+    authorCoverage = await computeUstcAuthorCoverage(db);
+    await db.collection('catalog_coverage_meta').updateOne(
+      { _id: 'author_coverage' },
+      { $set: { ...authorCoverage, computed_at: new Date() } },
+      { upsert: true },
+    );
+  } catch (e) {
+    // Never let the author metric take down the whole snapshot — but never
+    // fail silently either: the field records the failure.
+    authorCoverage = { error: String(e.message || e) };
+  }
+
   const snapshot = {
     date: new Date().toISOString().split('T')[0], // YYYY-MM-DD
     created_at: new Date(),
@@ -64,6 +82,7 @@ async function main() {
     with_translation: totals.translated,
     pct_translated: totals.editions > 0 ? +(totals.translated / totals.editions * 100).toFixed(2) : 0,
     in_source_library: totals.in_sl,
+    author_coverage: authorCoverage,
     // Live Source Library stats
     sl: {
       total_books: slBooks,
@@ -99,6 +118,11 @@ async function main() {
   console.log(`  Scanned: ${snapshot.with_scan.toLocaleString()} (${snapshot.pct_scanned}%)`);
   console.log(`  Translated: ${snapshot.with_translation.toLocaleString()} (${snapshot.pct_translated}%)`);
   console.log(`  In SL (census match): ${snapshot.in_source_library.toLocaleString()}`);
+  if (authorCoverage && !authorCoverage.error) {
+    console.log(`  Census authors held: ${authorCoverage.matched_exact.toLocaleString()}-${authorCoverage.matched_cluster.toLocaleString()} of ${authorCoverage.census_distinct_authors.toLocaleString()} (${authorCoverage.pct_authors_exact}-${authorCoverage.pct_authors_cluster}%; ${authorCoverage.pct_editions_exact}-${authorCoverage.pct_editions_cluster}% of authored editions)`);
+  } else if (authorCoverage?.error) {
+    console.log(`  Census authors held: FAILED — ${authorCoverage.error}`);
+  }
   console.log(`  Import candidates: ${snapshot.import_candidates.toLocaleString()}`);
   console.log(`  --- Source Library ---`);
   console.log(`  Books with pages: ${snapshot.sl.books_with_pages.toLocaleString()}`);

--- a/scripts/catalog-coverage/ustc-author-coverage.mjs
+++ b/scripts/catalog-coverage/ustc-author-coverage.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * CLI for the USTC author-coverage metric — see scripts/lib/ustc-author-coverage.mjs
+ * for what the tiers mean (exact = floor, cluster = estimate; truth between).
+ *
+ * Prints the current numbers and, with --save, upserts them to
+ * catalog_coverage_meta {_id: 'author_coverage'} so ad-hoc readers don't have
+ * to re-run the 2.4M-row aggregation. The nightly snapshot-stats.mjs records
+ * the same numbers into catalog_coverage_snapshots as a tracked series.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/catalog-coverage/ustc-author-coverage.mjs
+ *   node --env-file=.env.production.local scripts/catalog-coverage/ustc-author-coverage.mjs --save
+ */
+import { MongoClient } from 'mongodb';
+import { computeUstcAuthorCoverage } from '../lib/ustc-author-coverage.mjs';
+
+const SAVE = process.argv.includes('--save');
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db('bookstore');
+
+const t0 = Date.now();
+const c = await computeUstcAuthorCoverage(db);
+console.log(`USTC-derived census: ${c.census_distinct_authors.toLocaleString()} distinct authors over ${c.census_authored_editions.toLocaleString()} authored editions`);
+console.log(`Our name forms (thesaurus variants + book author strings): ${c.our_name_forms.toLocaleString()}`);
+console.log(`\nAuthors we hold >=1 book by:`);
+console.log(`  exact tier (floor):     ${c.matched_exact.toLocaleString()}  (${c.pct_authors_exact}% of authors, ${c.pct_editions_exact}% of authored editions)`);
+console.log(`  cluster tier (estimate): ${c.matched_cluster.toLocaleString()}  (${c.pct_authors_cluster}% of authors, ${c.pct_editions_cluster}% of authored editions)`);
+console.log(`\ncomputed in ${((Date.now() - t0) / 1000).toFixed(0)}s`);
+
+if (SAVE) {
+  await db.collection('catalog_coverage_meta').updateOne(
+    { _id: 'author_coverage' },
+    { $set: { ...c, computed_at: new Date() } },
+    { upsert: true },
+  );
+  console.log(`saved -> catalog_coverage_meta {_id: 'author_coverage'}`);
+}
+await mc.close();

--- a/scripts/lib/author-name-key.mjs
+++ b/scripts/lib/author-name-key.mjs
@@ -1,0 +1,35 @@
+/**
+ * Shared author name-keying rules — extracted from build-authors-collection.mjs
+ * (#2202) so its consumers can never drift apart. Three scripts previously
+ * carried verbatim copies: the builder, additive-mint-authors-3780.mjs, and
+ * the USTC coverage metric that motivated the extraction.
+ *
+ * canonicalKey: cluster key — folded Latin stems of the name tokens, sorted,
+ * so "Böhmer, Justus Henning", "Justus Henning Boehmer" and "Iustus Henningius
+ * Boehmerus" collapse together. Non-Latin names fall back to the
+ * diacritic-folded raw string so CJK/Cyrillic/Greek authors still cluster.
+ * The stemming is deliberately aggressive (Latin case endings) — right for
+ * clustering and for coverage estimates, too loose for anything destructive.
+ *
+ * authorSlug: URL slug — must match src/lib/slugify.ts authorSlug() exactly.
+ */
+export const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
+
+export const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
+
+export function canonicalKey(author) {
+  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
+  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
+  const stems = toks.map(t => t
+    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
+    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
+    .filter(t => t.length >= 3).sort();
+  if (!stems.length) {
+    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
+      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
+  }
+  return stems.join(' ');
+}
+
+export const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');

--- a/scripts/lib/ustc-author-coverage.mjs
+++ b/scripts/lib/ustc-author-coverage.mjs
@@ -1,0 +1,73 @@
+/**
+ * "How many distinct authors are in the USTC-derived census, and what
+ * proportion do we hold at least one book by?" — computed two ways, because
+ * the honest answer is a range:
+ *
+ *   - exact tier: NFD-normalized string identity between a census author and
+ *     any of our name forms (thesaurus variants + every books.author string).
+ *     Undercounts — "Luther, Martin, 1483-1546" won't meet "Martin Luther"
+ *     unless a form coincides. This is the FLOOR.
+ *   - cluster tier: the builder's canonicalKey (scripts/lib/author-name-key.mjs)
+ *     on both sides — folded Latin stems, order-insensitive, dates stripped.
+ *     Slightly overcounts (aggressive stemming can collide two people).
+ *     This is the ESTIMATE; truth sits between the tiers.
+ *
+ * Also reports edition-weighted coverage: the census is heavily Pareto —
+ * matched authors carry far more editions than their headcount suggests,
+ * because we hold the head of the distribution.
+ *
+ * First measured 2026-08-09 (post-#3780): 157,880 distinct census authors;
+ * exact tier 15,067 (9.5%) covering 41.6% of authored editions.
+ *
+ * Used by the ustc-author-coverage.mjs CLI and by the nightly
+ * snapshot-stats.mjs (so the number becomes a tracked series, not a one-off).
+ */
+import { canonicalKey } from './author-name-key.mjs';
+
+const normExact = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+  .replace(/[^a-z\s,]/g, ' ').replace(/\s+/g, ' ').trim();
+
+export async function computeUstcAuthorCoverage(db) {
+  // Our name forms, both tiers. Tombstoned docs still count — their variants
+  // point at a person we hold under the surviving doc.
+  const exact = new Set();
+  const cluster = new Set();
+  const add = (v) => {
+    if (!v) return;
+    const e = normExact(v);
+    if (e) exact.add(e);
+    const k = canonicalKey(v);
+    if (k) cluster.add(k);
+  };
+  for await (const a of db.collection('authors').find({}, { projection: { variants: 1, canonical_name: 1 } })) {
+    add(a.canonical_name);
+    for (const v of a.variants || []) add(v);
+  }
+  for (const s of await db.collection('books').distinct('author', { author: { $type: 'string', $ne: '' } })) add(s);
+
+  const cursor = db.collection('catalog_coverage').aggregate([
+    { $match: { author: { $type: 'string', $nin: ['', null] } } },
+    { $group: { _id: '$author', editions: { $sum: 1 } } },
+  ], { allowDiskUse: true });
+
+  const out = {
+    census_distinct_authors: 0,
+    census_authored_editions: 0,
+    matched_exact: 0,
+    matched_cluster: 0,
+    editions_matched_exact: 0,
+    editions_matched_cluster: 0,
+  };
+  for await (const r of cursor) {
+    out.census_distinct_authors++;
+    out.census_authored_editions += r.editions;
+    if (exact.has(normExact(r._id))) { out.matched_exact++; out.editions_matched_exact += r.editions; }
+    if (cluster.has(canonicalKey(r._id))) { out.matched_cluster++; out.editions_matched_cluster += r.editions; }
+  }
+  out.pct_authors_exact = +(100 * out.matched_exact / out.census_distinct_authors).toFixed(2);
+  out.pct_authors_cluster = +(100 * out.matched_cluster / out.census_distinct_authors).toFixed(2);
+  out.pct_editions_exact = +(100 * out.editions_matched_exact / out.census_authored_editions).toFixed(2);
+  out.pct_editions_cluster = +(100 * out.editions_matched_cluster / out.census_authored_editions).toFixed(2);
+  out.our_name_forms = exact.size;
+  return out;
+}

--- a/scripts/maintenance/additive-mint-authors-3780.mjs
+++ b/scripts/maintenance/additive-mint-authors-3780.mjs
@@ -44,24 +44,8 @@ const INPUT = (process.argv.find(a => a.startsWith('--input=')) || '').split('='
 const BACKUP = 'scripts/output/additive-mint-3780-backup.json';
 const SOURCE = 'additive-mint-3780';
 
-// ── the builder's clustering + slug rules, verbatim (build-authors-collection.mjs) ──
-const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
-function canonicalKey(author) {
-  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
-  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
-  const stems = toks.map(t => t
-    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
-    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
-    .filter(t => t.length >= 3).sort();
-  if (!stems.length) {
-    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
-      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
-  }
-  return stems.join(' ');
-}
-const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+// The builder's clustering + slug rules — shared via scripts/lib/author-name-key.mjs.
+import { norm, canonicalKey, authorSlug } from '../lib/author-name-key.mjs';
 
 const mc = new MongoClient(process.env.MONGODB_URI);
 await mc.connect();

--- a/scripts/maintenance/build-authors-collection.mjs
+++ b/scripts/maintenance/build-authors-collection.mjs
@@ -28,7 +28,6 @@ import { MongoClient, ObjectId } from 'mongodb';
 
 const APPLY = process.argv.includes('--apply');
 
-const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
 // People-only: drop placeholders, institutions, and ethnonym/anonymous buckets.
 const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumerian|babylonian|assyrian|traditional|chinese|japanese|tibetan|greek|roman)\b|collection|monastery|temple|press|library|dynasty|school of|circle of|workshop|^mtena|\b(church|council|society|congregation|order of|company of|guild|academy|université|university|conserv|ministry|commission|office|bureau)\b/i;
 /** Compound authorship ("A & B", "A | B", "A / B", "A; B", "A, B, C, …") — real
@@ -39,27 +38,9 @@ const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumeria
  *  entity-linked ones still resolve correctly and only no-entity ones drop. */
 const COMPOUND = /\s[|/&]\s|;\s|\bet\s+al\b|,[^,]+,[^,]+,/i;
 
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
-
-/** Cluster key: folded Latin stems of the name tokens; non-Latin names fall back
- *  to the diacritic-folded raw name so CJK/Cyrillic/Greek authors still cluster. */
-function canonicalKey(author) {
-  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
-  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
-  const stems = toks.map(t => t
-    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
-    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
-    .filter(t => t.length >= 3).sort();
-  if (!stems.length) {
-    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
-      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
-  }
-  return stems.join(' ');
-}
-
-/** URL slug — must match src/lib/slugify.ts authorSlug() exactly. */
-const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+// canonicalKey (cluster key) + authorSlug — shared with additive-mint-authors-3780
+// and the USTC coverage metric via scripts/lib/author-name-key.mjs.
+import { norm, canonicalKey, authorSlug } from '../lib/author-name-key.mjs';
 
 const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
 const db = mc.db('bookstore'); const books = db.collection('books'); const ents = db.collection('entities');

--- a/scripts/maintenance/repair-uri-author-strings.mjs
+++ b/scripts/maintenance/repair-uri-author-strings.mjs
@@ -49,7 +49,8 @@ async function resolveUri(uri) {
     const r = await fetch(`https://d-nb.info/gnd/${gnd}/about/lds.jsonld`, { headers: { Accept: 'application/json', 'User-Agent': UA }, signal: AbortSignal.timeout(20000) });
     if (!r.ok) throw new Error(`d-nb ${r.status}`);
     const d = await r.json();
-    const nodes = d['@graph'] || [d];
+    // d-nb.info lds.jsonld is a BARE ARRAY of nodes (no @graph wrapper)
+    const nodes = Array.isArray(d) ? d : d['@graph'] || [d];
     for (const n of nodes) {
       const name = n['preferredNameForThePerson'] || n['gndo:preferredNameForThePerson']
         || n['https://d-nb.info/standards/elementset/gnd#preferredNameForThePerson'];


### PR DESCRIPTION
Two-line fix: `d-nb.info/gnd/{id}/about/lds.jsonld` returns a bare top-level array of nodes, not an `@graph` wrapper, so the merged version of `repair-uri-author-strings.mjs` (PR #3812) fails every GND lookup with 'no preferredNameForThePerson'. This is the version that actually ran: all 55 URIs resolved, 148 books repaired (applied 2026-08-09, backup in `scripts/output/uri-author-repair-backup.jsonl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)