### PR TITLE
feat(eval): publish the FT verification corpus as a citable dataset (#3798)

### DIFF
--- a/.claude/docs/ft-first-translation-paper.md
+++ b/.claude/docs/ft-first-translation-paper.md
@@ -37,7 +37,7 @@ Our work sits at the intersection of four literatures.
 
 ## 3. Population and denominators
 
-All counts are live against the production catalogue, 19 June 2026.
+All counts are live against the production catalogue, 19 June 2026. **The catalogue has since grown; Appendix B carries the reconciled August 2026 denominators and the v2 system state — reconcile §3/§5 scale-ups to those before submission.**
 
 | Population | Count |
 |---|---|
@@ -201,7 +201,33 @@ A widely-quoted "~6,000 first translations" turns out to be roughly defensible a
 - Human gold standard: 150-book stratified sample, hybrid in-house + specialist annotation, anti-anchoring tool, double-annotated κ subset (PR #2614).
 - Per-book verdicts, evidence trails, and analysis code in the repository (issue #2564, PR #2573); each adjudication is an append-only provenance record.
 
+### Appendix B. System-state addendum — v2 architecture and August 2026 numbers (added 2026-08-09)
+
+The June draft describes the audit as run against the v1 system. Between June and August the production system changed in ways the paper must reflect; this appendix records the deltas and the reconciled counts, all measured live on 2026-08-09.
+
+**B.1 Reconciled denominators (2026-08-09, same definitions as §3).** The catalogue grew substantially after June (large acquisitions plus continued processing):
+
+| Population | 19 Jun | 9 Aug |
+|---|---|---|
+| Publicly visible books | 30,868 | 36,799 |
+| Translated to English (`pages_translated > 0`) | 15,707 | 18,211 |
+| — English-language originals | 1,737 | 1,976 |
+| First-translation-eligible | 13,970 | 16,235 |
+| Badged as first translations (visible) | 5,696 | 5,925 |
+| Eligible with a graded verdict (visible) | — | 10,122 |
+| Eligible, never assessed | 8,306 | 6,894 |
+
+§5's scaled estimates use the June population sizes; re-scaling to the August pool is mechanical (the stratum rates are the finding, the scale-up is arithmetic) but must be done before submission, and the recall-side population has *shrunk* relative to growth because the v2 pipeline assessed ~3,900 of the June backlog.
+
+**B.2 Single-writer derivation shipped.** The badge is no longer a mutable flag: `book.first_translation` (graded verdict + qualifiers, `src/lib/first-translation/types.ts`) is the single source, and one reconciliation job derives the public flag from it. Measured 2026-08-09: **99.95% of rendered badges (5,810 of 5,813 visible, translated, badged books) carry a graded verdict** with a `best_attempt_id` pointer into the append-only attempt ledger. The flag↔disposition drift that §9 warned about is structurally closed. The unattended reconcile loop is deliberately demote-only (`--only-demotions`): a valve that only removes claims can never silently mint one, and every promotion passes through the verified evidence path.
+
+**B.3 The escalation ladder (August 2026).** Tier-2 adjudication is now organised as an explicit ladder (`scripts/eval/ft-ladder.ts`): cheap grounded search → independent skeptic verification → (on disagreement or weak evidence) escalation to a stronger instrument, with every rung appending to `first_translation_attempts` under a recorded `prompt_version` (#3778) and, where persisted, a `transcript_ref` into a full-transcript store. The ledger held **64,834 attempts on 2026-08-09** (63,173 after takedown exclusions in the published snapshot), spanning 29,938 distinct books — this is the dataset described in B.5.
+
+**B.4 The 2026-08-09 stratified spot audit (independent replication of §5.1).** An 18-book stratified audit with full citation capture, run by independent verification subagents (2 badged `first_no_prior` per tradition, n=12; plus 6 unbadged "prior found" books): first-family precision 5/12 with Wilson 95% CI [19%, 68%] — consistent with §5.1's 46% (n=462) — and the failure *composition* replicated the headline finding: ill-posedness dominates (6/12: container fascicles, standard liturgy copies, a unique archival document, one volume of a reference work), with exactly one hard false first (Clüver, a 1657 English prior, Wing C4740). On the unbadged side 6/6 verdict directions were correct while 3/6 evidence trails were imperfect (one fabricated-shaped citation, one overstated prior, one muddled work-identity chain) — the verdict-right/evidence-flawed asymmetry §7 predicts. Full report: `scripts/output/ft-spot-audit-2026-08-09/report.md`; the six follow-up corrections were routed through the verified-evidence path, not applied directly.
+
+**B.5 The dataset is now a deliverable (#3798).** `scripts/eval/export-ft-dataset.mjs` produces a versioned, deterministic, PII-swept snapshot of the corpus — attempts, per-book verdicts, screening decisions, the taxonomy codebook, and reference-set composition — with a Datasheet (`scripts/eval/ft-dataset-datasheet.md`) and a Zenodo deposit script (`deposit-ft-dataset.mjs`; draft-only by default, DOI minting is a human action). Books removed by takedown or owner request are excluded from the snapshot entirely. This unbundles the venue strategy: the **JOHD data paper** can go first on the dataset alone (no Rogan–Gladen correction required), while the CHR methods paper waits on the §6 human gold standard, which remains the binding step and remains not yet run (0 annotations).
+
 ### Notes
 - **Citations are placeholders** (the *(To cite: …)* markers in §2) — fill before submission; Rogan & Gladen (1978, *Am. J. Epidemiology*) and the *Index Translationum* are load-bearing.
 - **Authorship/credit:** Source Library / EFM + collaborators; decide before drafting submission prose.
-- This draft is intentionally untracked (research draft in a public AGPL repo); it supersedes `ft-census-paper.md` and `ft-audit-paper-draft.md`.
+- This draft is tracked in the public AGPL repo (an earlier note claimed it was untracked — it is not, and nothing in it is sensitive); it supersedes `ft-census-paper.md` and `ft-audit-paper-draft.md`.

--- a/scripts/eval/deposit-ft-dataset.mjs
+++ b/scripts/eval/deposit-ft-dataset.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * deposit-ft-dataset.mjs — deposit an FT dataset snapshot on Zenodo (#3798).
+ *
+ * Takes a snapshot directory produced by export-ft-dataset.mjs, creates a
+ * Zenodo DRAFT record (resource type: dataset, CC BY 4.0), and uploads every
+ * file. It does NOT publish: minting a DOI is public and irreversible, so the
+ * default stops at the draft and prints its URL for human review. Publish from
+ * the Zenodo UI after review, or re-run with --publish once the draft has been
+ * reviewed.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/eval/deposit-ft-dataset.mjs --dir scripts/output/ft-dataset-2026-08-09
+ *   ... --publish            # actually publish (mints the DOI) — requires human sign-off first
+ *   ZENODO_SANDBOX=true ...  # rehearse against sandbox.zenodo.org
+ *
+ * Reuses the Zenodo record API flow of scripts/batch/batch-mint-doi.mjs
+ * (create draft → init/upload/commit files → publish).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+/** Files above this size are uploaded gzipped (Zenodo uploads time out on large plain files). */
+const GZIP_THRESHOLD = 2 * 1024 * 1024;
+
+const ZENODO_API = process.env.ZENODO_SANDBOX === 'true'
+  ? 'https://sandbox.zenodo.org/api'
+  : 'https://zenodo.org/api';
+const ZENODO_URL = process.env.ZENODO_SANDBOX === 'true'
+  ? 'https://sandbox.zenodo.org'
+  : 'https://zenodo.org';
+
+const args = process.argv.slice(2);
+const getArg = (f) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : null; };
+const DIR = getArg('--dir');
+const PUBLISH = args.includes('--publish');
+
+if (!DIR) {
+  console.error('Usage: deposit-ft-dataset.mjs --dir <snapshot dir> [--publish]');
+  process.exit(1);
+}
+if (!process.env.ZENODO_ACCESS_TOKEN) {
+  console.error('ZENODO_ACCESS_TOKEN is not set.');
+  process.exit(1);
+}
+
+const dir = resolve(DIR);
+const manifest = JSON.parse(readFileSync(join(dir, 'manifest.json'), 'utf8'));
+console.log(`Depositing ${manifest.dataset} v${manifest.version} (git ${manifest.git_sha.slice(0, 8)}) → ${ZENODO_URL}`);
+
+function headers(extra = {}) {
+  return { Authorization: `Bearer ${process.env.ZENODO_ACCESS_TOKEN}`, ...extra };
+}
+
+async function fail(resp, context) {
+  const text = await resp.text();
+  throw new Error(`Zenodo ${context}: HTTP ${resp.status} — ${text.slice(0, 400)}`);
+}
+
+const description = `
+<p>The first-translation verification corpus of Source Library (sourcelibrary.org):
+documented <b>evidence of absence at scale</b>. ${manifest.counts.attempts.toLocaleString('en-US')} recorded
+verification attempts with per-attempt provenance (instrument, sources consulted, verbatim
+queries, result, evidence grade), graded verdicts on ${manifest.counts.verdict_books.toLocaleString('en-US')} books
+under an 8-verdict taxonomy, durable screening decisions, and the composition of the
+bibliographic reference set every catalogue-tier absence claim is asserted against.</p>
+<p>Each "first English translation" claim on the site derives from this ledger; the dataset
+makes every such claim independently auditable. See <code>DATASHEET.md</code> inside the
+deposit for motivation, composition, collection process, known biases (measured reference-set
+recall, instrument fabrication rates, the post-1950 blind spot), and recommended uses.</p>
+<p>Snapshot ${manifest.version}, generated from git ${manifest.git_sha} by
+<code>scripts/eval/export-ft-dataset.mjs</code> in the
+<a href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2">sourcelibrary-v2</a>
+repository (AGPL-3.0). Data license: CC BY 4.0. Contains no personal or reader data.</p>
+`.trim();
+
+const metadata = {
+  resource_type: { id: 'dataset' },
+  title: `Source Library First-Translation Verification Corpus (snapshot ${manifest.version})`,
+  publication_date: manifest.version,
+  creators: [
+    {
+      person_or_org: {
+        type: 'personal',
+        family_name: 'Lomas',
+        given_name: 'J. Derek',
+        identifiers: [],
+      },
+      affiliations: [{ name: 'Source Library / Embassy of the Free Mind' }],
+    },
+    {
+      person_or_org: { type: 'organizational', name: 'Source Library / Embassy of the Free Mind' },
+    },
+  ],
+  description,
+  rights: [{ id: 'cc-by-4.0' }],
+  subjects: [
+    { subject: 'digital libraries' },
+    { subject: 'translation studies' },
+    { subject: 'bibliography' },
+    { subject: 'large language models' },
+    { subject: 'metadata quality' },
+    { subject: 'evidence of absence' },
+  ],
+  version: manifest.version,
+  publisher: 'Source Library / Embassy of the Free Mind',
+  related_identifiers: [
+    {
+      identifier: 'https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2',
+      scheme: 'url',
+      relation_type: { id: 'issupplementedby' },
+    },
+  ],
+};
+
+// 1. Create the draft.
+const draftResp = await fetch(`${ZENODO_API}/records`, {
+  method: 'POST',
+  headers: headers({ 'Content-Type': 'application/json' }),
+  body: JSON.stringify({ access: { record: 'public', files: 'public' }, files: { enabled: true }, metadata }),
+});
+if (!draftResp.ok) await fail(draftResp, 'create draft');
+const draft = await draftResp.json();
+console.log(`Draft created: ${draft.id}`);
+
+// 2. Upload every file in the snapshot. Large data files go up gzipped —
+// plain multi-MB uploads hit the client's header timeout, and .gz is kinder
+// to downloaders anyway. manifest.json checksums refer to the UNCOMPRESSED
+// files; `gunzip *.gz` restores byte-identical content.
+const files = readdirSync(dir).filter((f) => statSync(join(dir, f)).isFile()).sort();
+for (const f of files) {
+  const raw = readFileSync(join(dir, f));
+  const compress = raw.length > GZIP_THRESHOLD;
+  const key = compress ? `${f}.gz` : f;
+  const body = compress ? new Uint8Array(gzipSync(raw, { level: 9 })) : new Uint8Array(raw);
+  const initResp = await fetch(`${ZENODO_API}/records/${draft.id}/draft/files`, {
+    method: 'POST',
+    headers: headers({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify([{ key }]),
+  });
+  if (!initResp.ok) await fail(initResp, `file init (${key})`);
+  const upResp = await fetch(
+    `${ZENODO_API}/records/${draft.id}/draft/files/${encodeURIComponent(key)}/content`,
+    { method: 'PUT', headers: headers({ 'Content-Type': 'application/octet-stream' }), body },
+  );
+  if (!upResp.ok) await fail(upResp, `file upload (${key})`);
+  const commitResp = await fetch(
+    `${ZENODO_API}/records/${draft.id}/draft/files/${encodeURIComponent(key)}/commit`,
+    { method: 'POST', headers: headers() },
+  );
+  if (!commitResp.ok) await fail(commitResp, `file commit (${key})`);
+  console.log(`  uploaded ${key} (${(body.length / 1e6).toFixed(1)} MB${compress ? `, from ${(raw.length / 1e6).toFixed(1)} MB` : ''})`);
+}
+
+if (!PUBLISH) {
+  console.log(`\nDRAFT ONLY (no DOI minted). Review and publish at:\n  ${ZENODO_URL}/uploads/${draft.id}`);
+  process.exit(0);
+}
+
+// 3. Publish — mints the DOI. Only on explicit --publish.
+const pubResp = await fetch(`${ZENODO_API}/records/${draft.id}/draft/actions/publish`, {
+  method: 'POST',
+  headers: headers(),
+});
+if (!pubResp.ok) await fail(pubResp, 'publish');
+const published = await pubResp.json();
+const doi = published.pids?.doi?.identifier || published.doi;
+console.log(`\nPUBLISHED: https://doi.org/${doi}\n  ${ZENODO_URL}/records/${published.id}`);

--- a/scripts/eval/export-ft-dataset.mjs
+++ b/scripts/eval/export-ft-dataset.mjs
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/**
+ * export-ft-dataset.mjs — versioned snapshot of the first-translation
+ * verification corpus, for deposit as a citable dataset (#3798).
+ *
+ * What this exports, and why it is publishable: the corpus is documented
+ * EVIDENCE OF ABSENCE at scale — every recorded search attempt behind every
+ * "first English translation" verdict, with per-attempt provenance (sources
+ * consulted, queries issued, result, evidence grade), plus the per-book graded
+ * verdicts under the 8-verdict taxonomy of src/lib/first-translation/types.ts.
+ * No library publishes this layer; the dataset is the deliverable the working
+ * paper (.claude/docs/ft-first-translation-paper.md) describes.
+ *
+ * Files written to --out (default scripts/output/ft-dataset-<date>/):
+ *   attempts.jsonl / attempts.csv     append-only provenance log (one search per row)
+ *   verdicts.jsonl / verdicts.csv     one row per book: resolved verdict + public metadata
+ *   screening_decisions.jsonl         human/agent screening judgements, keyed (work, prior)
+ *   taxonomy.json                     verdict / qualifier / method definitions
+ *   reference-set-summary.json        composition stats of `reference_translations`
+ *                                     (summary only — the full set is LoC/ESTC/Wikidata
+ *                                     derived and reproducible from those sources)
+ *   manifest.json                     git SHA, timestamps, row counts, sha256 checksums,
+ *                                     exclusion + redaction tallies
+ *
+ * Invariants:
+ *  - DETERMINISTIC: rows are sorted (attempt_id / book_id / work+date) and field
+ *    order is explicit, so two runs against the same data produce byte-identical
+ *    files apart from manifest timestamps.
+ *  - EXCLUSION: books hidden by a takedown or an owner/curator removal request
+ *    are excluded entirely (attempts, verdicts, ids). Curation-hidden and
+ *    unprocessed books stay, flagged `visible: false` — a bibliographic fact is
+ *    public, a removal request is a removal request.
+ *  - REDACTION: notes/queries/URLs are swept for email addresses and query-string
+ *    credentials before writing. Tallies land in the manifest so a reviewer can
+ *    see how much was touched.
+ *  - READ-ONLY: this script never writes to Mongo. (Writing to a store an
+ *    automated job reads is actuation — this exports, nothing more.)
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/eval/export-ft-dataset.mjs [--out DIR]
+ */
+
+import { MongoClient } from 'mongodb';
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+const DB_NAME = 'bookstore';
+const DATASET_VERSION_DATE = new Date().toISOString().slice(0, 10);
+
+const argOut = process.argv.indexOf('--out');
+const OUT_DIR =
+  argOut > -1
+    ? resolve(process.argv[argOut + 1])
+    : join(REPO_ROOT, 'scripts', 'output', `ft-dataset-${DATASET_VERSION_DATE}`);
+
+/**
+ * Books excluded from the dataset entirely. A takedown or a removal request is
+ * a statement that we should stop distributing material about the item; the
+ * dataset honours it. Curation states (launch_curation, unprocessed, catalog
+ * stubs) are NOT exclusions — those books are simply not yet public.
+ */
+const EXCLUDED_REASON_RE = /kloss|takedown|removal requested|feedback_remove|test-record/i;
+
+// ── redaction ──────────────────────────────────────────────────────────────
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.-]+\.[a-z]{2,}|[\w.+-]+@[\w-]+\.[a-z]{2,}/gi;
+const TOKEN_PARAM_RE = /([?&])(key|token|apikey|api_key|sig|signature|access_token|secret|password)=[^&\s"']*/gi;
+
+const redactionTally = { emails: 0, token_params: 0 };
+
+function redactString(s) {
+  if (typeof s !== 'string') return s;
+  let out = s.replace(EMAIL_RE, () => {
+    redactionTally.emails++;
+    return '[email-redacted]';
+  });
+  out = out.replace(TOKEN_PARAM_RE, (_, sep, name) => {
+    redactionTally.token_params++;
+    return `${sep}${name}=[redacted]`;
+  });
+  return out;
+}
+
+/** Redact every string in a plain object/array, recursively. */
+function redactDeep(v) {
+  if (typeof v === 'string') return redactString(v);
+  if (v instanceof Date) return v;
+  if (Array.isArray(v)) return v.map(redactDeep);
+  if (v && typeof v === 'object') {
+    const out = {};
+    for (const [k, val] of Object.entries(v)) out[k] = redactDeep(val);
+    return out;
+  }
+  return v;
+}
+
+// ── output helpers ─────────────────────────────────────────────────────────
+
+/** Pick fields in a fixed order; omit undefined/null so files stay lean. */
+function pick(doc, fields) {
+  const out = {};
+  for (const f of fields) {
+    const v = doc[f];
+    if (v !== undefined && v !== null) out[f] = v;
+  }
+  return out;
+}
+
+function writeJsonl(path, rows) {
+  writeFileSync(path, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function csvCell(v) {
+  if (v === undefined || v === null) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function writeCsv(path, header, rows) {
+  const lines = [header.join(',')];
+  for (const r of rows) lines.push(header.map((h) => csvCell(r[h])).join(','));
+  writeFileSync(path, lines.join('\n') + '\n');
+}
+
+function sha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/** Same year logic as src/lib/dedup.ts editionYear — books.published is free text. */
+function editionYear(book) {
+  if (typeof book.year === 'number' && book.year > 0) return book.year;
+  const m = String(book.published || '').match(/\b(1[0-9]{3}|20[0-2][0-9])\b/);
+  return m ? Number(m[1]) : null;
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(DB_NAME);
+mkdirSync(OUT_DIR, { recursive: true });
+
+console.log(`Exporting FT dataset → ${OUT_DIR}`);
+
+// 1. The exclusion set: takedown / removal-request books, by BOTH id fields.
+const excludedBooks = await db
+  .collection('books')
+  .find(
+    { hidden_reason: { $regex: EXCLUDED_REASON_RE } },
+    { projection: { id: 1 } },
+  )
+  .toArray();
+const excludedIds = new Set();
+for (const b of excludedBooks) {
+  if (b.id) excludedIds.add(String(b.id));
+  excludedIds.add(String(b._id));
+}
+console.log(`Exclusion set: ${excludedBooks.length} books (takedown/removal/test)`);
+
+// 2. Verdict-carrying books, with the public-metadata join.
+const BOOK_FIELDS = {
+  id: 1, title: 1, author: 1, language: 1, original_language: 1,
+  published: 1, year: 1, visible: 1, pages_count: 1, pages_translated: 1,
+  work_id: 1, is_first_translation: 1, first_translation: 1,
+};
+const verdictBooks = await db
+  .collection('books')
+  .find({ 'first_translation.verdict': { $exists: true } }, { projection: BOOK_FIELDS })
+  .toArray();
+
+const verdictRows = [];
+let excludedVerdicts = 0;
+for (const b of verdictBooks) {
+  const bookId = String(b.id || b._id);
+  if (excludedIds.has(bookId) || excludedIds.has(String(b._id))) {
+    excludedVerdicts++;
+    continue;
+  }
+  const ft = b.first_translation || {};
+  verdictRows.push(
+    redactDeep({
+      book_id: bookId,
+      work_id: b.work_id ?? undefined,
+      title: b.title,
+      author: b.author,
+      language: b.language ?? undefined,
+      original_language: b.original_language ?? undefined,
+      published_raw: b.published ?? undefined,
+      year: editionYear(b) ?? undefined,
+      visible: b.visible === true,
+      pages_count: b.pages_count ?? undefined,
+      pages_translated: b.pages_translated ?? undefined,
+      badge_rendered: b.is_first_translation === true,
+      verdict: ft.verdict,
+      evidence_strength: ft.evidence_strength,
+      our_completeness: ft.our_completeness,
+      match_key: ft.match_key,
+      prior_relationship: ft.prior_relationship ?? undefined,
+      prior_refs: ft.prior_refs?.length ? ft.prior_refs : undefined,
+      resolver: ft.resolver,
+      best_attempt_id: ft.best_attempt_id ?? undefined,
+      resolved_at: ft.resolved_at ? new Date(ft.resolved_at).toISOString() : undefined,
+    }),
+  );
+}
+verdictRows.sort((a, b) => a.book_id.localeCompare(b.book_id));
+console.log(`Verdicts: ${verdictRows.length} books (${excludedVerdicts} excluded)`);
+
+// 3. Attempts — the append-only provenance log.
+const ATTEMPT_FIELDS = [
+  'attempt_id', 'book_id', 'work_id', 'date', 'method', 'match_key',
+  'sources_checked', 'queries', 'result', 'verdict', 'found_refs', 'priors',
+  'evidence_strength', 'independence_score', 'model', 'cost_usd',
+  'prompt_version', 'transcript_ref', 'notes',
+];
+const attemptRows = [];
+let excludedAttempts = 0;
+const attemptCursor = db.collection('first_translation_attempts').find({});
+for await (const a of attemptCursor) {
+  if (excludedIds.has(String(a.book_id))) {
+    excludedAttempts++;
+    continue;
+  }
+  const row = pick(a, ATTEMPT_FIELDS);
+  if (a._src) row.ingest_source = a._src;
+  attemptRows.push(redactDeep(row));
+}
+attemptRows.sort(
+  (a, b) => a.book_id.localeCompare(b.book_id) || String(a.attempt_id).localeCompare(String(b.attempt_id)),
+);
+console.log(`Attempts: ${attemptRows.length} rows (${excludedAttempts} excluded)`);
+
+// 4. Screening decisions (work, prior) — small but load-bearing: immutable
+// efforts re-open when the set improves; screening is what persists judgement.
+const screeningDocs = await db.collection('screening_decisions').find({}).toArray();
+const screeningRows = screeningDocs
+  .map((s) => redactDeep(pick(s, ['work', 'screen', 'reason', 'decided_by', 'decided_at'])))
+  .map((s) => {
+    const d = s.decided_at ? new Date(s.decided_at) : null;
+    return { ...s, decided_at: d && !Number.isNaN(d.getTime()) ? d.toISOString() : undefined };
+  })
+  .sort((a, b) => JSON.stringify(a.work).localeCompare(JSON.stringify(b.work)) || String(a.decided_at).localeCompare(String(b.decided_at)));
+console.log(`Screening decisions: ${screeningRows.length} rows`);
+
+// 5. Reference-set composition summary (the full 149K-row set derives from
+// LoC / ESTC / Wikidata dumps and is reproducible from those sources; what the
+// dataset needs is its SHAPE, because every absence claim is bounded by it).
+const refCol = db.collection('reference_translations');
+const [refTotal, refBySource, refByLang, refByDecade, refUniform] = await Promise.all([
+  refCol.countDocuments({}),
+  refCol.aggregate([{ $group: { _id: '$source', n: { $sum: 1 } } }, { $sort: { n: -1 } }]).toArray(),
+  refCol.aggregate([
+    { $unwind: { path: '$original_languages', preserveNullAndEmptyArrays: false } },
+    { $group: { _id: '$original_languages', n: { $sum: 1 } } },
+    { $sort: { n: -1 } }, { $limit: 40 },
+  ]).toArray(),
+  refCol.aggregate([
+    { $match: { year: { $type: 'number' } } },
+    { $group: { _id: { $multiply: [{ $floor: { $divide: ['$year', 10] } }, 10] }, n: { $sum: 1 } } },
+    { $sort: { _id: 1 } },
+  ]).toArray(),
+  refCol.countDocuments({ uniform_title: { $exists: true, $nin: [null, ''] } }),
+]);
+const referenceSetSummary = {
+  description:
+    'Composition of reference_translations, the bibliographic reference set every catalogue-tier absence claim is asserted against. An absence claim is only as strong as this set; its measured catalogue-only recall is 32.1% (2026-08-07, scripts/eval/ft-reference-set-recall.mjs), i.e. roughly two of every three known prior translations are invisible to it.',
+  total_rows: refTotal,
+  rows_by_source: Object.fromEntries(refBySource.map((r) => [String(r._id), r.n])),
+  rows_by_original_language_top40: Object.fromEntries(refByLang.map((r) => [String(r._id), r.n])),
+  rows_by_decade: Object.fromEntries(refByDecade.map((r) => [String(r._id), r.n])),
+  rows_with_uniform_title: refUniform,
+  measured_recall: {
+    catalogue_only: 0.321,
+    measured_at: '2026-08-07',
+    instrument: 'scripts/eval/ft-reference-set-recall.mjs',
+    baselines: { '2026-07-31': 0.22, '2026-08-01': 0.27, '2026-08-07': 0.321 },
+    note: 'Recall measured against attributed priors in translation_classification. none_found is therefore weak evidence by construction; positive findings are unaffected.',
+  },
+};
+
+// 6. Taxonomy — the codebook, verbatim from src/lib/first-translation/types.ts.
+const taxonomy = {
+  verdicts: {
+    first_no_prior: 'No English translation of this text in any form.',
+    first_from_source: 'English of the work exists from a different source language, but not from this text (source-language rule).',
+    first_complete: 'Only partial/excerpt/anthology English exists; ours is the first complete one. Gated on our item being complete.',
+    first_modern: 'Only antiquated (pre-~1900) English exists.',
+    not_first: 'A complete modern English translation of this text exists.',
+    not_applicable: 'Not a single translatable text (visual art, scripture manuscript copy, English-source original, multi-work container).',
+    unverifiable: 'Competent tradition sources are catalogue-blind here; the search cannot be bounded. Excluded from public headline counts.',
+    needs_review: 'Conflicting or inconclusive evidence, or unresolved work identity.',
+  },
+  first_family: ['first_no_prior', 'first_from_source', 'first_complete', 'first_modern'],
+  prior_relationship: {
+    same_text: 'Defeats "first".',
+    same_work_diff_edition: 'Defeats "first" (recension / authorial revision).',
+    different_source_language: 'Does NOT defeat (source-language rule).',
+    related_distinct_work: 'Does NOT defeat (parent/sibling/derivative work).',
+    partial: 'Supports first_complete.',
+    adaptation: 'Usually does not defeat; flagged for review.',
+  },
+  evidence_strength: {
+    strong: 'Prior positively found, OR absence confirmed in competent tradition sources.',
+    moderate: 'Well-searched absence, bounded (e.g. could not scan dissertations).',
+    weak: 'Absence from a blind catalogue only — effectively unsearched. Weak-evidence first claims are excluded from public headline counts.',
+  },
+  match_key: {
+    work_id: 'Matched via the work-identity layer.',
+    author_title: 'Matched on normalised author + title strings.',
+    transliteration: 'Matched via transliterated title.',
+    none: 'No usable match key.',
+  },
+  resolver: {
+    tier0_linked: 'Deterministic: a linked registry prior.',
+    tier1_catalog: 'Catalogue sweep against the reference set.',
+    tier2_agent: 'Per-book grounded model adjudication.',
+    human: 'Human judgement.',
+  },
+  attempt_method: {
+    tier0_linked: 'Deterministic registry lookup.',
+    tier1_catalog: 'Catalogue sweep against reference_translations.',
+    tier2_agent: 'Per-book tool-using agent adjudication.',
+    human: 'Human review.',
+    gemini_verifier: 'Nightly grounded-Gemini verification cron.',
+    gemini_grounded_search: 'Gemini call with Google-Search grounding enabled.',
+    claude_subagent_verify: 'Independent Claude subagent verification (stage-2, /ft-verify).',
+    llm_prior_adjudicate: 'LLM adjudication of a specific asserted prior.',
+    opus48_collection_scan: 'Collection-level Claude Opus scan (legacy instrument).',
+  },
+  attempt_result: {
+    found: 'A prior English translation was found.',
+    none: 'Searched; no prior found (evidence of absence, graded by evidence_strength).',
+    not_applicable: 'The book is not an English-translation candidate (original-language edition, container, non-English translation). NOT an absence vote.',
+    not_found: 'Demote-direction check: the agent searched for a SPECIFIC cited prior and could not confirm it exists (a targeted refutation).',
+    na: 'Legacy alias of not_applicable.',
+    not_first: 'Legacy collection-scan result: a prior exists.',
+    likely_first: 'Legacy collection-scan result: probably a first (weak).',
+  },
+};
+
+// ── write everything ───────────────────────────────────────────────────────
+
+writeJsonl(join(OUT_DIR, 'attempts.jsonl'), attemptRows);
+writeCsv(
+  join(OUT_DIR, 'attempts.csv'),
+  ['attempt_id', 'book_id', 'date', 'method', 'match_key', 'result', 'verdict', 'evidence_strength', 'model', 'cost_usd', 'n_sources', 'n_queries', 'n_priors', 'sources_checked'],
+  attemptRows.map((a) => ({
+    ...a,
+    n_sources: a.sources_checked?.length ?? 0,
+    n_queries: a.queries?.length ?? 0,
+    n_priors: a.priors?.length ?? 0,
+    sources_checked: (a.sources_checked || []).join('|'),
+  })),
+);
+writeJsonl(join(OUT_DIR, 'verdicts.jsonl'), verdictRows);
+writeCsv(
+  join(OUT_DIR, 'verdicts.csv'),
+  ['book_id', 'work_id', 'title', 'author', 'language', 'original_language', 'year', 'visible', 'badge_rendered', 'verdict', 'evidence_strength', 'our_completeness', 'match_key', 'prior_relationship', 'resolver', 'resolved_at'],
+  verdictRows,
+);
+writeJsonl(join(OUT_DIR, 'screening_decisions.jsonl'), screeningRows);
+writeFileSync(join(OUT_DIR, 'taxonomy.json'), JSON.stringify(taxonomy, null, 2) + '\n');
+writeFileSync(join(OUT_DIR, 'reference-set-summary.json'), JSON.stringify(referenceSetSummary, null, 2) + '\n');
+
+// Copy the datasheet in if it exists (kept tracked beside this script).
+const datasheetSrc = join(__dirname, 'ft-dataset-datasheet.md');
+if (existsSync(datasheetSrc)) {
+  writeFileSync(join(OUT_DIR, 'DATASHEET.md'), readFileSync(datasheetSrc));
+}
+
+// Manifest last, so it can checksum the rest.
+let gitSha = 'unknown';
+try {
+  gitSha = execSync('git rev-parse HEAD', { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+} catch { /* fine outside a checkout */ }
+
+const files = ['attempts.jsonl', 'attempts.csv', 'verdicts.jsonl', 'verdicts.csv', 'screening_decisions.jsonl', 'taxonomy.json', 'reference-set-summary.json']
+  .concat(existsSync(join(OUT_DIR, 'DATASHEET.md')) ? ['DATASHEET.md'] : []);
+
+const manifest = {
+  dataset: 'sourcelibrary-first-translation-verification-corpus',
+  version: DATASET_VERSION_DATE,
+  generated_at: new Date().toISOString(),
+  git_sha: gitSha,
+  license: 'CC-BY-4.0',
+  generator: 'scripts/eval/export-ft-dataset.mjs',
+  source_database: DB_NAME,
+  counts: {
+    attempts: attemptRows.length,
+    verdict_books: verdictRows.length,
+    screening_decisions: screeningRows.length,
+    reference_set_rows_summarised: refTotal,
+  },
+  exclusions: {
+    policy: 'Books hidden by takedown, owner/curator removal request, or marked as test records are excluded entirely (verdicts and attempts).',
+    excluded_books: excludedBooks.length,
+    excluded_verdict_rows: excludedVerdicts,
+    excluded_attempt_rows: excludedAttempts,
+  },
+  redactions: { ...redactionTally },
+  files: Object.fromEntries(files.map((f) => [f, { sha256: sha256(join(OUT_DIR, f)) }])),
+};
+writeFileSync(join(OUT_DIR, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+console.log(`\nDone. ${files.length + 1} files in ${OUT_DIR}`);
+console.log(`  attempts=${attemptRows.length} verdicts=${verdictRows.length} screening=${screeningRows.length}`);
+console.log(`  redactions: ${redactionTally.emails} emails, ${redactionTally.token_params} token params`);
+console.log(`  git_sha=${gitSha}`);
+
+await client.close();

--- a/scripts/eval/ft-dataset-datasheet.md
+++ b/scripts/eval/ft-dataset-datasheet.md
@@ -1,0 +1,160 @@
+# Datasheet: Source Library First-Translation Verification Corpus
+
+*Format follows Gebru et al., "Datasheets for Datasets" (CACM 2021). This file is
+copied into every export as `DATASHEET.md` by `scripts/eval/export-ft-dataset.mjs`;
+per-snapshot counts, checksums, and the generating git SHA live in the accompanying
+`manifest.json`. Figures quoted below are from the 2026-08-09 snapshot unless dated
+otherwise.*
+
+## Motivation
+
+**Why was this dataset created?** Digital libraries increasingly attach AI-generated
+"first English translation" claims to books. Such a claim asserts a *universal
+negative* — that no prior translation exists anywhere — which no lookup can prove and
+which fails in both directions (false firsts on famous works; genuine firsts never
+assessed). Source Library's response was to stop asserting the bare negative and
+instead record the *search*: every verification attempt, its sources, queries,
+result, and evidence grade, in an append-only provenance ledger. This dataset is
+that ledger, published. To our knowledge no library publishes documented
+evidence-of-absence at this scale, and the dataset exists so that (a) every public
+first-translation claim on sourcelibrary.org is independently auditable, and (b)
+researchers studying LLM factuality, negative-existence claims, and metadata quality
+have a real deployed-system corpus to work with.
+
+**Who created it?** Source Library (Embassy of the Free Mind), 2026. The verification
+instruments are AI systems (grounded Gemini calls, Claude tool-using agents,
+deterministic catalogue matchers) plus a small number of human reviews; the pipeline
+code is AGPL at https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2.
+
+## Composition
+
+**What do the instances represent?** Four related tables:
+
+1. **`attempts.jsonl` / `.csv` (63,173 rows)** — one row per verification attempt on
+   one book: instrument (`method`), date, match key, sources consulted, verbatim
+   queries (present on 17,736 rows), result (`found` / `none` / `not_applicable` +
+   legacy variants), structured priors found (18,189 rows carry at least one),
+   evidence strength, model id, cost, and free-text rationale. Append-only in the
+   source system; 29,938 distinct books are covered.
+2. **`verdicts.jsonl` / `.csv` (10,377 rows)** — one row per book carrying a resolved
+   graded verdict under the 8-verdict taxonomy, with public bibliographic metadata
+   (title, author, language, original language, year), the qualifiers
+   (evidence strength, our-item completeness, match key, prior relationship), the
+   resolving tier, and a pointer (`best_attempt_id`) into the attempts table.
+   Distribution at snapshot: 9,630 `first_no_prior`, 339 `not_first`,
+   124 `first_modern`, 106 `needs_review`, 79 `first_complete`, 77 `not_applicable`,
+   22 `first_from_source`. Evidence strength: 238 strong, 987 moderate, 9,152 weak.
+3. **`screening_decisions.jsonl` (82 rows)** — durable screening judgements keyed on
+   (work, prior), which persist across regenerations of the underlying search efforts.
+4. **`reference-set-summary.json`** — composition statistics of the 149,096-row
+   bibliographic reference set (LoC / ESTC / Wikidata / internal classification)
+   that catalogue-tier absence claims are asserted against, including its measured
+   recall (see *Known limitations*). The full reference set is derivable from public
+   catalogue dumps and is summarised rather than redistributed.
+
+`taxonomy.json` is the codebook: definitions for every verdict, qualifier, method,
+and result value, verbatim from the production type definitions.
+
+**Does the dataset contain confidential or personal data?** No reader or usage data
+of any kind. Book metadata is public bibliographic fact. Free-text fields are
+model-written bibliographic prose, swept at export time for email addresses and
+URL query-string credentials (tallies in `manifest.json`). The handful of human
+attempts are labelled by role (`human`), not by name.
+
+## Collection process
+
+**How was the data acquired?** By the production verification pipeline,
+February–August 2026, in tiers: deterministic registry links (tier 0), catalogue
+sweeps against the reference set (tier 1), per-book grounded model adjudication
+(tier 2: nightly grounded-Gemini crons and independent Claude verification
+subagents, each running real catalogue/web searches), and human review. Each
+attempt records which instrument ran, what it consulted, and what it concluded.
+Since #3778 automated rows carry a `prompt_version`; a `transcript_ref` points into
+a transcript store (full prompt + raw grounded response) where persisted. Rows
+ingested from legacy stores are marked via `ingest_source`, and legacy backfilled
+rows without an original timestamp carry epoch or nominal dates (e.g.
+`2026-06-01T00:00:00Z`, `1970-01-01`) — treat `date` as reliable only on rows
+written by the live instruments.
+
+**Sampling?** This is the full production ledger, not a sample — minus the
+exclusions below. The companion working paper additionally describes stratified
+samples drawn *from* it (n=462 precision, n=1,000 recall) whose row-level records
+are part of this ledger.
+
+## Preprocessing / cleaning
+
+- **Exclusions:** books hidden by takedown or owner/curator removal request, and
+  test records, are excluded entirely — verdicts, attempts, and identifiers
+  (2026-08-09 snapshot: 508 verdict rows, 1,661 attempt rows). Books hidden for
+  ordinary curation/processing reasons are retained and flagged `visible: false`.
+- **Redaction:** email addresses → `[email-redacted]`; URL query parameters named
+  like credentials (`key`, `token`, `signature`, …) → `[redacted]`. Counts per
+  snapshot are in `manifest.json`.
+- **Determinism:** rows are sorted and field order fixed; two runs against the same
+  database state produce byte-identical data files.
+
+## Uses
+
+**Recommended:** studying LLM behaviour on negative-existence claims (fabrication,
+grounding, abstention); metadata-quality auditing methodology; translation-studies
+bibliography (the structured `priors` are leads, graded by evidence); reproducing
+or extending the companion working paper; building better instruments against a
+documented baseline.
+
+**Uses to avoid:**
+
+- **Do not read a `none` result — or a `first_no_prior` verdict with `weak`
+  evidence — as proof no prior translation exists.** Absence is graded evidence
+  bounded by the reference set and the search; 9,152 of 10,377 verdicts rest on
+  weak evidence, and the public site excludes weak-evidence claims from its
+  headline counts for exactly this reason.
+- Do not treat model-written `notes` or `priors` as verified citations: sampled
+  audits found fabricated or muddled priors at material rates (see below). A prior
+  is verified only when its cited record has been independently opened.
+- Do not use the dataset to identify or profile any person; it contains none, and
+  attempts to join it against personal data are out of scope of the license intent.
+
+## Known limitations and biases
+
+Measured, not hypothetical — each figure has an instrument in the repo:
+
+- **Reference-set recall is 32.1%** (catalogue-only, 2026-08-07,
+  `scripts/eval/ft-reference-set-recall.mjs`): roughly two of three known prior
+  translations are invisible to the catalogue tier, so `none_found` at tier 1 is
+  weak by construction. A sampled check put `none_found`'s positive predictive
+  value near 50% pre-v2.
+- **Post-1950 blind spot:** 80.8% of known Latin/Greek priors are post-1950
+  imprints, while the deepest catalogue layers (e.g. ESTC) cover 1473–1800; the
+  residual loss sits in modern scholarly publishing.
+- **Badged-precision estimate ~46–58% first-family** on stratified samples
+  (n=462 + an independent n=12 spot audit, 2026-08-09) — the dominant error being
+  *ill-posed* claims (multi-work containers, standard liturgy copies, unique
+  documents), not missed priors. False firsts concentrate on famous works.
+- **Instrument fabrication:** single-pass model verdicts on the demote direction
+  fabricated priors at ~63% before independent verification was made binding; the
+  well-formed fabrication (a real scholar attached to a nonexistent work) defeats
+  structural detectors.
+- **Grounding is load-bearing:** a configuration flag that silently suppressed
+  search grounding inflated "first" rates by ~4 points before being caught; rows
+  from that period were re-run, but the incident is documented in the paper as a
+  hazard of the method.
+- **Source quality is uneven:** grounded search consults authoritative catalogues
+  alongside low-authority aggregators, and WorldCat blocks automated agents —
+  per-row `sources_checked` makes this auditable.
+- **No human gold standard yet:** accuracy figures are AI-vs-AI agreements; the
+  150-book human annotation pass (the binding step for the accuracy claim) is
+  designed and tooled but not yet run.
+
+## Distribution
+
+Zenodo, versioned by snapshot date, under **CC BY 4.0**. The generating code is
+AGPL-3.0 in the sourcelibrary-v2 repository; each snapshot's `manifest.json` pins
+the git SHA that produced it. Cite the dataset DOI plus the snapshot version.
+
+## Maintenance
+
+Source Library maintains the dataset. New snapshots are produced by re-running the
+exporter; the underlying ledger is append-only, so later snapshots strictly extend
+earlier ones apart from verdict re-resolutions (which are themselves recorded as
+new attempts) and any newly excluded takedowns. Errata: open an issue on the
+sourcelibrary-v2 repository or use the site's feedback channel.


### PR DESCRIPTION
## What

Steps 1–3, 5 (draft), and 6 of #3798 — the mechanical half of turning the first-translation verification work into a publishable, citable dataset.

- **`scripts/eval/export-ft-dataset.mjs`** — deterministic versioned snapshot: 63,173 attempts (append-only search provenance), 10,377 graded verdicts + public metadata, 82 screening decisions, taxonomy codebook, reference-set composition. Manifest carries git SHA, counts, sha256 checksums, exclusion + redaction tallies. Verified byte-identical across two runs against the same data.
- **Exclusion policy**: books hidden by takedown / owner-removal request / test records are excluded entirely (508 verdict rows, 1,661 attempt rows — mostly the Kloss set). Curation-hidden books stay, flagged `visible: false`.
- **Hygiene (step 3)**: emails → `[email-redacted]` (1 hit), URL credential params → `[redacted]` (117 hits); zero raw emails/tokens remain in output (grep-verified); IP-shaped strings checked and are canonical-reference numbering, not IPs. No reader data anywhere.
- **`scripts/eval/ft-dataset-datasheet.md`** (step 2) — Datasheets-for-Datasets doc, copied into every snapshot: measured biases (32.1% reference-set recall, ~50% `none_found` PPV, post-1950 blind spot, fabrication rates), recommended + to-avoid uses, CC BY 4.0.
- **`scripts/eval/deposit-ft-dataset.mjs`** (step 5) — Zenodo deposit, **draft-only by default**; `--publish` (DOI minting) is a deliberate human action. A reviewable draft of the 2026-08-09 snapshot is up: https://zenodo.org/uploads/21861661 — **no DOI minted**.
- **Paper draft Appendix B** (step 6) — reconciled 2026-08-09 denominators (36,799 visible / 16,235 eligible / 5,925 badged / 6,894 never-assessed), single-writer derivation shipped (99.95% of rendered badges verdict-backed, measured), escalation ladder, the 2026-08-09 spot-audit replication, JOHD-first venue split. Also fixes the stale 'intentionally untracked' footnote (the file is tracked).

## Out of scope

- **Step 4 (human gold standard)** — Derek's 150-book annotation pass; tool exists (PR #2614), still 0 annotations. Binding for the CHR paper, not for the JOHD data paper.
- **Publishing the Zenodo record** — awaits Derek's review of the draft (authorship/creators are editable there).
- Full `search_efforts` export (77,953 rows) — a different evidence layer; can be added to a later snapshot version if the data paper wants it.

Closes nothing yet; #3798 stays open for step 4 + the actual publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)