### PR TITLE
feat(admin): identity review UI — adjudicate work-merge queue + keeper-choice clusters

### DIFF
--- a/scripts/analysis/stamp-work-merge-queue-llm.mjs
+++ b/scripts/analysis/stamp-work-merge-queue-llm.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * stamp-work-merge-queue-llm.mjs (#3846) — LLM screening pass over pending
+ * `work_merge_queue` rows. Stamps `llm: {verdict, reason, model, at}` on each
+ * row so /admin/identity-review can put the SAME-verdict rows on a fast path
+ * and reserve human attention for `unsure` + disagreements. Writes NOTHING
+ * except the stamp — no merge happens here; the human approve button does.
+ *
+ * Follows the design of llm-verify-work-merges.mjs (under-cluster, never
+ * guess a merge), but pairwise over the queue, batched 20 pairs per call.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/stamp-work-merge-queue-llm.mjs --limit 40        # trial
+ *   node scripts/analysis/stamp-work-merge-queue-llm.mjs                   # full queue
+ *   node scripts/analysis/stamp-work-merge-queue-llm.mjs --force          # re-stamp already-screened rows
+ *
+ * Cost: gemini-3.1-flash-lite, ~100 calls for the full 1.9K queue — well
+ * under $1. Env: MONGODB_URI, GEMINI_API_KEY_TIER3|GEMINI_API_KEY.
+ */
+import { MongoClient } from 'mongodb';
+
+const FORCE = process.argv.includes('--force');
+const LIMIT = parseInt((process.argv.find((a) => a.startsWith('--limit=')) || '').split('=')[1]
+  || process.argv[process.argv.indexOf('--limit') + 1] || '0', 10) || 0;
+const KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
+const MODEL = 'gemini-3.1-flash-lite';
+const GEN_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${KEY}`;
+if (!KEY) { console.error('GEMINI_API_KEY[_TIER3] not set'); process.exit(1); }
+
+const BATCH = 20;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          pair: { type: 'string' },                                    // the P<n> ref
+          verdict: { type: 'string', enum: ['same', 'different', 'unsure'] },
+          reason: { type: 'string' },
+        },
+        required: ['pair', 'verdict', 'reason'],
+      },
+    },
+  },
+  required: ['verdicts'],
+};
+
+function sideLine(s) {
+  const langs = s.langs.size ? ` [${[...s.langs].join('/')}]` : '';
+  const years = s.years.length ? ` (${Math.min(...s.years)}${Math.max(...s.years) !== Math.min(...s.years) ? '-' + Math.max(...s.years) : ''})` : '';
+  return `"${s.title}"${langs}${years}, ${s.n} book${s.n === 1 ? '' : 's'}`;
+}
+
+async function judgeBatch(pairs) {
+  const list = pairs.map((p, i) =>
+    `P${i}: author "${p.author}"\n  A: ${sideLine(p.sideA)}\n  B: ${sideLine(p.sideB)}`
+  ).join('\n');
+  const prompt = `You are a bibliographic cataloger applying FRBR Work-level identity. For each pair below, decide whether A and B are the SAME intellectual WORK — i.e. editions, printings, or translations of one work (titles may differ across languages), or DIFFERENT works.
+
+Rules:
+- Separate VOLUMES or PARTS of a multi-volume set are DIFFERENT works.
+- A commentary ON a work, an excerpt, or a collected edition (Opera omnia) containing it is DIFFERENT from the work itself.
+- A generic title ("Fragments", "Letters", "Works") matched against a specific title is usually DIFFERENT unless the evidence is strong.
+- Use your bibliographic knowledge of original vs translated titles.
+- Answer "same" or "different" ONLY when confident; otherwise "unsure". Never guess a merge.
+
+Pairs:
+${list}`;
+
+  const body = {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: { responseMimeType: 'application/json', responseSchema: SCHEMA, thinkingConfig: { thinkingBudget: 0 }, temperature: 0 },
+  };
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const r = await fetch(GEN_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal: AbortSignal.timeout(60000) });
+      if (r.status === 429) { await sleep(5000 * (attempt + 1)); continue; }
+      if (!r.ok) { if (attempt === 3) throw new Error(`Gemini ${r.status}: ${(await r.text()).slice(0, 200)}`); await sleep(2000); continue; }
+      const j = await r.json();
+      const txt = j.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!txt) { if (attempt === 3) return null; await sleep(1500); continue; }
+      return JSON.parse(txt);
+    } catch (e) { if (attempt === 3) { console.error(`  ! batch failed: ${e.message}`); return null; } await sleep(2000); }
+  }
+  return null;
+}
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db(process.env.MONGODB_DB || 'bookstore');
+const queue = db.collection('work_merge_queue');
+const books = db.collection('books');
+
+const filter = { status: 'pending', ...(FORCE ? {} : { llm: { $exists: false } }) };
+let rows = await queue.find(filter).sort({ _id: 1 }).toArray();
+if (LIMIT) rows = rows.slice(0, LIMIT);
+console.log(`${rows.length} pending rows to screen (${FORCE ? 'force re-stamp' : 'unstamped only'})`);
+if (!rows.length) { await mc.close(); process.exit(0); }
+
+// Live context per side: representative title + languages + years, straight
+// from books (the frozen evidence strings are display-order-unstable).
+const wids = [...new Set(rows.flatMap((r) => [r.a, r.b]))];
+const sideByWid = new Map();
+for (let i = 0; i < wids.length; i += 500) {
+  const docs = await books.find(
+    { work_id: { $in: wids.slice(i, i + 500) } },
+    { projection: { _id: 0, work_id: 1, title: 1, display_title: 1, language: 1, year: 1 } }
+  ).toArray();
+  for (const b of docs) {
+    if (!sideByWid.has(b.work_id)) sideByWid.set(b.work_id, { title: '', langs: new Set(), years: [], n: 0 });
+    const s = sideByWid.get(b.work_id);
+    s.n++;
+    const t = b.display_title || b.title || '';
+    if (t.length > s.title.length) s.title = t;
+    if (b.language) s.langs.add(b.language);
+    if (typeof b.year === 'number') s.years.push(b.year);
+  }
+}
+
+const jobs = rows
+  .map((r) => ({
+    id: r._id, author: r.evidence?.author || 'unknown',
+    sideA: sideByWid.get(r.a), sideB: sideByWid.get(r.b),
+  }))
+  .filter((j) => j.sideA?.n && j.sideB?.n); // stale pairs are the UI's problem, not the screen's
+console.log(`${jobs.length} pairs have live books on both sides`);
+
+const now = new Date();
+let stamped = 0;
+const tally = { same: 0, different: 0, unsure: 0 };
+for (let i = 0; i < jobs.length; i += BATCH) {
+  const batch = jobs.slice(i, i + BATCH);
+  const res = await judgeBatch(batch);
+  if (!res?.verdicts) continue;
+  const ops = [];
+  for (const v of res.verdicts) {
+    const idx = parseInt((v.pair || '').replace(/^P/, ''), 10);
+    const job = batch[idx];
+    if (!job || !['same', 'different', 'unsure'].includes(v.verdict)) continue;
+    tally[v.verdict]++;
+    ops.push({
+      updateOne: {
+        filter: { _id: job.id, status: 'pending' }, // never touch a row reviewed mid-run
+        update: { $set: { llm: { verdict: v.verdict, reason: (v.reason || '').slice(0, 400), model: MODEL, at: now }, updated_at: now } },
+      },
+    });
+  }
+  if (ops.length) {
+    const r = await queue.bulkWrite(ops, { ordered: false });
+    stamped += r.modifiedCount;
+  }
+  process.stderr.write(`  ${Math.min(i + BATCH, jobs.length)}/${jobs.length} judged, ${stamped} stamped\n`);
+}
+
+console.log(`\nDONE — ${stamped} rows stamped: same=${tally.same} different=${tally.different} unsure=${tally.unsure}`);
+console.log('Review lanes: /admin/identity-review → filter "LLM: unsure" first, then spot-check "same".');
+await mc.close();

--- a/scripts/maintenance/ingest-keeper-choice-queue.mjs
+++ b/scripts/maintenance/ingest-keeper-choice-queue.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * ingest-keeper-choice-queue.mjs (#3846) — load a keeper-choice triage
+ * snapshot (scripts/output/keeper-choice-triage-*.json, produced by the
+ * 2026-08-09 triage run) into the `edition_keeper_queue` collection so the
+ * decisions stop living in gitignored JSON on one machine and become
+ * reviewable at /admin/identity-review.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/ingest-keeper-choice-queue.mjs --file scripts/output/keeper-choice-triage-2026-08-09.json
+ *   node scripts/maintenance/ingest-keeper-choice-queue.mjs --file ... --apply
+ *
+ * Upserts by edition_key. NEVER clobbers a row that has already been
+ * reviewed (status != pending) — re-ingesting a newer triage only refreshes
+ * pending rows' classification.
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+const fileArg = (process.argv.find((a) => a.startsWith('--file=')) || '').split('=')[1]
+  || process.argv[process.argv.indexOf('--file') + 1];
+if (!fileArg || !fs.existsSync(fileArg)) {
+  console.error('usage: node ingest-keeper-choice-queue.mjs --file <triage.json> [--apply]');
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(fileArg, 'utf8'));
+const clusters = data.clusters || [];
+console.log(`${fileArg}: ${clusters.length} clusters (generated ${data.generated})`);
+for (const s of data.summary || []) console.log(`  ${s.bucket}: ${s.clusters} clusters / ${s.books} books`);
+
+if (!APPLY) {
+  console.log('\nDRY-RUN — pass --apply to upsert into edition_keeper_queue.');
+  process.exit(0);
+}
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db(process.env.MONGODB_DB || 'bookstore');
+const queue = db.collection('edition_keeper_queue');
+
+const now = new Date();
+let inserted = 0, refreshed = 0, skippedReviewed = 0;
+for (const c of clusters) {
+  if (!c.edition_key || !Array.isArray(c.members) || c.members.length < 2) continue;
+  try {
+    const r = await queue.updateOne(
+      { _id: c.edition_key, $or: [{ status: 'pending' }, { status: { $exists: false } }] },
+      {
+        $setOnInsert: { status: 'pending', created_at: now },
+        $set: {
+          bucket: c.bucket,
+          keeper_suggested: c.keeper || null,
+          ft_flag: c.ft_flag === true,
+          page_ratio: c.page_ratio ?? null,
+          members: c.members,
+          source_file: fileArg.split('/').pop(),
+          generated_at: data.generated || null,
+          updated_at: now,
+        },
+      },
+      { upsert: true }
+    );
+    if (r.upsertedCount) inserted++;
+    else refreshed++;
+  } catch (e) {
+    // E11000: the row exists but is already reviewed (filter missed, upsert
+    // tried to re-insert the _id) — exactly the case we must leave alone.
+    if (e.code === 11000) skippedReviewed++;
+    else throw e;
+  }
+}
+
+const counts = await queue.aggregate([{ $group: { _id: '$status', n: { $sum: 1 } } }]).toArray();
+console.log(`\nUPSERTED — ${inserted} new, ${refreshed} pending refreshed, ${skippedReviewed} already-reviewed left untouched.`);
+console.log('queue status:', counts.map((c) => `${c._id}=${c.n}`).join('  '));
+await mc.close();

--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -14,6 +14,7 @@ interface NavItem {
 const adminLinks: NavItem[] = [
   { href: '/admin', label: 'Dashboard', exact: true },
   { href: '/admin/canon', label: 'Canon' },
+  { href: '/admin/identity-review', label: 'Identity review' },
   { href: '/admin/pipeline', label: 'Pipeline' },
   { href: '/admin/processing', label: 'Processing' },
   { href: '/admin/realtime', label: 'Realtime' },

--- a/src/app/admin/identity-review/page.tsx
+++ b/src/app/admin/identity-review/page.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+/**
+ * Identity adjudication (#3846): the human remainder of the identity stack.
+ * Tab 1 — work_merge_queue pairs ("same intellectual work?").
+ * Tab 2 — edition_keeper_queue clusters ("same printing: which scan do readers see?").
+ * Approve/keep actuates immediately through the same write semantics as the
+ * maintenance scripts, attributed to the signed-in admin — no second job
+ * reads these decisions later.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+
+// ── work merges ──
+
+interface WorkSide {
+  workId: string;
+  nBooks: number;
+  nVisible: number;
+  languages: string[];
+  yearMin: number | null;
+  yearMax: number | null;
+  samples: { id: string; title: string; slug: string; visible: boolean; thumb: string | null }[];
+}
+
+interface MergeItem {
+  id: string;
+  status: string;
+  author: string;
+  evidence: { cont: number | null; inter: number | null; source: string };
+  llm: { verdict: string; reason?: string } | null;
+  a: WorkSide;
+  b: WorkSide;
+  suggestedWinner: string;
+  winner: string | null;
+  note: string | null;
+  reviewed_by: string | null;
+}
+
+// ── edition keepers ──
+
+interface KeeperMember {
+  id: string;
+  found: boolean;
+  title: string;
+  author: string;
+  slug: string;
+  language: string;
+  year: number | null;
+  visible: boolean;
+  pages: number;
+  ocr: number;
+  translated: number;
+  quality: number | null;
+  ft: boolean;
+  provider: string;
+  thumb: string | null;
+}
+
+interface KeeperItem {
+  editionKey: string;
+  bucket: string;
+  status: string;
+  ftFlag: boolean;
+  pageRatio: number | null;
+  suggestedKeeper: string | null;
+  keeper: string | null;
+  members: KeeperMember[];
+}
+
+type Status = 'pending' | 'approved' | 'rejected' | 'kept' | 'dismissed' | 'stale';
+
+const VERDICT_STYLE: Record<string, string> = {
+  same: 'bg-emerald-100 text-emerald-800',
+  different: 'bg-rose-100 text-rose-800',
+  unsure: 'bg-amber-100 text-amber-800',
+};
+
+function Cover({ thumb, title }: { thumb: string | null; title: string }) {
+  return thumb ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={thumb} alt={title} className="w-12 h-16 object-cover rounded border border-stone-200 flex-shrink-0" loading="lazy" />
+  ) : (
+    <div className="w-12 h-16 rounded border border-stone-200 bg-stone-100 flex-shrink-0" />
+  );
+}
+
+function WorkSideCard({ side, isSuggested }: { side: WorkSide; isSuggested: boolean }) {
+  return (
+    <div className={`flex-1 min-w-0 rounded-lg border p-3 ${isSuggested ? 'border-emerald-300 bg-emerald-50/40' : 'border-stone-200'}`}>
+      <div className="flex items-baseline gap-2 mb-2">
+        <a href={`/work/${encodeURIComponent(side.workId)}`} target="_blank" rel="noopener noreferrer" className="text-xs font-mono text-accent-rust hover:underline truncate">
+          {side.workId}
+        </a>
+        {isSuggested && <span className="text-[10px] uppercase tracking-wide text-emerald-700 whitespace-nowrap">suggested keep</span>}
+      </div>
+      <div className="text-xs text-stone-500 mb-2">
+        {side.nBooks} book{side.nBooks === 1 ? '' : 's'} ({side.nVisible} visible)
+        {side.languages.length > 0 && <> · {side.languages.join(', ')}</>}
+        {side.yearMin !== null && <> · {side.yearMin === side.yearMax ? side.yearMin : `${side.yearMin}–${side.yearMax}`}</>}
+      </div>
+      <div className="space-y-1.5">
+        {side.samples.map((s) => (
+          <div key={s.id} className="flex items-center gap-2">
+            <Cover thumb={s.thumb} title={s.title} />
+            <a href={`/book/${s.id}`} target="_blank" rel="noopener noreferrer" className="text-sm text-stone-800 hover:underline leading-snug line-clamp-2">
+              {s.title || s.id}
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WorkMergesTab() {
+  const [status, setStatus] = useState<Status>('pending');
+  const [verdict, setVerdict] = useState<string>('');
+  const [items, setItems] = useState<MergeItem[]>([]);
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [total, setTotal] = useState(0);
+  const [skip, setSkip] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const LIMIT = 25;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ status, limit: String(LIMIT), skip: String(skip) });
+      if (verdict) params.set('verdict', verdict);
+      const res = await fetch(`/api/admin/work-merges?${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setItems(data.items || []);
+      setCounts(data.counts || {});
+      setTotal(data.total || 0);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [status, verdict, skip]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function act(item: MergeItem, action: 'approve' | 'reject', winner?: string) {
+    const note = action === 'reject' ? (prompt('Why is this not the same work? (optional)', '') ?? undefined) : undefined;
+    if (action === 'reject' && note === undefined) return;
+    setBusy(item.id);
+    try {
+      const res = await fetch('/api/admin/work-merges', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id, action, winner, note: note || undefined }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { alert(`${action} failed: ${data.error || res.status}`); return; }
+      setItems((prev) => prev.filter((i) => i.id !== item.id));
+      setCounts((c) => ({ ...c, pending: Math.max(0, (c.pending || 1) - 1), [data.status]: (c[data.status] || 0) + 1 }));
+      setTotal((t) => Math.max(0, t - 1));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        {(['pending', 'approved', 'rejected', 'stale'] as Status[]).map((s) => (
+          <button key={s} onClick={() => { setStatus(s); setSkip(0); }}
+            className={`px-3 py-1.5 text-sm rounded border ${status === s ? 'border-accent-rust text-accent-rust bg-white' : 'border-stone-200 text-stone-500 hover:text-stone-800'}`}>
+            {s} <span className="text-xs text-stone-400">({counts[s] || 0})</span>
+          </button>
+        ))}
+        <span className="mx-2 text-stone-300">|</span>
+        <select value={verdict} onChange={(e) => { setVerdict(e.target.value); setSkip(0); }} className="text-sm border border-stone-200 rounded px-2 py-1.5 bg-white text-stone-700">
+          <option value="">all LLM verdicts</option>
+          <option value="same">LLM: same</option>
+          <option value="different">LLM: different</option>
+          <option value="unsure">LLM: unsure</option>
+          <option value="none">not screened</option>
+        </select>
+        <span className="text-xs text-stone-400 ml-auto">{total} matching{loading ? ' · loading…' : ''}</span>
+      </div>
+
+      {!loading && items.length === 0 && <p className="text-sm text-stone-500">Nothing here.</p>}
+
+      <div className="space-y-4">
+        {items.map((item) => (
+          <article key={item.id} className="border border-stone-200 rounded-lg p-4 bg-white">
+            <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+              <h3 className="text-sm font-semibold text-stone-800">{item.author || 'unknown author'}</h3>
+              {item.evidence.cont !== null && (
+                <span className="text-xs text-stone-400">containment {item.evidence.cont} · overlap {item.evidence.inter}</span>
+              )}
+              {item.llm && (
+                <span title={item.llm.reason || ''} className={`text-[11px] px-2 py-0.5 rounded-full ${VERDICT_STYLE[item.llm.verdict] || 'bg-stone-100 text-stone-600'}`}>
+                  LLM: {item.llm.verdict}
+                </span>
+              )}
+              {item.status !== 'pending' && item.reviewed_by && (
+                <span className="text-xs text-stone-400 ml-auto">{item.status} by {item.reviewed_by}{item.winner ? ` → kept ${item.winner}` : ''}{item.note ? ` — ${item.note}` : ''}</span>
+              )}
+            </header>
+
+            <div className="flex flex-col sm:flex-row gap-3 mb-3">
+              <WorkSideCard side={item.a} isSuggested={item.suggestedWinner === item.a.workId} />
+              <WorkSideCard side={item.b} isSuggested={item.suggestedWinner === item.b.workId} />
+            </div>
+
+            {item.status === 'pending' && (
+              <div className="flex flex-wrap gap-2">
+                <button disabled={busy === item.id} onClick={() => act(item, 'approve', item.a.workId)}
+                  className={`text-xs px-3 py-1.5 rounded text-white transition-colors disabled:opacity-50 ${item.suggestedWinner === item.a.workId ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-emerald-500/80 hover:bg-emerald-600'}`}>
+                  Same work → keep left
+                </button>
+                <button disabled={busy === item.id} onClick={() => act(item, 'approve', item.b.workId)}
+                  className={`text-xs px-3 py-1.5 rounded text-white transition-colors disabled:opacity-50 ${item.suggestedWinner === item.b.workId ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-emerald-500/80 hover:bg-emerald-600'}`}>
+                  Same work → keep right
+                </button>
+                <button disabled={busy === item.id} onClick={() => act(item, 'reject')}
+                  className="text-xs px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded transition-colors disabled:opacity-50">
+                  Not the same work
+                </button>
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+
+      {total > LIMIT && (
+        <div className="flex items-center gap-3 mt-4 text-sm">
+          <button disabled={skip === 0} onClick={() => setSkip(Math.max(0, skip - LIMIT))} className="px-3 py-1 border border-stone-200 rounded disabled:opacity-40">← Prev</button>
+          <span className="text-stone-500">{skip + 1}–{Math.min(skip + LIMIT, total)} of {total}</span>
+          <button disabled={skip + LIMIT >= total} onClick={() => setSkip(skip + LIMIT)} className="px-3 py-1 border border-stone-200 rounded disabled:opacity-40">Next →</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EditionKeepersTab() {
+  const [status, setStatus] = useState<Status>('pending');
+  const [bucket, setBucket] = useState<string>('human');
+  const [items, setItems] = useState<KeeperItem[]>([]);
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [buckets, setBuckets] = useState<Record<string, number>>({});
+  const [total, setTotal] = useState(0);
+  const [skip, setSkip] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const LIMIT = 15;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ status, bucket, limit: String(LIMIT), skip: String(skip) });
+      const res = await fetch(`/api/admin/edition-keepers?${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setItems(data.items || []);
+      setCounts(data.counts || {});
+      setBuckets(data.buckets || {});
+      setTotal(data.total || 0);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [status, bucket, skip]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function act(item: KeeperItem, action: 'keep' | 'dismiss', keeperId?: string) {
+    if (action === 'keep' && item.ftFlag && !confirm('This cluster carries a First Translation badge — hiding a badged copy changes what FT counting sees. Proceed?')) return;
+    setBusy(item.editionKey);
+    try {
+      const res = await fetch('/api/admin/edition-keepers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ editionKey: item.editionKey, action, keeperId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { alert(`${action} failed: ${data.error || res.status}`); return; }
+      setItems((prev) => prev.filter((i) => i.editionKey !== item.editionKey));
+      setCounts((c) => ({ ...c, pending: Math.max(0, (c.pending || 1) - 1), [data.status]: (c[data.status] || 0) + 1 }));
+      setTotal((t) => Math.max(0, t - 1));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        {(['pending', 'kept', 'dismissed'] as Status[]).map((s) => (
+          <button key={s} onClick={() => { setStatus(s); setSkip(0); }}
+            className={`px-3 py-1.5 text-sm rounded border ${status === s ? 'border-accent-rust text-accent-rust bg-white' : 'border-stone-200 text-stone-500 hover:text-stone-800'}`}>
+            {s} <span className="text-xs text-stone-400">({counts[s] || 0})</span>
+          </button>
+        ))}
+        <span className="mx-2 text-stone-300">|</span>
+        <select value={bucket} onChange={(e) => { setBucket(e.target.value); setSkip(0); }} className="text-sm border border-stone-200 rounded px-2 py-1.5 bg-white text-stone-700">
+          <option value="human">Needs a human (TOSSUP + SUSPECT{buckets.TOSSUP !== undefined ? `: ${(buckets.TOSSUP || 0) + (buckets.SUSPECT_NOT_SAME || 0)}` : ''})</option>
+          <option value="TOSSUP">TOSSUP ({buckets.TOSSUP || 0})</option>
+          <option value="SUSPECT_NOT_SAME">SUSPECT_NOT_SAME ({buckets.SUSPECT_NOT_SAME || 0})</option>
+          <option value="MECHANICAL_KEEP">MECHANICAL_KEEP ({buckets.MECHANICAL_KEEP || 0})</option>
+          <option value="SCORED_KEEP">SCORED_KEEP ({buckets.SCORED_KEEP || 0})</option>
+          <option value="all">all buckets</option>
+        </select>
+        <span className="text-xs text-stone-400 ml-auto">{total} matching{loading ? ' · loading…' : ''}</span>
+      </div>
+
+      {!loading && items.length === 0 && (
+        <p className="text-sm text-stone-500">Nothing here. If the queue is empty entirely, run <code className="text-xs">scripts/maintenance/ingest-keeper-choice-queue.mjs</code> to load a triage snapshot.</p>
+      )}
+
+      <div className="space-y-4">
+        {items.map((item) => (
+          <article key={item.editionKey} className="border border-stone-200 rounded-lg p-4 bg-white">
+            <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+              <span className={`text-[11px] px-2 py-0.5 rounded-full ${item.bucket === 'SUSPECT_NOT_SAME' ? 'bg-rose-100 text-rose-800' : 'bg-amber-100 text-amber-800'}`}>{item.bucket}</span>
+              {item.ftFlag && <span className="text-[11px] px-2 py-0.5 rounded-full bg-purple-100 text-purple-800">FT badge in cluster</span>}
+              {item.pageRatio !== null && <span className="text-xs text-stone-400">page similarity {(item.pageRatio * 100).toFixed(0)}%</span>}
+              <span className="text-xs font-mono text-stone-400 truncate max-w-full" title={item.editionKey}>{item.editionKey.length > 90 ? item.editionKey.slice(0, 90) + '…' : item.editionKey}</span>
+            </header>
+
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 mb-3">
+              {item.members.map((m) => (
+                <div key={m.id} className={`rounded-lg border p-3 ${m.id === item.suggestedKeeper ? 'border-emerald-300 bg-emerald-50/40' : 'border-stone-200'} ${!m.visible ? 'opacity-60' : ''}`}>
+                  <div className="flex gap-2 mb-2">
+                    <Cover thumb={m.thumb} title={m.title} />
+                    <div className="min-w-0">
+                      <a href={`/book/${m.id}`} target="_blank" rel="noopener noreferrer" className="text-sm text-stone-800 hover:underline leading-snug line-clamp-2">{m.title || m.id}</a>
+                      <div className="text-[11px] text-stone-500 mt-0.5">
+                        {m.provider}{m.language ? ` · ${m.language}` : ''}{m.year ? ` · ${m.year}` : ''}
+                        {!m.visible && <span className="text-rose-600"> · hidden</span>}
+                        {m.ft && <span className="text-purple-600"> · FT</span>}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-[11px] text-stone-500 mb-2">
+                    {m.pages} pp · OCR {m.pages ? Math.round((m.ocr / m.pages) * 100) : 0}% · transl. {m.pages ? Math.round((m.translated / m.pages) * 100) : 0}%
+                    {m.quality !== null && <> · quality {m.quality}</>}
+                  </div>
+                  {item.status === 'pending' && (
+                    <button disabled={busy === item.editionKey} onClick={() => act(item, 'keep', m.id)}
+                      className={`w-full text-xs px-2 py-1.5 rounded text-white transition-colors disabled:opacity-50 ${m.id === item.suggestedKeeper ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-emerald-500/80 hover:bg-emerald-600'}`}>
+                      Keep this one · hide {item.members.length - 1} other{item.members.length === 2 ? '' : 's'}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {item.status === 'pending' ? (
+              <button disabled={busy === item.editionKey} onClick={() => act(item, 'dismiss')}
+                className="text-xs px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded transition-colors disabled:opacity-50">
+                Not the same edition — leave all visible
+              </button>
+            ) : (
+              <div className="text-xs text-stone-500">{item.status}{item.keeper ? ` — keeper ${item.keeper}` : ''}</div>
+            )}
+          </article>
+        ))}
+      </div>
+
+      {total > LIMIT && (
+        <div className="flex items-center gap-3 mt-4 text-sm">
+          <button disabled={skip === 0} onClick={() => setSkip(Math.max(0, skip - LIMIT))} className="px-3 py-1 border border-stone-200 rounded disabled:opacity-40">← Prev</button>
+          <span className="text-stone-500">{skip + 1}–{Math.min(skip + LIMIT, total)} of {total}</span>
+          <button disabled={skip + LIMIT >= total} onClick={() => setSkip(skip + LIMIT)} className="px-3 py-1 border border-stone-200 rounded disabled:opacity-40">Next →</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function IdentityReviewPage() {
+  const [tab, setTab] = useState<'merges' | 'keepers'>('merges');
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-10">
+      <h1 className="text-2xl font-semibold mb-2">Identity review</h1>
+      <p className="text-sm text-stone-500 mb-6 max-w-3xl">
+        The human remainder of the identity stack. <strong>Work merges</strong>: are these two work
+        ids the same intellectual work? Approving merges immediately (aliases + redirect + provenance,
+        revert path in <code className="text-xs">work_id_merges</code>). <strong>Edition keepers</strong>:
+        same printing scanned twice — which copy do readers see? Keeping hides the others as
+        duplicates. Screen the merge queue first with{' '}
+        <code className="text-xs">scripts/analysis/stamp-work-merge-queue-llm.mjs</code> and review
+        the <em>unsure</em> lane, not everything.
+      </p>
+
+      <div className="flex gap-2 mb-6 border-b border-stone-200">
+        {([['merges', 'Work merges'], ['keepers', 'Edition keepers']] as const).map(([key, label]) => (
+          <button key={key} onClick={() => setTab(key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === key ? 'border-accent-rust text-accent-rust' : 'border-transparent text-stone-500 hover:text-stone-800'}`}>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'merges' ? <WorkMergesTab /> : <EditionKeepersTab />}
+    </div>
+  );
+}

--- a/src/app/api/admin/duplicates/route.ts
+++ b/src/app/api/admin/duplicates/route.ts
@@ -277,6 +277,7 @@ export const POST = withAdminAuth(async (request) => {
       hidden: true, visible: false,
       hidden_reason: 'duplicate',
       hidden_at: now,
+      updated_at: now, // books_catalog sync keys on this — without it the flip never reaches Supabase
       ...(keeperId ? { duplicate_of: keeperId } : {}),
     }}
   );

--- a/src/app/api/admin/edition-keepers/route.ts
+++ b/src/app/api/admin/edition-keepers/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { getDb } from '@/lib/mongodb';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+export const maxDuration = 30;
+
+/**
+ * Review surface for `edition_keeper_queue` (#3846) — both-visible clusters
+ * sharing one full-quality `edition_key`, pre-classified by the 2026-08-09
+ * keeper-choice triage (ingested via
+ * `scripts/maintenance/ingest-keeper-choice-queue.mjs`). The human lane is
+ * TOSSUP + SUSPECT_NOT_SAME; MECHANICAL/SCORED keeps stay script territory.
+ *
+ * "Keep" hides the other members with the same semantics as
+ * /api/admin/duplicates (hidden_reason 'duplicate', duplicate_of → keeper),
+ * plus the `updated_at` bump the Supabase catalog sync keys on.
+ * "Dismiss" records "not the same edition" and touches no book.
+ */
+
+const HUMAN_BUCKETS = ['TOSSUP', 'SUSPECT_NOT_SAME'];
+
+export const GET = withAdminAuth(async (request) => {
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') || 'pending';
+  const bucket = url.searchParams.get('bucket') || 'human';
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '30', 10) || 30, 100);
+  const skip = Math.max(parseInt(url.searchParams.get('skip') || '0', 10) || 0, 0);
+
+  const db = await getDb();
+  const queue = db.collection('edition_keeper_queue');
+
+  const filter: Record<string, unknown> = { status };
+  if (bucket === 'human') filter.bucket = { $in: HUMAN_BUCKETS };
+  else if (bucket !== 'all') filter.bucket = bucket;
+
+  const [rows, total, statusCounts, bucketCounts] = await Promise.all([
+    queue.find(filter).sort({ ft_flag: -1, _id: 1 }).skip(skip).limit(limit).toArray(),
+    queue.countDocuments(filter),
+    queue.aggregate([{ $group: { _id: '$status', n: { $sum: 1 } } }]).toArray(),
+    queue.aggregate([
+      { $match: { status: 'pending' } },
+      { $group: { _id: '$bucket', n: { $sum: 1 } } },
+    ]).toArray(),
+  ]);
+
+  const memberIds = [...new Set(rows.flatMap((r) => ((r.members as { id: string }[]) || []).map((m) => m.id)))];
+  const books = memberIds.length
+    ? await db.collection('books').find(
+        { id: { $in: memberIds } },
+        { projection: {
+          _id: 0, id: 1, title: 1, author: 1, slug: 1, language: 1, year: 1, visible: 1,
+          pages_count: 1, pages_ocr: 1, pages_translated: 1, is_first_translation: 1,
+          'image_source.provider': 1,
+          image_thumb: 1, image_display: 1, thumbnail: 1, thumbnail_blob: 1,
+        } }
+      ).toArray()
+    : [];
+  const byId = new Map(books.map((b) => [b.id as string, b]));
+
+  const items = rows.map((r) => ({
+    editionKey: r._id,
+    bucket: r.bucket,
+    status: r.status,
+    ftFlag: r.ft_flag === true,
+    pageRatio: r.page_ratio ?? null,
+    suggestedKeeper: r.keeper_suggested || null,
+    keeper: r.keeper || null,
+    reviewed_by: r.reviewed_by || null,
+    members: ((r.members as { id: string; quality?: number }[]) || []).map((m) => {
+      const live = byId.get(m.id);
+      return {
+        id: m.id,
+        // quality is the triage-time score snapshot; everything else is live
+        quality: m.quality ?? null,
+        found: !!live,
+        title: (live?.title as string) || '',
+        author: (live?.author as string) || '',
+        slug: (live?.slug as string) || '',
+        language: (live?.language as string) || '',
+        year: (live?.year as number) ?? null,
+        visible: live?.visible === true,
+        pages: (live?.pages_count as number) || 0,
+        ocr: (live?.pages_ocr as number) || 0,
+        translated: (live?.pages_translated as number) || 0,
+        ft: live?.is_first_translation === true,
+        provider: ((live?.image_source as Record<string, string>)?.provider) || '',
+        thumb: live ? getBookThumbnailUrl(live as Parameters<typeof getBookThumbnailUrl>[0], 'thumb') : null,
+      };
+    }),
+  }));
+
+  const counts: Record<string, number> = {};
+  for (const c of statusCounts) counts[c._id as string] = c.n as number;
+  const buckets: Record<string, number> = {};
+  for (const c of bucketCounts) buckets[c._id as string] = c.n as number;
+
+  return NextResponse.json({ items, total, counts, buckets });
+});
+
+/**
+ * POST /api/admin/edition-keepers
+ * Body: { editionKey, action: 'keep' | 'dismiss', keeperId?, note? }
+ */
+export const POST = withAdminAuth(async (request, session) => {
+  const body = await request.json();
+  const { editionKey, action, keeperId, note } = body as { editionKey?: string; action?: string; keeperId?: string; note?: string };
+  if (!editionKey || (action !== 'keep' && action !== 'dismiss')) {
+    return NextResponse.json({ error: 'editionKey and action (keep|dismiss) required' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const queue = db.collection('edition_keeper_queue');
+  const row = await queue.findOne({ _id: editionKey as never });
+  if (!row) return NextResponse.json({ error: 'cluster not found' }, { status: 404 });
+  if (row.status !== 'pending') {
+    return NextResponse.json({ error: `cluster is already ${row.status}` }, { status: 409 });
+  }
+
+  const now = new Date();
+  const reviewer = session.user?.email || 'admin';
+
+  if (action === 'dismiss') {
+    await queue.updateOne({ _id: editionKey as never }, { $set: { status: 'dismissed', note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
+    return NextResponse.json({ status: 'dismissed' });
+  }
+
+  const memberIds = ((row.members as { id: string }[]) || []).map((m) => m.id);
+  if (!keeperId || !memberIds.includes(keeperId)) {
+    return NextResponse.json({ error: 'keeperId must be a member of the cluster' }, { status: 400 });
+  }
+  const others = memberIds.filter((m) => m !== keeperId);
+
+  const hidden = await db.collection('books').updateMany(
+    { id: { $in: others }, visible: true },
+    { $set: {
+      hidden: true, visible: false,
+      hidden_reason: 'duplicate', hidden_at: now,
+      duplicate_of: keeperId,
+      updated_at: now, // books_catalog sync keys on this — a flip without it is invisible to Supabase
+    } }
+  );
+
+  await queue.updateOne(
+    { _id: editionKey as never },
+    { $set: { status: 'kept', keeper: keeperId, note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } }
+  );
+
+  return NextResponse.json({ status: 'kept', keeper: keeperId, hidden: hidden.modifiedCount });
+});

--- a/src/app/api/admin/work-merges/route.ts
+++ b/src/app/api/admin/work-merges/route.ts
@@ -1,0 +1,217 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { getDb } from '@/lib/mongodb';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+export const maxDuration = 30;
+
+/**
+ * Review surface for `work_merge_queue` (#3846) — the MEDIUM-confidence
+ * containment pairs that `scripts/maintenance/merge-work-clusters.mjs` queues
+ * instead of auto-merging. Approving a pair here runs the exact apply
+ * semantics of that script's HIGH lane (loser books rewritten to the winner,
+ * `work_id_aliases` stamped on the whole cluster so /work/[id] redirects,
+ * provenance doc in `work_id_merges`), with `resolver: 'human'` and the
+ * per-book prior work_ids kept inside the provenance doc as the revert path.
+ *
+ * Titles/langs/covers shown to the reviewer are pulled LIVE from `books` —
+ * the frozen `evidence` strings on the queue row are display-order-unstable
+ * (the writer sorts a/b after building evidence) and can go stale.
+ */
+
+interface WorkSide {
+  workId: string;
+  nBooks: number;
+  nVisible: number;
+  languages: string[];
+  yearMin: number | null;
+  yearMax: number | null;
+  samples: { id: string; title: string; slug: string; visible: boolean; thumb: string | null }[];
+}
+
+function summarizeSide(workId: string, books: Record<string, unknown>[]): WorkSide {
+  const langs = new Set<string>();
+  const years: number[] = [];
+  for (const b of books) {
+    if (typeof b.language === 'string' && b.language) langs.add(b.language);
+    if (typeof b.year === 'number') years.push(b.year);
+  }
+  const samples = [...books]
+    .sort((a, b) => Number(b.visible === true) - Number(a.visible === true) || ((b.pages_count as number) || 0) - ((a.pages_count as number) || 0))
+    .slice(0, 3)
+    .map((b) => ({
+      id: b.id as string,
+      title: (b.title as string) || '',
+      slug: (b.slug as string) || '',
+      visible: b.visible === true,
+      thumb: getBookThumbnailUrl(b as Parameters<typeof getBookThumbnailUrl>[0], 'thumb'),
+    }));
+  return {
+    workId,
+    nBooks: books.length,
+    nVisible: books.filter((b) => b.visible === true).length,
+    languages: [...langs].sort(),
+    yearMin: years.length ? Math.min(...years) : null,
+    yearMax: years.length ? Math.max(...years) : null,
+    samples,
+  };
+}
+
+/** Default winner: a Wikidata QID beats a local mint; else the id holding more books. */
+function defaultWinner(a: WorkSide, b: WorkSide): string {
+  const aQ = /^Q\d/.test(a.workId);
+  const bQ = /^Q\d/.test(b.workId);
+  if (aQ !== bQ) return aQ ? a.workId : b.workId;
+  return b.nBooks > a.nBooks ? b.workId : a.workId;
+}
+
+/**
+ * GET /api/admin/work-merges?status=pending&limit=50&skip=0&verdict=unsure&author=homer
+ * Lists queue rows with live book context; `verdict` filters on the optional
+ * `llm` screening stamp (same|different|unsure|none).
+ */
+export const GET = withAdminAuth(async (request) => {
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') || 'pending';
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10) || 50, 200);
+  const skip = Math.max(parseInt(url.searchParams.get('skip') || '0', 10) || 0, 0);
+  const verdict = url.searchParams.get('verdict');
+  const author = url.searchParams.get('author');
+
+  const db = await getDb();
+  const queue = db.collection('work_merge_queue');
+
+  const filter: Record<string, unknown> = { status };
+  if (verdict === 'none') filter['llm'] = { $exists: false };
+  else if (verdict) filter['llm.verdict'] = verdict;
+  if (author) filter['evidence.author'] = { $regex: author.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
+
+  const [rows, total, statusCounts] = await Promise.all([
+    queue.find(filter).sort({ 'evidence.author': 1, _id: 1 }).skip(skip).limit(limit).toArray(),
+    queue.countDocuments(filter),
+    queue.aggregate([{ $group: { _id: '$status', n: { $sum: 1 } } }]).toArray(),
+  ]);
+
+  const workIds = [...new Set(rows.flatMap((r) => [r.a as string, r.b as string]))];
+  const books = workIds.length
+    ? await db.collection('books').find(
+        { work_id: { $in: workIds } },
+        { projection: {
+          _id: 0, id: 1, work_id: 1, title: 1, slug: 1, language: 1, year: 1, visible: 1,
+          pages_count: 1, image_thumb: 1, image_display: 1, thumbnail: 1, thumbnail_blob: 1,
+        } }
+      ).toArray()
+    : [];
+  const byWid = new Map<string, Record<string, unknown>[]>();
+  for (const b of books) {
+    const wid = b.work_id as string;
+    if (!byWid.has(wid)) byWid.set(wid, []);
+    byWid.get(wid)!.push(b);
+  }
+
+  const items = rows.map((r) => {
+    const sideA = summarizeSide(r.a as string, byWid.get(r.a as string) || []);
+    const sideB = summarizeSide(r.b as string, byWid.get(r.b as string) || []);
+    return {
+      id: r._id,
+      status: r.status,
+      author: r.evidence?.author || '',
+      evidence: { cont: r.evidence?.cont ?? null, inter: r.evidence?.inter ?? null, source: r.evidence?.source || '' },
+      llm: r.llm || null,
+      a: sideA,
+      b: sideB,
+      suggestedWinner: defaultWinner(sideA, sideB),
+      winner: r.winner || null,
+      note: r.note || null,
+      reviewed_by: r.reviewed_by || null,
+      reviewed_at: r.reviewed_at || null,
+    };
+  });
+
+  const counts: Record<string, number> = {};
+  for (const c of statusCounts) counts[c._id as string] = c.n as number;
+
+  return NextResponse.json({ items, total, counts });
+});
+
+/**
+ * POST /api/admin/work-merges
+ * Body: { id, action: 'approve' | 'reject', winner?, note? }
+ *
+ * approve = the merge actually happens, here, attributed to the signed-in
+ * admin. This is deliberate actuation-at-the-point-of-review (the #3726
+ * Tier 3 shape): no second job reads these rows later.
+ */
+export const POST = withAdminAuth(async (request, session) => {
+  const body = await request.json();
+  const { id, action, winner: winnerParam, note } = body as { id?: string; action?: string; winner?: string; note?: string };
+  if (!id || (action !== 'approve' && action !== 'reject')) {
+    return NextResponse.json({ error: 'id and action (approve|reject) required' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const queue = db.collection('work_merge_queue');
+  const row = await queue.findOne({ _id: id as never });
+  if (!row) return NextResponse.json({ error: 'queue row not found' }, { status: 404 });
+  if (row.status !== 'pending') {
+    return NextResponse.json({ error: `row is already ${row.status}` }, { status: 409 });
+  }
+
+  const now = new Date();
+  const reviewer = session.user?.email || 'admin';
+
+  if (action === 'reject') {
+    await queue.updateOne({ _id: id as never }, { $set: { status: 'rejected', note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
+    return NextResponse.json({ status: 'rejected' });
+  }
+
+  const ids = [row.a as string, row.b as string];
+  const booksCol = db.collection('books');
+  const cluster = await booksCol.find(
+    { work_id: { $in: ids } },
+    { projection: { _id: 0, id: 1, work_id: 1 } }
+  ).toArray();
+  const nA = cluster.filter((b) => b.work_id === row.a).length;
+  const nB = cluster.filter((b) => b.work_id === row.b).length;
+  if (nA === 0 || nB === 0) {
+    // One side has no books left — an earlier merge or repair already moved
+    // them. Nothing to do; mark it so it leaves the pending lane.
+    await queue.updateOne({ _id: id as never }, { $set: { status: 'stale', reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
+    return NextResponse.json({ status: 'stale', message: `no books left on ${nA === 0 ? row.a : row.b}` });
+  }
+
+  const winner = winnerParam && ids.includes(winnerParam)
+    ? winnerParam
+    : (/^Q\d/.test(row.a as string) !== /^Q\d/.test(row.b as string)
+        ? (/^Q\d/.test(row.a as string) ? row.a as string : row.b as string)
+        : (nB > nA ? row.b as string : row.a as string));
+  const loser = winner === row.a ? row.b as string : row.a as string;
+
+  // Revert path: the prior work_id of every rewritten book, kept in provenance
+  // (the script keeps this in a backup file; a request handler keeps it in the doc).
+  const affected = cluster.filter((b) => b.work_id === loser).map((b) => ({ book_id: b.id as string, old_work_id: loser }));
+
+  const moved = await booksCol.updateMany(
+    { work_id: loser },
+    { $set: { work_id: winner, updated_at: now }, $addToSet: { work_id_aliases: loser } }
+  );
+  // Winner-side books carry the alias too: the redirect describes the WORK,
+  // so every edition under it must resolve the retired id.
+  await booksCol.updateMany(
+    { work_id: winner, work_id_aliases: { $ne: loser } },
+    { $set: { updated_at: now }, $addToSet: { work_id_aliases: loser } }
+  );
+
+  await db.collection('work_id_merges').insertOne({
+    winner, losers: [loser], sources: ['queue:human'],
+    books_rewritten: moved.modifiedCount, affected,
+    resolver: 'human', reviewed_by: reviewer, issue: 3846, applied_at: now,
+  });
+
+  await queue.updateOne(
+    { _id: id as never },
+    { $set: { status: 'approved', winner, note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } }
+  );
+
+  return NextResponse.json({ status: 'approved', winner, loser, booksMoved: moved.modifiedCount });
+});


### PR DESCRIPTION
Closes #3846.

## What

One page, `/admin/identity-review`, two tabs — the adjudication surface for the human remainder of the identity stack, replacing terminal-JSON review of untracked `scripts/output/` files.

**Work merges** (`work_merge_queue`, 1,924 pending): side-by-side pair with live book context (titles/languages/years/covers pulled from `books` — the frozen `evidence` strings are display-order-unstable, so they are never rendered). Approve executes the `merge-work-clusters.mjs` apply semantics in the request: loser books rewritten to the winner, `work_id_aliases` stamped on the whole cluster (the `/work/[id]` redirect), provenance doc in `work_id_merges` with `resolver: 'human'` and per-book prior work_ids as the revert path (the script's backup file, moved into the doc). Winner defaults QID > more-books, overridable. Pairs whose side has no books left are marked `stale`, never merged.

**Edition keepers** (`edition_keeper_queue`, new collection): both-visible same-`edition_key` clusters from the 2026-08-09 keeper-choice triage, ingested by `scripts/maintenance/ingest-keeper-choice-queue.mjs` (never clobbers a reviewed row). Member cards with covers, provider, OCR/translation %, quality snapshot. Keep = hide the other members with the `/api/admin/duplicates` semantics **plus the `updated_at` bump the Supabase catalog sync keys on**; dismiss = 'not the same edition', no book writes. FT-flagged clusters get a confirm step. Default lane is TOSSUP + SUSPECT_NOT_SAME (175 clusters); mechanical buckets stay script territory.

**LLM screen** — `scripts/analysis/stamp-work-merge-queue-llm.mjs` stamps `llm: {verdict: same|different|unsure}` on pending merge rows (batched flash-lite, ~<$1 full queue, stamp only — no merge). The UI filters on it, so the human lane is 'unsure + disagreements', not 1,924 rows.

**Drive-by fix**: `/api/admin/duplicates` POST never set `updated_at`, so books it hid stayed listed in the Supabase `books_catalog` until something else bumped them (the synced-column lesson, #3445).

## Design constraints honored

- Approve/keep is actuation **at the point of review**, attributed to the signed-in admin — no second job reads these rows later (#3726 Tier 3 / the actuation rule in CLAUDE.md).
- One writer per decision: the API routes carry the same write semantics as the maintenance scripts (aliases, provenance, dedup fields), so a decision looks identical no matter how it arrived.
- Every merge is reversible: aliases + `work_id_merges.affected` (prior work_id per book).

## Out of scope (deliberate)

- FT badge flips stay script + ids-file sign-off — one-click is the wrong friction there (13 of 16 'obvious demotes' were correct badges).
- Bulk-apply of MECHANICAL_KEEP/SCORED_KEEP buckets — script lane later.
- Dark-cluster restores (needs the 3-step unhide), `ft_reverify_proposal` screening.

## Verification

- `npx tsc --noEmit` clean.
- Both routes behind `withAdminAuth`; POST bodies validated (action whitelist, keeper/winner membership checks, 409 on already-reviewed rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)