### PR TITLE
feat(reader): the editions rail — other printings of this work, other scans of this printing (#3730 §4)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1337,7 +1337,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           <div className="px-4 pb-4 md:px-6 md:pb-6">
             <BookBiblioPanel book={book} pagesCount={totalPages} showExternalLinks={embedPolicy.showExternalLinks} />
             {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (
-              <Suspense fallback={null}><RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} /></Suspense>
+              <Suspense fallback={null}><RelatedEditions
+                bookId={book.id}
+                workId={(book as unknown as { work_id?: string }).work_id!}
+                language={(book as unknown as { language?: string }).language}
+                editionKey={(book as unknown as { edition_key?: string }).edition_key}
+                editionKeyQuality={(book as unknown as { edition_key_quality?: string }).edition_key_quality}
+              /></Suspense>
             )}
             {embedPolicy.showIndexCatalogStatus && (
               <Suspense fallback={null}><IndexCatalogChip bookIds={[(book as unknown as { _id?: string })._id, book.id]} authorEntityId={(book as unknown as { author_entity_id?: string }).author_entity_id ?? null} /></Suspense>
@@ -2002,7 +2008,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
               >
                 {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (
                   <Suspense fallback={null}>
-                    <RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} />
+                    <RelatedEditions
+                      bookId={book.id}
+                      workId={(book as unknown as { work_id?: string }).work_id!}
+                      language={(book as unknown as { language?: string }).language}
+                      editionKey={(book as unknown as { edition_key?: string }).edition_key}
+                      editionKeyQuality={(book as unknown as { edition_key_quality?: string }).edition_key_quality}
+                    />
                   </Suspense>
                 )}
                 {embedPolicy.showIndexCatalogStatus && (

--- a/src/components/book/RelatedEditions.tsx
+++ b/src/components/book/RelatedEditions.tsx
@@ -1,40 +1,159 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
-import { Library } from 'lucide-react';
+import { Library, ScanSearch } from 'lucide-react';
+import { isTrustedEditionKey } from '@/lib/edition-key';
+
+/**
+ * The editions rail (#3730 §4, #3102 step 6): on a book page, show the reader
+ * what else the library holds of this thing — in two lanes with different
+ * identity grain:
+ *
+ *   - "Other printings & translations of this work"  — siblings by work_id
+ *   - "Other scans of this edition"                   — siblings by edition_key,
+ *     shown ONLY when both sides carry a full-quality key (isTrustedEditionKey:
+ *     a no-year key merges every printing of a title across centuries, fine for
+ *     a review queue and wrong for a reader-facing claim).
+ *
+ * Invariants (from #3730 §4 — do not relax):
+ *   - siblings must be `visible: true, pages_count > 0` — never leak a hidden book;
+ *   - books carrying `duplicate_of` are excluded even if somehow visible;
+ *   - callers gate on `embedPolicy.showRelatedEditions` (tenant lockdown): this
+ *     is a whole-library query and must not render on locked-down subdomains.
+ *
+ * Work-lane ordering is the collocation win first: editions in ANOTHER language
+ * rank above same-language reprints, and translated ones above untranslated —
+ * the reader on a Latin book is told about the English edition before the
+ * other Latin printing.
+ */
 
 interface RelatedEditionsProps {
   bookId: string;
   workId: string;
+  /** Current book's language — used to rank cross-language siblings first. */
+  language?: string | null;
+  /** Current book's stored edition key + quality; the scans lane renders only
+   * when this is full-quality. */
+  editionKey?: string | null;
+  editionKeyQuality?: string | null;
 }
 
-export default async function RelatedEditions({ bookId, workId }: RelatedEditionsProps) {
-  const db = await getDb();
+interface Sibling {
+  id?: string;
+  slug?: string;
+  title?: string;
+  display_title?: string;
+  year?: number;
+  language?: string;
+  pages_count?: number;
+  pages_translated?: number;
+  work_slug?: string;
+  edition_key?: string;
+  image_source?: { provider_name?: string };
+}
 
-  const related = await db.collection('books').find(
-    { work_id: workId, id: { $ne: bookId }, visible: true },
-    { projection: { 'image_source.provider_name': 1, work_slug: 1 }, maxTimeMS: 3000 }
-  ).toArray().catch(() => []);
+const SIBLING_FILTER = {
+  visible: true,
+  pages_count: { $gt: 0 },
+  // A duplicate pointer never appears as a sibling, whatever its visibility.
+  $or: [{ duplicate_of: { $exists: false } }, { duplicate_of: { $in: [null, ''] } }],
+};
 
-  if (related.length === 0) return null;
+const PROJ = {
+  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, year: 1, language: 1,
+  pages_count: 1, pages_translated: 1, work_slug: 1, edition_key: 1,
+  'image_source.provider_name': 1,
+};
+
+function bookHref(b: Sibling): string {
+  return `/book/${encodeURIComponent(b.slug || b.id || '')}`;
+}
+
+function transPct(b: Sibling): number {
+  return Math.round((100 * (b.pages_translated ?? 0)) / Math.max(1, b.pages_count ?? 0));
+}
+
+export default async function RelatedEditions({
+  bookId, workId, language, editionKey, editionKeyQuality,
+}: RelatedEditionsProps) {
+  const db = await getReadDb();
+
+  const workSiblings = (await db.collection('books').find(
+    { work_id: workId, id: { $ne: bookId }, ...SIBLING_FILTER },
+    { projection: PROJ, limit: 40, maxTimeMS: 3000 },
+  ).toArray().catch(() => [])) as Sibling[];
+
+  // Same-printing scans: separate, stricter query — trusted keys only, both sides.
+  const scanSiblings = isTrustedEditionKey(editionKeyQuality) && editionKey
+    ? (await db.collection('books').find(
+        { edition_key: editionKey, edition_key_quality: 'full', id: { $ne: bookId }, ...SIBLING_FILTER },
+        { projection: PROJ, limit: 4, maxTimeMS: 3000 },
+      ).toArray().catch(() => [])) as Sibling[]
+    : [];
+
+  if (workSiblings.length === 0 && scanSiblings.length === 0) return null;
+
+  const scanIds = new Set(scanSiblings.map((s) => s.id));
+  const printings = workSiblings.filter((s) => !scanIds.has(s.id));
+
+  const lang = (language || '').toLowerCase();
+  const ranked = [...printings].sort((a, b) => {
+    const crossA = (a.language || '').toLowerCase() !== lang ? 0 : 1;
+    const crossB = (b.language || '').toLowerCase() !== lang ? 0 : 1;
+    if (crossA !== crossB) return crossA - crossB;
+    const tA = transPct(a); const tB = transPct(b);
+    if (tA !== tB) return tB - tA;
+    return (a.year ?? 9999) - (b.year ?? 9999);
+  });
+  const shown = ranked.slice(0, 5);
+  const more = printings.length - shown.length;
 
   const libraryCount = new Set(
-    related.map(r => (r.image_source as { provider_name?: string })?.provider_name).filter(Boolean)
+    workSiblings.map((r) => r.image_source?.provider_name).filter(Boolean),
   ).size;
-  // link by the clean work_slug; fall back to the raw work_id (route accepts both)
-  const workHref = (related.find(r => (r as { work_slug?: string }).work_slug) as { work_slug?: string } | undefined)?.work_slug || workId;
+  const workHref = `/work/${workSiblings.find((r) => r.work_slug)?.work_slug || workId}`;
+
+  const row = (b: Sibling) => {
+    const pct = transPct(b);
+    return (
+      <li key={b.id}>
+        <Link href={bookHref(b)} className="group/re flex items-baseline gap-2 py-1 text-sm">
+          <span className="text-accent-gold group-hover/re:text-accent-gold/80 truncate">
+            {b.display_title || b.title}
+          </span>
+          <span className="text-stone-500 flex-shrink-0">
+            {[b.language, b.year, pct >= 99 ? 'translated' : pct > 0 ? `${pct}% translated` : null]
+              .filter(Boolean).join(' · ')}
+          </span>
+        </Link>
+      </li>
+    );
+  };
 
   return (
-    <div className="mt-4 pt-4 border-t border-stone-700">
-      <div className="flex gap-2 text-sm">
-        <span className="text-stone-500 w-24 flex-shrink-0">Editions:</span>
-        <Link
-          href={`/work/${workHref}`}
-          className="text-accent-gold hover:text-accent-gold/80 flex items-center gap-1.5 transition-colors"
-        >
-          {related.length} other edition{related.length !== 1 ? 's' : ''}{' '}
-          across {libraryCount} {libraryCount === 1 ? 'library' : 'libraries'}
-        </Link>
-      </div>
+    <div className="mt-4 pt-4 border-t border-stone-700 space-y-3">
+      {printings.length > 0 && (
+        <div className="text-sm">
+          <div className="flex items-center gap-1.5 text-stone-500 mb-1">
+            <Library className="w-3.5 h-3.5" aria-hidden />
+            <span>Other printings &amp; translations of this work</span>
+          </div>
+          <ul>{shown.map(row)}</ul>
+          <Link href={workHref} className="text-accent-gold hover:text-accent-gold/80 text-sm">
+            {more > 0
+              ? `All ${printings.length} editions${libraryCount > 1 ? ` across ${libraryCount} libraries` : ''} →`
+              : 'View this work →'}
+          </Link>
+        </div>
+      )}
+      {scanSiblings.length > 0 && (
+        <div className="text-sm">
+          <div className="flex items-center gap-1.5 text-stone-500 mb-1">
+            <ScanSearch className="w-3.5 h-3.5" aria-hidden />
+            <span>Other scans of this printing</span>
+          </div>
+          <ul>{scanSiblings.map(row)}</ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes the reader-facing step of #3730 §4 (#3102 step 6). RelatedEditions grows from a one-line count into the collocation rail with two lanes at different identity grain: work siblings (cross-language + translated ranked first) and same-printing scans (rendered only when BOTH sides carry a full-quality edition key — isTrustedEditionKey).

Invariants from the issue, enforced at the query and documented in the component: siblings must be visible with pages_count>0; duplicate_of carriers excluded even if visible; callers gate on embedPolicy.showRelatedEditions (tenant lockdown); scans lane trusts full-quality keys only. Uses existing indexes (work_id_1, edition_key_1_visible_1), maxTimeMS + graceful catch on both queries.

Verified on the preview deployment: Monas Hieroglyphica (Q908061) shows 5 ranked work siblings + work link; Zarlino's Istitutioni harmoniche shows only the scans lane (its sibling is a same-edition scan, correctly excluded from the printings lane). tsc clean, 2,385 unit tests green. CF purge on rollout is covered by the merge-triggered post-deploy-warm workflow.

Out of scope: /work/[id] as a richer destination (the remaining §4 sub-item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)