### PR TITLE
fix(dedup): artwork revalidate paths are slug-keyed, not id-keyed

### DIFF
--- a/scripts/lib/triage-apply.mjs
+++ b/scripts/lib/triage-apply.mjs
@@ -72,9 +72,15 @@ export async function recordRun(db, doc) {
   await db.collection('dedup_apply_runs').insertOne({ ...doc, at: new Date() });
 }
 
-/** /artwork/:id vs /book/:id — ANY resource_type value routes to /artwork. */
+/**
+ * ANY resource_type value routes to /artwork — and that route is
+ * /artwork/[slug], while books are /book/[id]. Verified 2026-08-09:
+ * /artwork/<id> 404s even for a visible artwork.
+ */
 export function pagePath(doc) {
-  return `${doc.resource_type ? '/artwork' : '/book'}/${doc.id}`;
+  return doc.resource_type || doc.content_type === 'artwork'
+    ? `/artwork/${doc.slug || doc.id}`
+    : `/book/${doc.id}`;
 }
 
 /**


### PR DESCRIPTION
Supersedes #3841/#3842 (recreated-branch CI trap, then a stale-base conflict). Single clean commit off origin/main.

Follow-up to #3836, found while executing the approved lanes: the `/artwork` route is `[slug]`-keyed and 404s on an id (verified live), so `pagePath()` was emitting no-op revalidate paths for artworks. Fixed to use `slug || id` for anything with `resource_type`/`content_type: 'artwork'`; books stay `/book/[id]`.

The 603 affected artwork pages from today's runs were re-revalidated by slug out-of-band (all 200 now), so this fix is for future runs, not a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)