### PR TITLE
fix(pipeline): spend controls that actually control spend (#3826)

### DIFF
--- a/scripts/lib/spend-guard.mjs
+++ b/scripts/lib/spend-guard.mjs
@@ -12,26 +12,46 @@
  *     `paused` flag off must not reopen unbounded spending by accident)
  *   - positive number   → dispatch until today's spend reaches it (UTC day)
  *
- * Spend is measured from `gemini_usage`. Two deliberate choices:
- *   - Rows are selected by **ObjectId time range**, not the `timestamp` field —
- *     old rows store timestamp as a string, and Date-range queries silently
- *     return nothing (known trap, pipeline-architecture "Known traps").
- *   - `cost_usd` is a computed estimate, not billed truth, and some writers
- *     omit it. Missing costs count as 0, so the guard can UNDERCOUNT — treat
- *     the ceiling as a strong brake, not an accounting system. The costless
- *     row count is returned so the log shows how blind the measurement is.
+ * Spend is measured from BOTH `gemini_usage` stores and SUMMED (#3826).
+ * `supabase-usage-logger.mjs` writes to Supabase first and falls back to
+ * Mongo only when the key is missing or the write errors — the two stores
+ * are mutually exclusive per row (infrastructure-costs doc). The original
+ * guard read Mongo alone and saw $9.00 on a day Supabase held ~$830: the
+ * dial never closed and the day billed ~$2.3K. Never measure one store.
+ *
+ * Deliberate choices:
+ *   - Mongo rows are selected by **ObjectId time range**, not the `timestamp`
+ *     field — old rows store timestamp as a string, and Date-range queries
+ *     silently return nothing (known trap, pipeline-architecture "Known traps").
+ *   - Supabase `timestamp` is ISO text (its writer always sets it), queried
+ *     via PostgREST with pagination — aggregates are disabled on this project
+ *     (PGRST123), so we sum client-side, cost_usd column only.
+ *   - FAIL CLOSED: if the Supabase read errors or overflows the pagination
+ *     cap, the guard reports the failure and budgetAllowsDispatch refuses.
+ *     An unreadable meter must stop the line, not green-light it — an
+ *     unreadable primary store is exactly how the incident began.
+ *   - `cost_usd` is a computed estimate, not billed truth (billed runs ~3×
+ *     computed on runaway-heavy days), and some writers omit it. Treat the
+ *     ceiling as a strong brake, not an accounting system. The costless row
+ *     count is returned so the log shows how blind the measurement is.
  */
 
 import { ObjectId } from 'mongodb';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// 40 pages × 1000 rows. A day with >40K usage rows is far past any sane dial —
+// treat overflow as over-budget rather than scanning forever.
+const SUPABASE_MAX_PAGES = 40;
 
 /** Start of the current UTC day. */
 export function utcDayStart(now = new Date()) {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
-/** Today's measured Gemini spend: { usd, rows, costlessRows }. */
-export async function getTodaySpendUsd(db, now = new Date()) {
-  const minId = ObjectId.createFromTime(Math.floor(utcDayStart(now).getTime() / 1000));
+/** Today's spend in the Mongo fallback store: { usd, rows, costlessRows }. */
+async function getMongoSpend(db, dayStart) {
+  const minId = ObjectId.createFromTime(Math.floor(dayStart.getTime() / 1000));
   const [agg] = await db.collection('gemini_usage').aggregate([
     { $match: { _id: { $gte: minId } } },
     {
@@ -44,6 +64,72 @@ export async function getTodaySpendUsd(db, now = new Date()) {
     },
   ]).toArray();
   return { usd: agg?.usd || 0, rows: agg?.rows || 0, costlessRows: agg?.costlessRows || 0 };
+}
+
+/**
+ * Today's spend in the Supabase primary store. Client-side paginated sum
+ * (PostgREST aggregates are disabled). Returns { usd, rows, costlessRows,
+ * error } — error non-null means the meter is UNREADABLE, not zero.
+ */
+async function getSupabaseSpend(dayStart) {
+  if (!SUPABASE_SERVICE_KEY) {
+    return { usd: 0, rows: 0, costlessRows: 0, error: 'SUPABASE_SERVICE_ROLE_KEY missing' };
+  }
+  let usd = 0, rows = 0, costlessRows = 0;
+  try {
+    for (let pageNo = 0; ; pageNo++) {
+      if (pageNo >= SUPABASE_MAX_PAGES) {
+        return { usd, rows, costlessRows, error: `>${SUPABASE_MAX_PAGES * 1000} rows today — sum truncated` };
+      }
+      const from = pageNo * 1000;
+      const resp = await fetch(
+        `${SUPABASE_URL}/rest/v1/gemini_usage?select=cost_usd&timestamp=gte.${dayStart.toISOString()}&order=id.asc`,
+        {
+          headers: {
+            apikey: SUPABASE_SERVICE_KEY,
+            Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+            Range: `${from}-${from + 999}`,
+          },
+        },
+      );
+      if (!resp.ok && resp.status !== 206) {
+        return { usd, rows, costlessRows, error: `Supabase read failed (${resp.status})` };
+      }
+      const batch = await resp.json();
+      for (const r of batch) {
+        rows++;
+        if (r.cost_usd == null) costlessRows++;
+        else usd += r.cost_usd;
+      }
+      if (batch.length < 1000) break;
+    }
+    return { usd, rows, costlessRows, error: null };
+  } catch (err) {
+    return { usd, rows, costlessRows, error: `Supabase read error: ${err.message}` };
+  }
+}
+
+// Test seam: unit tests replace the Supabase reader (no network in tests).
+let supabaseSpendReader = getSupabaseSpend;
+export function _setSupabaseSpendReaderForTests(fn) {
+  supabaseSpendReader = fn || getSupabaseSpend;
+}
+
+/**
+ * Today's measured Gemini spend across BOTH stores (they are mutually
+ * exclusive per row — sum, don't pick): { usd, rows, costlessRows,
+ * meterError }. meterError non-null means the primary store could not be
+ * fully read; callers must fail closed on it.
+ */
+export async function getTodaySpendUsd(db, now = new Date()) {
+  const dayStart = utcDayStart(now);
+  const [mongo, supa] = await Promise.all([getMongoSpend(db, dayStart), supabaseSpendReader(dayStart)]);
+  return {
+    usd: mongo.usd + supa.usd,
+    rows: mongo.rows + supa.rows,
+    costlessRows: mongo.costlessRows + supa.costlessRows,
+    meterError: supa.error,
+  };
 }
 
 /** The dial's current value, or null when unset/invalid. */
@@ -73,8 +159,12 @@ export async function budgetAllowsDispatch(db, label, { bypass = false, control:
     return false;
   }
   const spend = await getTodaySpendUsd(db);
+  if (spend.meterError) {
+    console.log(`  [spend-guard] ${label}: METER UNREADABLE (${spend.meterError}) — refusing dispatch. Partial sum was $${spend.usd.toFixed(2)}.`);
+    return false;
+  }
   const allowed = spend.usd < budget;
   const blind = spend.costlessRows > 0 ? ` (${spend.costlessRows} rows without cost_usd — spend is undercounted)` : '';
-  console.log(`  [spend-guard] ${label}: spend $${spend.usd.toFixed(2)} / $${budget.toFixed(2)} today (UTC), ${spend.rows} calls${blind} → ${allowed ? 'DISPATCH' : 'CEILING REACHED — no new dispatch'}`);
+  console.log(`  [spend-guard] ${label}: spend $${spend.usd.toFixed(2)} / $${budget.toFixed(2)} today (UTC, both stores), ${spend.rows} calls${blind} → ${allowed ? 'DISPATCH' : 'CEILING REACHED — no new dispatch'}`);
   return allowed;
 }

--- a/scripts/lib/translate-core.mjs
+++ b/scripts/lib/translate-core.mjs
@@ -20,7 +20,7 @@
  * routing here or in ai-models.ts, change both or the suite fails.
  */
 
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { buildVisiblePageCountPipeline } from './page-counts.mjs';
 import { saveRevisionBeforeOverwrite } from './page-revisions.mjs';
 
@@ -257,6 +257,45 @@ export function assessTranslationHealth(ocrText, translationText) {
   return { healthy: true, reason: null };
 }
 
+// Refused output is stored truncated — a 350K-char loop is evidence of a loop,
+// not 350K chars of evidence. Original length is recorded alongside.
+const REFUSED_TEXT_CAP = 50000;
+
+/**
+ * Persist health-gate-refused output to page_revisions as evidence (#3826).
+ *
+ * The 2026-08-08 incident refused 5,352 generations and kept none of them:
+ * each cost real money (runaways bill 10-40× a normal page) and was reduced
+ * to a boolean flag. Keeping the text costs ~nothing and buys loop-detector
+ * tuning data, salvageable prefixes, and honest accounting. The row carries
+ * `source: 'health-gate-refused'` — page_revisions is ALWAYS segmented by
+ * source before measurement (data-provenance doc), so these rows can never
+ * contaminate the OCR-agreement corpus.
+ *
+ * Never throws; evidence loss must not block the refusal itself.
+ */
+export async function persistRefusedTranslation(db, page, text, reason, { jobId, model } = {}) {
+  try {
+    const raw = text || '';
+    await db.collection('page_revisions').insertOne({
+      id: randomBytes(6).toString('hex'),
+      page_id: page.id,
+      book_id: page.book_id,
+      field: 'translation',
+      data: raw.slice(0, REFUSED_TEXT_CAP),
+      source: 'health-gate-refused',
+      reason,
+      original_length: raw.length,
+      truncated: raw.length > REFUSED_TEXT_CAP,
+      model,
+      job_id: jobId,
+      created_at: new Date(),
+    });
+  } catch (e) {
+    console.error(`[health-gate] Failed to persist refused output for ${page?.id}: ${e.message?.slice(0, 80)}`);
+  }
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Edge cases (issue #3734): one definition of "is this page translatable",
 // replacing ~10 forked skip-lists across writers, and the blank-from-OCR
@@ -349,11 +388,13 @@ export async function writePageTranslation(db, { page, book, text, promptRef, mo
   const clean = sanitizeTranslationTags(text);
 
   // Opt-in semantic health gate (#3756): never persist an obviously collapsed
-  // or runaway translation. Checked before any DB access — an unhealthy result
-  // must leave no trace (no revision snapshot, no write).
+  // or runaway translation to pages. The refused text IS kept as evidence in
+  // page_revisions (source: 'health-gate-refused', #3826) — it cost real money
+  // and tunes the detector; only the reader-facing write is refused.
   if (refuseUnhealthy) {
     const health = assessTranslationHealth(page?.ocr?.data, clean);
     if (!health.healthy) {
+      await persistRefusedTranslation(db, page, clean, health.reason, { jobId, model });
       return { written: false, protected: false, unhealthy: true, reason: health.reason, text: clean };
     }
   }

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -33,10 +33,12 @@ import {
   SKIP_TRANSLATION_PAGE_TYPES,
   isBlankFromOcr,
   assessTranslationHealth,
+  persistRefusedTranslation,
 } from '../lib/translate-core.mjs';
 import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-revisions.mjs';
 import { syncPageUpdate, syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
 
 // Selective-unpause scope confinement, set in main() after the pause check and
 // read by the candidate queries (incl. selfDispatch). In normal operation
@@ -237,6 +239,21 @@ async function buildPromptHeader(db, book) {
 }
 
 // ── Translate a single page ──
+// ── Output-token cap (#3826) ──
+// A runaway loop bills every token it generates: the incident's worst pages
+// produced 65K output tokens against ~300-token pages, at 10-40× normal cost,
+// and the health gate could only refuse AFTER the bill. Cap generation at the
+// source: an English translation of a page runs ~0.3 output tokens per OCR
+// char; grant ~3× that headroom plus a fixed allowance for the editorial
+// wrappers (<note>/<summary>/<keywords>). A legitimate translation never
+// approaches the cap; a loop hits it and stops billing 6-30× sooner. Truncated
+// loops still fail the health gate downstream (repetition, not length).
+function maxOutputTokensFor(pages) {
+  const ocrChars = pages.reduce((n, p) => n + (p.ocr?.data || '').length, 0);
+  const perPageOverhead = 1200 * pages.length;
+  return Math.min(32768, Math.max(4096, Math.ceil(ocrChars * 1.0) + perPageOverhead));
+}
+
 async function translatePage(db, page, book, prevTranslation) {
   const { prompt: headerPrompt, isEnglish, promptRef } = await buildPromptHeader(db, book);
   let prompt = headerPrompt;
@@ -253,7 +270,11 @@ async function translatePage(db, page, book, prevTranslation) {
 
   const ai = getClient();
   const selectedModel = getModelForBook(book);
-  const model = ai.getGenerativeModel({ model: selectedModel, safetySettings: SAFETY_SETTINGS });
+  const model = ai.getGenerativeModel({
+    model: selectedModel,
+    safetySettings: SAFETY_SETTINGS,
+    generationConfig: { maxOutputTokens: maxOutputTokensFor([page]) },
+  });
   const start = Date.now();
   const result = await model.generateContent(prompt);
   const durationMs = Date.now() - start;
@@ -325,7 +346,11 @@ async function translateBatch(db, pages, book, prevTranslation) {
 
   const ai = getClient();
   const selectedModel = getModelForBook(book);
-  const model = ai.getGenerativeModel({ model: selectedModel, safetySettings: SAFETY_SETTINGS });
+  const model = ai.getGenerativeModel({
+    model: selectedModel,
+    safetySettings: SAFETY_SETTINGS,
+    generationConfig: { maxOutputTokens: maxOutputTokensFor(pages) },
+  });
   const start = Date.now();
   const result = await model.generateContent(prompt);
   const durationMs = Date.now() - start;
@@ -423,7 +448,9 @@ async function writePageTranslation(db, page, text, book, promptRef) {
       { id: page.id },
       { $set: { 'translation.health_blocked': health.reason, 'translation.health_blocked_at': new Date(), updated_at: new Date() } }
     );
-    console.log(`  [health-gate] ${page.id} p${page.page_number}: ${health.reason} (${(text || '').length} chars) — write refused`);
+    // Keep the refused text as evidence (#3826) — it was billed in full.
+    await persistRefusedTranslation(db, page, text, health.reason, { jobId: book?.job?.job_id, model: getModelForBook(book) });
+    console.log(`  [health-gate] ${page.id} p${page.page_number}: ${health.reason} (${(text || '').length} chars) — write refused, evidence kept`);
     return { written: false, reason: health.reason };
   }
   await saveRevisionBeforeOverwrite(db, page.id, 'translation', book?.job?.job_id);
@@ -454,14 +481,18 @@ async function bulkWritePageTranslations(db, entries, book, promptRef) {
   const unhealthy = [];
   entries = entries.filter(({ page, text }) => {
     const h = assessTranslationHealth(page.ocr?.data, text);
-    if (!h.healthy) { unhealthy.push({ page, reason: h.reason, len: (text || '').length }); return false; }
+    if (!h.healthy) { unhealthy.push({ page, text, reason: h.reason, len: (text || '').length }); return false; }
     return true;
   });
   if (unhealthy.length > 0) {
     await db.collection('pages').bulkWrite(unhealthy.map(({ page, reason }) => ({
       updateOne: { filter: { id: page.id }, update: { $set: { 'translation.health_blocked': reason, 'translation.health_blocked_at': new Date(), updated_at: new Date() } } },
     })), { ordered: false }).catch(() => {});
-    for (const u of unhealthy) console.log(`  [health-gate] ${u.page.id} p${u.page.page_number}: ${u.reason} (${u.len} chars) — write refused`);
+    // Keep each refusal as evidence (#3826) — the tokens were billed in full.
+    for (const u of unhealthy) {
+      await persistRefusedTranslation(db, u.page, u.text, u.reason, { jobId: book?.job?.job_id, model: getModelForBook(book) });
+      console.log(`  [health-gate] ${u.page.id} p${u.page.page_number}: ${u.reason} (${u.len} chars) — write refused, evidence kept`);
+    }
   }
   if (entries.length === 0) return;
   if (entries.length === 1) {
@@ -721,12 +752,17 @@ async function processBook(db, book, job, globalCounter, deadline) {
             }
             consecutiveErrors = Math.max(0, consecutiveErrors - 1); // don't count toward circuit breaker
           }
+          // Gemini bills the prompt even when the response is blocked or errors
+          // (#3826: 630 failed rows logged $0 during the incident). Estimate
+          // input from the OCR we sent (~4 chars/token + prompt header) so the
+          // spend-guard's sum isn't blind to failure-heavy runs.
+          const estInputTokens = Math.ceil(((page.ocr?.data || '').length / 4) + 1000);
           await logUsage({
             type: 'translation', mode: 'realtime', model: getModelForBook(book),
             book_id: book.id, page_ids: [page.id],
-            input_tokens: 0, output_tokens: 0, status: 'failed',
+            input_tokens: estInputTokens, output_tokens: 0, status: 'failed',
             error_message: msg.substring(0, 500), endpoint: 'worker/hetzner-translate',
-            batch_size: 1,
+            batch_size: 1, error_category: 'tokens_estimated',
           }, db);
         }
       }
@@ -1036,6 +1072,12 @@ function langSpeedTier(lang) {
 // ── Self-dispatch: create jobs for books that need translation ──
 // Eliminates the gap between translate-worker finishing and Phase 4 dispatching new books.
 async function selfDispatch(db, limit) {
+  // The dial gates SELF-dispatch too (#3826). This function creates new paid
+  // work exactly like orchestrator Phase 4 does, and during the 2026-08-08
+  // incident it was the only dispatcher actually running — ungated. Every
+  // path that turns a book into Gemini calls must ask the budget first.
+  if (!await budgetAllowsDispatch(db, 'translate-self-dispatch')) return [];
+
   // Find fresh books (ocr_complete) — sorted by language speed tier
   // so each batch is homogeneous (all fast or all slow books together).
   const fresh = await db.collection('books').aggregate([
@@ -1124,6 +1166,28 @@ async function selfDispatch(db, limit) {
     const label = (book.title || '').substring(0, 50);
     const pageIds = pages.map(p => p.id);
 
+    // Atomic claim (#3826): concurrent selfDispatch calls (each finishing book
+    // triggers a backfill) all read the same candidates before any of them
+    // flipped a status, so one book got 3-4 jobs within seconds — quadruple
+    // paid translation of the same pages. Claim the book by compare-and-swap
+    // on its status FIRST; only the winner creates a job. A claim that dies
+    // before the job insert self-heals: processWithJob rolls a book with a
+    // missing job back to ocr_complete.
+    const claim = await db.collection('books').updateOne(
+      { id: book.id, 'pipeline_auto.status': { $in: ['ocr_complete', 'translate_partial'] } },
+      { $set: {
+        'pipeline_auto.status': 'translate_submitted',
+        'pipeline_auto.last_updated': new Date(),
+        'pipeline_auto.translate_job_id': jobId,
+        job: { type: 'hetzner-inline', job_id: jobId },
+        updated_at: new Date(),
+      }},
+    );
+    if (claim.modifiedCount === 0) {
+      console.log(`[TRANSLATE] Skipped duplicate dispatch: ${label} (claimed by a concurrent dispatcher)`);
+      continue;
+    }
+
     await db.collection('jobs').insertOne({
       id: jobId,
       type: 'translation',
@@ -1140,17 +1204,6 @@ async function selfDispatch(db, limit) {
       created_at: new Date(),
       updated_at: new Date(),
     });
-
-    await db.collection('books').updateOne(
-      { id: book.id },
-      { $set: {
-        'pipeline_auto.status': 'translate_submitted',
-        'pipeline_auto.last_updated': new Date(),
-        'pipeline_auto.translate_job_id': jobId,
-        job: { type: 'hetzner-inline', job_id: jobId },
-        updated_at: new Date(),
-      }},
-    );
 
     dispatched.push({ ...book, job: { job_id: jobId } });
     console.log(`[TRANSLATE] Self-dispatched: ${label} — ${pageIds.length} pages (job ${jobId})`);

--- a/tests/unit/spend-guard.test.ts
+++ b/tests/unit/spend-guard.test.ts
@@ -2,17 +2,30 @@
  * The budget dial (issue #3737): default-closed, UTC-day windowed, and
  * measured via ObjectId time range (the `timestamp` field is a string on old
  * rows — Date-range matching silently returns nothing).
+ *
+ * Since #3826 the guard sums BOTH gemini_usage stores (Supabase primary +
+ * Mongo fallback) and FAILS CLOSED when the Supabase read errors — reading
+ * one store is how a $15 dial billed $2.3K. Tests inject the Supabase half
+ * via _setSupabaseSpendReaderForTests.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectId } from 'mongodb';
 import {
   utcDayStart,
   getTodaySpendUsd,
   readDailyBudgetUsd,
   budgetAllowsDispatch,
+  _setSupabaseSpendReaderForTests,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore — plain-JS module, no declarations
 } from '../../scripts/lib/spend-guard.mjs';
+
+// Default: Supabase store empty and readable. Individual tests override.
+beforeEach(() => {
+  _setSupabaseSpendReaderForTests(async () => ({ usd: 0, rows: 0, costlessRows: 0, error: null }));
+});
+const supaStub = (usd: number, rows = 0, error: string | null = null) =>
+  _setSupabaseSpendReaderForTests(async () => ({ usd, rows, costlessRows: 0, error }));
 
 function makeDbStub({ spendUsd = 0, rows = 0, costlessRows = 0, budget }: {
   spendUsd?: number; rows?: number; costlessRows?: number; budget?: unknown;
@@ -65,7 +78,20 @@ describe('getTodaySpendUsd', () => {
   });
   it('empty day → zeros', async () => {
     const { db } = makeDbStub({});
-    expect(await getTodaySpendUsd(db)).toEqual({ usd: 0, rows: 0, costlessRows: 0 });
+    expect(await getTodaySpendUsd(db)).toEqual({ usd: 0, rows: 0, costlessRows: 0, meterError: null });
+  });
+  it('SUMS both stores — the stores are mutually exclusive per row (#3826)', async () => {
+    const { db } = makeDbStub({ spendUsd: 9, rows: 10 });
+    supaStub(830, 6000);
+    const spend = await getTodaySpendUsd(db);
+    expect(spend.usd).toBe(839);
+    expect(spend.rows).toBe(6010);
+  });
+  it('surfaces a Supabase read failure as meterError, never as zero', async () => {
+    const { db } = makeDbStub({ spendUsd: 9, rows: 10 });
+    supaStub(0, 0, 'Supabase read failed (500)');
+    const spend = await getTodaySpendUsd(db);
+    expect(spend.meterError).toBe('Supabase read failed (500)');
   });
 });
 
@@ -85,6 +111,18 @@ describe('budgetAllowsDispatch', () => {
   });
   it('refuses above the ceiling', async () => {
     const { db } = makeDbStub({ spendUsd: 9.99, rows: 200, budget: 5 });
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
+  });
+  it('spend in the PRIMARY store alone closes the dial (the #3826 blindness)', async () => {
+    // Mongo (fallback) shows $9 — exactly what the incident-day guard saw —
+    // while Supabase holds the real spend. The summed guard must refuse.
+    const { db } = makeDbStub({ spendUsd: 9, rows: 10, budget: 15 });
+    supaStub(830, 6000);
+    expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
+  });
+  it('FAILS CLOSED when the primary store is unreadable', async () => {
+    const { db } = makeDbStub({ spendUsd: 0, rows: 0, budget: 15 });
+    supaStub(0, 0, 'Supabase read error: fetch failed');
     expect(await budgetAllowsDispatch(db, 'test')).toBe(false);
   });
   it('bypass (explicit --book operator run) skips both reads', async () => {


### PR DESCRIPTION
## Why

The 2026-08-08 relight billed ~**$2.3K against a $15/day dial** (incident #3826, GCP anomaly on `booksplit`). Every safety layer failed silently and simultaneously. This PR fixes the four code defects at their roots. The line stays **paused** until this lands and is verified on Hetzner.

## In scope

**1. The blind meter** (`scripts/lib/spend-guard.mjs`)
`getTodaySpendUsd` read only Mongo `gemini_usage`; the logger writes Supabase first and falls back to Mongo only on error — the two stores are mutually exclusive per row (infrastructure-costs doc). The guard saw $9.00 on a ~$830 day. Now: sums **both** stores (Supabase via paginated PostgREST — aggregates are disabled on this project), and **fails closed** — a Supabase read error or >40K-row overflow refuses dispatch instead of green-lighting it. An unreadable meter must stop the line.

**2. The ungated dispatcher** (`scripts/workers/translate-worker.mjs`)
`selfDispatch` — the only dispatcher actually running during the incident — never called `budgetAllowsDispatch`. Now it does, before touching any candidates, covering both the slot-fill and mid-run backfill paths.

**3. The duplicate dispatch** (same file)
Each finishing book triggers a backfill; concurrent `selfDispatch` calls all read the same `ocr_complete` candidates before any status flipped, so one book got 3–4 jobs in seconds (Krestos Gospels ×4). Now: compare-and-swap claim on `pipeline_auto.status` before job creation; a lost claim skips. A claim that dies pre-insert self-heals via the existing missing-job rollback in `processWithJob`.

**4. The money furnace** (both files)
Runaways billed up to 65K output tokens for ~300-token pages; the health gate refused only *after* generation. Now `generateContent` carries `maxOutputTokens` sized to the batch's OCR (~3× headroom + wrapper allowance, clamp 4096–32768) — legitimate pages never approach it (p90 saved length ≈ 1.5K tokens); loops stop billing 6–30× sooner and still fail the gate on repetition. Plus: refused text is **kept** in `page_revisions` (`source: 'health-gate-refused'`, 50K-char cap, original_length recorded) instead of discarded — segmented by source per the data-provenance doctrine so it can't contaminate agreement metrics. Thrown-error usage rows estimate billed prompt tokens instead of logging $0.

## Tests
`spend-guard.test.ts` now injects the Supabase reader (new `_setSupabaseSpendReaderForTests` seam). New cases pin: summed arithmetic, the exact incident scenario (Mongo $9 + Supabase $830 vs $15 → refuse), fail-closed on meter error. 182/182 green across spend-guard, translate-core-parity, translate-edge-cases, translate-write-guard.

## Out of scope (deliberate)
- **Other paid workers** (enrich, image-extract, archive-ocr, embed-gemini) are pause-gated but not dial-gated; embed-gemini's cron is disabled with a `#PAUSED-3826#` marker until it gets a pause check. Follow-up in #3826.
- **Phase-scoped processing_priority** (the May archive bump steering the August translation queue) — a design decision, tracked in #3826.
- **Quality sweep of the ~22K saved Aug 8–9 translations** — separate maintenance run.
- **Relight** — only after this deploys to Hetzner and the $5 bounded metering test (Derek-authorized) passes.

Closes nothing; #3826 stays open until the metering test and quality sweep are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)