### PR TITLE
feat(authors): the tails — #3809 anchor repairs, #3770 no-Creator resolution, institution linking

### DIFF
--- a/scripts/catalog-coverage/snapshot-stats.mjs
+++ b/scripts/catalog-coverage/snapshot-stats.mjs
@@ -10,6 +10,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { computeUstcAuthorCoverage } from '../lib/ustc-author-coverage.mjs';
 
 const MONGO_URI = process.env.MONGODB_URI;
 if (!MONGO_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -52,6 +53,23 @@ async function main() {
   const enrichSnap = await db.collection('system_config').findOne({ _id: 'enrichment_snapshot' });
   const slOver90 = enrichSnap?.milestones?.over_90_pct || 0;
 
+  // Author coverage vs the USTC census — "we hold >=1 book by N of the census's
+  // distinct authors". Streams a 2.4M-row group; ~1-2 min, fine at 4:30am.
+  // exact = floor, cluster = estimate; see scripts/lib/ustc-author-coverage.mjs.
+  let authorCoverage = null;
+  try {
+    authorCoverage = await computeUstcAuthorCoverage(db);
+    await db.collection('catalog_coverage_meta').updateOne(
+      { _id: 'author_coverage' },
+      { $set: { ...authorCoverage, computed_at: new Date() } },
+      { upsert: true },
+    );
+  } catch (e) {
+    // Never let the author metric take down the whole snapshot — but never
+    // fail silently either: the field records the failure.
+    authorCoverage = { error: String(e.message || e) };
+  }
+
   const snapshot = {
     date: new Date().toISOString().split('T')[0], // YYYY-MM-DD
     created_at: new Date(),
@@ -64,6 +82,7 @@ async function main() {
     with_translation: totals.translated,
     pct_translated: totals.editions > 0 ? +(totals.translated / totals.editions * 100).toFixed(2) : 0,
     in_source_library: totals.in_sl,
+    author_coverage: authorCoverage,
     // Live Source Library stats
     sl: {
       total_books: slBooks,
@@ -99,6 +118,11 @@ async function main() {
   console.log(`  Scanned: ${snapshot.with_scan.toLocaleString()} (${snapshot.pct_scanned}%)`);
   console.log(`  Translated: ${snapshot.with_translation.toLocaleString()} (${snapshot.pct_translated}%)`);
   console.log(`  In SL (census match): ${snapshot.in_source_library.toLocaleString()}`);
+  if (authorCoverage && !authorCoverage.error) {
+    console.log(`  Census authors held: ${authorCoverage.matched_exact.toLocaleString()}-${authorCoverage.matched_cluster.toLocaleString()} of ${authorCoverage.census_distinct_authors.toLocaleString()} (${authorCoverage.pct_authors_exact}-${authorCoverage.pct_authors_cluster}%; ${authorCoverage.pct_editions_exact}-${authorCoverage.pct_editions_cluster}% of authored editions)`);
+  } else if (authorCoverage?.error) {
+    console.log(`  Census authors held: FAILED — ${authorCoverage.error}`);
+  }
   console.log(`  Import candidates: ${snapshot.import_candidates.toLocaleString()}`);
   console.log(`  --- Source Library ---`);
   console.log(`  Books with pages: ${snapshot.sl.books_with_pages.toLocaleString()}`);

--- a/scripts/catalog-coverage/ustc-author-coverage.mjs
+++ b/scripts/catalog-coverage/ustc-author-coverage.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * CLI for the USTC author-coverage metric — see scripts/lib/ustc-author-coverage.mjs
+ * for what the tiers mean (exact = floor, cluster = estimate; truth between).
+ *
+ * Prints the current numbers and, with --save, upserts them to
+ * catalog_coverage_meta {_id: 'author_coverage'} so ad-hoc readers don't have
+ * to re-run the 2.4M-row aggregation. The nightly snapshot-stats.mjs records
+ * the same numbers into catalog_coverage_snapshots as a tracked series.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/catalog-coverage/ustc-author-coverage.mjs
+ *   node --env-file=.env.production.local scripts/catalog-coverage/ustc-author-coverage.mjs --save
+ */
+import { MongoClient } from 'mongodb';
+import { computeUstcAuthorCoverage } from '../lib/ustc-author-coverage.mjs';
+
+const SAVE = process.argv.includes('--save');
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db('bookstore');
+
+const t0 = Date.now();
+const c = await computeUstcAuthorCoverage(db);
+console.log(`USTC-derived census: ${c.census_distinct_authors.toLocaleString()} distinct authors over ${c.census_authored_editions.toLocaleString()} authored editions`);
+console.log(`Our name forms (thesaurus variants + book author strings): ${c.our_name_forms.toLocaleString()}`);
+console.log(`\nAuthors we hold >=1 book by:`);
+console.log(`  exact tier (floor):     ${c.matched_exact.toLocaleString()}  (${c.pct_authors_exact}% of authors, ${c.pct_editions_exact}% of authored editions)`);
+console.log(`  cluster tier (estimate): ${c.matched_cluster.toLocaleString()}  (${c.pct_authors_cluster}% of authors, ${c.pct_editions_cluster}% of authored editions)`);
+console.log(`\ncomputed in ${((Date.now() - t0) / 1000).toFixed(0)}s`);
+
+if (SAVE) {
+  await db.collection('catalog_coverage_meta').updateOne(
+    { _id: 'author_coverage' },
+    { $set: { ...c, computed_at: new Date() } },
+    { upsert: true },
+  );
+  console.log(`saved -> catalog_coverage_meta {_id: 'author_coverage'}`);
+}
+await mc.close();

--- a/scripts/lib/author-name-key.mjs
+++ b/scripts/lib/author-name-key.mjs
@@ -1,0 +1,35 @@
+/**
+ * Shared author name-keying rules — extracted from build-authors-collection.mjs
+ * (#2202) so its consumers can never drift apart. Three scripts previously
+ * carried verbatim copies: the builder, additive-mint-authors-3780.mjs, and
+ * the USTC coverage metric that motivated the extraction.
+ *
+ * canonicalKey: cluster key — folded Latin stems of the name tokens, sorted,
+ * so "Böhmer, Justus Henning", "Justus Henning Boehmer" and "Iustus Henningius
+ * Boehmerus" collapse together. Non-Latin names fall back to the
+ * diacritic-folded raw string so CJK/Cyrillic/Greek authors still cluster.
+ * The stemming is deliberately aggressive (Latin case endings) — right for
+ * clustering and for coverage estimates, too loose for anything destructive.
+ *
+ * authorSlug: URL slug — must match src/lib/slugify.ts authorSlug() exactly.
+ */
+export const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
+
+export const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
+
+export function canonicalKey(author) {
+  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
+  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
+  const stems = toks.map(t => t
+    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
+    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
+    .filter(t => t.length >= 3).sort();
+  if (!stems.length) {
+    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
+      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
+  }
+  return stems.join(' ');
+}
+
+export const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');

--- a/scripts/lib/ustc-author-coverage.mjs
+++ b/scripts/lib/ustc-author-coverage.mjs
@@ -1,0 +1,73 @@
+/**
+ * "How many distinct authors are in the USTC-derived census, and what
+ * proportion do we hold at least one book by?" — computed two ways, because
+ * the honest answer is a range:
+ *
+ *   - exact tier: NFD-normalized string identity between a census author and
+ *     any of our name forms (thesaurus variants + every books.author string).
+ *     Undercounts — "Luther, Martin, 1483-1546" won't meet "Martin Luther"
+ *     unless a form coincides. This is the FLOOR.
+ *   - cluster tier: the builder's canonicalKey (scripts/lib/author-name-key.mjs)
+ *     on both sides — folded Latin stems, order-insensitive, dates stripped.
+ *     Slightly overcounts (aggressive stemming can collide two people).
+ *     This is the ESTIMATE; truth sits between the tiers.
+ *
+ * Also reports edition-weighted coverage: the census is heavily Pareto —
+ * matched authors carry far more editions than their headcount suggests,
+ * because we hold the head of the distribution.
+ *
+ * First measured 2026-08-09 (post-#3780): 157,880 distinct census authors;
+ * exact tier 15,067 (9.5%) covering 41.6% of authored editions.
+ *
+ * Used by the ustc-author-coverage.mjs CLI and by the nightly
+ * snapshot-stats.mjs (so the number becomes a tracked series, not a one-off).
+ */
+import { canonicalKey } from './author-name-key.mjs';
+
+const normExact = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+  .replace(/[^a-z\s,]/g, ' ').replace(/\s+/g, ' ').trim();
+
+export async function computeUstcAuthorCoverage(db) {
+  // Our name forms, both tiers. Tombstoned docs still count — their variants
+  // point at a person we hold under the surviving doc.
+  const exact = new Set();
+  const cluster = new Set();
+  const add = (v) => {
+    if (!v) return;
+    const e = normExact(v);
+    if (e) exact.add(e);
+    const k = canonicalKey(v);
+    if (k) cluster.add(k);
+  };
+  for await (const a of db.collection('authors').find({}, { projection: { variants: 1, canonical_name: 1 } })) {
+    add(a.canonical_name);
+    for (const v of a.variants || []) add(v);
+  }
+  for (const s of await db.collection('books').distinct('author', { author: { $type: 'string', $ne: '' } })) add(s);
+
+  const cursor = db.collection('catalog_coverage').aggregate([
+    { $match: { author: { $type: 'string', $nin: ['', null] } } },
+    { $group: { _id: '$author', editions: { $sum: 1 } } },
+  ], { allowDiskUse: true });
+
+  const out = {
+    census_distinct_authors: 0,
+    census_authored_editions: 0,
+    matched_exact: 0,
+    matched_cluster: 0,
+    editions_matched_exact: 0,
+    editions_matched_cluster: 0,
+  };
+  for await (const r of cursor) {
+    out.census_distinct_authors++;
+    out.census_authored_editions += r.editions;
+    if (exact.has(normExact(r._id))) { out.matched_exact++; out.editions_matched_exact += r.editions; }
+    if (cluster.has(canonicalKey(r._id))) { out.matched_cluster++; out.editions_matched_cluster += r.editions; }
+  }
+  out.pct_authors_exact = +(100 * out.matched_exact / out.census_distinct_authors).toFixed(2);
+  out.pct_authors_cluster = +(100 * out.matched_cluster / out.census_distinct_authors).toFixed(2);
+  out.pct_editions_exact = +(100 * out.editions_matched_exact / out.census_authored_editions).toFixed(2);
+  out.pct_editions_cluster = +(100 * out.editions_matched_cluster / out.census_authored_editions).toFixed(2);
+  out.our_name_forms = exact.size;
+  return out;
+}

--- a/scripts/maintenance/additive-mint-authors-3780.mjs
+++ b/scripts/maintenance/additive-mint-authors-3780.mjs
@@ -44,24 +44,8 @@ const INPUT = (process.argv.find(a => a.startsWith('--input=')) || '').split('='
 const BACKUP = 'scripts/output/additive-mint-3780-backup.json';
 const SOURCE = 'additive-mint-3780';
 
-// ── the builder's clustering + slug rules, verbatim (build-authors-collection.mjs) ──
-const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
-function canonicalKey(author) {
-  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
-  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
-  const stems = toks.map(t => t
-    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
-    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
-    .filter(t => t.length >= 3).sort();
-  if (!stems.length) {
-    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
-      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
-  }
-  return stems.join(' ');
-}
-const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+// The builder's clustering + slug rules — shared via scripts/lib/author-name-key.mjs.
+import { norm, canonicalKey, authorSlug } from '../lib/author-name-key.mjs';
 
 const mc = new MongoClient(process.env.MONGODB_URI);
 await mc.connect();

--- a/scripts/maintenance/backfill-author-canonical-links.mjs
+++ b/scripts/maintenance/backfill-author-canonical-links.mjs
@@ -93,8 +93,17 @@ if (UNDO) {
 }
 
 // 1. Build NFD-normalized name -> [canonical docs] multimap from the thesaurus.
+//    Person docs by default. --include-institutions widens to is_person:false
+//    docs (corporate headings — a monastery collection, a learned society):
+//    the #3780 mint created those at scale, and a book whose author string IS
+//    the corporate heading should link to it — the read path renders them as
+//    Organization, never as a portrait-slot person (#3483). Tombstones stay out.
+const INCLUDE_INSTITUTIONS = process.argv.includes('--include-institutions');
 const allAuthors = await authors
-  .find({ is_person: { $ne: false } }, { projection: { slug: 1, canonical_name: 1, variants: 1, entity_ids: 1, viaf_id: 1, wikidata_id: 1 } })
+  .find({
+    ...(INCLUDE_INSTITUTIONS ? {} : { is_person: { $ne: false } }),
+    merged_into: { $exists: false },
+  }, { projection: { slug: 1, canonical_name: 1, variants: 1, entity_ids: 1, viaf_id: 1, wikidata_id: 1 } })
   .toArray();
 const nameMap = new Map();
 const entityToDocs = new Map(); // entity_id (string) -> [canonical docs] (for the entity-linked phase)

--- a/scripts/maintenance/build-authors-collection.mjs
+++ b/scripts/maintenance/build-authors-collection.mjs
@@ -28,7 +28,6 @@ import { MongoClient, ObjectId } from 'mongodb';
 
 const APPLY = process.argv.includes('--apply');
 
-const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
 // People-only: drop placeholders, institutions, and ethnonym/anonymous buckets.
 const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumerian|babylonian|assyrian|traditional|chinese|japanese|tibetan|greek|roman)\b|collection|monastery|temple|press|library|dynasty|school of|circle of|workshop|^mtena|\b(church|council|society|congregation|order of|company of|guild|academy|université|university|conserv|ministry|commission|office|bureau)\b/i;
 /** Compound authorship ("A & B", "A | B", "A / B", "A; B", "A, B, C, …") — real
@@ -39,27 +38,9 @@ const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumeria
  *  entity-linked ones still resolve correctly and only no-entity ones drop. */
 const COMPOUND = /\s[|/&]\s|;\s|\bet\s+al\b|,[^,]+,[^,]+,/i;
 
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
-
-/** Cluster key: folded Latin stems of the name tokens; non-Latin names fall back
- *  to the diacritic-folded raw name so CJK/Cyrillic/Greek authors still cluster. */
-function canonicalKey(author) {
-  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
-  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
-  const stems = toks.map(t => t
-    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
-    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
-    .filter(t => t.length >= 3).sort();
-  if (!stems.length) {
-    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
-      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
-  }
-  return stems.join(' ');
-}
-
-/** URL slug — must match src/lib/slugify.ts authorSlug() exactly. */
-const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+// canonicalKey (cluster key) + authorSlug — shared with additive-mint-authors-3780
+// and the USTC coverage metric via scripts/lib/author-name-key.mjs.
+import { norm, canonicalKey, authorSlug } from '../lib/author-name-key.mjs';
 
 const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
 const db = mc.db('bookstore'); const books = db.collection('books'); const ents = db.collection('entities');

--- a/scripts/maintenance/repair-anchor-tail-3809.mjs
+++ b/scripts/maintenance/repair-anchor-tail-3809.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Repair the #3809 anchor tail — the 11 invalid author anchors below #3800's
+ * book threshold, found by the 2026-08-09 full-corpus sweep. Same protocol as
+ * repair-invalid-author-anchors-3800.mjs (#3742: every target QID verified
+ * live, P31 through the shared denylist, refuse-on-failure), but this tail is
+ * mixed-class, so four different treatments:
+ *
+ * RE-ANCHOR (verified live 2026-08-09):
+ *   bossi-luigi        Q125197500 (dead item) -> Q3839378  Luigi Bossi Visconti
+ *                      1758-1835, VIAF 32127973 — the Della istoria d'Italia author
+ *   mantreshwara       Q7180226 (the Phaladeepika itself) -> Q6752212 Mantreswara,
+ *                      Indian astrologer, VIAF 119812752
+ *   honorius           Q4121506 (a literary work) -> Q10298139 Honorius of Thebes,
+ *                      "possibly mythical" human — the legendary-author class the
+ *                      denylist deliberately admits (Homer rule)
+ *   abraham-the-jew-2  Q22257011 (a grimoire) -> Q330911 Abraham of Worms
+ *                      1362-1458, VIAF 52496006; canonical_name updated to match.
+ *                      (abraham-the-jew, unanchored, is the DIFFERENT legendary
+ *                      figure from Flamel's Figures — correctly separate.)
+ *
+ * UNSET (no person item exists; an honest null beats a wrong anchor):
+ *   suidas             Q216299 is the Suda lexicon; "Suidas" is the traditional
+ *                      presumed author with no Wikidata person item
+ *   dattila            Q5227769 is the Dattilam treatise; attributed author has
+ *                      no item
+ *   mr-foster          Q59195028 is a VIDEO GAME CHARACTER; the real author of
+ *                      Hoplocrisma-spongus (William Foster, 1591-1643, English
+ *                      clergyman) has no Wikidata item. canonical_name fixed
+ *                      "Mr. Foster" -> "William Foster".
+ *   anonymous-author   Q567620 deleted/redirected; a placeholder must carry no
+ *                      anchor — also gets is_person: false (#3483 read path)
+ *
+ * MERGE: liezi-2 (1 English translation, unanchored dup) -> liezi, whose
+ * existing anchor Q2984064 (Lie Yukou, human-disputed) was re-verified live.
+ *
+ * JUNK (minted from defect data; docs deleted, books unlinked):
+ *   richard            variant "Richardus Anglicus; Braccesco; Geber; and
+ *                      others" — a compound anthology string minted as a person
+ *   wikidata-sandbox   minted from a VISIBLE production test book (title
+ *                      "Test", author "Test", year 1498). The doc dies here;
+ *                      the book is HIDDEN (hidden_reason) but NOT deleted —
+ *                      deletion needs Derek per the data-protection rule.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/repair-anchor-tail-3809.mjs            # dry-run
+ *   node --env-file=.env.production.local scripts/maintenance/repair-anchor-tail-3809.mjs --apply
+ *   node --env-file=.env.production.local scripts/maintenance/repair-anchor-tail-3809.mjs --revert
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { anchorProblem } from '../lib/author-anchor-classes.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const REVERT = process.argv.includes('--revert');
+const BACKUP = 'scripts/output/anchor-tail-repair-3809-backup.json';
+const UA = 'SourceLibrary-anchor-tail-3809/1.0 (https://sourcelibrary.org)';
+
+const RE_ANCHOR = [
+  { slug: 'bossi-luigi',       from: 'Q125197500', to: 'Q3839378',  why: 'dead item -> Luigi Bossi Visconti 1758-1835, VIAF 32127973' },
+  { slug: 'mantreshwara',      from: 'Q7180226',   to: 'Q6752212',  why: 'was the Phaladeepika itself -> its astrologer author, VIAF 119812752' },
+  { slug: 'honorius',          from: 'Q4121506',   to: 'Q10298139', why: 'was a literary work -> Honorius of Thebes (legendary author, Homer rule)' },
+  { slug: 'abraham-the-jew-2', from: 'Q22257011',  to: 'Q330911',   why: 'was the Abramelin grimoire -> Abraham of Worms 1362-1458, VIAF 52496006', rename: 'Abraham of Worms' },
+  // Found by the post-repair sweep rerun (was hiding in the originally-429'd range):
+  { slug: 'garga-the-elder',   from: 'Q6116103',   to: 'Q139554417', why: 'was a disambiguation page -> Garga, sage in Hinduism (Q5), the Garga Muni of our Sanskrit book' },
+];
+const UNSET = [
+  { slug: 'suidas',           from: 'Q216299',   why: 'the Suda lexicon; presumed author "Suidas" has no person item' },
+  { slug: 'dattila',          from: 'Q5227769',  why: 'the Dattilam treatise; attributed author has no person item' },
+  { slug: 'mr-foster',        from: 'Q59195028', why: 'a video game character; the 1631 clergyman has no item', rename: 'William Foster' },
+  { slug: 'anonymous-author', from: 'Q567620',   why: 'deleted item; placeholders carry no anchor', nonPerson: true },
+];
+const JUNK_DOCS = ['richard', 'wikidata-sandbox'];
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db('bookstore');
+const authors = db.collection('authors');
+const books = db.collection('books');
+
+if (REVERT) {
+  if (!existsSync(BACKUP)) { console.error(`No backup at ${BACKUP}.`); process.exit(1); }
+  const saved = JSON.parse(readFileSync(BACKUP, 'utf8'));
+  let n = 0;
+  for (const row of saved.authors) {
+    if (row.deleted_doc) { await authors.insertOne(row.deleted_doc).catch(() => {}); n++; continue; }
+    n += (await authors.updateOne({ _id: row._id }, { $set: row.before })).modifiedCount;
+  }
+  for (const row of saved.books) {
+    n += (await books.updateOne({ id: row.id }, { $set: row.before })).modifiedCount;
+  }
+  console.log(`Reverted ${n} writes from ${saved.created_at}. (The Test book stays hidden unless its backup row says otherwise.)`);
+  await mc.close();
+  process.exit(0);
+}
+
+// live verification of every RE_ANCHOR target through the shared denylist
+const targets = RE_ANCHOR.map(f => f.to);
+const query = `SELECT ?a ?type WHERE { VALUES ?a { ${targets.map(q => `wd:${q}`).join(' ')} } OPTIONAL { ?a wdt:P31 ?type } }`;
+const r = await fetch('https://query.wikidata.org/sparql?' + new URLSearchParams({ query, format: 'json' }),
+  { headers: { 'User-Agent': UA, Accept: 'application/sparql-results+json' }, signal: AbortSignal.timeout(60000) });
+if (!r.ok) { console.error(`SPARQL ${r.status} — cannot verify targets, refusing to proceed.`); process.exit(2); }
+const p31 = new Map();
+for (const b of (await r.json()).results.bindings) {
+  const a = b.a.value.split('/').pop();
+  if (!p31.has(a)) p31.set(a, new Set());
+  if (b.type) p31.get(a).add(b.type.value.split('/').pop());
+}
+let bad = false;
+for (const q of targets) {
+  const problem = anchorProblem(p31.get(q));
+  if (problem) { console.error(`TARGET ${q} FAILS: ${problem}`); bad = true; }
+}
+if (bad) { console.error('Refusing to write.'); process.exit(2); }
+console.log(`All ${targets.length} re-anchor targets pass the denylist (live P31).\n`);
+
+const authorWrites = [];   // { _id, before, set }
+const bookWrites = [];     // { id, before, set }
+const docDeletes = [];     // full docs
+const skips = [];
+
+for (const f of RE_ANCHOR) {
+  const doc = await authors.findOne({ _id: f.slug });
+  if (!doc) { skips.push(`${f.slug}: no doc`); continue; }
+  if (doc.wikidata_id !== f.from) { skips.push(`${f.slug}: wikidata_id now ${doc.wikidata_id} — changed since audit, re-verify`); continue; }
+  const set = { wikidata_id: f.to, anchor_repair_3809: { date: new Date(), why: f.why } };
+  const before = { wikidata_id: doc.wikidata_id };
+  if (f.rename) { set.canonical_name = f.rename; before.canonical_name = doc.canonical_name; set.variants = [...new Set([...(doc.variants || []), f.rename])]; before.variants = doc.variants; }
+  authorWrites.push({ _id: f.slug, before, set, why: f.why });
+}
+for (const f of UNSET) {
+  const doc = await authors.findOne({ _id: f.slug });
+  if (!doc) { skips.push(`${f.slug}: no doc`); continue; }
+  if (doc.wikidata_id !== f.from) { skips.push(`${f.slug}: wikidata_id now ${doc.wikidata_id} — changed since audit, re-verify`); continue; }
+  const set = { wikidata_id: null, anchor_repair_3809: { date: new Date(), why: f.why } };
+  const before = { wikidata_id: doc.wikidata_id };
+  if (f.rename) { set.canonical_name = f.rename; before.canonical_name = doc.canonical_name; set.variants = [...new Set([...(doc.variants || []), f.rename])]; before.variants = doc.variants; }
+  if (f.nonPerson) { set.is_person = false; before.is_person = doc.is_person ?? null; }
+  authorWrites.push({ _id: f.slug, before, set, why: f.why });
+}
+
+// liezi-2 -> liezi merge (anchor of the survivor re-verified above by the sweep;
+// belt: refuse if liezi lost its anchor since)
+const l1 = await authors.findOne({ _id: 'liezi' });
+const l2 = await authors.findOne({ _id: 'liezi-2' });
+if (l1 && l2 && !l2.merged_into) {
+  if (l1.wikidata_id !== 'Q2984064') { skips.push(`liezi: anchor now ${l1.wikidata_id}, expected Q2984064 — re-verify before merging`); }
+  else {
+    authorWrites.push({ _id: 'liezi', before: { variants: l1.variants }, set: { variants: [...new Set([...(l1.variants || []), ...(l2.variants || [])])] }, why: 'absorb liezi-2 variants' });
+    authorWrites.push({ _id: 'liezi-2', before: { merged_into: l2.merged_into ?? null }, set: { merged_into: 'liezi' }, why: 'tombstone duplicate' });
+    for (const b of await books.find({ author_id: 'liezi-2' }, { projection: { id: 1, title: 1 } }).toArray()) {
+      bookWrites.push({ id: b.id, title: b.title, before: { author_id: 'liezi-2' }, set: { author_id: 'liezi' }, why: 'liezi-2 merged into liezi' });
+    }
+  }
+} else if (l2?.merged_into) skips.push(`liezi-2: already merged`);
+
+// junk docs: unlink their books, delete the docs
+for (const slug of JUNK_DOCS) {
+  const doc = await authors.findOne({ _id: slug });
+  if (!doc) { skips.push(`${slug}: no doc`); continue; }
+  docDeletes.push(doc);
+  for (const b of await books.find({ author_id: slug }, { projection: { id: 1, title: 1, visible: 1 } }).toArray()) {
+    bookWrites.push({ id: b.id, title: b.title, before: { author_id: slug }, set: { author_id: null }, unsetAuthorId: true, why: `unlink from junk doc ${slug}` });
+  }
+}
+
+// the visible Test book: hide, never delete (Derek's call to delete)
+const testBook = await books.findOne({ author: 'Test', title: 'Test', visible: true }, { projection: { id: 1, title: 1, visible: 1, hidden: 1 } });
+if (testBook) {
+  bookWrites.push({ id: testBook.id, title: 'Test', before: { visible: true, hidden: testBook.hidden ?? null, hidden_reason: null }, set: { visible: false, hidden: true, hidden_reason: 'test-record: title/author "Test", flagged in #3809 — delete needs human confirmation' }, why: 'visible production test record' });
+}
+
+console.log(`Author-doc writes: ${authorWrites.length}`);
+for (const w of authorWrites) console.log(`  ${w._id.padEnd(20)} ${JSON.stringify(w.before).slice(0, 70)} -> ${JSON.stringify(w.set).slice(0, 90)}`);
+console.log(`\nDoc deletions: ${docDeletes.map(d => d._id).join(', ') || 'none'}`);
+console.log(`\nBook writes: ${bookWrites.length}`);
+for (const w of bookWrites) console.log(`  ${w.id}  ${JSON.stringify(w.set).slice(0, 80)}  ${String(w.title).slice(0, 40)}`);
+if (skips.length) { console.log('\nSkips:'); for (const s of skips) console.log(`  ${s}`); }
+
+if (!APPLY) { console.log('\nDRY-RUN. --apply to write.'); await mc.close(); process.exit(0); }
+
+mkdirSync(dirname(BACKUP), { recursive: true });
+const prior = existsSync(BACKUP) ? JSON.parse(readFileSync(BACKUP, 'utf8')) : { authors: [], books: [] };
+const haveA = new Set(prior.authors.map(a => a._id));
+const haveB = new Set(prior.books.map(b => b.id));
+for (const w of authorWrites) if (!haveA.has(w._id)) prior.authors.push({ _id: w._id, before: w.before });
+for (const d of docDeletes) if (!haveA.has(d._id)) prior.authors.push({ _id: d._id, deleted_doc: d });
+for (const w of bookWrites) if (!haveB.has(w.id)) prior.books.push({ id: w.id, before: w.before });
+prior.issue = 3809;
+prior.created_at = prior.created_at || new Date().toISOString();
+prior.last_run_at = new Date().toISOString();
+writeFileSync(BACKUP, JSON.stringify(prior, null, 2));
+
+let na = 0, nb = 0, nd = 0;
+for (const w of authorWrites) na += (await authors.updateOne({ _id: w._id }, { $set: w.set })).modifiedCount;
+for (const d of docDeletes) nd += (await authors.deleteOne({ _id: d._id })).deletedCount;
+for (const w of bookWrites) {
+  const update = w.unsetAuthorId
+    ? { $unset: { author_id: '' }, $set: { updated_at: new Date() } }
+    : { $set: { ...w.set, updated_at: new Date() } };
+  nb += (await books.updateOne({ id: w.id }, update)).modifiedCount;
+}
+console.log(`\nAPPLIED: ${na}/${authorWrites.length} author docs, ${nd}/${docDeletes.length} docs deleted, ${nb}/${bookWrites.length} book writes. Backup: ${BACKUP}`);
+console.log('The hidden Test book needs the Supabase catalog sync + Derek\'s confirmation to delete.');
+console.log('Rerun scripts/audit/author-anchor-validity.mjs to confirm a clean sweep (and cover any 429 tail).');
+await mc.close();

--- a/scripts/maintenance/repair-object-object-anonymous-3770.mjs
+++ b/scripts/maintenance/repair-object-object-anonymous-3770.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * The second half of #3770 — the 146 books whose MDZ manifest has NO Creator
+ * field. Sampling shows why no automation may attribute them: the manifests'
+ * Contributor field mixes true authors (Cardilucius on his own Magnalia) with
+ * referenced authors (Schröder on an appendix TO his pharmacopoeia) and
+ * translators (Lange, "übersetzet durch J. L.") — mapping Contributor to
+ * author would recreate the editor-as-author trap (#3434: never guess).
+ *
+ * So: author is UNSET (an anonymous imprint honestly has no author), the
+ * propagated pollution goes (slug regenerated title-only, local:n:object:
+ * work_id unset, identity fields restamped), and everything recoverable is
+ * PRESERVED in field_provenance.author for future human attribution:
+ * the "By" statement of responsibility and the Contributor names verbatim.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/repair-object-object-anonymous-3770.mjs            # dry-run
+ *   node --env-file=.env.production.local scripts/maintenance/repair-object-object-anonymous-3770.mjs --apply
+ */
+import { MongoClient } from 'mongodb';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { computeIdentityFields } from '../lib/identity-fields.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const BACKUP = 'scripts/output/object-object-anonymous-3770-backup.jsonl';
+const BAD = '[object Object]';
+
+// Hand-reviewed 2026-08-09 against each manifest's statement of responsibility
+// ("By") — books where the statement EXPLICITLY names the author, or the title
+// itself is the attribution (Aureum Vellus "Von ... Salomone Trißmosino"). Not
+// inferred from Contributor role, which mixes authors with translators and
+// referenced authors. Everything not listed here — excerpt anthologies,
+// Problemata compilations, academic funeral broadsides, pseudonymous
+// initialisms — is honestly anonymous and gets the unset path.
+const ATTRIBUTE = new Map([
+  ['6a4a57fb9050f0b4342e381b', 'Wecker, Johann Jacob'],        // De secretis "digesti & aucti per Ioan. Iacobum Weckerum"
+  ['6a4a58259050f0b4342e5c0d', 'Cardilucius, Johannes Hiskias'], // Magnalia continuata "publiciret von Johanne Hiskia Cardilucio"
+  ['6a4a58759050f0b4342eaf71', 'Trismosin, Salomon'],          // Aureum Vellus "Von ... Salomone Trißmosino"
+  ['6a4a5ac19050f0b434308ccc', 'Trismosin, Salomon'],          // Aureum Vellus (second printing)
+  ['6a4a593b9050f0b4342f4d45', 'Dippel, Johann Conrad'],       // Microcosmische Vorspiele — sole contributor, standard attribution
+  ['6a4a595c9050f0b4342f6e7a', 'Libavius, Andreas'],           // "autore Andrea Libavio"
+  ['6a4a5bc79050f0b434314f6b', 'Emrich, Heinrich'],            // Mercurius catholicus "... Henrico Emrici"
+  ['6a4a5cc29050f0b43431fdb7', 'Meier, David'],                // Oeconomie "von ..." + sole contributor
+  ['6a504cde78825bd7fdd97325', 'Kazenberger, Kilian'],         // "Authore P. F. Kiliano Kazenberger"
+  ['6a504ce678825bd7fdd9785f', 'Kazenberger, Kilian'],
+  ['6a5075e078825bd7fde1d381', 'Possel, Johann'],              // Apophtegmata "autore Johanne Posselio"
+  ['6a50890878825bd7fde8c7b2', 'Batteux, Charles'],            // Les quatre poétiques "Par M. l'Abbé Batteux"
+  ['6a50890d78825bd7fde8ccac', 'Batteux, Charles'],
+  ['6a5089f878825bd7fde9a067', 'Batteux, Charles'],
+  ['6a508a3078825bd7fde9b92f', 'Batteux, Charles'],
+  ['6a508cc078825bd7fdebab66', 'Vergerius, Petrus Paulus'],    // "Pauli Vergerii ... de ingenuorum educatione" — title names the author
+  ['6a4a59759050f0b4342f9003', 'Collegium Medicum (Augsburg)'], // Pharmacopoeia Augustana — corporate author
+  ['6a4a59759050f0b4342f9004', 'Collegium Medicum (Augsburg)'],
+]);
+// The Coimbra Jesuit commentaries: the TITLE is the corporate attribution, and
+// the #3780 mint created the is_person:false doc for it.
+const CONIMBRICENSE_RX = /colleg\w*\s+conimbricensis/i;
+const CONIMBRICENSE = 'Collegium Conimbricense';
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const books = mc.db('bookstore').collection('books');
+
+const slugify = (text, maxLength) => {
+  let s = String(text || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+  if (s.length > maxLength) {
+    s = s.substring(0, maxLength);
+    const h = s.lastIndexOf('-');
+    if (h > maxLength * 0.5) s = s.substring(0, h);
+  }
+  return s;
+};
+const enLabel = (l) => typeof l === 'string' ? l : Array.isArray(l) ? (l.find(x => x['@language'] === 'en')?.['@value'] || '') : (l?.['@value'] || '');
+const vals = (v) => (Array.isArray(v) ? v : [v]).map(x => typeof x === 'string' ? x : x?.['@value'] || '').filter(Boolean);
+
+const targets = await books.find(
+  { author: BAD },
+  { projection: { id: 1, title: 1, display_title: 1, slug: 1, published: 1, year: 1, visible: 1, work_id: 1, 'image_source.iiif_manifest': 1 } },
+).toArray();
+console.log(`${targets.length} books still carry ${JSON.stringify(BAD)} (expected: the 146 no-Creator set).`);
+
+mkdirSync('scripts/output', { recursive: true });
+const claimed = new Set();
+let done = 0, failed = 0;
+for (const b of targets) {
+  let statement = null, contributors = [];
+  try {
+    const m = await (await fetch(b.image_source.iiif_manifest, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(30000) })).json();
+    for (const md of m.metadata || []) {
+      const l = enLabel(md.label);
+      if (l === 'By') statement = vals(md.value).join(' | ') || null;
+      if (l === 'Contributor') contributors.push(...vals(md.value).map(v => v.replace(/<[^>]+>/g, '')));
+      if (l === 'Creator') { statement = `UNEXPECTED Creator present: ${vals(md.value).join('|')}`; }
+    }
+  } catch (e) { failed++; console.log(`  FETCH FAIL ${b.id} — ${e.message} (left untouched)`); continue; }
+
+  const attributed = ATTRIBUTE.get(b.id)
+    || (CONIMBRICENSE_RX.test(`${b.title} ${b.display_title || ''}`) ? CONIMBRICENSE : null);
+
+  const identity = computeIdentityFields({ ...b, author: attributed || '' });
+  const lastName = attributed
+    ? (attributed.includes(',') ? attributed.split(',')[0].trim() : attributed.trim().split(/\s+/).pop())
+    : '';
+  const base = [slugify(b.display_title || b.title, 60), attributed ? slugify(lastName, 20) : '']
+    .filter(Boolean).join('-') || 'untitled';
+  let slug = base;
+  for (let n = 2; claimed.has(slug) || await books.findOne({ slug, id: { $ne: b.id } }, { projection: { _id: 1 } }); n++) slug = `${base}-${n}`;
+  claimed.add(slug);
+
+  if (!APPLY) {
+    console.log(`  ${b.id}  ${attributed ? `ATTRIBUTE "${attributed}"` : 'clear'}  slug -> ${slug}`);
+    if (!attributed && statement) console.log(`      By: ${statement.slice(0, 100)}`);
+    done++;
+    continue;
+  }
+  appendFileSync(BACKUP, JSON.stringify({ id: b.id, before: { author: BAD, slug: b.slug, work_id: b.work_id ?? null }, action: attributed ? `attributed: ${attributed}` : 'cleared' }) + '\n');
+  const provenance = {
+    source: 'maintenance', script: 'repair-object-object-anonymous-3770.mjs', issue: 3770,
+    date: new Date(), previous_value: BAD,
+    action: attributed ? 'attributed' : 'cleared',
+    note: attributed
+      ? 'MDZ manifest has no Creator; author from the statement of responsibility / corporate title, human-reviewed 2026-08-09'
+      : 'MDZ manifest has no Creator — anonymous/pseudonymous imprint; never guess (#3434)',
+    ...(statement ? { statement_of_responsibility: statement } : {}),
+    ...(contributors.length ? { manifest_contributors: contributors } : {}),
+  };
+  const update = attributed
+    ? { $set: { author: attributed, slug, ...identity, updated_at: new Date(), 'field_provenance.author': provenance },
+        $unset: { work_id: '', work_slug: '', work_title: '', work_id_confidence: '', work_id_source: '' } }
+    : { $unset: { author: '', work_id: '', work_slug: '', work_title: '', work_id_confidence: '', work_id_source: '' },
+        $set: { slug, ...identity, updated_at: new Date(), 'field_provenance.author': provenance } };
+  const r = await books.updateOne({ id: b.id, author: BAD }, update);
+  if (r.modifiedCount) done++;
+}
+console.log(`\n${APPLY ? 'APPLIED' : 'DRY-RUN'}: ${done} cleared, ${failed} fetch failures (self-limiting — rerun covers them).${APPLY ? ` Backup: ${BACKUP}` : ''}`);
+await mc.close();

--- a/scripts/maintenance/repair-uri-author-strings.mjs
+++ b/scripts/maintenance/repair-uri-author-strings.mjs
@@ -49,7 +49,8 @@ async function resolveUri(uri) {
     const r = await fetch(`https://d-nb.info/gnd/${gnd}/about/lds.jsonld`, { headers: { Accept: 'application/json', 'User-Agent': UA }, signal: AbortSignal.timeout(20000) });
     if (!r.ok) throw new Error(`d-nb ${r.status}`);
     const d = await r.json();
-    const nodes = d['@graph'] || [d];
+    // d-nb.info lds.jsonld is a BARE ARRAY of nodes (no @graph wrapper)
+    const nodes = Array.isArray(d) ? d : d['@graph'] || [d];
     for (const n of nodes) {
       const name = n['preferredNameForThePerson'] || n['gndo:preferredNameForThePerson']
         || n['https://d-nb.info/standards/elementset/gnd#preferredNameForThePerson'];


### PR DESCRIPTION
The remaining author-identity tails, all applied to production 2026-08-09 with backups:

## #3809 — the sub-threshold anchor tail (`repair-anchor-tail-3809.mjs`)
Mixed-class, per-case, every target verified live through the shared denylist:
- **5 re-anchors**: Luigi Bossi Q3839378 (dead item before), Mantreswara Q6752212, Honorius of Thebes Q10298139 (the legendary-author class the denylist deliberately admits), Abraham of Worms Q330911 (was the Abramelin grimoire itself; doc renamed to match), Garga Q139554417 (surfaced by the sweep rerun from the originally-429'd range).
- **4 honest unsets**: Suidas and Dattila (works whose presumed authors have no Wikidata person item), `mr-foster` (anchored to a **video game character**; the real 1631 clergyman has no item — canonical name fixed from "Mr. Foster" to "William Foster"), `anonymous-author` (placeholder — no anchor, plus `is_person: false`).
- **liezi-2 → liezi** merge (survivor's anchor re-verified: Q2984064, Lie Yukou).
- **2 junk docs deleted**: `richard` (a compound anthology string minted as a person) and `wikidata-sandbox` — minted from a **visible production test book** (title "Test", author "Test", year 1498). That book is now hidden with `hidden_reason`; **deleting it is Derek's call** per data protection.

Post-repair sweep: all tail anchors clean; ~350 anchors unchecked this run on WDQS 429/502s (flaky today — rerun when calm).

## #3770 — the 146 no-Creator books (`repair-object-object-anonymous-3770.mjs`)
Hand-reviewed against each manifest's statement of responsibility. ~45 attributed where the statement or the corporate title names the author (28 Conimbricenses → `Collegium Conimbricense`, Trismosin's Aureum Vellus ×2, "autore Andrea Libavio", Kazenberger ×2, Batteux ×4, Wecker, Cardilucius, Vergerio, Pharmacopoeia Augustana → Collegium Medicum…). The rest honestly cleared — with the By-statement and Contributor names **preserved in `field_provenance`** for future human attribution. Contributor was deliberately NOT auto-mapped to author: sampling showed it mixes true authors with translators and referenced authors (the editor-as-author trap). `[object Object]` count is now **0**.

## Institution linking (`backfill-author-canonical-links.mjs --include-institutions`)
The backfill only linked person docs; the #3780 mint created corporate-heading docs at scale (Bhutanese monastery collections, learned societies — 15 minted this session). New opt-in flag widens the doc map to `is_person: false` docs; tombstones are now excluded from the map, which also fixed a latent Phase B defect (merged docs competed as entity owners — 114 entity-linked books resolved that were previously orphaned). Applied: **2,944 more author_id links**.

Also run this session (no code change): `mint-local-work-ids.mjs --include-hidden` re-minted work_ids for the repaired books (in flight), and `reconcile-authors-grounded.mjs --apply` is anchoring the 2,992 unanchored docs (flash-lite, ~$0.05 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)