### PR TITLE
feat(lexicon): Lewis & Short lookup chain + eval gate (#3823 Phase 1)

### DIFF
--- a/scripts/eval/lexicon-lookup-eval.ts
+++ b/scripts/eval/lexicon-lookup-eval.ts
@@ -1,0 +1,151 @@
+/**
+ * Phase-1 eval gate for the parsing reader (#3823): measure the lexicon
+ * lookup chain against REAL OCR — not clean critical editions — before any
+ * UI ships on top of it.
+ *
+ * Samples words from interior OCR pages of visible Latin books (front matter
+ * lies — see lesson), runs the exact production chain (lookupLatinWord), and
+ * reports hit rate per tier plus every miss and a random sample of hits for
+ * manual precision spot-checking. Writes a scorecard JSON to
+ * scripts/eval/results/.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/eval/lexicon-lookup-eval.ts [--books 25] [--words 500]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { MongoClient } from 'mongodb';
+import { lookupLatinWord } from '../../src/lib/lexicon/lookup';
+import { cleanOcrToken, normalizeLatin } from '../../src/lib/lexicon/normalize';
+
+const args = process.argv.slice(2);
+function flag(name: string, dflt: number): number {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? Number(args[i + 1]) : dflt;
+}
+const N_BOOKS = flag('books', 25);
+const N_WORDS = flag('words', 500);
+
+const ROMAN_NUMERAL = /^[ivxlcdm]+$/;
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || 'bookstore';
+  if (!uri) throw new Error('MONGODB_URI not set');
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+
+  // Latin books, canonical live filter (visible + processed).
+  const books = await db
+    .collection('books')
+    .aggregate([
+      {
+        $match: {
+          visible: true,
+          pages_ocr: { $gt: 20 },
+          language: { $in: ['la', 'lat', 'Latin', 'latin'] },
+        },
+      },
+      { $sample: { size: N_BOOKS } },
+      { $project: { id: 1, title: 1, published: 1, pages_count: 1 } },
+    ])
+    .toArray();
+  if (books.length < 15) throw new Error(`Only ${books.length} Latin books matched — check the language filter.`);
+  console.log(`Sampled ${books.length} Latin books`);
+
+  const perBook = Math.ceil(N_WORDS / books.length);
+  interface Sample { word: string; bookId: string; title: string; page: number }
+  const samples: Sample[] = [];
+
+  for (const b of books) {
+    // Interior pages only: skip the first/last 15% (front matter lies).
+    const total = b.pages_count || 100;
+    const lo = Math.floor(total * 0.15);
+    const hi = Math.ceil(total * 0.85);
+    const pages = await db
+      .collection('pages')
+      .aggregate([
+        { $match: { book_id: b.id, page_number: { $gte: lo, $lte: hi }, 'ocr.data': { $type: 'string' } } },
+        { $sample: { size: 3 } },
+        { $project: { page_number: 1, 'ocr.data': 1 } },
+      ])
+      .toArray();
+    const words: string[] = [];
+    for (const p of pages) {
+      // OCR text embeds structural XML (<page-type>, <scan-quality>,
+      // <image-desc>English prose</image-desc>, <margin>, <vocab>…) — strip
+      // element content that isn't source text, then the tags themselves,
+      // before tokenizing. A reader clicking words never sees these.
+      const text: string = (p.ocr?.data ?? '')
+        .replace(/<(image-desc|page-type|scan-quality|script|header)>[\s\S]*?<\/\1>/g, ' ')
+        .replace(/<[^<>]{1,60}>/g, ' ')
+        // rejoin line-break hyphenation: "ha-\nbentur" → habentur
+        .replace(/[-­]\s*\n\s*/g, '');
+      for (const tok of text.split(/[\s.·:]+/)) {
+        const w = cleanOcrToken(tok);
+        const norm = normalizeLatin(w);
+        if (norm.length >= 3 && !ROMAN_NUMERAL.test(norm) && !/[\d<>="/]/.test(w)) {
+          words.push(w);
+        }
+      }
+    }
+    // Random sample without replacement, dedupe within book.
+    const seen = new Set<string>();
+    while (seen.size < perBook && words.length) {
+      const i = Math.floor(Math.random() * words.length);
+      const [w] = words.splice(i, 1);
+      if (!seen.has(w.toLowerCase())) {
+        seen.add(w.toLowerCase());
+        const page = pages[0]?.page_number ?? 0;
+        samples.push({ word: w, bookId: b.id, title: String(b.title).slice(0, 60), page });
+      }
+    }
+  }
+  const finalSamples = samples.slice(0, N_WORDS);
+  console.log(`Collected ${finalSamples.length} word samples; running lookups…`);
+
+  const tierCounts: Record<string, number> = {};
+  const misses: Array<{ word: string; title: string }> = [];
+  const hits: Array<{ word: string; headword: string; tier: string; title: string }> = [];
+  let done = 0;
+  for (const s of finalSamples) {
+    const res = await lookupLatinWord(db, s.word);
+    if (res.found) {
+      const m = res.matches[0];
+      tierCounts[m.matchType] = (tierCounts[m.matchType] || 0) + 1;
+      hits.push({ word: s.word, headword: m.headword, tier: m.matchType, title: s.title });
+    } else {
+      tierCounts.miss = (tierCounts.miss || 0) + 1;
+      misses.push({ word: s.word, title: s.title });
+    }
+    if (++done % 100 === 0) console.log(`  ${done}/${finalSamples.length}`);
+  }
+
+  const n = finalSamples.length;
+  const found = n - (tierCounts.miss || 0);
+  const confident = (tierCounts.exact || 0) + (tierCounts.variant || 0) + (tierCounts.irregular || 0) + (tierCounts.inflected || 0);
+  const scorecard = {
+    date: new Date().toISOString().slice(0, 10),
+    issue: 3823,
+    sample: { books: books.length, words: n, selection: 'interior pages (15–85%), tokens ≥3 letters, non-numeric' },
+    hitRate: +(found / n).toFixed(3),
+    confidentHitRate: +(confident / n).toFixed(3),
+    tierCounts,
+    spotCheckHits: hits.sort(() => Math.random() - 0.5).slice(0, 40),
+    misses,
+  };
+  const outPath = path.join('scripts/eval/results', `lexicon-lookup-eval-${scorecard.date}.json`);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(scorecard, null, 2));
+  console.log(`\nHit rate: ${(scorecard.hitRate * 100).toFixed(1)}% (confident tiers: ${(scorecard.confidentHitRate * 100).toFixed(1)}%)`);
+  console.log('Tiers:', tierCounts);
+  console.log(`Scorecard → ${outPath}`);
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/results/lexicon-lookup-eval-2026-08-09.json
+++ b/scripts/eval/results/lexicon-lookup-eval-2026-08-09.json
@@ -1,0 +1,1021 @@
+{
+  "date": "2026-08-09",
+  "issue": 3823,
+  "sample": {
+    "books": 40,
+    "words": 786,
+    "selection": "interior pages (15–85%), tokens ≥3 letters, non-numeric"
+  },
+  "hitRate": 0.76,
+  "confidentHitRate": 0.683,
+  "tierCounts": {
+    "ocr": 10,
+    "irregular": 62,
+    "exact": 239,
+    "inflected": 233,
+    "miss": 189,
+    "suffix": 48,
+    "variant": 3,
+    "loose": 2
+  },
+  "spotCheckHits": [
+    {
+      "word": "Mathematici",
+      "headword": "mathematicus",
+      "tier": "suffix",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "super",
+      "headword": "super",
+      "tier": "exact",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "prædictum",
+      "headword": "praedictum",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "non",
+      "headword": "non",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "audent",
+      "headword": "audeo",
+      "tier": "inflected",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "longius",
+      "headword": "longus",
+      "tier": "inflected",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "cum",
+      "headword": "cum",
+      "tier": "exact",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "nil",
+      "headword": "nil",
+      "tier": "exact",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Tantali",
+      "headword": "Tantalus",
+      "tier": "inflected",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "hostes",
+      "headword": "hostis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "euangeliū",
+      "headword": "evangelium",
+      "tier": "exact",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "esse",
+      "headword": "sum",
+      "tier": "irregular",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "illorum",
+      "headword": "ille",
+      "tier": "irregular",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "lingua",
+      "headword": "lingua",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "æquale",
+      "headword": "aequalis",
+      "tier": "inflected",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "pisces",
+      "headword": "piscis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "circulus",
+      "headword": "circulus",
+      "tier": "exact",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "signant",
+      "headword": "signo",
+      "tier": "inflected",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "notum",
+      "headword": "notus",
+      "tier": "suffix",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "hypotenusa",
+      "headword": "hypotenusa",
+      "tier": "exact",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "alijs",
+      "headword": "Alius",
+      "tier": "irregular",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "mente",
+      "headword": "mens",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "sui",
+      "headword": "sui",
+      "tier": "exact",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "pacta",
+      "headword": "pacta",
+      "tier": "exact",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "dignoſces",
+      "headword": "dignosco",
+      "tier": "suffix",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "Forma",
+      "headword": "forma",
+      "tier": "exact",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "the",
+      "headword": "thus",
+      "tier": "suffix",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Pannoniam",
+      "headword": "Pannonia",
+      "tier": "suffix",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "etiā",
+      "headword": "etiam",
+      "tier": "exact",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "defunctorum",
+      "headword": "defunctus",
+      "tier": "suffix",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "diametrum",
+      "headword": "diametrum",
+      "tier": "exact",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "ſilentio",
+      "headword": "silentium",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "fuperioribus",
+      "headword": "superus",
+      "tier": "ocr",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "horribile",
+      "headword": "horribilis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "supra",
+      "headword": "supra",
+      "tier": "exact",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "mare",
+      "headword": "mare",
+      "tier": "exact",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "conſuetudinem",
+      "headword": "consuetudo",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "carnibus",
+      "headword": "caro",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "latinitas",
+      "headword": "latinitas",
+      "tier": "exact",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "unde",
+      "headword": "unde",
+      "tier": "exact",
+      "title": "Opera Varia, Vol. 2"
+    }
+  ],
+  "misses": [
+    {
+      "word": "CAP",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "LVII",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "each",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "olimpias",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "usqʒ",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "p̄hibentibʒ",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "most",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "lasciuie",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "paperclip",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "common",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "root",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "script",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "flanked",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "illustration",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "woodcut",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Tulipa",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "detailed",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "heads",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "marginalia",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "plant",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "tulip",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "flower",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "upright",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "vertical",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "botany",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "two",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "identified",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Voetium",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "Dietericum",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "adire",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "nominaque",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "Junonis",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "enterrer",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "religieuse",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "German",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "ist",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "viuras",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "entierement",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "morts",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "veux",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tromperas",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tousiours",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "debtes",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "atq",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "donneras",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "peu",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tiene",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "discontinuitate",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "mirabil",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "ignitio",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "tranea",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "mediamque",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "representat",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "idque",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "pferri",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "aliquaz",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "ꝓcept",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "spon",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "cās",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "amp",
+      "title": "Cornelii Valerii Ultraiectini In universam benedicendi [sic]"
+    },
+    {
+      "word": "tiá",
+      "title": "Cornelii Valerii Ultraiectini In universam benedicendi [sic]"
+    },
+    {
+      "word": "quadr",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectangulum",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "which",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "Fig",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectang",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectangulo",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "postrema",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "clearly",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "xpi",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "Glozia",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "teq",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "sup",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "exorcism",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "aliquib",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "equalis",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "misericordie",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "John",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "facienda",
+      "title": "Rhetorica ad C. Herennium. Comm: Franciscus Maturantius [Mat"
+    },
+    {
+      "word": "oio",
+      "title": "Rhetorica ad C. Herennium. Comm: Franciscus Maturantius [Mat"
+    },
+    {
+      "word": "Eleemosyn",
+      "title": "Summa Theologica, Secunda Secundae (On Justice and Just Pric"
+    },
+    {
+      "word": "Corinth",
+      "title": "Summa Theologica, Secunda Secundae (On Justice and Just Pric"
+    },
+    {
+      "word": "script",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Iohannem",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Leftmost",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "above",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "image",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "text",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Latin",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "notation",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "introiuit",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "amp;c",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "tuam",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "potentior",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "catchword",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "obtinuisse",
+      "title": "Physica subterranea. Specimen Beccherianum"
+    },
+    {
+      "word": "Latin",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "nunq",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "mathcal{q",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "Dianamq",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "BIBLIOTHEK",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "STIFTES",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "sepactas",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "loops",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Latin",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Mellensis",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "stamp",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "precipue",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Senging",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Mellicensis",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "catchword",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Romana",
+      "title": "Opera Omnia Vol. 1"
+    },
+    {
+      "word": "Iudæi",
+      "title": "Opera Omnia Vol. 1"
+    },
+    {
+      "word": "tūc",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "Quatuor",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "effe",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "lexagexies",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "exalationibus",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "Alibotra",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Vatic",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Hictiophagi",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "inmergitur",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Metaphysicam",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "SYMME",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "nostra",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "ACTVA",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "partē",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "Maiorque",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "Turkish",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "manuscript",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "instruction",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Naskh",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Arabic",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Ottoman",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Handwritten",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "moral",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Nasta'liq",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "script",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "ethics",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "gracia",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "Theb",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "temperancia",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "temperancie",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "collaudacio",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "misericordes",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "Latin",
+      "title": "De annorum revolutionibus astronomicis"
+    },
+    {
+      "word": "viderit",
+      "title": "De annorum revolutionibus astronomicis"
+    },
+    {
+      "word": "inferiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "perfectiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "adsint",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "propinquiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "Analemmate",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Boetius",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Finchius",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Holometrum",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Geometr",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Commandin",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Beruhr",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "Experiolus",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "pannisq",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Latin",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "catchword",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "crowned",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Latin",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "rotumba",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "fac",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "ogni",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "uoglio",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "descriuendolo",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "impossibil",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Vadano",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "auenga",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "ragione",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "son",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "petto",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Che'l",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "alcune",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "fiamme",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Dal",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "cagione",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Vecchi",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Enea",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "deh",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "motiua",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "effe",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "cutting",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "partial",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "ondum",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "oportere",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    }
+  ]
+}

--- a/scripts/lexicon/import-lewis-short.ts
+++ b/scripts/lexicon/import-lewis-short.ts
@@ -192,6 +192,8 @@ async function main() {
   await newMap.createIndex({ form_loose: 1 });
   await newMap.rename('lexicon_lemma_map', { dropTarget: true });
 
+  await db.collection('lexicon_misses').createIndex({ form: 1 }, { unique: true });
+  await db.collection('lexicon_misses').createIndex({ count: -1 });
   await entriesCol.createIndex({ key: 1 }, { unique: true });
   await entriesCol.createIndex({ key_normalized: 1 });
   await entriesCol.createIndex({ key_loose: 1 });

--- a/scripts/lexicon/import-lewis-short.ts
+++ b/scripts/lexicon/import-lewis-short.ts
@@ -1,0 +1,209 @@
+/**
+ * Import Lewis & Short (1879) into Mongo for the parsing reader (#3823).
+ *
+ * Source: the lewis-short-json conversion of Perseus's TEI digitisation
+ * (https://github.com/IohannesArnold/lewis-short-json, CC BY-SA — text itself
+ * is public domain). Download the ls_*.json letter files first and pass the
+ * directory with --dir (default: _tmp-ls-json/ next to the repo root).
+ *
+ * Writes two collections in the `bookstore` db:
+ *   lexicon_entries   — one doc per L&S entry (~51.6K), with normalized keys
+ *   lexicon_lemma_map — generated inflected form → entry keys, built from
+ *                       each entry's own declension/genitive/principal parts
+ *                       via src/lib/lexicon/latin-morph.ts
+ *
+ * Idempotent: upserts entries by key and rebuilds the lemma map atomically
+ * (writes to lexicon_lemma_map_new, then renames over the old one).
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/lexicon/import-lewis-short.ts --dir _tmp-ls-json
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { MongoClient, AnyBulkWriteOperation, Document } from 'mongodb';
+import { normalizeLatin, looseKey } from '../../src/lib/lexicon/normalize';
+import { nounForms, adjectiveForms, verbForms, principalPartStems } from '../../src/lib/lexicon/latin-morph';
+
+interface RawEntry {
+  entry_type: string;
+  key: string;
+  main_notes: string;
+  part_of_speech: string;
+  senses?: unknown[];
+  declension?: number;
+  gender?: string;
+  title_genitive?: string;
+  title_orthography?: string;
+  alternative_orthography?: string[];
+  alternative_genative?: string;
+  greek_word?: string;
+}
+
+const args = process.argv.slice(2);
+const dirFlag = args.indexOf('--dir');
+const DIR = dirFlag >= 0 ? args[dirFlag + 1] : '_tmp-ls-json';
+const MAX_KEYS_PER_FORM = 12;
+
+function parseVerbParts(headNorm: string, notes: string): { conjs: Array<1 | 2 | 3 | 4>; perfect: string[]; supine: string[] } {
+  // Typical shape: "ămo, āvi, ātum, 1, v. a. (…" — principal parts as
+  // abbreviated tokens, then a bare conjugation digit. Many entries truncate
+  // before the digit ("vŏco, āvi, ātum ("), so when it's absent we infer the
+  // conjugation from the principal-part signature / headword shape — and when
+  // genuinely ambiguous we generate the UNION of candidate paradigms (every
+  // form still maps to the right entry; see over-generation note in
+  // latin-morph.ts).
+  const headChunk = notes.slice(0, 120).split('(')[0];
+  const conjMatch = headChunk.match(/,\s*([1-4])\s*[,.;)\s]/);
+  const perfect: string[] = [];
+  const supine: string[] = [];
+  let sawAvi = false;
+  let sawIvi = false;
+  for (const rawTok of headChunk.split(',').slice(1)) {
+    for (const tok of rawTok.split(/\s+or\s+/)) {
+      const t = normalizeLatin(tok.trim());
+      if (!t || /^[1-4]$/.test(tok.trim())) continue;
+      if (t.endsWith('i') && !t.endsWith('ari') && !t.endsWith('eri') && !t.endsWith('iri') && t.length >= 2) {
+        if (t.endsWith('aui')) sawAvi = true;
+        if (t.endsWith('iui') || t === 'ii') sawIvi = true;
+        for (const s of principalPartStems(headNorm, t.replace(/i$/, ''))) perfect.push(s);
+      } else if (t.endsWith('um') || t.endsWith('us')) {
+        for (const s of principalPartStems(headNorm, t.replace(/(um|us)$/, ''))) supine.push(s);
+      }
+    }
+  }
+  let conjs: Array<1 | 2 | 3 | 4>;
+  if (conjMatch) conjs = [Number(conjMatch[1]) as 1 | 2 | 3 | 4];
+  else if (sawAvi) conjs = [1];
+  else if (headNorm.endsWith('eo') || headNorm.endsWith('eor')) conjs = [2];
+  else if (headNorm.endsWith('io') || headNorm.endsWith('ior')) conjs = sawIvi ? [4] : [3, 4];
+  else conjs = [1, 3];
+  return { conjs, perfect: [...new Set(perfect)].slice(0, 4), supine: [...new Set(supine)].slice(0, 4) };
+}
+
+function generateForms(e: RawEntry, headNorm: string): string[] {
+  if (e.entry_type !== 'main' && e.entry_type !== 'hapax') return [];
+  const pos = (e.part_of_speech || '').toLowerCase();
+  const gen = e.title_genitive ? normalizeLatin(e.title_genitive) : undefined;
+
+  if (e.declension && (e.gender || gen)) {
+    return nounForms(headNorm, e.declension, gen);
+  }
+  if (pos.includes('adj') || pos === 'p. a.') {
+    return adjectiveForms(headNorm);
+  }
+  if (pos.includes('v') && (headNorm.endsWith('o') || headNorm.endsWith('or'))) {
+    const { conjs, perfect, supine } = parseVerbParts(headNorm, e.main_notes || '');
+    const forms = new Set<string>();
+    for (const c of conjs) for (const f of verbForms(headNorm, c, perfect, supine)) forms.add(f);
+    return [...forms];
+  }
+  return [];
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || 'bookstore';
+  if (!uri) throw new Error('MONGODB_URI not set — source .env.production.local first.');
+
+  const files = fs.readdirSync(DIR).filter((f) => /^ls_[A-Z]\.json$/.test(f)).sort();
+  if (files.length < 20) throw new Error(`Only ${files.length} ls_*.json files in ${DIR} — incomplete download?`);
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+  const entriesCol = db.collection('lexicon_entries');
+
+  let entryCount = 0;
+  let formCount = 0;
+  const lemmaMap = new Map<string, Set<string>>();
+
+  for (const file of files) {
+    const raw: RawEntry[] = JSON.parse(fs.readFileSync(path.join(DIR, file), 'utf8'));
+    const ops: AnyBulkWriteOperation<Document>[] = [];
+    for (const e of raw) {
+      if (!e.key) continue;
+      const headword = e.key.replace(/\d+$/, '');
+      const keyNorm = normalizeLatin(headword);
+      if (!keyNorm) continue;
+      const altNorm = [...new Set((e.alternative_orthography || []).map(normalizeLatin).filter((a) => a && a !== keyNorm))];
+      ops.push({
+        updateOne: {
+          filter: { key: e.key },
+          update: {
+            $set: {
+              dict: 'lewis-short',
+              key: e.key,
+              headword,
+              key_normalized: keyNorm,
+              key_loose: looseKey(keyNorm),
+              alt_normalized: altNorm,
+              entry_type: e.entry_type,
+              part_of_speech: e.part_of_speech || null,
+              gender: e.gender ?? null,
+              declension: e.declension ?? null,
+              title_genitive: e.title_genitive ?? null,
+              title_orthography: e.title_orthography ?? null,
+              greek_word: e.greek_word ?? null,
+              main_notes: e.main_notes ?? null,
+              senses: e.senses ?? [],
+              imported_at: new Date(),
+            },
+          },
+          upsert: true,
+        },
+      });
+
+      // Greek-script entries get no Latin paradigm.
+      if (!e.greek_word) {
+        for (const form of generateForms(e, keyNorm)) {
+          if (form === keyNorm) continue;
+          const set = lemmaMap.get(form) ?? new Set<string>();
+          if (set.size < MAX_KEYS_PER_FORM) set.add(e.key);
+          lemmaMap.set(form, set);
+        }
+        for (const alt of altNorm) {
+          const set = lemmaMap.get(alt) ?? new Set<string>();
+          if (set.size < MAX_KEYS_PER_FORM) set.add(e.key);
+          lemmaMap.set(alt, set);
+        }
+      }
+    }
+    const res = await entriesCol.bulkWrite(ops, { ordered: false });
+    entryCount += res.upsertedCount + res.modifiedCount + res.matchedCount - res.modifiedCount;
+    console.log(`${file}: ${ops.length} entries upserted (running total ${entryCount})`);
+  }
+
+  // Rebuild lemma map atomically: write _new, create indexes, rename over.
+  const newMap = db.collection('lexicon_lemma_map_new');
+  await newMap.drop().catch(() => {});
+  const mapDocs: Document[] = [];
+  for (const [form, keys] of lemmaMap) {
+    mapDocs.push({ form, form_loose: looseKey(form), keys: [...keys] });
+  }
+  console.log(`lemma map: ${mapDocs.length} distinct generated forms`);
+  const BATCH = 20000;
+  for (let i = 0; i < mapDocs.length; i += BATCH) {
+    await newMap.insertMany(mapDocs.slice(i, i + BATCH), { ordered: false });
+    formCount += Math.min(BATCH, mapDocs.length - i);
+    if (formCount % 100000 < BATCH) console.log(`  inserted ${formCount}/${mapDocs.length}`);
+  }
+  await newMap.createIndex({ form: 1 }, { unique: true });
+  await newMap.createIndex({ form_loose: 1 });
+  await newMap.rename('lexicon_lemma_map', { dropTarget: true });
+
+  await entriesCol.createIndex({ key: 1 }, { unique: true });
+  await entriesCol.createIndex({ key_normalized: 1 });
+  await entriesCol.createIndex({ key_loose: 1 });
+  await entriesCol.createIndex({ alt_normalized: 1 });
+
+  const finalEntries = await entriesCol.countDocuments();
+  const finalForms = await db.collection('lexicon_lemma_map').countDocuments();
+  console.log(`DONE: lexicon_entries=${finalEntries}, lexicon_lemma_map=${finalForms}`);
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -44,9 +44,38 @@ export async function GET(request: NextRequest) {
   try {
     const db = await getReadDb();
     const result = await lookupLatinWord(db, word);
+    if (!result.found && result.normalized.length >= 3) {
+      // Miss telemetry: aggregated per normalized form (bounded by vocabulary,
+      // no PII, nothing automated reads it). This is the Phase-2.5 worklist —
+      // the most-tapped missing words are the next tier to build.
+      db.collection('lexicon_misses')
+        .updateOne(
+          { form: result.normalized },
+          { $inc: { count: 1 }, $set: { last_seen: new Date(), sample_query: result.query } },
+          { upsert: true }
+        )
+        .catch(() => {});
+    }
     return NextResponse.json(result, { headers: CACHE_HEADERS });
   } catch (err) {
     console.error('[lexicon/lookup] failed:', err);
+    // Same store the client-side reporter uses (application_errors), so
+    // lookup failures surface in the admin errors view instead of only in
+    // function logs. Fire-and-forget: logging must never fail the response.
+    try {
+      const db = await getReadDb();
+      db.collection('application_errors')
+        .insertOne({
+          message: `lexicon lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+          source: 'api/lexicon/lookup',
+          url: request.nextUrl.pathname + '?word=' + encodeURIComponent(word),
+          stack: err instanceof Error ? err.stack?.slice(0, 2000) : undefined,
+          timestamp: new Date(),
+        })
+        .catch(() => {});
+    } catch {
+      /* logging is best-effort */
+    }
     return NextResponse.json({ error: 'Lookup failed.' }, { status: 500 });
   }
 }

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -1,0 +1,52 @@
+/**
+ * GET /api/lexicon/lookup?word=cœlum — dictionary lookup for the parsing
+ * reader (issue #3823, Phase 1).
+ *
+ * Resolves a (possibly early modern, possibly OCR-noisy) Latin word to Lewis
+ * & Short entries via the tiered chain in src/lib/lexicon/lookup.ts:
+ * exact → variant → irregular → generated paradigm → suffix heuristic →
+ * loose orthography. Uncertain tiers return `confident: false`; a miss is a
+ * structured `found: false`, never a wrong entry dressed up as an answer.
+ *
+ * &lang=la is accepted and required to be Latin for now — the parameter
+ * exists so Greek (LSJ) can slot in later without a URL change.
+ *
+ * Anonymous, read-only, aggressively CDN-cached: word → entry is immutable
+ * short of a re-import, so cache hard and let deploys purge.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { lookupLatinWord } from '@/lib/lexicon/lookup';
+
+export const dynamic = 'force-dynamic';
+
+const CACHE_HEADERS = {
+  // max-age matters: a Cache-Control without it survives CDN purges in
+  // browser caches (see lesson on s-maxage-only headers).
+  'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+  'CDN-Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+} as const;
+
+export async function GET(request: NextRequest) {
+  const word = request.nextUrl.searchParams.get('word') ?? '';
+  const lang = request.nextUrl.searchParams.get('lang') ?? 'la';
+
+  if (lang !== 'la') {
+    return NextResponse.json(
+      { error: `Unsupported lang "${lang}" — only "la" (Latin) is available.` },
+      { status: 400 }
+    );
+  }
+  if (!word.trim() || word.length > 80) {
+    return NextResponse.json({ error: 'Provide ?word= (1–80 chars).' }, { status: 400 });
+  }
+
+  try {
+    const db = await getReadDb();
+    const result = await lookupLatinWord(db, word);
+    return NextResponse.json(result, { headers: CACHE_HEADERS });
+  } catch (err) {
+    console.error('[lexicon/lookup] failed:', err);
+    return NextResponse.json({ error: 'Lookup failed.' }, { status: 500 });
+  }
+}

--- a/src/lib/lexicon/latin-morph.ts
+++ b/src/lib/lexicon/latin-morph.ts
@@ -1,0 +1,514 @@
+/**
+ * Rule-based Latin morphology for dictionary lookup — deliberately honest
+ * about being heuristic. Two jobs:
+ *
+ *  1. Import time: generate inflected-form paradigms for Lewis & Short
+ *     entries (nouns from declension+genitive, verbs from principal parts,
+ *     adjectives from headword shape) to build the `lexicon_lemma_map`
+ *     collection. Over-generation is acceptable: every generated form maps
+ *     back to its own entry key, so junk forms are unreachable noise, not
+ *     wrong answers.
+ *
+ *  2. Query time: irregular-form table + suffix-swap candidate generation as
+ *     a fallback tier when a form isn't in the map.
+ *
+ * All inputs and outputs are NORMALIZED strings (see normalize.ts) — v→u,
+ * j→i, no diacritics. Tables below are written in normalized orthography.
+ */
+
+// ---------------------------------------------------------------------------
+// Irregular forms (query-time tier). form → lemma headwords (normalized).
+// ---------------------------------------------------------------------------
+
+const IRR: Record<string, string[]> = {};
+function irr(lemma: string, forms: string) {
+  for (const f of forms.split(/\s+/)) {
+    if (!f) continue;
+    (IRR[f] ||= []).push(lemma);
+  }
+}
+
+irr(
+  'sum',
+  `sum es est sumus estis sunt eram eras erat eramus eratis erant ero eris erit
+   erimus eritis erunt fui fuisti fuit fuimus fuistis fuerunt fueram fuerat
+   fuerant fuero fuerit fuerint sim sis sit simus sitis sint essem esses esset
+   essemus essetis essent forem fores foret forent esse fuisse fore futurus
+   futura futurum futuri futurae futuro futuram futuros futuras futurorum
+   futurarum futuris este esto`
+);
+irr(
+  'possum',
+  `possum potes potest possumus potestis possunt poteram poterat poterant
+   potero poterit poterunt potui potuit potuerunt potuerat potuerit possim
+   possit possint possem posset possent posse potuisse potens potentis potenti
+   potentem potente potentes potentium potentibus`
+);
+irr(
+  'uolo',
+  `uolo uis uult uolt uolumus uultis uolunt uolebam uolebat uolebant uolam
+   uolet uolent uolui uoluit uoluerunt uelim uelis uelit uelimus uelitis
+   uelint uellem uelles uellet uellent uelle uoluisse uolens uolentis uolenti
+   uolentem uolentes`
+);
+irr('nolo', `nolo non-uis nolumus nolunt nolebat nolui noluit nolim nolit nollem nollet nolle noli nolite nolens`);
+irr('malo', `malo mauis mauult malumus mauultis malunt malebat malui maluit malim malit mallem mallet malle`);
+irr(
+  'fero',
+  `fero fers fert ferimus fertis ferunt ferebam ferebat ferebant feram feret
+   ferent tuli tulisti tulit tulimus tulistis tulerunt tuleram tulerat tulero
+   tulerit feram ferat ferant ferrem ferret ferrent ferre tulisse ferens
+   ferentis ferenti ferentem ferentes ferentibus latus lata latum lati latae
+   lato latam latos latas latorum latarum latis feror fertur feruntur ferri
+   fer ferte`
+);
+irr(
+  'eo1',
+  `eo is it imus itis eunt ibam ibas ibat ibamus ibatis ibant ibo ibis ibit
+   ibimus ibitis ibunt ii iui iit iuit iimus ierunt iuerunt ieram ierat ierant
+   iero ierit eam eas eat eamus eatis eant irem ires iret iremus iretis irent
+   ire isse iuisse iens euntis eunti euntem euntes euntium euntibus itum itus
+   ita iturus itura iturum i ite`
+);
+irr('fio', `fio fis fit fimus fitis fiunt fiebam fiebat fiebant fiam fiet fient fiam fiat fiant fierem fieret fierent fieri factus facta factum facti factae facto factam factos factas factorum factarum factis`);
+irr('edo1', `edo edis est edimus editis edunt edi esse esum`);
+
+// Pronouns & determiners — the highest-frequency words in any Latin text.
+irr('hic', `hic haec hoc huius huic hunc hanc hi hae horum harum his hos has`);
+irr('qui1', `qui quae quod cuius cui quem quam quo qua quorum quarum quibus quos quas quicumque quaecumque quodcumque`);
+irr('quis1', `quis quid cuius cui quem quo`);
+irr('is', `is ea id eius ei eum eam eo ii ei eae eorum earum iis eis eos eas idem`);
+irr('ille', `ille illa illud illius illi illum illam illo illorum illarum illis illos illas`);
+irr('iste', `iste ista istud istius isti istum istam isto istorum istarum istis istos istas`);
+irr('ipse', `ipse ipsa ipsum ipsius ipsi ipsum ipsam ipso ipsorum ipsarum ipsis ipsos ipsas`);
+irr('idem', `idem eadem eiusdem eidem eundem eandem eodem eadem eidem eorundem earundem eisdem iisdem eosdem easdem`);
+irr('ego', `ego mei mihi me mecum nos nostri nostrum nobis nobiscum`);
+irr('tu', `tu tui tibi te tecum uos uestri uestrum uobis uobiscum`);
+irr('sui', `sui sibi se sese secum`);
+irr('nemo', `nemo neminis nemini neminem`);
+irr('quisquam', `quisquam quidquam quicquam cuiusquam cuiquam quemquam quicquid quidquid`);
+irr('nihil', `nihil nihilum nihili nihilo nil`);
+irr('duo', `duo duae duorum duarum duobus duabus duos duas`);
+irr('tres', `tres tria trium tribus`);
+irr('unus', `unus una unum unius uni unam uno`);
+irr('alius', `alius alia aliud alius alii aliud aliam alio aliorum aliarum aliis alios alias`);
+irr('uterque', `uterque utraque utrumque utriusque utrique utrumque utramque utroque`);
+irr('quisque', `quisque quaeque quodque quidque cuiusque cuique quemque quamque quoque`);
+irr('quidam', `quidam quaedam quoddam quiddam cuiusdam cuidam quendam quandam quodam quadam quorundam quarundam quibusdam quosdam quasdam`);
+
+// Irregular comparison — the classical suppletives.
+irr('bonus', `melior melioris meliori meliorem meliore meliores meliorum melioribus melius optimus optima optimum optimi optimae optimo optimam optimos optimas optimorum optimarum optimis optime`);
+irr('malus3', `peior peioris peiorem peiores peiorum peioribus peius pessimus pessima pessimum pessimi pessimae pessimo pessimis pessime`);
+irr('magnus', `maior maioris maiori maiorem maiore maiores maiorum maioribus maius maximus maxima maximum maximi maximae maximo maximam maximos maximorum maximis maxime`);
+irr('paruus', `minor minoris minorem minores minorum minoribus minus minimus minima minimum minimi minimae minimo minimis minime`);
+irr('multus', `plus pluris plura plurium pluribus plures plurimus plurima plurimum plurimi plurimae plurimo plurimis plurimum`);
+
+/** Irregular-forms lookup. Returns candidate lemma headwords (normalized). */
+export function irregularLemmas(normalizedWord: string): string[] {
+  return IRR[normalizedWord] ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Shared paradigm ending tables (normalized orthography).
+// ---------------------------------------------------------------------------
+
+const DECL_1 = ['a', 'ae', 'am', 'as', 'arum', 'is'];
+const DECL_2_MASC = ['us', 'i', 'o', 'um', 'e', 'os', 'orum', 'is'];
+const DECL_2_NEUT = ['um', 'i', 'o', 'a', 'orum', 'is'];
+const DECL_3_ENDINGS = ['is', 'i', 'em', 'e', 'es', 'um', 'ium', 'ibus', 'a', 'ia'];
+const DECL_4 = ['us', 'ui', 'um', 'u', 'uum', 'ibus'];
+const DECL_5 = ['es', 'ei', 'em', 'e', 'erum', 'ebus'];
+const ADJ_212 = ['us', 'a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is', 'e'];
+
+/**
+ * Derive oblique-stem candidates from headword + printed genitive suffix
+ * (e.g. corpus + "oris" → corpor-). Dictionary suffix conventions are not
+ * fully deterministic, so this over-generates candidates; junk stems produce
+ * junk forms that map to the right entry and are simply never queried.
+ */
+export function obliqueStems(head: string, genSuffix: string): string[] {
+  const gs = genSuffix;
+  const out = new Set<string>();
+  let tail = '';
+  if (gs.endsWith('is')) tail = gs.slice(0, -2);
+  else if (gs.endsWith('i')) tail = gs.slice(0, -1);
+  else if (gs.endsWith('us') || gs.endsWith('ei') || gs.endsWith('ae')) tail = '';
+  else return [];
+
+  // Rule 1: strip a known nominative ending, append the suffix stem-tail.
+  for (const strip of ['us', 'is', 'es', 'er', 'ir', 'or', 'en', 'on', 'o', 'x', 's', 'e', 'a', 'um', '']) {
+    if (strip && !head.endsWith(strip)) continue;
+    if (!strip && !tail) continue; // bare headword handled by caller
+    const stem = head.slice(0, head.length - strip.length) + tail;
+    if (stem.length >= 2) out.add(stem);
+  }
+  // Rule 2: printed convention "ager, gri" — replace from the last
+  // occurrence of the suffix's first letter.
+  if (tail) {
+    const idx = head.lastIndexOf(tail[0]);
+    if (idx > 0) out.add(head.slice(0, idx) + tail);
+  }
+  // Rule 3: the "suffix" is really a full genitive form ("rex, regis").
+  if (tail && gs.length >= 4 && gs[0] === head[0]) out.add(tail);
+  if (!tail) out.add(head.replace(/(us|es|ae|a|um)$/, ''));
+  return [...out];
+}
+
+/**
+ * Reverse-nominative stem guesses for 3rd-declension entries that carry no
+ * genitive in the source data (rex → reg-/rec-, corpus → corpor-, …).
+ * Over-generates; see note at top.
+ */
+export function guessThirdDeclStems(head: string): string[] {
+  const out = new Set<string>();
+  const rules: Array<[RegExp, string[]]> = [
+    [/x$/, ['g', 'c']],
+    [/as$/, ['at']],
+    [/us$/, ['or', 'er', 'ur']],
+    [/is$/, ['']],
+    [/es$/, ['', 'it']],
+    [/o$/, ['on', 'in']],
+    [/en$/, ['in']],
+    [/ut$/, ['it']],
+    [/er$/, ['r']],
+    [/or$/, ['or']],
+    [/(b|l|n|r)s$/, ['$1']],
+  ];
+  for (const [re, tails] of rules) {
+    if (!re.test(head)) continue;
+    for (const t of tails) {
+      const stem = head.replace(re, t.startsWith('$') ? '$1' : t);
+      if (stem.length >= 2 && stem !== head) out.add(stem);
+    }
+  }
+  return [...out];
+}
+
+export function nounForms(head: string, declension: number, genSuffix: string | undefined): string[] {
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+  switch (declension) {
+    case 1:
+      if (head.endsWith('a')) add(head.slice(0, -1), DECL_1);
+      break;
+    case 2:
+      if (head.endsWith('us')) add(head.slice(0, -2), DECL_2_MASC);
+      else if (head.endsWith('um')) add(head.slice(0, -2), DECL_2_NEUT);
+      else if (genSuffix) for (const s of obliqueStems(head, genSuffix)) add(s, ['i', 'o', 'um', 'orum', 'os', 'is', 'e']);
+      break;
+    case 3:
+      if (genSuffix) for (const s of obliqueStems(head, genSuffix)) add(s, DECL_3_ENDINGS);
+      else for (const s of guessThirdDeclStems(head)) add(s, DECL_3_ENDINGS);
+      break;
+    case 4:
+      if (head.endsWith('us')) add(head.slice(0, -2), DECL_4);
+      else if (head.endsWith('u')) add(head.slice(0, -1), ['u', 'us', 'ua', 'uum', 'ibus']);
+      break;
+    case 5:
+      if (head.endsWith('es')) add(head.slice(0, -2), DECL_5);
+      break;
+  }
+  return [...forms];
+}
+
+export function adjectiveForms(head: string): string[] {
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+  if (head.endsWith('us')) {
+    const stem = head.slice(0, -2);
+    add(stem, ADJ_212);
+    add(stem, ['ior', 'ioris', 'iori', 'iorem', 'iore', 'iores', 'iorum', 'ioribus', 'ius']); // comparative
+    add(stem, ['issimus', 'issima', 'issimum', 'issimi', 'issimae', 'issimo', 'issimam', 'issimis', 'issime']); // superlative
+    forms.add(stem + 'e'); // adverb
+  } else if (head.endsWith('is')) {
+    const stem = head.slice(0, -2);
+    add(stem, ['is', 'e', 'em', 'i', 'es', 'ia', 'ium', 'ibus', 'iter', 'ior', 'ioris', 'iorem', 'iores', 'issimus', 'issime']);
+  } else if (head.endsWith('er')) {
+    add(head, ['i', 'o', 'um', 'os', 'orum', 'is']);
+    // Both stem shapes: pulcher → pulchr-a, but alter → alter-a keeps the e.
+    for (const stem of [head.slice(0, -2) + 'r', head]) {
+      add(stem, ['a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is', 'e']);
+    }
+  } else if (head.endsWith('x')) {
+    // ferax, feracis — 3rd declension in -x, one termination.
+    const stem = head.slice(0, -1) + 'c';
+    add(stem, ['is', 'i', 'em', 'e', 'es', 'ia', 'ium', 'ibus', 'ior', 'ioris', 'iorem', 'iores', 'issimus', 'issima', 'issimum', 'issime', 'iter']);
+  } else if (head.endsWith('ns')) {
+    const stem = head.slice(0, -2) + 'nt';
+    add(stem, ['is', 'i', 'em', 'e', 'es', 'ium', 'ibus', 'ia', 'er']);
+  }
+  return [...forms];
+}
+
+// ---------------------------------------------------------------------------
+// Verb paradigms.
+// ---------------------------------------------------------------------------
+
+const PERFECT_ENDINGS = [
+  'i', 'isti', 'it', 'imus', 'istis', 'erunt', 'ere',
+  'eram', 'eras', 'erat', 'eramus', 'eratis', 'erant',
+  'ero', 'erit', 'erimus', 'eritis', 'erint',
+  'erim', 'eris',
+  'isse', 'issem', 'isses', 'isset', 'issemus', 'issetis', 'issent',
+];
+
+interface ConjTable {
+  active: string[];
+  passive: string[];
+  infinitives: string[];
+  imperatives: string[];
+  participleStems: string[]; // present participle: stem+ns / stem+nt-…
+  gerundStem: string; // +ndum etc.
+}
+
+// Endings are applied to the present stem (headword minus -o / -or).
+const CONJ: Record<string, ConjTable> = {
+  '1': {
+    active: ['o', 'as', 'at', 'amus', 'atis', 'ant', 'abam', 'abas', 'abat', 'abamus', 'abatis', 'abant',
+      'abo', 'abis', 'abit', 'abimus', 'abitis', 'abunt', 'em', 'es', 'et', 'emus', 'etis', 'ent',
+      'arem', 'ares', 'aret', 'aremus', 'aretis', 'arent'],
+    passive: ['or', 'aris', 'atur', 'amur', 'amini', 'antur', 'abar', 'abaris', 'abatur', 'abamur', 'abamini', 'abantur',
+      'abor', 'aberis', 'abitur', 'abimur', 'abimini', 'abuntur', 'er', 'eris', 'etur', 'emur', 'emini', 'entur',
+      'arer', 'areris', 'aretur', 'aremur', 'aremini', 'arentur'],
+    infinitives: ['are', 'ari'],
+    imperatives: ['a', 'ate', 'ator', 'antor'],
+    participleStems: ['ans|ant'],
+    gerundStem: 'and',
+  },
+  '2': {
+    // stem already ends in e (uide-)
+    active: ['o', 's', 't', 'mus', 'tis', 'nt', 'bam', 'bas', 'bat', 'bamus', 'batis', 'bant',
+      'bo', 'bis', 'bit', 'bimus', 'bitis', 'bunt', 'am', 'as', 'at', 'amus', 'atis', 'ant',
+      'rem', 'res', 'ret', 'remus', 'retis', 'rent'],
+    passive: ['or', 'ris', 'tur', 'mur', 'mini', 'ntur', 'bar', 'baris', 'batur', 'bamur', 'bamini', 'bantur',
+      'bor', 'beris', 'bitur', 'bimur', 'bimini', 'buntur', 'ar', 'aris', 'atur', 'amur', 'amini', 'antur',
+      'rer', 'reris', 'retur', 'remur', 'remini', 'rentur'],
+    infinitives: ['re', 'ri'],
+    imperatives: ['', 'te', 'tor', 'ntor'],
+    participleStems: ['ns|nt'],
+    gerundStem: 'nd',
+  },
+  '3': {
+    active: ['o', 'is', 'it', 'imus', 'itis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant',
+      'erem', 'eres', 'eret', 'eremus', 'eretis', 'erent'],
+    passive: ['or', 'eris', 'itur', 'imur', 'imini', 'untur', 'ebar', 'ebaris', 'ebatur', 'ebamur', 'ebamini', 'ebantur',
+      'ar', 'aris', 'atur', 'amur', 'amini', 'antur',
+      'erer', 'ereris', 'eretur', 'eremur', 'eremini', 'erentur'],
+    infinitives: ['ere', 'i'],
+    imperatives: ['e', 'ite', 'ito', 'itor', 'untor'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+  '3io': {
+    // stem ends in i (capi-); imperfect-subjunctive/infinitive drop it (cap-ere)
+    active: ['o', 's', 't', 'mus', 'tis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant'],
+    passive: ['or', 'tur', 'mur', 'mini', 'untur', 'ebar', 'ebatur', 'ebantur', 'ar', 'atur', 'antur'],
+    infinitives: [],
+    imperatives: ['', 'te'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+  '4': {
+    active: ['o', 's', 't', 'mus', 'tis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant',
+      'rem', 'res', 'ret', 'remus', 'retis', 'rent'],
+    passive: ['or', 'ris', 'tur', 'mur', 'mini', 'untur', 'ebar', 'ebatur', 'ebantur', 'ar', 'atur', 'antur',
+      'rer', 'retur', 'rentur'],
+    infinitives: ['re', 'ri'],
+    imperatives: ['', 'te', 'unto'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+};
+
+const PARTICIPLE_NT_ENDINGS = ['is', 'i', 'em', 'e', 'es', 'ium', 'ibus', 'ia'];
+const GERUND_ENDINGS = ['us', 'a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is'];
+
+/**
+ * Attach an abbreviated principal-part token ("aui", "xi", "ct") to the
+ * present stem. Dictionary abbreviation conventions vary, so this returns
+ * several candidates (see over-generation note at top).
+ */
+export function principalPartStems(head: string, token: string): string[] {
+  const presStem = head.replace(/or?$/, '');
+  const out = new Set<string>();
+  if (token.length >= 4 && token[0] === head[0]) out.add(token); // full form, e.g. "uidi"
+  out.add(presStem + token);
+  if (presStem.length > 2) out.add(presStem.slice(0, -1) + token);
+  if (presStem.length > 3) out.add(presStem.slice(0, -2) + token);
+  return [...out].filter((s) => s.length >= 3);
+}
+
+export function verbForms(
+  head: string,
+  conjugation: 1 | 2 | 3 | 4,
+  perfectStems: string[],
+  supineStems: string[]
+): string[] {
+  const deponent = head.endsWith('or');
+  const presStem = head.replace(/or?$/, '');
+  const io3 = conjugation === 3 && presStem.endsWith('i');
+  const table = CONJ[io3 ? '3io' : String(conjugation)];
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+
+  add(presStem, table.active);
+  add(presStem, table.passive);
+  add(presStem, table.infinitives);
+  add(presStem, table.imperatives);
+  for (const p of table.participleStems) {
+    const [nom, oblique] = p.split('|');
+    forms.add(presStem + nom);
+    add(presStem + oblique, PARTICIPLE_NT_ENDINGS);
+  }
+  add(presStem + table.gerundStem, GERUND_ENDINGS);
+  if (io3) {
+    // cap-ere, cap-erem, cap-eris…
+    const short = presStem.slice(0, -1);
+    add(short, ['ere', 'erem', 'eres', 'eret', 'eremus', 'eretis', 'erent', 'eris', 'erer', 'eretur', 'i', 'e', 'ite']);
+  }
+  for (const ps of perfectStems) {
+    add(ps, PERFECT_ENDINGS);
+    // Syncopated perfects: amauisse → amasse, amauerunt → amarunt;
+    // audiuisse → audisse, audiuerunt → audierunt.
+    if (ps.endsWith('au')) {
+      add(ps.slice(0, -2), ['asse', 'assem', 'asses', 'asset', 'assemus', 'assetis', 'assent',
+        'asti', 'astis', 'arunt', 'aram', 'aras', 'arat', 'aramus', 'arant', 'aro', 'arit', 'arint']);
+    } else if (ps.endsWith('iu')) {
+      add(ps.slice(0, -1), ['sse', 'ssem', 'sset', 'ssent', 'sti', 'stis', 'erunt', 'erat', 'erant', 'ero', 'erit']);
+    }
+  }
+  for (const ss of supineStems) {
+    add(ss, GERUND_ENDINGS); // perfect participle: -us -a -um…
+    add(ss + 'ur', GERUND_ENDINGS); // future participle: -urus…
+    forms.add(ss + 'u');
+    forms.add(ss + 'um');
+  }
+  if (deponent) forms.add(head);
+  return [...forms].filter((f) => f.length >= 2);
+}
+
+// ---------------------------------------------------------------------------
+// Query-time fallback: suffix-swap candidate headwords for an unknown form.
+// ---------------------------------------------------------------------------
+
+const SUFFIX_SWAPS: Array<[string, string[]]> = [
+  ['ibus', ['', 'is', 's', 'us']],
+  ['orum', ['us', 'um', 'i']],
+  ['arum', ['a']],
+  ['erunt', ['o', 'i']],
+  ['issent', ['o']],
+  ['isset', ['o']],
+  ['isse', ['o']],
+  ['issimus', ['us', 'is']],
+  ['issima', ['us', 'is']],
+  ['issimum', ['us', 'is']],
+  ['ionis', ['io']],
+  ['ione', ['io']],
+  ['ionem', ['io']],
+  ['iones', ['io']],
+  ['ionum', ['io']],
+  ['ionibus', ['io']],
+  ['atur', ['o', 'or']],
+  ['antur', ['o', 'or']],
+  ['etur', ['eo', 'o', 'eor']],
+  ['itur', ['o', 'io']],
+  ['untur', ['o']],
+  ['abat', ['o']],
+  ['ebat', ['eo', 'o']],
+  ['abant', ['o']],
+  ['ebant', ['eo', 'o']],
+  ['auit', ['o']],
+  ['euit', ['eo']],
+  ['iuit', ['io']],
+  ['atus', ['o', 'us']],
+  ['ata', ['o', 'us']],
+  ['atum', ['o', 'us']],
+  ['ati', ['o', 'us']],
+  ['atis', ['o', 'a', 'us']],
+  ['ntis', ['ns', 'o']],
+  ['ntem', ['ns', 'o']],
+  ['ntes', ['ns', 'o']],
+  ['ntia', ['ns', 'o']],
+  ['ntium', ['ns', 'o']],
+  ['ndi', ['o', 'us']],
+  ['ndo', ['o', 'us']],
+  ['ndum', ['o', 'us']],
+  ['nda', ['o', 'us']],
+  ['are', ['o']],
+  ['ari', ['o', 'or']],
+  ['ere', ['eo', 'o']],
+  ['ire', ['io']],
+  ['amus', ['o']],
+  ['emus', ['eo', 'o']],
+  ['imus', ['o', 'io']],
+  ['atis', ['o']],
+  ['etis', ['eo', 'o']],
+  ['itis', ['o', 'io']],
+  ['ant', ['o']],
+  ['ent', ['eo', 'o']],
+  ['unt', ['o']],
+  ['iunt', ['io']],
+  ['at', ['o', 'a']],
+  ['et', ['eo', 'o']],
+  ['it', ['o', 'io', 'eo']],
+  ['as', ['o', 'a']],
+  ['es', ['o', 'eo', 'is', 'es', '']],
+  ['is', ['is', '', 's', 'us', 'o', 'a']],
+  ['ae', ['a']],
+  ['am', ['a', 'o']],
+  ['a', ['a', 'um', 'us']],
+  ['os', ['us']],
+  ['um', ['us', 'um', 'a', '']],
+  ['o', ['us', 'um', 'o']],
+  ['i', ['us', 'um', '', 'is', 'o']],
+  ['em', ['is', '', 's']],
+  ['e', ['is', 'us', '']],
+  ['u', ['us']],
+  ['us', ['us']],
+];
+
+/**
+ * Long-s OCR error variants: early modern ſ is routinely misread as f
+ * ("fpiffandi" for spissandi, "refina" for resina). Generate f→s
+ * substitution variants, bounded to 15 combinations. Lowest-confidence tier.
+ */
+export function longSVariants(word: string): string[] {
+  const positions: number[] = [];
+  for (let i = 0; i < word.length && positions.length < 4; i++) if (word[i] === 'f') positions.push(i);
+  if (!positions.length) return [];
+  const out: string[] = [];
+  for (let mask = 1; mask < 1 << positions.length; mask++) {
+    const chars = word.split('');
+    for (let b = 0; b < positions.length; b++) if (mask & (1 << b)) chars[positions[b]] = 's';
+    out.push(chars.join(''));
+  }
+  return out;
+}
+
+/** Candidate headwords for an unknown normalized form, best-guess order. */
+export function suffixSwapCandidates(word: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>([word]);
+  for (const [suffix, replacements] of SUFFIX_SWAPS) {
+    if (!word.endsWith(suffix)) continue;
+    const stem = word.slice(0, word.length - suffix.length);
+    if (stem.length < 2) continue;
+    for (const r of replacements) {
+      const cand = stem + r;
+      if (cand.length >= 2 && !seen.has(cand)) {
+        seen.add(cand);
+        out.push(cand);
+      }
+    }
+  }
+  return out;
+}

--- a/src/lib/lexicon/lookup.ts
+++ b/src/lib/lexicon/lookup.ts
@@ -1,0 +1,229 @@
+import { Collection, Db } from 'mongodb';
+import { normalizeLatin, looseKey, cleanOcrToken } from './normalize';
+import { irregularLemmas, suffixSwapCandidates, longSVariants } from './latin-morph';
+
+/**
+ * Lookup chain for the parsing reader (issue #3823, Phase 1).
+ *
+ * Tiers, strongest first — the first tier that matches wins:
+ *  1. exact     — normalized form equals a headword
+ *  2. variant   — equals a recorded alternative orthography
+ *  3. irregular — hand-tabled irregular form (est → sum, tulit → fero)
+ *  4. inflected — form generated from the entry's own paradigm at import
+ *                 time (lexicon_lemma_map)
+ *  5. loose     — ae/oe/e + y/i collapsed match (coelum → caelum), a
+ *                 deterministic orthographic equivalence, so it outranks…
+ *  6. suffix    — heuristic suffix-swap candidate (labelled uncertain)
+ *  7. ocr       — long-s misread repair: f→s variants (fpiffandi →
+ *                 spissandi), re-run through tiers 1/4/5
+ *
+ * A miss is a structured miss. We never return a fuzzy "best guess" beyond
+ * tier 5/6, and those tiers carry `confident: false` so the UI can hedge.
+ */
+
+export type MatchType = 'exact' | 'variant' | 'irregular' | 'inflected' | 'loose' | 'suffix' | 'ocr';
+
+export interface LexiconMatch {
+  key: string;
+  headword: string;
+  matchType: MatchType;
+  confident: boolean;
+  entryType: string;
+  partOfSpeech: string | null;
+  orthography: string | null;
+  genitive: string | null;
+  gender: string | null;
+  declension: number | null;
+  mainNotes: string | null;
+  senses: unknown[];
+  sensesTruncated: boolean;
+}
+
+export interface LexiconLookupResult {
+  query: string;
+  normalized: string;
+  found: boolean;
+  matches: LexiconMatch[];
+}
+
+const MAX_MATCHES = 4;
+const MAX_SENSE_CHARS = 4000;
+
+interface EntryDoc {
+  key: string;
+  headword: string;
+  key_normalized: string;
+  key_loose: string;
+  alt_normalized?: string[];
+  entry_type: string;
+  part_of_speech?: string;
+  gender?: string;
+  declension?: number;
+  title_genitive?: string;
+  title_orthography?: string;
+  main_notes?: string;
+  senses?: unknown[];
+}
+
+function flattenSenseChars(senses: unknown[]): number {
+  let n = 0;
+  for (const s of senses) n += typeof s === 'string' ? s.length : flattenSenseChars(s as unknown[]);
+  return n;
+}
+
+function truncateSenses(senses: unknown[]): { senses: unknown[]; truncated: boolean } {
+  const out: unknown[] = [];
+  let used = 0;
+  for (const s of senses) {
+    const cost = typeof s === 'string' ? s.length : flattenSenseChars(s as unknown[]);
+    if (used + cost > MAX_SENSE_CHARS && out.length > 0) return { senses: out, truncated: true };
+    out.push(s);
+    used += cost;
+  }
+  return { senses: out, truncated: false };
+}
+
+function toMatch(doc: EntryDoc, matchType: MatchType): LexiconMatch {
+  const { senses, truncated } = truncateSenses(doc.senses ?? []);
+  return {
+    key: doc.key,
+    headword: doc.headword,
+    matchType,
+    confident: matchType !== 'suffix' && matchType !== 'ocr',
+    entryType: doc.entry_type,
+    partOfSpeech: doc.part_of_speech ?? null,
+    orthography: doc.title_orthography ?? null,
+    genitive: doc.title_genitive ?? null,
+    gender: doc.gender ?? null,
+    declension: doc.declension ?? null,
+    mainNotes: doc.main_notes ? doc.main_notes.slice(0, 600) : null,
+    senses,
+    sensesTruncated: truncated,
+  };
+}
+
+/** Prefer main entries and lower homonym numbers when several keys match. */
+function rankEntries(docs: EntryDoc[]): EntryDoc[] {
+  const typeRank: Record<string, number> = { main: 0, greek: 1, hapax: 2, gloss: 3, foreign: 4, spur: 5 };
+  return [...docs].sort(
+    (a, b) => (typeRank[a.entry_type] ?? 9) - (typeRank[b.entry_type] ?? 9) || a.key.localeCompare(b.key)
+  );
+}
+
+/**
+ * Pre-normalization variants tried through the whole chain, in order:
+ * the word itself; enclitic stripped (-que/-ne/-ue: veniamque → veniam);
+ * h toggled (early modern h-variance: humidum → umidum, arena → harena).
+ * These rewrite the QUERY only, so they stay consistent with the stored
+ * normalized keys (both sides of the guard keep the same normalizer).
+ */
+function queryVariants(normalized: string): string[] {
+  const out = [normalized];
+  const enclitic = normalized.match(/^(.{3,})(que|ne|ue|ce)$/);
+  if (enclitic) out.push(enclitic[1]);
+  if (normalized.startsWith('h')) out.push(normalized.slice(1));
+  else if (/^[aeiou]/.test(normalized)) out.push('h' + normalized);
+  if (enclitic && enclitic[1].startsWith('h')) out.push(enclitic[1].slice(1));
+  return out;
+}
+
+export async function lookupLatinWord(db: Db, rawWord: string): Promise<LexiconLookupResult> {
+  const query = cleanOcrToken(rawWord).slice(0, 60);
+  const normalized = normalizeLatin(query);
+  const entries = db.collection<EntryDoc>('lexicon_entries');
+  const lemmaMap = db.collection<{ form: string; form_loose?: string; keys: string[] }>('lexicon_lemma_map');
+  const miss: LexiconLookupResult = { query, normalized, found: false, matches: [] };
+  if (normalized.length < 1) return miss;
+
+  for (const variant of queryVariants(normalized)) {
+    const res = await runTiers(entries, lemmaMap, query, variant);
+    if (res) return { ...res, normalized };
+  }
+  return miss;
+}
+
+async function runTiers(
+  entries: Collection<EntryDoc>,
+  lemmaMap: Collection<{ form: string; form_loose?: string; keys: string[] }>,
+  query: string,
+  normalized: string
+): Promise<LexiconLookupResult | null> {
+  const finish = (docs: EntryDoc[], type: MatchType): LexiconLookupResult => ({
+    query,
+    normalized,
+    found: true,
+    matches: rankEntries(docs).slice(0, MAX_MATCHES).map((d) => toMatch(d, type)),
+  });
+
+  // 1. exact headword
+  const exact = await entries.find({ key_normalized: normalized }).limit(8).toArray();
+  if (exact.length) return finish(exact, 'exact');
+
+  // 2. recorded orthographic variant
+  const variant = await entries.find({ alt_normalized: normalized }).limit(8).toArray();
+  if (variant.length) return finish(variant, 'variant');
+
+  // 3. irregular forms — keep the table's order (est → sum before edo)
+  const irrLemmas = irregularLemmas(normalized);
+  if (irrLemmas.length) {
+    const docs = await entries
+      .find({ $or: [{ key_normalized: { $in: irrLemmas } }, { key: { $in: irrLemmas } }] })
+      .limit(8)
+      .toArray();
+    if (docs.length) {
+      const order = new Map(irrLemmas.map((l, i) => [l, i]));
+      const pos = (d: EntryDoc) => order.get(d.key) ?? order.get(d.key_normalized) ?? 99;
+      docs.sort((a, b) => pos(a) - pos(b));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'irregular')) };
+    }
+  }
+
+  // 4. generated paradigm map
+  const mapped = await lemmaMap.findOne({ form: normalized });
+  if (mapped?.keys?.length) {
+    const docs = await entries.find({ key: { $in: mapped.keys.slice(0, 8) } }).toArray();
+    if (docs.length) return finish(docs, 'inflected');
+  }
+
+  // 5. loose orthography (ae/oe/e, y/i collapse) — deterministic, so it
+  // outranks the suffix heuristic ("forme" is formae, not a guess at formus).
+  const loose = looseKey(normalized);
+  if (loose !== normalized) {
+    const docs = await entries.find({ key_loose: loose }).limit(8).toArray();
+    if (docs.length) return finish(docs, 'loose');
+    const mappedLoose = await lemmaMap.findOne({ form_loose: loose });
+    if (mappedLoose?.keys?.length) {
+      const docs2 = await entries.find({ key: { $in: mappedLoose.keys.slice(0, 8) } }).toArray();
+      if (docs2.length) return finish(docs2, 'loose');
+    }
+  }
+
+  // 6. suffix-swap heuristic (uncertain)
+  const candidates = suffixSwapCandidates(normalized).slice(0, 24);
+  if (candidates.length) {
+    const docs = await entries.find({ key_normalized: { $in: candidates } }).limit(8).toArray();
+    if (docs.length) {
+      // keep candidate order, not mongo order
+      const order = new Map(candidates.map((c, i) => [c, i]));
+      docs.sort((a, b) => (order.get(a.key_normalized) ?? 99) - (order.get(b.key_normalized) ?? 99));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'suffix')) };
+    }
+  }
+
+  // 7. long-s OCR repair: f→s variants through headword, paradigm map, loose.
+  const fsVariants = longSVariants(normalized);
+  if (fsVariants.length) {
+    const docs = await entries.find({ key_normalized: { $in: fsVariants } }).limit(8).toArray();
+    if (docs.length) return finish(docs, 'ocr');
+    const mappedFs = await lemmaMap.findOne({ form: { $in: fsVariants } });
+    if (mappedFs?.keys?.length) {
+      const docs2 = await entries.find({ key: { $in: mappedFs.keys.slice(0, 8) } }).toArray();
+      if (docs2.length) return finish(docs2, 'ocr');
+    }
+    const looseFs = [...new Set(fsVariants.map(looseKey))];
+    const docs3 = await entries.find({ key_loose: { $in: looseFs } }).limit(8).toArray();
+    if (docs3.length) return finish(docs3, 'ocr');
+  }
+
+  return null;
+}

--- a/src/lib/lexicon/normalize.ts
+++ b/src/lib/lexicon/normalize.ts
@@ -1,0 +1,61 @@
+/**
+ * Latin orthography normalization for dictionary lookup.
+ *
+ * Both sides of every comparison — dictionary headwords at import time and
+ * reader words at query time — MUST go through the same function. Never
+ * normalize only one side (see lesson: a guard must normalize both sides).
+ *
+ * Two tiers:
+ *  - normalizeLatin: safe, near-lossless canonical key (diacritics, ligatures,
+ *    u/v, i/j, case). Used as the primary lookup key.
+ *  - looseKey: additionally collapses ae/oe → e, which early modern printing
+ *    (coelum/caelum, foemina/femina) makes necessary. Lossier; used only as a
+ *    fallback tier so strict matches always win.
+ */
+
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+export function normalizeLatin(word: string): string {
+  return (
+    word
+      .normalize('NFD')
+      // Early modern contraction marks, BEFORE stripping combining chars.
+      // A tilde/macron over a vowel is a suspended nasal in early modern
+      // print: word-final → m ("Latinorū" → latinorum, "Cōsortiū" →
+      // consortium's final -um), mid-word tilde → m before labials
+      // ("cõbibo" → combibo) else n ("Sapiētia" → sapientia). Mid-word
+      // MACRONS are left to the generic strip — in dictionary orthography
+      // they mark length, not contraction. U+0303 = tilde, U+0304 = macron.
+      .replace(/([aeiouAEIOU])[̃̄](?=[^\p{L}̀-ͯ]|$)/gu, '$1m')
+      .replace(/([aeiouAEIOU])̃(?=[̀-ͯ]*[bpmBPM])/gu, '$1m')
+      .replace(/([aeiouAEIOU])̃/gu, '$1n')
+      .replace(COMBINING_MARKS, '') // remaining macrons, breves, accents
+      .toLowerCase()
+      .replace(/æ/g, 'ae')
+      .replace(/œ/g, 'oe')
+      .replace(/ſ/g, 's') // long s surviving in OCR
+      .replace(/j/g, 'i')
+      .replace(/v/g, 'u')
+      .replace(/w/g, 'uu')
+      // early modern tilde contractions: õ = om/on etc. NFD splits the tilde
+      // off as U+0303 (stripped above), so the base vowel survives; nothing
+      // more to do here, but the char class below drops any leftovers.
+      .replace(/[^a-z]/g, '')
+  );
+}
+
+/** Lossier key: early modern ae/oe/e and y/i conflation. */
+export function looseKey(normalized: string): string {
+  return normalized.replace(/ae/g, 'e').replace(/oe/g, 'e').replace(/y/g, 'i');
+}
+
+/**
+ * Strip punctuation and line-break hyphenation from a raw OCR token before
+ * normalization. Keeps internal letters only; returns '' for non-words.
+ */
+export function cleanOcrToken(token: string): string {
+  return token
+    .replace(/[­­-]\s*$/g, '') // trailing hyphen (line break)
+    .replace(/^[^\p{L}]+|[^\p{L}]+$/gu, '') // surrounding punctuation
+    .trim();
+}

--- a/tests/unit/lexicon-morph.test.ts
+++ b/tests/unit/lexicon-morph.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLatin, looseKey, cleanOcrToken } from '@/lib/lexicon/normalize';
+import {
+  nounForms,
+  verbForms,
+  adjectiveForms,
+  guessThirdDeclStems,
+  suffixSwapCandidates,
+  irregularLemmas,
+  longSVariants,
+} from '@/lib/lexicon/latin-morph';
+
+describe('normalizeLatin', () => {
+  it('handles early modern orthography', () => {
+    expect(normalizeLatin('cœlum')).toBe('coelum');
+    expect(normalizeLatin('Cælum')).toBe('caelum');
+    expect(normalizeLatin('ejus')).toBe('eius');
+    // Final macron reads as a suspended nasal — the early modern default in
+    // our OCR (Latinorū). The cost is dictionary-style length marks
+    // ('Vīvō' → uiuom), which effectively never appear in reader queries.
+    expect(normalizeLatin('Vīvō')).toBe('uiuom');
+    expect(normalizeLatin('āvi')).toBe('aui');
+    expect(normalizeLatin('cõmunis')).toBe('communis'); // tilde before labial → m
+  });
+  it('strips non-letters', () => {
+    expect(normalizeLatin('anno,')).toBe('anno');
+    expect(normalizeLatin('1651')).toBe('');
+  });
+  it('expands early modern contraction marks', () => {
+    expect(normalizeLatin('Latinorū')).toBe('latinorum'); // final macron → m
+    expect(normalizeLatin('conditũ')).toBe('conditum'); // final tilde → m
+    expect(normalizeLatin('Sapiẽtia')).toBe('sapientia'); // mid tilde → n
+    expect(normalizeLatin('cõbibo')).toBe('combibo'); // tilde before labial → m
+    expect(normalizeLatin('āvi')).toBe('aui'); // mid/lone macron still just strips
+  });
+  it('looseKey collapses ae/oe', () => {
+    expect(looseKey('caelum')).toBe('celum');
+    expect(looseKey('coelum')).toBe('celum');
+    expect(looseKey(normalizeLatin('cœlum'))).toBe(looseKey(normalizeLatin('cælum')));
+  });
+  it('cleanOcrToken strips punctuation and hyphenation', () => {
+    expect(cleanOcrToken('(natura)')).toBe('natura');
+    expect(cleanOcrToken('anno;')).toBe('anno');
+  });
+});
+
+describe('verbForms', () => {
+  it('conjugation 1 (amo)', () => {
+    const f = verbForms('amo', 1, ['amau'], ['amat']);
+    for (const w of ['amat', 'amamus', 'amant', 'amabat', 'amare', 'amauit', 'amatus', 'amandum', 'amans', 'amantis', 'amatur', 'amemus'])
+      expect(f, w).toContain(w);
+  });
+  it('conjugation 2 (uideo)', () => {
+    const f = verbForms('uideo', 2, ['uid'], ['uis']);
+    for (const w of ['uidet', 'uident', 'uidere', 'uidit', 'uiderunt', 'uisum', 'uidens', 'uidetur', 'uideatur'])
+      expect(f, w).toContain(w);
+  });
+  it('conjugation 3 and 3io', () => {
+    const duco = verbForms('duco', 3, ['dux'], ['duct']);
+    for (const w of ['ducit', 'ducunt', 'ducere', 'duxit', 'ductus', 'ducens', 'ducitur']) expect(duco, w).toContain(w);
+    const capio = verbForms('capio', 3, ['cep'], ['capt']);
+    for (const w of ['capit', 'capiunt', 'capere', 'cepit', 'captus', 'capiens', 'caperet']) expect(capio, w).toContain(w);
+  });
+  it('conjugation 4 (audio)', () => {
+    const f = verbForms('audio', 4, ['audiu'], ['audit']);
+    for (const w of ['audit', 'audiunt', 'audire', 'audiuit', 'auditus', 'audiens', 'auditur']) expect(f, w).toContain(w);
+  });
+});
+
+describe('nounForms', () => {
+  it('covers the five declensions', () => {
+    expect(nounForms('natura', 1, 'ae')).toEqual(expect.arrayContaining(['naturae', 'naturam', 'naturis']));
+    expect(nounForms('deus', 2, 'i')).toEqual(expect.arrayContaining(['dei', 'deorum', 'deos']));
+    expect(nounForms('corpus', 3, 'oris')).toEqual(expect.arrayContaining(['corporis', 'corpora', 'corporibus']));
+    expect(nounForms('spiritus', 4, 'us')).toEqual(expect.arrayContaining(['spiritum', 'spirituum', 'spiritibus']));
+    expect(nounForms('res', 5, 'ei')).toEqual(expect.arrayContaining(['rei', 'rerum', 'rebus']));
+  });
+  it('derives 3rd-declension stems from a full genitive (rex, regis)', () => {
+    expect(nounForms('rex', 3, 'regis')).toEqual(expect.arrayContaining(['regis', 'regem', 'regibus']));
+  });
+  it('guesses 3rd-declension stems when no genitive is given', () => {
+    expect(guessThirdDeclStems('rex')).toContain('reg');
+    expect(guessThirdDeclStems('urbs')).toContain('urb');
+    expect(guessThirdDeclStems('corpus')).toContain('corpor');
+    expect(nounForms('rex', 3, undefined)).toContain('regibus');
+  });
+});
+
+describe('adjectiveForms', () => {
+  it('1st/2nd declension with comparison', () => {
+    const f = adjectiveForms('altus');
+    for (const w of ['alta', 'altum', 'altorum', 'altior', 'altissimus', 'alte']) expect(f, w).toContain(w);
+  });
+  it('3rd declension', () => {
+    expect(adjectiveForms('omnis')).toEqual(expect.arrayContaining(['omne', 'omnia', 'omnium', 'omnibus']));
+  });
+});
+
+describe('irregularLemmas', () => {
+  it('resolves high-frequency irregular forms', () => {
+    expect(irregularLemmas('est')[0]).toBe('sum'); // sum outranks edo
+    expect(irregularLemmas('fuit')).toContain('sum');
+    expect(irregularLemmas('tulit')).toContain('fero');
+    expect(irregularLemmas('quibus')).toContain('qui1');
+    expect(irregularLemmas('melior')).toContain('bonus');
+    expect(irregularLemmas('maxime')).toContain('magnus');
+  });
+  it('returns empty for regular words', () => {
+    expect(irregularLemmas('natura')).toEqual([]);
+  });
+});
+
+describe('suffixSwapCandidates', () => {
+  it('proposes plausible headwords', () => {
+    expect(suffixSwapCandidates('philosophorum')).toContain('philosophus');
+    expect(suffixSwapCandidates('amauit')).toContain('amo');
+    expect(suffixSwapCandidates('rationis')).toContain('ratio');
+  });
+  it('never proposes sub-2-char stems', () => {
+    for (const c of suffixSwapCandidates('ibus')) expect(c.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('longSVariants', () => {
+  it('generates f→s substitutions for long-s OCR errors', () => {
+    expect(longSVariants('refina')).toContain('resina');
+    expect(longSVariants('fpiffandi')).toContain('spissandi');
+    expect(longSVariants('natura')).toEqual([]);
+  });
+  it('is bounded', () => {
+    expect(longSVariants('ffffffff').length).toBeLessThanOrEqual(15);
+  });
+});
+
+describe('syncopated perfects', () => {
+  it('amasse / amarunt from an -au perfect stem', () => {
+    const f = verbForms('amo', 1, ['amau'], ['amat']);
+    for (const w of ['amasse', 'amarunt', 'amasti']) expect(f, w).toContain(w);
+  });
+  it('audisse from an -iu perfect stem', () => {
+    expect(verbForms('audio', 4, ['audiu'], ['audit'])).toContain('audisse');
+  });
+});


### PR DESCRIPTION
Phase 1 of #3823 — the data layer and lookup API for the parsing reader (click-a-word Latin dictionary lookup), gated by an eval against real OCR before any UI ships.

## In scope

- **`scripts/lexicon/import-lewis-short.ts`** — imports Lewis & Short (51,596 entries, from the Perseus-derived lewis-short-json conversion, CC BY-SA/public domain) into `lexicon_entries`, and generates `lexicon_lemma_map` (~1.4M inflected forms) from each entry's own declension, genitive, and principal parts. Idempotent; the lemma map rebuilds atomically via rename. **Both collections are already imported to prod Mongo** — merging this PR has no deploy dependency on the data.
- **`src/lib/lexicon/`** — normalization (`æ/œ`, u/v, i/j, long-s, early modern tilde/macron contractions like `Latinorū` → *latinorum*; both sides of every comparison use the same normalizer), a rule-based Latin morphology engine (paradigm generation + irregular-form table + suffix heuristics), and the tiered lookup chain: exact → variant → irregular → inflected → loose orthography → suffix heuristic → long-s OCR repair, with query variants for enclitics (-que/-ne/-ue) and h-variance. Heuristic tiers return `confident: false`; a miss is a structured miss.
- **`GET /api/lexicon/lookup?word=cœlum&lang=la`** — anonymous, read-only, CDN-cached (with `max-age`, per the purge-survival lesson). `lang` is pinned to `la`; Greek slots in later without a URL change.
- **`tests/unit/lexicon-morph.test.ts`** — 22 tests pinning normalization and paradigm generation.
- **Eval gate** (`scripts/eval/lexicon-lookup-eval.ts` + scorecard in `scripts/eval/results/`): 786 words sampled from interior OCR pages of 40 visible Latin books, through the production chain:

| Metric | Result |
|---|---|
| Hit rate | **76.0%** |
| Confident tiers only | **68.3%** |
| Heuristic tiers (flagged uncertain) | +7.4% |

Misses are dominated by non-lexical tokens — proper names, roman numerals, embedded editorial vocabulary, and heavy brevigraph clusters (`usqʒ`, `p̄hibentibʒ`) — not by common Latin. Sampling variance at this size is real: 70–81% across rounds; treat 76% as a point estimate, not a floor.

## Out of scope (deliberately)

- **Phase 2 reader UI** (tap-a-word popover) — separate PR, so this one stays reviewable and the UI conversation doesn't block the data layer.
- **Greek (LSJ/odyCy)** — same architecture, after Latin proves out in the reader.
- **LatinCy neural lemmatization** — the rule-based chain got to 76% without a model service; wiring LatinCy in as a tier between `inflected` and `suffix` is a natural follow-up if Phase 2 usage shows the miss rate matters.
- **Brevigraph expansion** (ʒ, p̄ with following consonants) — the long tail of early modern abbreviation; worth its own focused pass.

Closes nothing; #3823 stays open to track Phases 2–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
