### PR TITLE
feat(dedup): apply tooling for the triage approval lanes (#3730 §3)

### DIFF
--- a/scripts/lib/triage-apply.mjs
+++ b/scripts/lib/triage-apply.mjs
@@ -1,0 +1,118 @@
+/**
+ * triage-apply — shared plumbing for the two triage apply-scripts (#3730 §3):
+ *   scripts/maintenance/apply-dark-cluster-triage.mjs
+ *   scripts/maintenance/apply-keeper-choice-triage.mjs
+ *
+ * The triage scripts (scripts/audit/dark-cluster-triage.mjs,
+ * scripts/audit/keeper-choice-triage.mjs) are READ-ONLY classifiers; these
+ * helpers exist so that, once Derek approves a lane, executing it is one
+ * command with the safety shape every approved-write here shares:
+ *   - dry-run by default, writes only under --apply
+ *   - every guard re-verified against LIVE data at apply time (a report is a
+ *     snapshot; state drifts between triage and approval)
+ *   - backup of every touched doc's prior fields in scripts/output/
+ *   - a provenance row in `dedup_apply_runs`
+ *   - visibility flips bump updated_at (synced-column lesson) and are followed
+ *     by catalog sync + ISR revalidate (+ CF purge, done by the revalidate
+ *     endpoint itself)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Kloss lesson: bulk visibility flips must respect deliberate holds. Mirrors
+// TAKEDOWN_RX in scripts/audit/dark-cluster-triage.mjs — change both together.
+export const TAKEDOWN_RX = /takedown|copyright|dmca|rights\s*holder|cease/i;
+// A hidden_reason that merely records the duplicate mark itself (safe to clear
+// when the mark is proven false), as opposed to an independent curatorial hold.
+export const DUP_REASON_RX = /duplicate/i;
+
+export const STAMP = new Date().toISOString().slice(0, 10);
+
+export function flagValue(name) {
+  const i = process.argv.indexOf(name);
+  return i > -1 ? process.argv[i + 1] : undefined;
+}
+
+/** --only a,b,c or --only @file (one id per line, # comments ok). Null = no filter. */
+export function idFilter(name = '--only') {
+  const raw = flagValue(name);
+  if (!raw) return null;
+  const items = raw.startsWith('@')
+    ? fs.readFileSync(raw.slice(1), 'utf8').split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'))
+    : raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return new Set(items);
+}
+
+/** Resolve the report path: --report <path>, else newest scripts/output/<prefix>-*.json */
+export function resolveReport(prefix) {
+  const explicit = flagValue('--report');
+  if (explicit) return explicit;
+  const dir = path.join(process.cwd(), 'scripts', 'output');
+  const candidates = fs.existsSync(dir)
+    ? fs.readdirSync(dir).filter((f) => f.startsWith(`${prefix}-`) && f.endsWith('.json')).sort()
+    : [];
+  if (!candidates.length) {
+    console.error(`No ${prefix}-*.json in scripts/output/ — run the triage script first, or pass --report <path>.`);
+    process.exit(1);
+  }
+  return path.join(dir, candidates[candidates.length - 1]);
+}
+
+export function writeBackup(name, payload) {
+  const dir = path.join(process.cwd(), 'scripts', 'output');
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, `${name}-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+  fs.writeFileSync(p, JSON.stringify(payload, null, 1));
+  return p;
+}
+
+/** Provenance row so `dedup_apply_runs` answers "who flipped this and from which report". */
+export async function recordRun(db, doc) {
+  await db.collection('dedup_apply_runs').insertOne({ ...doc, at: new Date() });
+}
+
+/** /artwork/:id vs /book/:id — ANY resource_type value routes to /artwork. */
+export function pagePath(doc) {
+  return `${doc.resource_type ? '/artwork' : '/book'}/${doc.id}`;
+}
+
+/**
+ * The post-write steps of the 3-step unhide (Mongo flip is the caller's):
+ *   2. Supabase catalog sync (incremental picks up the updated_at bumps;
+ *      hides propagate as visible:false rows, restores as new/updated rows)
+ *   3. ISR revalidate — the endpoint purges Cloudflare for the same paths.
+ * With execute=false, prints the exact commands instead (golive pattern).
+ */
+export async function finalizeCaches({ paths, execute }) {
+  const uniq = [...new Set(paths)];
+  const body = JSON.stringify({ paths: uniq });
+  if (!execute) {
+    console.log('\nNOW RUN (finalize was not requested):');
+    console.log('  node scripts/workers/sync-books-catalog.mjs');
+    console.log(`  curl -s -X POST https://sourcelibrary.org/api/admin/revalidate -H "x-revalidate-secret: $REVALIDATE_SECRET" -H "Content-Type: application/json" --data '${body}'`);
+    return;
+  }
+  console.log('\nfinalize: syncing Supabase catalog…');
+  const sync = spawnSync('node', ['scripts/workers/sync-books-catalog.mjs'], { stdio: 'inherit' });
+  if (sync.status !== 0) {
+    console.error('catalog sync FAILED — run it by hand before trusting public listings.');
+  }
+  console.log(`finalize: revalidating ${uniq.length} paths (endpoint also purges Cloudflare)…`);
+  const res = await fetch('https://sourcelibrary.org/api/admin/revalidate', {
+    method: 'POST',
+    headers: {
+      'x-revalidate-secret': process.env.REVALIDATE_SECRET || '',
+      'Content-Type': 'application/json',
+      'User-Agent': 'Mozilla/5.0 (sourcelibrary maintenance; triage-apply)',
+    },
+    body,
+  });
+  const j = await res.json().catch(() => ({}));
+  console.log(`revalidate: HTTP ${res.status} — revalidated ${j.revalidated ?? '?'} paths`);
+  if (!res.ok) console.error('revalidate FAILED — run the printed curl by hand.');
+}
+
+export function skipLine(id, why) {
+  console.log(`  skip ${id}: ${why}`);
+}

--- a/scripts/maintenance/apply-dark-cluster-triage.mjs
+++ b/scripts/maintenance/apply-dark-cluster-triage.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * apply-dark-cluster-triage — execute Derek-approved rows from the read-only
+ * dark-cluster triage report (#3814, scripts/audit/dark-cluster-triage.mjs).
+ *
+ * The report pre-classified 1,993 dark duplicate pointers by hidden keeper.
+ * Three of its buckets have a mechanical action once a human approves them;
+ * this script owns those actions and nothing else:
+ *
+ *   --lane restore   (bucket RESTORE_CANDIDATE) flip the keeper visible —
+ *                    one visibility flip un-darkens the whole cluster.
+ *   --lane repoint   (bucket REPOINT) aim each pointer's duplicate_of at the
+ *                    VISIBLE artwork carrying the same commons_sha1.
+ *   --lane unmark    (bucket SUSPECT_NOT_DUP) remove the false duplicate_of
+ *                    mark (sha1 proves not-a-copy) and restore visibility
+ *                    when the only reason the doc was hidden was the mark.
+ *
+ * Every guard is re-verified against LIVE data at apply time — the report is
+ * a snapshot, and a keeper acquired hidden_reason / a pointer re-resolved
+ * since triage must not be touched on stale evidence. Kloss rule throughout:
+ * any takedown-shaped hidden_reason anywhere in a cluster excludes it.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/apply-dark-cluster-triage.mjs --lane restore                  # dry-run, newest report
+ *   node scripts/maintenance/apply-dark-cluster-triage.mjs --lane restore --apply          # write
+ *   node scripts/maintenance/apply-dark-cluster-triage.mjs --lane repoint --only id1,id2 --apply
+ *   node scripts/maintenance/apply-dark-cluster-triage.mjs --lane unmark --only @approved.txt --apply --finalize
+ *
+ *   --report <path>   use a specific triage JSON (default: newest in scripts/output/)
+ *   --only a,b | @f   subset by keeper id (restore) / pointer id (repoint, unmark)
+ *   --apply           write (default is dry-run)
+ *   --finalize        after writing: catalog sync + ISR revalidate + CF purge
+ *
+ * Writes it makes: books.visible/hidden/duplicate_of/hidden_reason/updated_at,
+ * a backup in scripts/output/, one provenance row in dedup_apply_runs.
+ * Downstream automated readers (say so, don't discover it): the Hetzner
+ * sync-worker refreshes collection counts on its next cycle; sync-books-catalog
+ * propagates visibility to Supabase (run here by --finalize, otherwise by the
+ * Hetzner supabase-sync cron). Nothing else consumes duplicate_of unattended —
+ * dedup reads it at import time only.
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import {
+  TAKEDOWN_RX, DUP_REASON_RX, flagValue, idFilter, resolveReport,
+  writeBackup, recordRun, pagePath, finalizeCaches, skipLine,
+} from '../lib/triage-apply.mjs';
+
+const LANE = flagValue('--lane');
+const APPLY = process.argv.includes('--apply');
+const FINALIZE = process.argv.includes('--finalize');
+const only = idFilter('--only');
+const LANE_BUCKET = { restore: 'RESTORE_CANDIDATE', repoint: 'REPOINT', unmark: 'SUSPECT_NOT_DUP' };
+if (!LANE_BUCKET[LANE]) {
+  console.error('--lane restore | repoint | unmark is required (one lane per run — approvals are per lane).');
+  process.exit(1);
+}
+
+const reportPath = resolveReport('dark-cluster-triage');
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+const clusters = report.clusters.filter((c) => c.bucket === LANE_BUCKET[LANE]);
+console.log(`${reportPath}\nlane ${LANE}: ${clusters.length} clusters in report${only ? `, filtered by --only (${only.size})` : ''}${APPLY ? '' : '  [DRY-RUN]'}`);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+const PROJ = { _id: 0, id: 1, title: 1, slug: 1, visible: 1, hidden: 1, hidden_reason: 1, duplicate_of: 1, commons_sha1: 1, resource_type: 1 };
+
+const now = new Date();
+const backupDocs = [];   // prior state of every doc we will touch
+const ops = [];          // bulkWrite ops
+const touchedPaths = []; // ISR paths to revalidate after apply
+const applied = [];      // ids actually written, for the provenance row
+let skipped = 0;
+
+/** Shared exclusion: live takedown-shaped reason anywhere near the write. */
+const takedownHold = (...docs) => docs.some((d) => d?.hidden_reason && TAKEDOWN_RX.test(d.hidden_reason));
+
+// ── batch prefetch (one $in query per shape, not one query per cluster) ──
+// Everything below reads from these maps; the per-row guards stay identical.
+const allIds = new Set();
+for (const c of clusters) {
+  if (c.keeper_id) allIds.add(c.keeper_id);
+  for (const pid of c.pointer_ids || []) allIds.add(pid);
+  for (const t of c.repoint_targets || []) { allIds.add(t.pointer); allIds.add(t.visible_copy); }
+}
+const byId = new Map();
+const idList = [...allIds];
+for (let i = 0; i < idList.length; i += 500) {
+  for (const d of await books.find({ id: { $in: idList.slice(i, i + 500) } }, { projection: PROJ }).toArray()) byId.set(d.id, d);
+}
+// restore lane needs each keeper's LIVE pointer set (report lists a snapshot)
+const pointersByKeeper = new Map();
+if (LANE === 'restore') {
+  const keeperIds = clusters.map((c) => c.keeper_id).filter(Boolean);
+  for (let i = 0; i < keeperIds.length; i += 500) {
+    for (const d of await books.find({ duplicate_of: { $in: keeperIds.slice(i, i + 500) } }, { projection: { ...PROJ, duplicate_of: 1 } }).toArray()) {
+      if (!pointersByKeeper.has(d.duplicate_of)) pointersByKeeper.set(d.duplicate_of, []);
+      pointersByKeeper.get(d.duplicate_of).push(d);
+    }
+  }
+}
+
+for (const c of clusters) {
+  if (LANE === 'restore') {
+    if (only && !only.has(c.keeper_id)) continue;
+    const keeper = byId.get(c.keeper_id);
+    if (!keeper) { skipLine(c.keeper_id, 'keeper no longer exists'); skipped++; continue; }
+    if (keeper.visible === true) { skipLine(c.keeper_id, 'already visible'); skipped++; continue; }
+    // Kloss guard, live: a reason written since triage is a deliberate hold.
+    if (keeper.hidden_reason) { skipLine(c.keeper_id, `HOLD hidden_reason="${keeper.hidden_reason}"`); skipped++; continue; }
+    const pointers = pointersByKeeper.get(c.keeper_id) || [];
+    if (takedownHold(...pointers)) { skipLine(c.keeper_id, 'takedown-shaped reason on a pointer'); skipped++; continue; }
+    backupDocs.push(keeper);
+    ops.push({ updateOne: { filter: { id: keeper.id, visible: { $ne: true }, hidden_reason: keeper.hidden_reason ?? null }, update: { $set: { visible: true, hidden: false, updated_at: now } } } });
+    applied.push(keeper.id);
+    touchedPaths.push(pagePath(keeper));
+    console.log(`  restore ${keeper.id} "${(keeper.title || '').slice(0, 60)}" (un-darkens ${pointers.length} pointer(s))`);
+  }
+
+  if (LANE === 'repoint') {
+    for (const t of c.repoint_targets || []) {
+      if (only && !only.has(t.pointer)) continue;
+      const ptr = byId.get(t.pointer);
+      const copy = byId.get(t.visible_copy);
+      if (!ptr || !copy) { skipLine(t.pointer, 'pointer or target gone'); skipped++; continue; }
+      if (ptr.duplicate_of !== c.keeper_id) { skipLine(t.pointer, `duplicate_of changed to ${ptr.duplicate_of} since triage`); skipped++; continue; }
+      // The whole basis of REPOINT is the sha1 identity — require it live.
+      if (!ptr.commons_sha1 || ptr.commons_sha1 !== copy.commons_sha1) { skipLine(t.pointer, 'sha1 evidence no longer holds'); skipped++; continue; }
+      if (copy.visible !== true) { skipLine(t.pointer, `target ${copy.id} no longer visible`); skipped++; continue; }
+      if (takedownHold(ptr, copy)) { skipLine(t.pointer, 'takedown-shaped reason'); skipped++; continue; }
+      backupDocs.push(ptr);
+      ops.push({ updateOne: { filter: { id: ptr.id, duplicate_of: c.keeper_id }, update: { $set: { duplicate_of: copy.id, updated_at: now } } } });
+      applied.push(ptr.id);
+      console.log(`  repoint ${ptr.id} -> ${copy.id} (was dark keeper ${c.keeper_id})`);
+    }
+  }
+
+  if (LANE === 'unmark') {
+    const keeper = c.keeper_id ? byId.get(c.keeper_id) : null;
+    for (const pid of c.pointer_ids || []) {
+      if (only && !only.has(pid)) continue;
+      const ptr = byId.get(pid);
+      if (!ptr) { skipLine(pid, 'pointer gone'); skipped++; continue; }
+      if (ptr.duplicate_of !== c.keeper_id) { skipLine(pid, 'duplicate_of changed since triage'); skipped++; continue; }
+      // Live re-check of the bucket's evidence: a file hash that differs from
+      // the keeper's proves this is not a copy of it (artwork identity is
+      // sha1-exact). No hash → no proof → no write.
+      if (!ptr.commons_sha1 || (keeper?.commons_sha1 && ptr.commons_sha1 === keeper.commons_sha1)) {
+        skipLine(pid, 'sha1 no longer proves not-a-copy'); skipped++; continue;
+      }
+      if (takedownHold(ptr, keeper)) { skipLine(pid, 'takedown-shaped reason'); skipped++; continue; }
+      const reasonIsJustTheMark = !ptr.hidden_reason || DUP_REASON_RX.test(ptr.hidden_reason);
+      backupDocs.push(ptr);
+      const set = { updated_at: now };
+      const unset = { duplicate_of: '' };
+      if (reasonIsJustTheMark) {
+        // Hidden only because it was marked a duplicate — the mark was false,
+        // so the doc returns to the public pool.
+        set.visible = true; set.hidden = false;
+        if (ptr.hidden_reason) unset.hidden_reason = '';
+        touchedPaths.push(pagePath(ptr));
+      } // else: an independent curatorial reason — clear the false mark, keep the hold.
+      ops.push({ updateOne: { filter: { id: ptr.id, duplicate_of: c.keeper_id }, update: { $set: set, $unset: unset } } });
+      applied.push(ptr.id);
+      console.log(`  unmark ${ptr.id}${reasonIsJustTheMark ? ' + restore visibility' : ` (keep HOLD "${ptr.hidden_reason}")`}`);
+    }
+  }
+}
+
+console.log(`\n${LANE}: ${ops.length} write(s) planned, ${skipped} skipped by live guards`);
+
+if (APPLY && ops.length) {
+  const backupPath = writeBackup(`apply-dark-cluster-${LANE}`, { report: reportPath, lane: LANE, docs: backupDocs });
+  const r = await books.bulkWrite(ops, { ordered: false });
+  console.log(`modified: ${r.modifiedCount} (backup: ${backupPath})`);
+  await recordRun(db, {
+    script: 'apply-dark-cluster-triage', lane: LANE, report: reportPath,
+    planned: ops.length, modified: r.modifiedCount, skipped, ids: applied, backup: backupPath,
+  });
+  await finalizeCaches({
+    paths: [...touchedPaths, '/collections', '/gallery', '/browse'],
+    execute: FINALIZE,
+  });
+} else if (APPLY) {
+  console.log('nothing to write.');
+} else {
+  console.log('dry-run only — add --apply to write.');
+}
+await client.close();

--- a/scripts/maintenance/apply-keeper-choice-triage.mjs
+++ b/scripts/maintenance/apply-keeper-choice-triage.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * apply-keeper-choice-triage — execute Derek-approved keeper choices from the
+ * read-only keeper-choice triage report (#3816,
+ * scripts/audit/keeper-choice-triage.mjs).
+ *
+ * The report pre-classified the both-visible same-edition clusters (2+ visible
+ * books sharing one FULL-quality edition_key). Resolving one hides the
+ * loser(s) behind a duplicate_of pointer to the keeper — a VISIBILITY change,
+ * so it runs only on approved rows, and every signal is re-verified against
+ * LIVE data first: translation/OCR progress since triage can flip which copy
+ * dominates, and a cluster whose signals drifted is skipped, not guessed.
+ *
+ *   --lane mechanical  (bucket MECHANICAL_KEEP) keeper must still weakly
+ *                      dominate every loser on pages/ocr/translated/quality.
+ *   --lane scored      (bucket SCORED_KEEP) same leader must still lead by
+ *                      the >=10% weighted margin (translation 3x, OCR 1x,
+ *                      pages 0.5x).
+ *   --lane tossup      (bucket TOSSUP) no recommendation existed — Derek's
+ *                      per-cluster picks come in via --choices <file.json>:
+ *                      [{ "edition_key": "...", "keeper": "<book id>" }, ...]
+ *
+ * FT guard (always, every lane): if any losing member carries
+ * is_first_translation, the cluster is refused. Hiding a badge-holder has
+ * public-claim consequences (first-translation-claims invariant) and is not
+ * batch work — resolve those through the FT machinery, one by one.
+ * SUSPECT_NOT_SAME has no apply lane on purpose: those are edition-key
+ * collisions to investigate, not duplicates to hide.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/apply-keeper-choice-triage.mjs --lane mechanical            # dry-run
+ *   node scripts/maintenance/apply-keeper-choice-triage.mjs --lane mechanical --apply --finalize
+ *   node scripts/maintenance/apply-keeper-choice-triage.mjs --lane scored --only key1,key2 --apply
+ *   node scripts/maintenance/apply-keeper-choice-triage.mjs --lane tossup --choices picks.json --apply
+ *
+ *   --report <path>   use a specific triage JSON (default: newest in scripts/output/)
+ *   --only k1,k2 | @f subset by edition_key
+ *   --apply           write (default is dry-run)
+ *   --finalize        after writing: catalog sync + ISR revalidate + CF purge
+ *
+ * Writes: losers get { hidden:true, visible:false, duplicate_of: keeper,
+ * hidden_reason: 'same_edition_duplicate', updated_at } (#3102 structured
+ * shape); backup in scripts/output/; provenance row in dedup_apply_runs.
+ * Downstream automated readers: Hetzner sync-worker refreshes collection
+ * counts next cycle; sync-books-catalog propagates the hides to Supabase
+ * (run by --finalize, else by the Hetzner supabase-sync cron). Dedup itself
+ * reads duplicate_of at import time only — no unattended job acts on it.
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import {
+  TAKEDOWN_RX, flagValue, idFilter, resolveReport,
+  writeBackup, recordRun, finalizeCaches, skipLine,
+} from '../lib/triage-apply.mjs';
+
+const LANE = flagValue('--lane');
+const APPLY = process.argv.includes('--apply');
+const FINALIZE = process.argv.includes('--finalize');
+const only = idFilter('--only');
+const LANE_BUCKET = { mechanical: 'MECHANICAL_KEEP', scored: 'SCORED_KEEP', tossup: 'TOSSUP' };
+if (!LANE_BUCKET[LANE]) {
+  console.error('--lane mechanical | scored | tossup is required.');
+  process.exit(1);
+}
+let choices = null; // tossup: edition_key -> Derek's keeper pick
+if (LANE === 'tossup') {
+  const p = flagValue('--choices');
+  if (!p) { console.error('--lane tossup needs --choices <file.json> ([{edition_key, keeper}]).'); process.exit(1); }
+  choices = new Map(JSON.parse(fs.readFileSync(p, 'utf8')).map((c) => [c.edition_key, c.keeper]));
+}
+
+// Same signals as the triage script (keep in sync with
+// scripts/audit/keeper-choice-triage.mjs — change both together).
+const score = (m) => m.trans * 3 + m.ocr * 1 + m.pages * 0.5;
+const dominates = (a, b) =>
+  a.pages >= b.pages && a.ocr >= b.ocr && a.trans >= b.trans && a.quality >= b.quality &&
+  (a.pages > b.pages || a.ocr > b.ocr || a.trans > b.trans || a.quality > b.quality);
+
+const reportPath = resolveReport('keeper-choice-triage');
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+const rows = report.clusters.filter((c) => c.bucket === LANE_BUCKET[LANE]);
+console.log(`${reportPath}\nlane ${LANE}: ${rows.length} clusters in report${only ? `, filtered by --only (${only.size})` : ''}${APPLY ? '' : '  [DRY-RUN]'}`);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+
+const now = new Date();
+const backupDocs = [];
+const ops = [];
+const touchedPaths = [];
+const applied = [];
+let skipped = 0;
+
+for (const cl of rows) {
+  if (only && !only.has(cl.edition_key)) continue;
+  const key = cl.edition_key;
+  const keeperId = LANE === 'tossup' ? choices.get(key) : cl.keeper;
+  if (!keeperId) { if (LANE === 'tossup') continue; skipLine(key, 'no keeper in report row'); skipped++; continue; }
+
+  // ── live refetch of every member named by the report ──
+  const live = await books.find(
+    { id: { $in: cl.members.map((m) => m.id) } },
+    { projection: { _id: 0, id: 1, title: 1, visible: 1, hidden_reason: 1, edition_key: 1, edition_key_quality: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, quality_score: 1, is_first_translation: 1, duplicate_of: 1 } },
+  ).toArray();
+  const ms = live.map((b) => ({
+    id: b.id, title: b.title, visible: b.visible, reason: b.hidden_reason,
+    key: b.edition_key, kq: b.edition_key_quality, dup: b.duplicate_of,
+    pages: b.pages_count || 0, ocr: b.pages_ocr || 0, trans: b.pages_translated || 0,
+    quality: b.quality_score || 0, ft: b.is_first_translation === true,
+  }));
+
+  // ── guards, all against live state ──
+  if (ms.length !== cl.members.length) { skipLine(key, 'a member no longer exists'); skipped++; continue; }
+  if (ms.some((m) => m.visible !== true)) { skipLine(key, 'a member is no longer visible (already resolved elsewhere?)'); skipped++; continue; }
+  if (ms.some((m) => m.dup)) { skipLine(key, 'a member already carries duplicate_of'); skipped++; continue; }
+  if (ms.some((m) => m.key !== key || m.kq !== 'full')) { skipLine(key, 'edition_key changed since triage (key repair?)'); skipped++; continue; }
+  if (ms.some((m) => m.reason && TAKEDOWN_RX.test(m.reason))) { skipLine(key, 'takedown-shaped reason on a member'); skipped++; continue; }
+  const keeper = ms.find((m) => m.id === keeperId);
+  if (!keeper) { skipLine(key, `keeper ${keeperId} is not a member`); skipped++; continue; }
+  const losers = ms.filter((m) => m.id !== keeperId);
+  // FT guard — always. A hidden badge-holder is a public-claim change.
+  const ftLosers = losers.filter((m) => m.ft);
+  if (ftLosers.length) { skipLine(key, `FT badge on loser(s) ${ftLosers.map((m) => m.id).join(',')} — resolve via FT machinery, not here`); skipped++; continue; }
+  // The recommendation must still hold on today's numbers.
+  if (LANE === 'mechanical' && !losers.every((m) => dominates(keeper, m))) {
+    skipLine(key, 'keeper no longer dominates — signals drifted, re-run triage'); skipped++; continue;
+  }
+  if (LANE === 'scored') {
+    const sorted = [...ms].sort((a, b) => score(b) - score(a));
+    const margin = (score(sorted[0]) - score(sorted[1])) / Math.max(score(sorted[0]), 1);
+    if (sorted[0].id !== keeperId || margin < 0.1) {
+      skipLine(key, `leader/margin drifted (leader ${sorted[0].id}, margin ${margin.toFixed(2)}) — re-run triage`); skipped++; continue;
+    }
+  }
+
+  for (const m of losers) {
+    backupDocs.push(live.find((b) => b.id === m.id));
+    ops.push({ updateOne: {
+      filter: { id: m.id, visible: true, duplicate_of: { $in: [null, ''] } },
+      update: { $set: { hidden: true, visible: false, duplicate_of: keeperId, hidden_reason: 'same_edition_duplicate', updated_at: now } },
+    } });
+    applied.push(m.id);
+    touchedPaths.push(`/book/${m.id}`);
+  }
+  touchedPaths.push(`/book/${keeperId}`); // the editions rail on the keeper changes too
+  console.log(`  keep ${keeperId} [p${keeper.pages} o${keeper.ocr} t${keeper.trans}] — hide ${losers.map((m) => `${m.id}[p${m.pages} o${m.ocr} t${m.trans}]`).join(', ')}  (${key.slice(0, 50)})`);
+}
+
+console.log(`\n${LANE}: ${ops.length} hide(s) planned across ${applied.length ? new Set(touchedPaths).size : 0} pages, ${skipped} clusters skipped by live guards`);
+
+if (APPLY && ops.length) {
+  const backupPath = writeBackup(`apply-keeper-choice-${LANE}`, { report: reportPath, lane: LANE, docs: backupDocs });
+  const r = await books.bulkWrite(ops, { ordered: false });
+  console.log(`modified: ${r.modifiedCount} (backup: ${backupPath})`);
+  await recordRun(db, {
+    script: 'apply-keeper-choice-triage', lane: LANE, report: reportPath,
+    planned: ops.length, modified: r.modifiedCount, skipped, ids: applied, backup: backupPath,
+  });
+  await finalizeCaches({ paths: [...touchedPaths, '/collections', '/browse'], execute: FINALIZE });
+} else if (APPLY) {
+  console.log('nothing to write.');
+} else {
+  console.log('dry-run only — add --apply to write.');
+}
+await client.close();


### PR DESCRIPTION
## What

The dark-cluster (#3814) and keeper-choice (#3816) triage scripts are deliberately read-only; approving their lanes had no execution path. This adds it:

- `scripts/maintenance/apply-dark-cluster-triage.mjs` — `--lane restore | repoint | unmark`
- `scripts/maintenance/apply-keeper-choice-triage.mjs` — `--lane mechanical | scored | tossup` (tossup takes per-cluster picks via `--choices file.json`)
- `scripts/lib/triage-apply.mjs` — shared plumbing

## Safety shape

- Dry-run by default; writes only under `--apply`; `--only a,b | @file` subsets.
- **Every guard re-verified against live data at apply time** — the report is a snapshot. Kloss `hidden_reason` holds, takedown regex, sha1 evidence (repoint/unmark), dominance/margin recomputed from today's numbers (mechanical/scored), write filters conditional on the state the guard saw.
- **FT guard is unconditional**: any cluster whose loser carries `is_first_translation` is refused — badge-holders go through the FT machinery, never batch hides.
- Backups of prior fields in `scripts/output/`; provenance row per run in `dedup_apply_runs`; visibility writes bump `updated_at`; `--finalize` runs catalog sync + ISR revalidate (endpoint purges Cloudflare itself). Downstream readers stated in each header (Hetzner sync-worker counts, supabase-sync) per the ingest-is-actuation rule.

## Verification (dry-runs against prod, zero writes)

| lane | report | planned | skipped by live guards |
|---|---|---|---|
| restore | 244 keepers | 244 | 0 |
| repoint | 0 (bucket empty in current report; positive-control checked) | 0 | 0 |
| unmark | 366 pointers | 361 | 5 (sha1 no longer proves not-a-copy) |
| mechanical | 89 clusters | 64 (69 hides) | 25 (all FT) |
| scored | 47 clusters | 34 (35 hides) | 12 FT + 1 already resolved |

FT skips total 37 — exactly the 37 FT-flagged clusters the triage counted.

## Out of scope

- No writes were made; Derek approves lanes, then runs with `--apply`.
- SUSPECT_NOT_SAME has no apply lane **on purpose** — those are edition-key collisions to investigate, not duplicates to hide.
- ALBUM_PARKING routing to the album→book conversion queue — separate workstream.
- `/api/admin/revalidate` turns out to be effectively unauthenticated in prod (`REVALIDATE_SECRET` never set) — flagged privately, not fixed here (one concern per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)