### PR TITLE
feat(audit): artwork image-integrity detector + repair tool (#3815)

### DIFF
--- a/scripts/audit/artwork-image-integrity.mjs
+++ b/scripts/audit/artwork-image-integrity.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Audit: does an artwork doc's R2 image actually depict the catalog record
+ * it's attached to? (#3815)
+ *
+ * THE INVARIANT
+ *   For a `resource_type` artwork doc with a museum/Commons source, the
+ *   bytes served from the doc's own `thumbnail`/`thumbnail_blob`/
+ *   `archived_full_url` R2 keys must match what the AUTHORITATIVE SOURCE
+ *   (Cleveland/Met/AIC API, or the Commons file page) reports for that
+ *   record's own id — never assumed from the slug or from a sibling record.
+ *
+ * WHY IT MATTERS
+ *   Two Jain-art Cleveland records (#3815) carry correct title/author
+ *   metadata (resolved via `source_ids.cleveland`, the CMA numeric object
+ *   id) but serve a DIFFERENT artwork's image — a Greek red-figure krater
+ *   and a Pahari Shaiva-ascetic painting, neither Jain nor Indian. Root
+ *   cause traced 2026-08-09: the (never-committed, session-only) importer
+ *   that created these docs on 2026-04-14 wrote a `source_url` accession
+ *   number that does NOT match the accession CMA reports for
+ *   `source_ids.cleveland` — e.g. doc says accession 1926.549, but CMA's
+ *   own id 107362 is accession 1925.1340. The image that was fetched and
+ *   uploaded to R2 corresponds to the WRONG accession in `source_url`, not
+ *   the correct id used for the title. `scripts/normalize-artwork-images.mjs`
+ *   (run 2026-05-03, since deleted from the repo — see git history at
+ *   c3dadee0) later re-derived all 4 R2 tiers (display/thumb/grid/full) from
+ *   this already-wrong image, which is why every tier is wrong and all
+ *   share one `image_normalized_at` timestamp. See #3815 for the full
+ *   writeup.
+ *
+ * DETECTION STRATEGY
+ *   - cleveland: authoritative and CHEAP — no image download needed. Refetch
+ *     CMA by `source_ids.cleveland`; if the accession it reports disagrees
+ *     with the accession embedded in `source_url`, that's a confirmed
+ *     mismatch on its own (this is exactly the #3815 mechanism).
+ *   - met / aic / commons: dHash the source's own image and this doc's own
+ *     R2 thumb (scripts/lib/dhash.mjs); Hamming distance >= HASH_DIFF (16,
+ *     see scripts/lib/page-alignment.mjs) is a confirmed mismatch, <= 12 is
+ *     a match, the small band between is "ambiguous" (kept, not auto-fixed).
+ *   - rijksmuseum / nga / wellcome: NOT integrated (see
+ *     scripts/lib/artwork-sources.mjs header) — reported as `unverifiable`.
+ *   - no recognizable source at all: reported as `no-source`.
+ *
+ * SCOPE (per #3815 instructions — full sweep of ~24.8K docs is too slow)
+ *   - Cleveland/Met/AIC: EXHAUSTIVE (only 230/617/48 docs respectively, and
+ *     the Cleveland check needs no image fetch).
+ *   - Commons: every dedup-touched doc (`dedup_date` exists) EXHAUSTIVE,
+ *     plus a random sample (--sample, default 300) of the rest. Report the
+ *     sampled mismatch rate separately from the exhaustive one.
+ *
+ * USAGE
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/artwork-image-integrity.mjs                  # default scope
+ *   node scripts/audit/artwork-image-integrity.mjs --sample 500     # bigger commons sample
+ *   node scripts/audit/artwork-image-integrity.mjs --commons-cap 1000  # cap exhaustive commons dedup set
+ *   node scripts/audit/artwork-image-integrity.mjs --json out.json
+ *
+ * READ-ONLY — never writes to Mongo or R2. Exits non-zero if any confirmed
+ * mismatch is found, so it can be re-run standing-detector style.
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import { computeDHash } from '../lib/dhash.mjs';
+import { hammingHex, HASH_MATCH, HASH_DIFF } from '../lib/page-alignment.mjs';
+import { detectProvider, fetchSourceFor, fetchImageBuffer } from '../lib/artwork-sources.mjs';
+
+const args = process.argv.slice(2);
+const argVal = (name, def) => {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : def;
+};
+const SAMPLE = parseInt(argVal('--sample', '300'), 10);
+const COMMONS_CAP = parseInt(argVal('--commons-cap', '0'), 10) || Infinity; // 0 = no cap
+const JSON_OUT = argVal('--json', null);
+const CONCURRENCY = parseInt(argVal('--concurrency', '4'), 10);
+const DELAY_MS = parseInt(argVal('--delay', '250'), 10);
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(2); }
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+
+const PROJECTION = {
+  _id: 1, id: 1, slug: 1, title: 1, author: 1, resource_type: 1,
+  source_url: 1, commons_url: 1, commons_title: 1, source_ids: 1,
+  dedup_date: 1, dedup_reason: 1, visible: 1, hidden: 1,
+  thumbnail: 1, thumbnail_blob: 1, archived_full_url: 1, image_thumb: 1,
+  image_width: 1, image_height: 1,
+};
+
+function r2ThumbUrl(doc) {
+  // Prefer the actual thumb tier; fall back to the display tier if the
+  // thumb field is missing (a normalize-style script sometimes leaves it
+  // pointed at the same URL as -full).
+  return doc.thumbnail_blob || doc.image_thumb || doc.thumbnail || null;
+}
+
+async function checkOne(doc) {
+  const provider = detectProvider(doc);
+  const base = { id: doc.id || String(doc._id), slug: doc.slug, title: doc.title, provider };
+
+  if (!provider) return { ...base, status: 'no-source' };
+  if (provider === 'rijksmuseum' || provider === 'nga' || provider === 'wellcome') {
+    return { ...base, status: 'unverifiable', detail: `${provider} not integrated` };
+  }
+
+  const src = await fetchSourceFor(provider, doc);
+  if (!src.ok) return { ...base, status: 'source-error', detail: src.error };
+
+  if (provider === 'cleveland') {
+    // Cheap, authoritative — no image download needed to call this confirmed.
+    if (src.accessionMismatch) {
+      return {
+        ...base, status: 'mismatch', detail: `source_url accession ${src.urlAccession} != CMA accession ${src.sourceAccession} for id ${doc.source_ids.cleveland}`,
+        correctImageUrl: src.imageUrl, correctTitle: src.title,
+      };
+    }
+    // Still worth a dHash spot-check even when accessions agree, in case the
+    // image upload itself failed independently of the accession bug.
+  }
+
+  const thumbUrl = r2ThumbUrl(doc);
+  if (!thumbUrl) return { ...base, status: 'no-r2-thumb' };
+
+  const [srcBuf, r2Buf] = await Promise.all([
+    fetchImageBuffer(src.imageUrl),
+    fetchImageBuffer(thumbUrl),
+  ]);
+  if (!srcBuf) return { ...base, status: 'source-fetch-failed', detail: 'source image did not download' };
+  if (!r2Buf) return { ...base, status: 'r2-fetch-failed', detail: `R2 thumb did not download: ${thumbUrl}` };
+
+  let srcHash, r2Hash;
+  try {
+    [srcHash, r2Hash] = await Promise.all([computeDHash(srcBuf), computeDHash(r2Buf)]);
+  } catch (e) {
+    return { ...base, status: 'hash-error', detail: e.message };
+  }
+  const dist = hammingHex(srcHash, r2Hash);
+
+  if (dist >= HASH_DIFF) {
+    return {
+      ...base, status: 'mismatch', detail: `dHash distance ${dist} (>= ${HASH_DIFF})`,
+      correctImageUrl: src.imageUrl, correctFullImageUrl: src.fullImageUrl || src.imageUrl, correctTitle: src.title,
+    };
+  }
+  if (dist <= HASH_MATCH) {
+    return { ...base, status: 'match', detail: `dHash distance ${dist}` };
+  }
+  return { ...base, status: 'ambiguous', detail: `dHash distance ${dist} (between ${HASH_MATCH} and ${HASH_DIFF})`, correctImageUrl: src.imageUrl };
+}
+
+async function runBatch(docs, label) {
+  const results = [];
+  for (let i = 0; i < docs.length; i += CONCURRENCY) {
+    const batch = docs.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(d => checkOne(d).catch(e => ({
+      id: d.id || String(d._id), slug: d.slug, title: d.title, status: 'error', detail: e.message,
+    }))));
+    results.push(...batchResults);
+    if ((i + CONCURRENCY) % 40 < CONCURRENCY) {
+      const mism = results.filter(r => r.status === 'mismatch').length;
+      console.log(`  [${label}] ${Math.min(i + CONCURRENCY, docs.length)}/${docs.length} — ${mism} mismatch(es) so far`);
+    }
+    await new Promise(r => setTimeout(r, DELAY_MS));
+  }
+  return results;
+}
+
+function shuffle(arr) {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+async function main() {
+  console.log('=== Artwork image integrity sweep (#3815) ===\n');
+
+  const allResults = [];
+
+  // ── Cleveland: exhaustive, cheap ──────────────────────────────────────
+  const clevelandDocs = await books.find(
+    { resource_type: { $exists: true }, 'source_ids.cleveland': { $exists: true } },
+    { projection: PROJECTION }
+  ).toArray();
+  console.log(`Cleveland: ${clevelandDocs.length} docs (exhaustive, accession cross-check)`);
+  allResults.push(...await runBatch(clevelandDocs, 'cleveland'));
+
+  // ── Met: exhaustive ────────────────────────────────────────────────────
+  const metDocs = await books.find(
+    { resource_type: { $exists: true }, 'source_ids.met': { $exists: true } },
+    { projection: PROJECTION }
+  ).toArray();
+  console.log(`\nMet: ${metDocs.length} docs (exhaustive, dHash)`);
+  allResults.push(...await runBatch(metDocs, 'met'));
+
+  // ── AIC: exhaustive ─────────────────────────────────────────────────────
+  const aicDocs = await books.find(
+    { resource_type: { $exists: true }, 'source_ids.aic': { $exists: true } },
+    { projection: PROJECTION }
+  ).toArray();
+  console.log(`\nAIC: ${aicDocs.length} docs (exhaustive, dHash)`);
+  allResults.push(...await runBatch(aicDocs, 'aic'));
+
+  // ── Commons: dedup-touched exhaustive + random sample of the rest ─────
+  const commonsQuery = { resource_type: { $exists: true }, commons_url: /commons\.wikimedia\.org/i };
+  const commonsDedup = await books.find(
+    { ...commonsQuery, dedup_date: { $exists: true } },
+    { projection: PROJECTION }
+  ).limit(COMMONS_CAP === Infinity ? 0 : COMMONS_CAP).toArray();
+  console.log(`\nCommons (dedup-touched): ${commonsDedup.length} docs (exhaustive${COMMONS_CAP !== Infinity ? `, capped at ${COMMONS_CAP}` : ''}, dHash)`);
+  allResults.push(...await runBatch(commonsDedup, 'commons-dedup'));
+
+  const commonsRestIds = await books.find(
+    { ...commonsQuery, dedup_date: { $exists: false } },
+    { projection: { _id: 1 } }
+  ).toArray();
+  const sampleIds = shuffle(commonsRestIds).slice(0, SAMPLE).map(d => d._id);
+  const commonsSample = await books.find(
+    { _id: { $in: sampleIds } },
+    { projection: PROJECTION }
+  ).toArray();
+  console.log(`\nCommons (random sample of non-dedup-touched, ${commonsRestIds.length} eligible): ${commonsSample.length} docs, dHash`);
+  const commonsSampleResults = await runBatch(commonsSample, 'commons-sample');
+  allResults.push(...commonsSampleResults);
+
+  // ── Report ──────────────────────────────────────────────────────────────
+  const byStatus = {};
+  for (const r of allResults) byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+
+  console.log('\n━━━ SUMMARY ━━━');
+  console.log(`Total checked: ${allResults.length}`);
+  for (const [status, n] of Object.entries(byStatus).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${status}: ${n}`);
+  }
+
+  const sampleMismatches = commonsSampleResults.filter(r => r.status === 'mismatch').length;
+  const sampleChecked = commonsSampleResults.filter(r => ['mismatch', 'match', 'ambiguous'].includes(r.status)).length;
+  if (sampleChecked > 0) {
+    console.log(`\nCommons random-sample mismatch rate: ${sampleMismatches}/${sampleChecked} = ${(100 * sampleMismatches / sampleChecked).toFixed(1)}%`);
+    console.log(`(Extrapolated to ${commonsRestIds.length} non-dedup-touched Commons docs: ~${Math.round(commonsRestIds.length * sampleMismatches / sampleChecked)} potential mismatches — NOT verified individually.)`);
+  }
+
+  const mismatches = allResults.filter(r => r.status === 'mismatch');
+  if (mismatches.length) {
+    console.log(`\n${mismatches.length} CONFIRMED mismatch(es):`);
+    for (const m of mismatches) {
+      console.log(`  ${m.id} "${(m.title || '').slice(0, 50)}" [${m.provider}] — ${m.detail}`);
+    }
+  }
+
+  const outPath = JSON_OUT || `scripts/output/artwork-image-integrity-${new Date().toISOString().slice(0, 10)}.json`;
+  fs.mkdirSync('scripts/output', { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify({
+    generated_at: new Date().toISOString(),
+    counts: byStatus,
+    commons_sample: { checked: sampleChecked, mismatches: sampleMismatches, eligible_population: commonsRestIds.length },
+    results: allResults,
+  }, null, 2));
+  console.log(`\nFull results → ${outPath}`);
+
+  await client.close();
+  process.exit(mismatches.length ? 1 : 0);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/lib/artwork-sources.mjs
+++ b/scripts/lib/artwork-sources.mjs
@@ -1,0 +1,152 @@
+/**
+ * Authoritative-source lookups for artwork docs (#3815).
+ *
+ * Used by scripts/audit/artwork-image-integrity.mjs (detection) and
+ * scripts/maintenance/repair-artwork-images.mjs (repair). Each fetch*Source
+ * function returns the museum/Commons API's OWN account of what image
+ * belongs to a given doc — never derived from our own slug or R2 keys.
+ *
+ * Provider coverage (2026-08-09): Cleveland, Met, AIC, and true Wikimedia
+ * Commons file pages are supported. Rijksmuseum's public collection API
+ * returns 410 Gone (deprecated, no working replacement found in a quick
+ * check) and NGA's open data is a static CSV dump, not a live API — both
+ * are reported as `unverifiable` rather than guessed at. ~1,892 Rijksmuseum
+ * + ~590 NGA artwork docs are therefore NOT covered by this integrity check;
+ * a follow-up would need a Rijksmuseum API key (dead endpoint otherwise) or
+ * NGA's bulk opendata CSVs.
+ */
+
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org) bot';
+
+// One string, both fields: the Cleveland/Met/AIC importer wrote its source
+// link into `source_url`; a separate, older importer generation (or a
+// Commons-native record) uses `commons_url` for the same purpose. Neither
+// field is reserved to one provider, so always check both.
+export function sourceLink(doc) {
+  return doc.source_url || doc.commons_url || null;
+}
+
+export function detectProvider(doc) {
+  if (doc.source_ids?.cleveland) return 'cleveland';
+  if (doc.source_ids?.met) return 'met';
+  if (doc.source_ids?.aic) return 'aic';
+  const link = sourceLink(doc);
+  if (!link) return null;
+  let host;
+  try { host = new URL(link).hostname; } catch { return null; }
+  if (/clevelandart\.org$/i.test(host)) return 'cleveland';
+  if (/metmuseum\.org$/i.test(host)) return 'met';
+  if (/artic\.edu$/i.test(host)) return 'aic';
+  if (/commons\.wikimedia\.org$/i.test(host)) return 'commons';
+  if (/rijksmuseum\.nl$/i.test(host)) return 'rijksmuseum'; // unverifiable — see header
+  if (/nga\.gov$/i.test(host)) return 'nga';                // unverifiable — see header
+  if (/wellcomecollection\.org$/i.test(host)) return 'wellcome'; // not yet integrated
+  return null;
+}
+
+async function getJson(url, timeoutMs = 15000) {
+  const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+  return { ok: true, json: await res.json() };
+}
+
+/**
+ * Cleveland Museum of Art. `source_ids.cleveland` is the CMA API's own
+ * numeric object id (NOT the human accession number) — fetching it directly
+ * by id is a single authoritative lookup, no search/matching involved.
+ *
+ * Also returns `accessionMismatch`: whether the accession number embedded in
+ * this doc's `source_url` (e.g. clevelandart.org/art/1926.549) differs from
+ * the accession number CMA reports for `source_ids.cleveland`. Every
+ * confirmed-bad doc found in #3815 shows this mismatch — the doc's own
+ * `source_url` names a DIFFERENT artwork than the id used to build the
+ * title/metadata, and the image that ended up on R2 matches the wrong one.
+ * This check needs no image download and is authoritative on its own.
+ */
+export async function fetchClevelandSource(doc) {
+  const id = doc.source_ids?.cleveland;
+  if (!id) return { ok: false, error: 'no source_ids.cleveland' };
+  const r = await getJson(`https://openaccess-api.clevelandart.org/api/artworks/${encodeURIComponent(id)}`);
+  if (!r.ok) return r;
+  const obj = r.json.data;
+  if (!obj) return { ok: false, error: 'no data in response' };
+  const link = sourceLink(doc) || '';
+  const urlAccession = link.match(/\/art\/([^/?#]+)/)?.[1] || null;
+  const sourceAccession = obj.accession_number || null;
+  const imageUrl = obj.images?.web?.url || obj.images?.print?.url || null;
+  const fullImageUrl = obj.images?.print?.url || obj.images?.web?.url || null;
+  if (!imageUrl) return { ok: false, error: 'no image on CMA object' };
+  return {
+    ok: true,
+    title: obj.title,
+    sourceAccession,
+    urlAccession,
+    accessionMismatch: !!(urlAccession && sourceAccession && urlAccession !== sourceAccession),
+    imageUrl,
+    fullImageUrl,
+  };
+}
+
+/** Metropolitan Museum of Art — objectID is a direct, unambiguous lookup. */
+export async function fetchMetSource(doc) {
+  const id = doc.source_ids?.met;
+  if (!id) return { ok: false, error: 'no source_ids.met' };
+  const r = await getJson(`https://collectionapi.metmuseum.org/public/collection/v1/objects/${encodeURIComponent(id)}`);
+  if (!r.ok) return r;
+  const obj = r.json;
+  const imageUrl = obj.primaryImageSmall || obj.primaryImage || null;
+  if (!imageUrl) return { ok: false, error: 'no image on Met object' };
+  return { ok: true, title: obj.title, imageUrl, fullImageUrl: obj.primaryImage || imageUrl };
+}
+
+/** Art Institute of Chicago — artwork id is a direct lookup; images served via IIIF. */
+export async function fetchAicSource(doc) {
+  const id = doc.source_ids?.aic;
+  if (!id) return { ok: false, error: 'no source_ids.aic' };
+  const r = await getJson(`https://api.artic.edu/api/v1/artworks/${encodeURIComponent(id)}?fields=id,title,image_id`);
+  if (!r.ok) return r;
+  const obj = r.json.data;
+  if (!obj?.image_id) return { ok: false, error: 'no image_id on AIC object' };
+  return {
+    ok: true,
+    title: obj.title,
+    imageUrl: `https://www.artic.edu/iiif/2/${obj.image_id}/full/843,/0/default.jpg`,
+    fullImageUrl: `https://www.artic.edu/iiif/2/${obj.image_id}/full/full/0/default.jpg`,
+  };
+}
+
+/** True Wikimedia Commons file page — looked up by File: title, not by our slug. */
+export async function fetchCommonsSource(doc) {
+  const link = sourceLink(doc);
+  let fileTitle = null;
+  if (doc.commons_title && /^File:/i.test(doc.commons_title)) fileTitle = doc.commons_title;
+  if (!fileTitle && link) {
+    const decoded = decodeURIComponent(link);
+    const m = decoded.match(/File:([^&?#]+)/i);
+    if (m) fileTitle = `File:${m[1].replace(/_/g, ' ')}`;
+  }
+  if (!fileTitle) return { ok: false, error: 'no File: title resolvable' };
+  const apiUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=${encodeURIComponent(fileTitle)}&prop=imageinfo&iiprop=url|size&iiurlwidth=800&format=json`;
+  const r = await getJson(apiUrl);
+  if (!r.ok) return r;
+  const page = Object.values(r.json.query?.pages || {})[0];
+  const info = page?.imageinfo?.[0];
+  if (!info) return { ok: false, error: 'file not found on Commons' };
+  return { ok: true, imageUrl: info.thumburl || info.url, fullImageUrl: info.url, width: info.width, height: info.height };
+}
+
+export async function fetchSourceFor(provider, doc) {
+  switch (provider) {
+    case 'cleveland': return fetchClevelandSource(doc);
+    case 'met': return fetchMetSource(doc);
+    case 'aic': return fetchAicSource(doc);
+    case 'commons': return fetchCommonsSource(doc);
+    default: return { ok: false, error: `provider '${provider}' not integrated (see file header)` };
+  }
+}
+
+export async function fetchImageBuffer(url, timeoutMs = 30000) {
+  const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) return null;
+  return Buffer.from(await res.arrayBuffer());
+}

--- a/scripts/maintenance/repair-artwork-images.mjs
+++ b/scripts/maintenance/repair-artwork-images.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Repair artwork docs whose R2 image doesn't match their catalog record (#3815).
+ *
+ * Input: the mismatch list from scripts/audit/artwork-image-integrity.mjs
+ * (scripts/output/artwork-image-integrity-*.json, `results[].status === 'mismatch'`).
+ *
+ * SAFETY
+ *   - DRY-RUN by default. Nothing is written without --apply.
+ *   - Every candidate is RE-VERIFIED live (fresh source lookup, not the cached
+ *     audit JSON) immediately before writing — the audit may be hours old.
+ *   - Never derives an R2 key from the slug. Every key this script writes is
+ *     read from the DOC'S OWN existing URL fields (thumbnail, thumbnail_blob,
+ *     archived_full_url, grid_thumbnail, image_display, image_thumb,
+ *     image_full) and must resolve to host images.sourcelibrary.org with an
+ *     `artwork/` prefix — anything else is skipped, not guessed at.
+ *   - Only touches the fields this doc's own record already uses for images,
+ *     plus image_width/image_height (and full_width/full_height if present).
+ *   - Never touches visible/hidden/dedup_date/dedup_reason — those reflect a
+ *     separate curatorial judgment (resolution/duplication) and are out of
+ *     scope for an image-content fix. Docs that were hidden stay hidden;
+ *     that's a follow-up curation decision, not this repair's job.
+ *   - Writes a manifest (what would/did happen) before touching R2 or Mongo.
+ *
+ * USAGE
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/repair-artwork-images.mjs                        # dry-run, latest audit JSON
+ *   node scripts/maintenance/repair-artwork-images.mjs --input scripts/output/artwork-image-integrity-2026-08-09.json
+ *   node scripts/maintenance/repair-artwork-images.mjs --apply
+ *   node scripts/maintenance/repair-artwork-images.mjs --apply --limit 5
+ *
+ * After --apply, purge the printed URL list from Cloudflare — this script
+ * does not call the Cloudflare API itself (needs CLOUDFLARE_API_TOKEN/ZONE_ID,
+ * kept as a separate deliberate step per repo convention).
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import fs from 'fs';
+import path from 'path';
+import { detectProvider, fetchSourceFor, fetchImageBuffer } from '../lib/artwork-sources.mjs';
+import { computeDHash } from '../lib/dhash.mjs';
+import { hammingHex, HASH_MATCH } from '../lib/page-alignment.mjs';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const LIMIT = parseInt((args[args.indexOf('--limit') + 1]) || '0', 10) || Infinity;
+const INPUT = args[args.indexOf('--input') + 1] || null;
+
+const R2_HOST = 'images.sourcelibrary.org';
+const IMAGE_FIELDS = ['thumbnail', 'thumbnail_blob', 'archived_full_url', 'grid_thumbnail', 'image_display', 'image_thumb', 'image_full'];
+
+function latestAuditFile() {
+  const dir = 'scripts/output';
+  const files = fs.readdirSync(dir).filter(f => /^artwork-image-integrity-.*\.json$/.test(f));
+  if (!files.length) throw new Error('No scripts/output/artwork-image-integrity-*.json found — run the audit first.');
+  files.sort();
+  return path.join(dir, files[files.length - 1]);
+}
+
+/** Extract an R2 key from a doc's own URL field. Returns null if it doesn't
+ *  look like our own artwork bucket — repair NEVER guesses a key. */
+function ownKey(url) {
+  if (!url || typeof url !== 'string') return null;
+  let u;
+  try { u = new URL(url); } catch { return null; }
+  if (u.hostname !== R2_HOST) return null;
+  const key = u.pathname.replace(/^\//, '');
+  if (!key.startsWith('artwork/')) return null;
+  return key;
+}
+
+function r2ThumbUrl(doc) {
+  return doc.thumbnail_blob || doc.image_thumb || doc.thumbnail || null;
+}
+
+/** Which rendered tier a key belongs to, by its own suffix — not by slug. */
+function tierOf(key) {
+  if (key.endsWith('-thumb.jpg')) return 'thumb';
+  if (key.endsWith('-grid.jpg')) return 'grid';
+  if (key.endsWith('-full.jpg')) return 'full';
+  return 'display';
+}
+
+async function main() {
+  const inputPath = INPUT || latestAuditFile();
+  console.log(`Reading mismatches from ${inputPath}`);
+  const audit = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const mismatches = audit.results.filter(r => r.status === 'mismatch');
+  console.log(`${mismatches.length} candidate mismatch(es) in audit report`);
+
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const books = db.collection('books');
+
+  const s3 = new S3Client({
+    region: 'auto',
+    endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    },
+  });
+
+  const manifest = { generated_at: new Date().toISOString(), apply: APPLY, input: inputPath, repaired: [], skipped: [] };
+  const purgeUrls = [];
+
+  let n = 0;
+  for (const m of mismatches) {
+    if (n >= LIMIT) break;
+    n++;
+    const doc = await books.findOne({ id: m.id }, { projection: {
+      _id: 1, id: 1, slug: 1, title: 1, resource_type: 1, source_url: 1, commons_url: 1,
+      commons_title: 1, source_ids: 1, dedup_date: 1, visible: 1, hidden: 1,
+      image_width: 1, image_height: 1, full_width: 1, full_height: 1,
+      ...Object.fromEntries(IMAGE_FIELDS.map(f => [f, 1])),
+    } });
+    if (!doc) { manifest.skipped.push({ id: m.id, reason: 'doc no longer exists' }); continue; }
+    if (!doc.resource_type) { manifest.skipped.push({ id: m.id, reason: 'no longer resource_type (no longer an artwork)' }); continue; }
+
+    // Re-verify LIVE — the audit JSON may be stale.
+    const provider = detectProvider(doc);
+    if (!provider) { manifest.skipped.push({ id: m.id, slug: doc.slug, reason: 're-check: no provider detected now' }); continue; }
+    const src = await fetchSourceFor(provider, doc);
+    if (!src.ok) { manifest.skipped.push({ id: m.id, slug: doc.slug, reason: `re-check: source fetch failed: ${src.error}` }); continue; }
+    if (provider === 'cleveland' && !src.accessionMismatch) {
+      // Accession agrees now (either it always did — this doc was flagged via
+      // the dHash spot-check, not the accession bug — or a prior repair run
+      // already fixed source_url). Either way, don't skip blind: re-verify
+      // with the same dHash check the audit used before trusting "fixed".
+      const thumbUrl = r2ThumbUrl(doc);
+      const [srcBuf, r2Buf] = thumbUrl ? await Promise.all([fetchImageBuffer(src.imageUrl), fetchImageBuffer(thumbUrl)]) : [null, null];
+      if (srcBuf && r2Buf) {
+        const [srcHash, r2Hash] = await Promise.all([computeDHash(srcBuf), computeDHash(r2Buf)]);
+        const dist = hammingHex(srcHash, r2Hash);
+        if (dist <= HASH_MATCH) {
+          manifest.skipped.push({ id: m.id, slug: doc.slug, reason: `re-check: accession agrees AND dHash distance ${dist} (already correct)` });
+          continue;
+        }
+        console.log(`\n${doc.id} "${(doc.title || '').slice(0, 60)}" [${provider}] — accession agrees but dHash distance ${dist}, image itself still wrong`);
+      } else {
+        manifest.skipped.push({ id: m.id, slug: doc.slug, reason: 're-check: accession agrees but could not dHash-verify (fetch failed) — not auto-repairing without confirmation' });
+        continue;
+      }
+    }
+
+    const correctUrl = src.fullImageUrl || src.imageUrl;
+    console.log(`\n${doc.id} "${(doc.title || '').slice(0, 60)}" [${provider}]`);
+    console.log(`  correct source image: ${correctUrl}`);
+
+    // Which of the doc's own keys are ours to write?
+    const keysByTier = { display: new Set(), thumb: new Set(), grid: new Set(), full: new Set() };
+    for (const field of IMAGE_FIELDS) {
+      const key = ownKey(doc[field]);
+      if (key) keysByTier[tierOf(key)].add(key);
+    }
+    const totalKeys = Object.values(keysByTier).reduce((s, set) => s + set.size, 0);
+    if (totalKeys === 0) {
+      manifest.skipped.push({ id: m.id, slug: doc.slug, reason: 'no image field resolves to our own images.sourcelibrary.org/artwork/ key' });
+      continue;
+    }
+
+    if (!APPLY) {
+      console.log(`  [DRY-RUN] would overwrite: ${[...keysByTier.display, ...keysByTier.thumb, ...keysByTier.grid, ...keysByTier.full].join(', ')}`);
+      manifest.repaired.push({ id: doc.id, slug: doc.slug, title: doc.title, provider, correctUrl, keys: Object.fromEntries(Object.entries(keysByTier).map(([t, s]) => [t, [...s]])), applied: false });
+      continue;
+    }
+
+    const buf = await fetchImageBuffer(correctUrl, 60000);
+    if (!buf) { manifest.skipped.push({ id: m.id, slug: doc.slug, reason: `could not download correct image from ${correctUrl}` }); continue; }
+    let meta;
+    try { meta = await sharp(buf).metadata(); } catch (e) { manifest.skipped.push({ id: m.id, slug: doc.slug, reason: `sharp could not read downloaded image: ${e.message}` }); continue; }
+
+    const renders = {};
+    if (keysByTier.display.size) renders.display = await sharp(buf).resize({ width: 2000, withoutEnlargement: true }).jpeg({ quality: 85, mozjpeg: true }).toBuffer();
+    if (keysByTier.thumb.size) renders.thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+    if (keysByTier.full.size) renders.full = await sharp(buf).jpeg({ quality: 92, mozjpeg: true }).toBuffer();
+    if (keysByTier.grid.size) {
+      const side = Math.min(meta.width, meta.height);
+      const left = Math.round((meta.width - side) / 2);
+      const top = Math.round((meta.height - side) / 2);
+      renders.grid = await sharp(buf).extract({ left, top, width: side, height: side }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+    }
+
+    const written = [];
+    for (const [tier, keys] of Object.entries(keysByTier)) {
+      if (!keys.size) continue;
+      for (const key of keys) {
+        await s3.send(new PutObjectCommand({
+          Bucket: process.env.R2_BUCKET_NAME,
+          Key: key,
+          Body: renders[tier],
+          ContentType: 'image/jpeg',
+          CacheControl: 'public, max-age=31536000, immutable',
+        }));
+        written.push(key);
+        purgeUrls.push(`https://${R2_HOST}/${key}`);
+      }
+    }
+    console.log(`  wrote ${written.length} R2 object(s): ${written.join(', ')}`);
+
+    const setFields = {
+      image_width: meta.width, image_height: meta.height,
+      image_repaired_at: new Date(), image_repair_source: correctUrl, image_repair_issue: '#3815',
+      updated_at: new Date(),
+    };
+    if (doc.full_width !== undefined) setFields.full_width = meta.width;
+    if (doc.full_height !== undefined) setFields.full_height = meta.height;
+    // Cleveland's root cause is a wrong accession in source_url itself (see
+    // file header) — fix the field that caused the bug, not just its output,
+    // so a future re-run of this same detector doesn't flag it again.
+    if (provider === 'cleveland' && src.sourceAccession && src.accessionMismatch) {
+      setFields.source_url = `https://www.clevelandart.org/art/${src.sourceAccession}`;
+    }
+    await books.updateOne({ _id: doc._id }, { $set: setFields });
+    console.log(`  updated doc: image_width=${meta.width} image_height=${meta.height}${setFields.source_url ? `, source_url -> ${setFields.source_url}` : ''}`);
+
+    manifest.repaired.push({ id: doc.id, slug: doc.slug, title: doc.title, provider, correctUrl, keysWritten: written, applied: true });
+  }
+
+  const manifestPath = `scripts/output/artwork-image-repair-manifest-${new Date().toISOString().slice(0, 10)}.json`;
+  fs.mkdirSync('scripts/output', { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  console.log('\n━━━ SUMMARY ━━━');
+  console.log(`${APPLY ? 'Repaired' : 'Would repair'}: ${manifest.repaired.length}`);
+  console.log(`Skipped: ${manifest.skipped.length}`);
+  if (manifest.skipped.length) {
+    for (const s of manifest.skipped) console.log(`  SKIP ${s.id} ${s.slug || ''}: ${s.reason}`);
+  }
+  console.log(`Manifest → ${manifestPath}`);
+  if (APPLY && purgeUrls.length) {
+    console.log(`\n${purgeUrls.length} URL(s) need a Cloudflare purge (batches of <=30):`);
+    for (const u of purgeUrls) console.log(`  ${u}`);
+  }
+
+  await mc.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What

The three scripts from the #3815 investigation, committed as standing tooling:

- **`scripts/lib/artwork-sources.mjs`** — authoritative by-id source lookups for artwork docs (Cleveland / Met / AIC / Commons). Rijksmuseum (dead API) and NGA (CSV-only) are reported `unverifiable`, never guessed.
- **`scripts/audit/artwork-image-integrity.mjs`** — read-only standing detector: does the R2 image match what the source reports for this record's own id? Cleveland is checked by a cheap accession cross-check (`source_url` accession vs what CMA reports for `source_ids.cleveland` — the exact #3815 mechanism); Met/AIC/Commons by dHash (thresholds from `scripts/lib/page-alignment.mjs`). Exits 1 on any confirmed mismatch.
- **`scripts/maintenance/repair-artwork-images.mjs`** — repair tool. Dry-run by default; re-verifies each candidate live before writing; every R2 key is read from the doc's own URL fields and must resolve to `images.sourcelibrary.org/artwork/…` (never slug-derived — the #3362 lesson); writes a manifest; fixes the causal `source_url` accession on Cleveland docs so the detector doesn't re-flag repaired docs.

## Context

These already ran in production on 2026-08-09: 39 confirmed mismatches (35 Cleveland = 16.7% of that batch, 4 Commons), all repaired and CF-purged; details in #3815. Committing them makes the detector re-runnable (e.g. over the ~2K Commons docs that rate-limited out of the first sweep) and gives the artwork wing a permanent integrity check analogous to `scripts/audit/r2-key-book-scope.mjs`.

## Out of scope

- Rijksmuseum/NGA verification (needs an API key / bulk-CSV pipeline — noted in the lib header)
- Any importer changes; the faulty importer was a never-committed session script, and `normalize-artwork-images.mjs` is already deleted
- Wiring the audit into cron (worth discussing — it costs external API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)