### PR TITLE
feat(reader): tap-a-word Latin dictionary popover (#3823 Phase 2, stacked on #3840)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -117,14 +117,17 @@ const nextConfig: NextConfig = {
             value: [
               // Next.js requires 'unsafe-inline' for styles and 'unsafe-eval' for dev; in prod we need 'unsafe-inline' for React inline styles
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://translate.google.com https://translate.googleapis.com https://www.googletagmanager.com https://analytics.ahrefs.com https://eu-assets.i.posthog.com",
-              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://translate.googleapis.com",
+              // PROTOTYPE (#3823): jsdelivr allowed for the Alpheios embedded
+              // reading-tools evaluation. A production ship vendors the
+              // bundles and removes these entries.
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://translate.google.com https://translate.googleapis.com https://www.googletagmanager.com https://analytics.ahrefs.com https://eu-assets.i.posthog.com https://cdn.jsdelivr.net",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://translate.googleapis.com https://cdn.jsdelivr.net",
               "font-src 'self' https://fonts.gstatic.com",
               // Images: self + all configured remote image sources + data URIs for base64 thumbnails.
               // Host list lives in src/lib/csp-img-hosts.ts (shared with getBookThumbnailUrl's
               // renderability screen — edit it there, never inline here).
               CSP_IMG_SRC,
-              "connect-src 'self' https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co https://api.elevenlabs.io wss://*.elevenlabs.io https://www.google-analytics.com https://region1.google-analytics.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://analytics.ahrefs.com",
+              "connect-src 'self' https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co https://api.elevenlabs.io wss://*.elevenlabs.io https://www.google-analytics.com https://region1.google-analytics.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://analytics.ahrefs.com https://*.alpheios.net https://cdn.jsdelivr.net",
               "media-src 'self' blob: https://api.elevenlabs.io https://images.sourcelibrary.org",
               "frame-src 'self' https://translate.google.com",
               "worker-src 'self' blob: data:",

--- a/scripts/eval/lexicon-lookup-eval.ts
+++ b/scripts/eval/lexicon-lookup-eval.ts
@@ -1,0 +1,151 @@
+/**
+ * Phase-1 eval gate for the parsing reader (#3823): measure the lexicon
+ * lookup chain against REAL OCR — not clean critical editions — before any
+ * UI ships on top of it.
+ *
+ * Samples words from interior OCR pages of visible Latin books (front matter
+ * lies — see lesson), runs the exact production chain (lookupLatinWord), and
+ * reports hit rate per tier plus every miss and a random sample of hits for
+ * manual precision spot-checking. Writes a scorecard JSON to
+ * scripts/eval/results/.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/eval/lexicon-lookup-eval.ts [--books 25] [--words 500]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { MongoClient } from 'mongodb';
+import { lookupLatinWord } from '../../src/lib/lexicon/lookup';
+import { cleanOcrToken, normalizeLatin } from '../../src/lib/lexicon/normalize';
+
+const args = process.argv.slice(2);
+function flag(name: string, dflt: number): number {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? Number(args[i + 1]) : dflt;
+}
+const N_BOOKS = flag('books', 25);
+const N_WORDS = flag('words', 500);
+
+const ROMAN_NUMERAL = /^[ivxlcdm]+$/;
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || 'bookstore';
+  if (!uri) throw new Error('MONGODB_URI not set');
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+
+  // Latin books, canonical live filter (visible + processed).
+  const books = await db
+    .collection('books')
+    .aggregate([
+      {
+        $match: {
+          visible: true,
+          pages_ocr: { $gt: 20 },
+          language: { $in: ['la', 'lat', 'Latin', 'latin'] },
+        },
+      },
+      { $sample: { size: N_BOOKS } },
+      { $project: { id: 1, title: 1, published: 1, pages_count: 1 } },
+    ])
+    .toArray();
+  if (books.length < 15) throw new Error(`Only ${books.length} Latin books matched — check the language filter.`);
+  console.log(`Sampled ${books.length} Latin books`);
+
+  const perBook = Math.ceil(N_WORDS / books.length);
+  interface Sample { word: string; bookId: string; title: string; page: number }
+  const samples: Sample[] = [];
+
+  for (const b of books) {
+    // Interior pages only: skip the first/last 15% (front matter lies).
+    const total = b.pages_count || 100;
+    const lo = Math.floor(total * 0.15);
+    const hi = Math.ceil(total * 0.85);
+    const pages = await db
+      .collection('pages')
+      .aggregate([
+        { $match: { book_id: b.id, page_number: { $gte: lo, $lte: hi }, 'ocr.data': { $type: 'string' } } },
+        { $sample: { size: 3 } },
+        { $project: { page_number: 1, 'ocr.data': 1 } },
+      ])
+      .toArray();
+    const words: string[] = [];
+    for (const p of pages) {
+      // OCR text embeds structural XML (<page-type>, <scan-quality>,
+      // <image-desc>English prose</image-desc>, <margin>, <vocab>…) — strip
+      // element content that isn't source text, then the tags themselves,
+      // before tokenizing. A reader clicking words never sees these.
+      const text: string = (p.ocr?.data ?? '')
+        .replace(/<(image-desc|page-type|scan-quality|script|header)>[\s\S]*?<\/\1>/g, ' ')
+        .replace(/<[^<>]{1,60}>/g, ' ')
+        // rejoin line-break hyphenation: "ha-\nbentur" → habentur
+        .replace(/[-­]\s*\n\s*/g, '');
+      for (const tok of text.split(/[\s.·:]+/)) {
+        const w = cleanOcrToken(tok);
+        const norm = normalizeLatin(w);
+        if (norm.length >= 3 && !ROMAN_NUMERAL.test(norm) && !/[\d<>="/]/.test(w)) {
+          words.push(w);
+        }
+      }
+    }
+    // Random sample without replacement, dedupe within book.
+    const seen = new Set<string>();
+    while (seen.size < perBook && words.length) {
+      const i = Math.floor(Math.random() * words.length);
+      const [w] = words.splice(i, 1);
+      if (!seen.has(w.toLowerCase())) {
+        seen.add(w.toLowerCase());
+        const page = pages[0]?.page_number ?? 0;
+        samples.push({ word: w, bookId: b.id, title: String(b.title).slice(0, 60), page });
+      }
+    }
+  }
+  const finalSamples = samples.slice(0, N_WORDS);
+  console.log(`Collected ${finalSamples.length} word samples; running lookups…`);
+
+  const tierCounts: Record<string, number> = {};
+  const misses: Array<{ word: string; title: string }> = [];
+  const hits: Array<{ word: string; headword: string; tier: string; title: string }> = [];
+  let done = 0;
+  for (const s of finalSamples) {
+    const res = await lookupLatinWord(db, s.word);
+    if (res.found) {
+      const m = res.matches[0];
+      tierCounts[m.matchType] = (tierCounts[m.matchType] || 0) + 1;
+      hits.push({ word: s.word, headword: m.headword, tier: m.matchType, title: s.title });
+    } else {
+      tierCounts.miss = (tierCounts.miss || 0) + 1;
+      misses.push({ word: s.word, title: s.title });
+    }
+    if (++done % 100 === 0) console.log(`  ${done}/${finalSamples.length}`);
+  }
+
+  const n = finalSamples.length;
+  const found = n - (tierCounts.miss || 0);
+  const confident = (tierCounts.exact || 0) + (tierCounts.variant || 0) + (tierCounts.irregular || 0) + (tierCounts.inflected || 0);
+  const scorecard = {
+    date: new Date().toISOString().slice(0, 10),
+    issue: 3823,
+    sample: { books: books.length, words: n, selection: 'interior pages (15–85%), tokens ≥3 letters, non-numeric' },
+    hitRate: +(found / n).toFixed(3),
+    confidentHitRate: +(confident / n).toFixed(3),
+    tierCounts,
+    spotCheckHits: hits.sort(() => Math.random() - 0.5).slice(0, 40),
+    misses,
+  };
+  const outPath = path.join('scripts/eval/results', `lexicon-lookup-eval-${scorecard.date}.json`);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(scorecard, null, 2));
+  console.log(`\nHit rate: ${(scorecard.hitRate * 100).toFixed(1)}% (confident tiers: ${(scorecard.confidentHitRate * 100).toFixed(1)}%)`);
+  console.log('Tiers:', tierCounts);
+  console.log(`Scorecard → ${outPath}`);
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/lexicon-lookup-eval.ts
+++ b/scripts/eval/lexicon-lookup-eval.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { MongoClient } from 'mongodb';
 import { lookupLatinWord } from '../../src/lib/lexicon/lookup';
+import { lookupGreekWord, normGreekKey } from '../../src/lib/lexicon/lookup-grc';
 import { cleanOcrToken, normalizeLatin } from '../../src/lib/lexicon/normalize';
 
 const args = process.argv.slice(2);
@@ -26,6 +27,8 @@ function flag(name: string, dflt: number): number {
 }
 const N_BOOKS = flag('books', 25);
 const N_WORDS = flag('words', 500);
+const LANG = args.includes('--lang') ? args[args.indexOf('--lang') + 1] : 'la';
+const GREEK_TOKEN = /[Ͱ-Ͽἀ-῿]{2,}/u;
 
 const ROMAN_NUMERAL = /^[ivxlcdm]+$/;
 
@@ -45,7 +48,7 @@ async function main() {
         $match: {
           visible: true,
           pages_ocr: { $gt: 20 },
-          language: { $in: ['la', 'lat', 'Latin', 'latin'] },
+          language: LANG === 'grc' ? 'Greek' : { $in: ['la', 'lat', 'Latin', 'latin'] },
         },
       },
       { $sample: { size: N_BOOKS } },
@@ -83,8 +86,12 @@ async function main() {
         .replace(/<[^<>]{1,60}>/g, ' ')
         // rejoin line-break hyphenation: "ha-\nbentur" → habentur
         .replace(/[-­]\s*\n\s*/g, '');
-      for (const tok of text.split(/[\s.·:]+/)) {
+      for (const tok of text.split(/[\s.·:,;]+/)) {
         const w = cleanOcrToken(tok);
+        if (LANG === 'grc') {
+          if (GREEK_TOKEN.test(w) && normGreekKey(w).length >= 3) words.push(w);
+          continue;
+        }
         const norm = normalizeLatin(w);
         if (norm.length >= 3 && !ROMAN_NUMERAL.test(norm) && !/[\d<>="/]/.test(w)) {
           words.push(w);
@@ -111,7 +118,7 @@ async function main() {
   const hits: Array<{ word: string; headword: string; tier: string; title: string }> = [];
   let done = 0;
   for (const s of finalSamples) {
-    const res = await lookupLatinWord(db, s.word);
+    const res = LANG === 'grc' ? await lookupGreekWord(db, s.word) : await lookupLatinWord(db, s.word);
     if (res.found) {
       const m = res.matches[0];
       tierCounts[m.matchType] = (tierCounts[m.matchType] || 0) + 1;
@@ -129,6 +136,7 @@ async function main() {
   const scorecard = {
     date: new Date().toISOString().slice(0, 10),
     issue: 3823,
+    lang: LANG,
     sample: { books: books.length, words: n, selection: 'interior pages (15–85%), tokens ≥3 letters, non-numeric' },
     hitRate: +(found / n).toFixed(3),
     confidentHitRate: +(confident / n).toFixed(3),
@@ -136,7 +144,7 @@ async function main() {
     spotCheckHits: hits.sort(() => Math.random() - 0.5).slice(0, 40),
     misses,
   };
-  const outPath = path.join('scripts/eval/results', `lexicon-lookup-eval-${scorecard.date}.json`);
+  const outPath = path.join('scripts/eval/results', `lexicon-lookup-eval-${LANG}-${scorecard.date}.json`);
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, JSON.stringify(scorecard, null, 2));
   console.log(`\nHit rate: ${(scorecard.hitRate * 100).toFixed(1)}% (confident tiers: ${(scorecard.confidentHitRate * 100).toFixed(1)}%)`);

--- a/scripts/eval/results/lexicon-lookup-eval-2026-08-09.json
+++ b/scripts/eval/results/lexicon-lookup-eval-2026-08-09.json
@@ -1,0 +1,1021 @@
+{
+  "date": "2026-08-09",
+  "issue": 3823,
+  "sample": {
+    "books": 40,
+    "words": 786,
+    "selection": "interior pages (15–85%), tokens ≥3 letters, non-numeric"
+  },
+  "hitRate": 0.76,
+  "confidentHitRate": 0.683,
+  "tierCounts": {
+    "ocr": 10,
+    "irregular": 62,
+    "exact": 239,
+    "inflected": 233,
+    "miss": 189,
+    "suffix": 48,
+    "variant": 3,
+    "loose": 2
+  },
+  "spotCheckHits": [
+    {
+      "word": "Mathematici",
+      "headword": "mathematicus",
+      "tier": "suffix",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "super",
+      "headword": "super",
+      "tier": "exact",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "prædictum",
+      "headword": "praedictum",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "non",
+      "headword": "non",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "audent",
+      "headword": "audeo",
+      "tier": "inflected",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "longius",
+      "headword": "longus",
+      "tier": "inflected",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "cum",
+      "headword": "cum",
+      "tier": "exact",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "nil",
+      "headword": "nil",
+      "tier": "exact",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Tantali",
+      "headword": "Tantalus",
+      "tier": "inflected",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "hostes",
+      "headword": "hostis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "euangeliū",
+      "headword": "evangelium",
+      "tier": "exact",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "esse",
+      "headword": "sum",
+      "tier": "irregular",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "illorum",
+      "headword": "ille",
+      "tier": "irregular",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "lingua",
+      "headword": "lingua",
+      "tier": "exact",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "æquale",
+      "headword": "aequalis",
+      "tier": "inflected",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "pisces",
+      "headword": "piscis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "circulus",
+      "headword": "circulus",
+      "tier": "exact",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "signant",
+      "headword": "signo",
+      "tier": "inflected",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "notum",
+      "headword": "notus",
+      "tier": "suffix",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "hypotenusa",
+      "headword": "hypotenusa",
+      "tier": "exact",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "alijs",
+      "headword": "Alius",
+      "tier": "irregular",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "mente",
+      "headword": "mens",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "sui",
+      "headword": "sui",
+      "tier": "exact",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "pacta",
+      "headword": "pacta",
+      "tier": "exact",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "dignoſces",
+      "headword": "dignosco",
+      "tier": "suffix",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "Forma",
+      "headword": "forma",
+      "tier": "exact",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "the",
+      "headword": "thus",
+      "tier": "suffix",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Pannoniam",
+      "headword": "Pannonia",
+      "tier": "suffix",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "etiā",
+      "headword": "etiam",
+      "tier": "exact",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "defunctorum",
+      "headword": "defunctus",
+      "tier": "suffix",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "diametrum",
+      "headword": "diametrum",
+      "tier": "exact",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "ſilentio",
+      "headword": "silentium",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "fuperioribus",
+      "headword": "superus",
+      "tier": "ocr",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "horribile",
+      "headword": "horribilis",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "supra",
+      "headword": "supra",
+      "tier": "exact",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "mare",
+      "headword": "mare",
+      "tier": "exact",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "conſuetudinem",
+      "headword": "consuetudo",
+      "tier": "inflected",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "carnibus",
+      "headword": "caro",
+      "tier": "inflected",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "latinitas",
+      "headword": "latinitas",
+      "tier": "exact",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "unde",
+      "headword": "unde",
+      "tier": "exact",
+      "title": "Opera Varia, Vol. 2"
+    }
+  ],
+  "misses": [
+    {
+      "word": "CAP",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "LVII",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "each",
+      "title": "Opera ea quae ad adinventam ab ipso artem universalem scient"
+    },
+    {
+      "word": "olimpias",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "usqʒ",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "p̄hibentibʒ",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "most",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "lasciuie",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "paperclip",
+      "title": "De claris mulieribus (c.1474-75 Strasbourg incunabulum)"
+    },
+    {
+      "word": "common",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "root",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "script",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "flanked",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "illustration",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "woodcut",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Tulipa",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "detailed",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "heads",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "marginalia",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "plant",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "tulip",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "flower",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "upright",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "vertical",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "botany",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "two",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "identified",
+      "title": "Rariorum Stirpium per Pannoniam Historia"
+    },
+    {
+      "word": "Voetium",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "Dietericum",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "adire",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "nominaque",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "Junonis",
+      "title": "De nummis dissertationes XX"
+    },
+    {
+      "word": "enterrer",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "religieuse",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "German",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "ist",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "viuras",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "entierement",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "morts",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "veux",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tromperas",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tousiours",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "debtes",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "atq",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "donneras",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "peu",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "tiene",
+      "title": "Tintinabulum sophorum"
+    },
+    {
+      "word": "discontinuitate",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "mirabil",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "ignitio",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "tranea",
+      "title": "Summa perfectionis magisterii. Add: Liber trium verborum. Al"
+    },
+    {
+      "word": "mediamque",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "representat",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "idque",
+      "title": "In hoc volumine haec continentur. Aurelii Cornelii Celsii Me"
+    },
+    {
+      "word": "pferri",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "aliquaz",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "ꝓcept",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "spon",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "cās",
+      "title": "Speculum judiciale. With the additions of Johannes Andreae a"
+    },
+    {
+      "word": "amp",
+      "title": "Cornelii Valerii Ultraiectini In universam benedicendi [sic]"
+    },
+    {
+      "word": "tiá",
+      "title": "Cornelii Valerii Ultraiectini In universam benedicendi [sic]"
+    },
+    {
+      "word": "quadr",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectangulum",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "which",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "Fig",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectang",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "rectangulo",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "postrema",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "clearly",
+      "title": "Opera Varia, Vol. 2"
+    },
+    {
+      "word": "xpi",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "Glozia",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "teq",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "sup",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "exorcism",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "aliquib",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "equalis",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "misericordie",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "John",
+      "title": "Coniuratio malignorum spirituum [Coniuratio daemonum]"
+    },
+    {
+      "word": "facienda",
+      "title": "Rhetorica ad C. Herennium. Comm: Franciscus Maturantius [Mat"
+    },
+    {
+      "word": "oio",
+      "title": "Rhetorica ad C. Herennium. Comm: Franciscus Maturantius [Mat"
+    },
+    {
+      "word": "Eleemosyn",
+      "title": "Summa Theologica, Secunda Secundae (On Justice and Just Pric"
+    },
+    {
+      "word": "Corinth",
+      "title": "Summa Theologica, Secunda Secundae (On Justice and Just Pric"
+    },
+    {
+      "word": "script",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Iohannem",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Leftmost",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "above",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "image",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "text",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "Latin",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "notation",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "introiuit",
+      "title": "[Kyriale, Troper-Proser and processional]"
+    },
+    {
+      "word": "amp;c",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "tuam",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "potentior",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "catchword",
+      "title": "Arcana Politica"
+    },
+    {
+      "word": "obtinuisse",
+      "title": "Physica subterranea. Specimen Beccherianum"
+    },
+    {
+      "word": "Latin",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "nunq",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "mathcal{q",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "Dianamq",
+      "title": "In Somnium Scipionis Explanatio; Saturnaliorum libri VII; Ce"
+    },
+    {
+      "word": "BIBLIOTHEK",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "STIFTES",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "sepactas",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "loops",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Latin",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Mellensis",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "stamp",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "precipue",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Senging",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Mellicensis",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "catchword",
+      "title": "Modus scribendi"
+    },
+    {
+      "word": "Romana",
+      "title": "Opera Omnia Vol. 1"
+    },
+    {
+      "word": "Iudæi",
+      "title": "Opera Omnia Vol. 1"
+    },
+    {
+      "word": "tūc",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "Quatuor",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "effe",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "lexagexies",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "exalationibus",
+      "title": "De omnibus rebus naturalibus"
+    },
+    {
+      "word": "Alibotra",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Vatic",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Hictiophagi",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "inmergitur",
+      "title": "Geographi Latini Minores"
+    },
+    {
+      "word": "Metaphysicam",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "SYMME",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "nostra",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "ACTVA",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "partē",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "Maiorque",
+      "title": "Monas hieroglyphica"
+    },
+    {
+      "word": "Turkish",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "manuscript",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "instruction",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Naskh",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Arabic",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Ottoman",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Handwritten",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "moral",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "Nasta'liq",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "script",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "ethics",
+      "title": "Sirr al-Asrar (Secret of Secrets)"
+    },
+    {
+      "word": "gracia",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "Theb",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "temperancia",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "temperancie",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "collaudacio",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "misericordes",
+      "title": "Summa de virtutibus"
+    },
+    {
+      "word": "Latin",
+      "title": "De annorum revolutionibus astronomicis"
+    },
+    {
+      "word": "viderit",
+      "title": "De annorum revolutionibus astronomicis"
+    },
+    {
+      "word": "inferiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "perfectiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "adsint",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "propinquiora",
+      "title": "Procli philosophi Platonici opera : E codd. mss. biblioth. r"
+    },
+    {
+      "word": "Analemmate",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Boetius",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Finchius",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Holometrum",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Geometr",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Commandin",
+      "title": "Neopaedia : sive Methodi ratio"
+    },
+    {
+      "word": "Beruhr",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "Experiolus",
+      "title": "De secretis mulierum libellus : scholiis auctus"
+    },
+    {
+      "word": "pannisq",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Latin",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "catchword",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "crowned",
+      "title": "Abortus Chimicus, Sive Valleis Arcanitatum Divae Sapientiae."
+    },
+    {
+      "word": "Latin",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "rotumba",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "fac",
+      "title": "Compendium alchimiae"
+    },
+    {
+      "word": "ogni",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "uoglio",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "descriuendolo",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "impossibil",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Vadano",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "auenga",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "ragione",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "son",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "petto",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Che'l",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "alcune",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "fiamme",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Dal",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "cagione",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Vecchi",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "Enea",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "deh",
+      "title": "Didone, tragedia di m. Lodouico Dolce."
+    },
+    {
+      "word": "motiua",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "effe",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "cutting",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "partial",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "ondum",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    },
+    {
+      "word": "oportere",
+      "title": "Tractatus duo physici : prior de impostoria vulnerum per ung"
+    }
+  ]
+}

--- a/scripts/eval/results/lexicon-lookup-eval-grc-2026-08-10.json
+++ b/scripts/eval/results/lexicon-lookup-eval-grc-2026-08-10.json
@@ -1,0 +1,617 @@
+{
+  "date": "2026-08-10",
+  "issue": 3823,
+  "lang": "grc",
+  "sample": {
+    "books": 25,
+    "words": 440,
+    "selection": "interior pages (15–85%), tokens ≥3 letters, non-numeric"
+  },
+  "hitRate": 0.798,
+  "confidentHitRate": 0.3,
+  "tierCounts": {
+    "lemma": 219,
+    "exact": 132,
+    "miss": 89
+  },
+  "spotCheckHits": [
+    {
+      "word": "ποιητικῶς",
+      "headword": "ποιητικός",
+      "tier": "lemma",
+      "title": "Andocides: Orationes"
+    },
+    {
+      "word": "ἠλπίκατε",
+      "headword": "ἐλπίζω",
+      "tier": "lemma",
+      "title": "[Gospels of Luke and John in Greek]"
+    },
+    {
+      "word": "μήτε",
+      "headword": "μήτε",
+      "tier": "exact",
+      "title": "Justini Philosophi et Martyris Opera"
+    },
+    {
+      "word": "ἅπαντας",
+      "headword": "ἅπᾱς",
+      "tier": "lemma",
+      "title": "[Gospels of Luke and John in Greek]"
+    },
+    {
+      "word": "τῆς",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "μης",
+      "headword": "μείς",
+      "tier": "lemma",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "πανηγύρεως",
+      "headword": "πᾰνήγῠρις",
+      "tier": "lemma",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "δοκεῖτε",
+      "headword": "δοκέω",
+      "tier": "lemma",
+      "title": "[Gospels of Luke and John in Greek]"
+    },
+    {
+      "word": "ἀποπεπτωκότας",
+      "headword": "ἀποπίπτω",
+      "tier": "lemma",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "ἕλκει",
+      "headword": "ἑλκέω",
+      "tier": "lemma",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "μεταλλικὰ",
+      "headword": "μεταλλικός",
+      "tier": "lemma",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "περὶ",
+      "headword": "περί",
+      "tier": "exact",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "καθαρος",
+      "headword": "ἄγχῐ",
+      "tier": "lemma",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "λεγομένην",
+      "headword": "λέγω",
+      "tier": "lemma",
+      "title": "Justini Philosophi et Martyris Opera"
+    },
+    {
+      "word": "τὴν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "ἀδικεῖν",
+      "headword": "ἀδῐκέω",
+      "tier": "lemma",
+      "title": "Andocides: Orationes"
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "τοῦ",
+      "headword": "τις",
+      "tier": "lemma",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "ἐναντίων",
+      "headword": "ἐναντίος",
+      "tier": "lemma",
+      "title": "Platonos, Thoukydidous, kai Demosthenous, Epitaphioi logoi. "
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Bodleian Library MS. Holkham Gr. 76"
+    },
+    {
+      "word": "δούλῳ",
+      "headword": "δοῦλος",
+      "tier": "lemma",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "πρὸς",
+      "headword": "πρός",
+      "tier": "exact",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "καὶ",
+      "headword": "καί",
+      "tier": "exact",
+      "title": "Fragmenta philosophorum graecorum"
+    },
+    {
+      "word": "γενέσθαι",
+      "headword": "γίγνομαι",
+      "tier": "lemma",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "ἀνώνυμον",
+      "headword": "ἀνώνῠμος",
+      "tier": "lemma",
+      "title": "Plotini Enneades (13th c. copy B)"
+    },
+    {
+      "word": "τοὺς",
+      "headword": "ὦμος",
+      "tier": "lemma",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "χῶρον",
+      "headword": "χῶρος",
+      "tier": "lemma",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "κακια",
+      "headword": "ἑβδομάς",
+      "tier": "lemma",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "καὶ",
+      "headword": "καί",
+      "tier": "exact",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "θείᾳ",
+      "headword": "θεία",
+      "tier": "lemma",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "καὶ",
+      "headword": "καί",
+      "tier": "exact",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "Ἕκτορος",
+      "headword": "ἕκτωρ",
+      "tier": "lemma",
+      "title": "Omerou ilias. = Homeri ilias"
+    },
+    {
+      "word": "Ἀπολλώνιος",
+      "headword": "Ἀπολλώνιος",
+      "tier": "exact",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "ζητεῖτε",
+      "headword": "ζητέω",
+      "tier": "lemma",
+      "title": "[Gospels of Luke and John in Greek]"
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Fragmenta philosophorum graecorum"
+    },
+    {
+      "word": "τῶν",
+      "headword": "ὁ",
+      "tier": "lemma",
+      "title": "Plotini Enneades (13th c. copy B)"
+    },
+    {
+      "word": "τοῦ",
+      "headword": "τις",
+      "tier": "lemma",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "αὑτὸν",
+      "headword": "ἑαυτοῦ",
+      "tier": "lemma",
+      "title": "Bodleian Library MS. Holkham Gr. 76"
+    }
+  ],
+  "misses": [
+    {
+      "word": "κατεδύντες",
+      "title": "Omerou ilias. = Homeri ilias"
+    },
+    {
+      "word": "Τρώων",
+      "title": "Omerou ilias. = Homeri ilias"
+    },
+    {
+      "word": "περιττοσυλλάβως",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "γνῷ",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "προστάττει",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "ἤνωρον",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "τύθρας",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "πολυσωμένα",
+      "title": "Lascaris, De Octo Partibus Orationis — Greek Grammar (Aldine"
+    },
+    {
+      "word": "ἀργυρίτιδος",
+      "title": "Peri hylīs iatrikīs [...];De materia medica [...]. Peri dīlī"
+    },
+    {
+      "word": "ΚΕΦ",
+      "title": "Peri hylīs iatrikīs [...];De materia medica [...]. Peri dīlī"
+    },
+    {
+      "word": "ἥτις",
+      "title": "Peri hylīs iatrikīs [...];De materia medica [...]. Peri dīlī"
+    },
+    {
+      "word": "οὔτ",
+      "title": "Description of Greece (1491 MS, Grec 1410)"
+    },
+    {
+      "word": "περιθρέξω",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "εος",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "κέχαρκα",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "Προψω",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "προϋποστήσω",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "έος",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "προϋπῆρχον",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "θρώπε",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "προέφηνα",
+      "title": "Lexicon Graeco-Latinum in Novum Testamentum"
+    },
+    {
+      "word": "μωϋσῇ",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "ἀποκτενόντων",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "συνεχειν",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "παῦλε",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "κατασχέσει",
+      "title": "Novum Testamentum Graece (Editio Octava Critica Maior)"
+    },
+    {
+      "word": "φαί",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "χιχο",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "Παῖτος",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "βίσκον",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "Μενεκλῆς",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "Πτολεμαίου",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "ἐγδοῦναι",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "κζc",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "συντελέσομεν",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "Ἀπολλοφάνης",
+      "title": "Zenon Papyri Vol. I - Cairo Museum"
+    },
+    {
+      "word": "ἐκπεπόμφεσαν",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "στρατιῶται",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "στρατιωτῶν",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "κατασπαθίζειν",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "σπαθισμός",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "σφοδρῶς",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "σπαθιάς",
+      "title": "Leonis Diaconi Historia"
+    },
+    {
+      "word": "Ιεροσολυμα",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "αληθειαι",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "συγγραφεως",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "οψιν",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "Αιγυπτος",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "σοφων",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "επανερχεται",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "Ἰσραὴλ",
+      "title": "Evagrius Ponticus. Abhandlungen der Königlichen Gesellschaft"
+    },
+    {
+      "word": "ἤσπαιρε",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "Ἀντίλοχος",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "Ἕλενος",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "μεῖν",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "ὀϊστῷ",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "νεμέσα",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "Μυρμιδόνεσσι",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "μελανόχροες",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "ὕστατα",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "κόρσην",
+      "title": "Homeri Ilias (1517 Aldine Edition)"
+    },
+    {
+      "word": "συμμίξαντες",
+      "title": "Platonos, Thoukydidous, kai Demosthenous, Epitaphioi logoi. "
+    },
+    {
+      "word": "φάσκοντες",
+      "title": "Bodleian Library MS. Holkham Gr. 76"
+    },
+    {
+      "word": "καδμείαν",
+      "title": "Bodleian Library MS. Holkham Gr. 76"
+    },
+    {
+      "word": "αἰσθητῷ",
+      "title": "Plotini Enneades (13th c. copy B)"
+    },
+    {
+      "word": "Ὀλύμπιον",
+      "title": "Fragmenta philosophorum graecorum"
+    },
+    {
+      "word": "Ξενιάδῃ",
+      "title": "Fragmenta philosophorum graecorum"
+    },
+    {
+      "word": "παραπρεσβείας",
+      "title": "Andocides: Orationes"
+    },
+    {
+      "word": "συμβουλευτικόν",
+      "title": "Andocides: Orationes"
+    },
+    {
+      "word": "Ἰσαίου",
+      "title": "Andocides: Orationes"
+    },
+    {
+      "word": "σοφούς",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "ἀπεχώμεθά",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "πνι",
+      "title": "Origenes: Contra Celsum (Greek Critical Edition)"
+    },
+    {
+      "word": "Ἀθηναίοις",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "ὅσον",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "Κρησὶ",
+      "title": "Historiae Commentitiae"
+    },
+    {
+      "word": "συνιστάμεραι",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "φερά",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "Φύσιντα",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "ἠλίου",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "ἠρεμέντι",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "ἐστήθετα",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "πνεύσθαι",
+      "title": "Mathesis (De nativitatibus libri VIII). Ed: Franciscus Niger"
+    },
+    {
+      "word": "σχήματος",
+      "title": "Justini Philosophi et Martyris Opera"
+    },
+    {
+      "word": "πρωῒ",
+      "title": "Justini Philosophi et Martyris Opera"
+    },
+    {
+      "word": "ἐνεπεπλήκει",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "Συηναῖοι",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "Καλασíριδος",
+      "title": "Scriptores Erotici Graeci, Vol. 2 (Xenophon of Ephesus)"
+    },
+    {
+      "word": "μετ",
+      "title": "[Gospels of Luke and John in Greek]"
+    }
+  ]
+}

--- a/scripts/lexicon/enumerate-greek-forms.mjs
+++ b/scripts/lexicon/enumerate-greek-forms.mjs
@@ -1,0 +1,64 @@
+/**
+ * Enumerate distinct Greek word forms across the corpus (#3823 Phase 3).
+ *
+ * Streams ocr.data for every visible Greek book's pages, tokenizes on Greek
+ * script runs, NFC-normalizes, converts grave→acute (running-text accent →
+ * lexical accent), strips length marks, and writes a frequency-sorted TSV
+ * (form \t count) for the Morpheus bulk run. Betacode conversion happens in
+ * the cruncher driver, not here — this file is the reusable corpus fact.
+ *
+ * Run: node --env-file=.env.production.local scripts/lexicon/enumerate-greek-forms.mjs
+ * Output: scripts/lexicon/output/greek-forms.tsv (gitignored dir)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { MongoClient } from 'mongodb';
+
+const OUT = 'scripts/lexicon/output/greek-forms.tsv';
+const GREEK_TOKEN = /[Ͱ-Ͽἀ-῿]+/gu;
+
+function normalizeGreekForm(raw) {
+  let s = raw.normalize('NFC');
+  // grave → acute: final-syllable graves are a running-text sandhi artifact
+  const GRAVE_TO_ACUTE = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ': 'ή', 'ὶ': 'ί', 'ὸ': 'ό', 'ὺ': 'ύ', 'ὼ': 'ώ', 'ᾃ': 'ᾅ', 'ἃ': 'ἅ', 'ἓ': 'ἕ', 'ἳ': 'ἵ', 'ὃ': 'ὅ', 'ὓ': 'ὕ', 'ὣ': 'ὥ', 'ἂ': 'ἄ', 'ἒ': 'ἔ', 'ἲ': 'ἴ', 'ὂ': 'ὄ', 'ὒ': 'ὔ', 'ὢ': 'ὤ', 'ᾲ': 'ᾴ', 'ῂ': 'ῄ', 'ῲ': 'ῴ' };
+  s = [...s].map((ch) => GRAVE_TO_ACUTE[ch] ?? ch).join('');
+  return s;
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = await db
+    .collection('books')
+    .find({ visible: true, language: 'Greek', pages_ocr: { $gt: 0 } }, { projection: { id: 1 } })
+    .toArray();
+  console.log(`${books.length} Greek books`);
+
+  const counts = new Map();
+  let pagesSeen = 0;
+  for (const [bi, b] of books.entries()) {
+    const cursor = db.collection('pages').find(
+      { book_id: b.id, 'ocr.data': { $type: 'string' } },
+      { projection: { 'ocr.data': 1 } }
+    );
+    for await (const p of cursor) {
+      pagesSeen++;
+      const text = (p.ocr?.data ?? '').replace(/<[^<>]{1,60}>/g, ' ');
+      for (const m of text.matchAll(GREEK_TOKEN)) {
+        const form = normalizeGreekForm(m[0]);
+        if (form.length < 2 || form.length > 40) continue;
+        counts.set(form, (counts.get(form) ?? 0) + 1);
+      }
+    }
+    if (bi % 50 === 0) console.log(`book ${bi}/${books.length}, pages ${pagesSeen}, distinct ${counts.size}`);
+  }
+
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  fs.writeFileSync(OUT, sorted.map(([f, c]) => `${f}\t${c}`).join('\n'));
+  console.log(`DONE: ${sorted.length} distinct forms from ${pagesSeen} pages → ${OUT}`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lexicon/import-lewis-short.ts
+++ b/scripts/lexicon/import-lewis-short.ts
@@ -192,6 +192,8 @@ async function main() {
   await newMap.createIndex({ form_loose: 1 });
   await newMap.rename('lexicon_lemma_map', { dropTarget: true });
 
+  await db.collection('lexicon_misses').createIndex({ form: 1 }, { unique: true });
+  await db.collection('lexicon_misses').createIndex({ count: -1 });
   await entriesCol.createIndex({ key: 1 }, { unique: true });
   await entriesCol.createIndex({ key_normalized: 1 });
   await entriesCol.createIndex({ key_loose: 1 });

--- a/scripts/lexicon/import-lewis-short.ts
+++ b/scripts/lexicon/import-lewis-short.ts
@@ -1,0 +1,209 @@
+/**
+ * Import Lewis & Short (1879) into Mongo for the parsing reader (#3823).
+ *
+ * Source: the lewis-short-json conversion of Perseus's TEI digitisation
+ * (https://github.com/IohannesArnold/lewis-short-json, CC BY-SA — text itself
+ * is public domain). Download the ls_*.json letter files first and pass the
+ * directory with --dir (default: _tmp-ls-json/ next to the repo root).
+ *
+ * Writes two collections in the `bookstore` db:
+ *   lexicon_entries   — one doc per L&S entry (~51.6K), with normalized keys
+ *   lexicon_lemma_map — generated inflected form → entry keys, built from
+ *                       each entry's own declension/genitive/principal parts
+ *                       via src/lib/lexicon/latin-morph.ts
+ *
+ * Idempotent: upserts entries by key and rebuilds the lemma map atomically
+ * (writes to lexicon_lemma_map_new, then renames over the old one).
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/lexicon/import-lewis-short.ts --dir _tmp-ls-json
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { MongoClient, AnyBulkWriteOperation, Document } from 'mongodb';
+import { normalizeLatin, looseKey } from '../../src/lib/lexicon/normalize';
+import { nounForms, adjectiveForms, verbForms, principalPartStems } from '../../src/lib/lexicon/latin-morph';
+
+interface RawEntry {
+  entry_type: string;
+  key: string;
+  main_notes: string;
+  part_of_speech: string;
+  senses?: unknown[];
+  declension?: number;
+  gender?: string;
+  title_genitive?: string;
+  title_orthography?: string;
+  alternative_orthography?: string[];
+  alternative_genative?: string;
+  greek_word?: string;
+}
+
+const args = process.argv.slice(2);
+const dirFlag = args.indexOf('--dir');
+const DIR = dirFlag >= 0 ? args[dirFlag + 1] : '_tmp-ls-json';
+const MAX_KEYS_PER_FORM = 12;
+
+function parseVerbParts(headNorm: string, notes: string): { conjs: Array<1 | 2 | 3 | 4>; perfect: string[]; supine: string[] } {
+  // Typical shape: "ămo, āvi, ātum, 1, v. a. (…" — principal parts as
+  // abbreviated tokens, then a bare conjugation digit. Many entries truncate
+  // before the digit ("vŏco, āvi, ātum ("), so when it's absent we infer the
+  // conjugation from the principal-part signature / headword shape — and when
+  // genuinely ambiguous we generate the UNION of candidate paradigms (every
+  // form still maps to the right entry; see over-generation note in
+  // latin-morph.ts).
+  const headChunk = notes.slice(0, 120).split('(')[0];
+  const conjMatch = headChunk.match(/,\s*([1-4])\s*[,.;)\s]/);
+  const perfect: string[] = [];
+  const supine: string[] = [];
+  let sawAvi = false;
+  let sawIvi = false;
+  for (const rawTok of headChunk.split(',').slice(1)) {
+    for (const tok of rawTok.split(/\s+or\s+/)) {
+      const t = normalizeLatin(tok.trim());
+      if (!t || /^[1-4]$/.test(tok.trim())) continue;
+      if (t.endsWith('i') && !t.endsWith('ari') && !t.endsWith('eri') && !t.endsWith('iri') && t.length >= 2) {
+        if (t.endsWith('aui')) sawAvi = true;
+        if (t.endsWith('iui') || t === 'ii') sawIvi = true;
+        for (const s of principalPartStems(headNorm, t.replace(/i$/, ''))) perfect.push(s);
+      } else if (t.endsWith('um') || t.endsWith('us')) {
+        for (const s of principalPartStems(headNorm, t.replace(/(um|us)$/, ''))) supine.push(s);
+      }
+    }
+  }
+  let conjs: Array<1 | 2 | 3 | 4>;
+  if (conjMatch) conjs = [Number(conjMatch[1]) as 1 | 2 | 3 | 4];
+  else if (sawAvi) conjs = [1];
+  else if (headNorm.endsWith('eo') || headNorm.endsWith('eor')) conjs = [2];
+  else if (headNorm.endsWith('io') || headNorm.endsWith('ior')) conjs = sawIvi ? [4] : [3, 4];
+  else conjs = [1, 3];
+  return { conjs, perfect: [...new Set(perfect)].slice(0, 4), supine: [...new Set(supine)].slice(0, 4) };
+}
+
+function generateForms(e: RawEntry, headNorm: string): string[] {
+  if (e.entry_type !== 'main' && e.entry_type !== 'hapax') return [];
+  const pos = (e.part_of_speech || '').toLowerCase();
+  const gen = e.title_genitive ? normalizeLatin(e.title_genitive) : undefined;
+
+  if (e.declension && (e.gender || gen)) {
+    return nounForms(headNorm, e.declension, gen);
+  }
+  if (pos.includes('adj') || pos === 'p. a.') {
+    return adjectiveForms(headNorm);
+  }
+  if (pos.includes('v') && (headNorm.endsWith('o') || headNorm.endsWith('or'))) {
+    const { conjs, perfect, supine } = parseVerbParts(headNorm, e.main_notes || '');
+    const forms = new Set<string>();
+    for (const c of conjs) for (const f of verbForms(headNorm, c, perfect, supine)) forms.add(f);
+    return [...forms];
+  }
+  return [];
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || 'bookstore';
+  if (!uri) throw new Error('MONGODB_URI not set — source .env.production.local first.');
+
+  const files = fs.readdirSync(DIR).filter((f) => /^ls_[A-Z]\.json$/.test(f)).sort();
+  if (files.length < 20) throw new Error(`Only ${files.length} ls_*.json files in ${DIR} — incomplete download?`);
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+  const entriesCol = db.collection('lexicon_entries');
+
+  let entryCount = 0;
+  let formCount = 0;
+  const lemmaMap = new Map<string, Set<string>>();
+
+  for (const file of files) {
+    const raw: RawEntry[] = JSON.parse(fs.readFileSync(path.join(DIR, file), 'utf8'));
+    const ops: AnyBulkWriteOperation<Document>[] = [];
+    for (const e of raw) {
+      if (!e.key) continue;
+      const headword = e.key.replace(/\d+$/, '');
+      const keyNorm = normalizeLatin(headword);
+      if (!keyNorm) continue;
+      const altNorm = [...new Set((e.alternative_orthography || []).map(normalizeLatin).filter((a) => a && a !== keyNorm))];
+      ops.push({
+        updateOne: {
+          filter: { key: e.key },
+          update: {
+            $set: {
+              dict: 'lewis-short',
+              key: e.key,
+              headword,
+              key_normalized: keyNorm,
+              key_loose: looseKey(keyNorm),
+              alt_normalized: altNorm,
+              entry_type: e.entry_type,
+              part_of_speech: e.part_of_speech || null,
+              gender: e.gender ?? null,
+              declension: e.declension ?? null,
+              title_genitive: e.title_genitive ?? null,
+              title_orthography: e.title_orthography ?? null,
+              greek_word: e.greek_word ?? null,
+              main_notes: e.main_notes ?? null,
+              senses: e.senses ?? [],
+              imported_at: new Date(),
+            },
+          },
+          upsert: true,
+        },
+      });
+
+      // Greek-script entries get no Latin paradigm.
+      if (!e.greek_word) {
+        for (const form of generateForms(e, keyNorm)) {
+          if (form === keyNorm) continue;
+          const set = lemmaMap.get(form) ?? new Set<string>();
+          if (set.size < MAX_KEYS_PER_FORM) set.add(e.key);
+          lemmaMap.set(form, set);
+        }
+        for (const alt of altNorm) {
+          const set = lemmaMap.get(alt) ?? new Set<string>();
+          if (set.size < MAX_KEYS_PER_FORM) set.add(e.key);
+          lemmaMap.set(alt, set);
+        }
+      }
+    }
+    const res = await entriesCol.bulkWrite(ops, { ordered: false });
+    entryCount += res.upsertedCount + res.modifiedCount + res.matchedCount - res.modifiedCount;
+    console.log(`${file}: ${ops.length} entries upserted (running total ${entryCount})`);
+  }
+
+  // Rebuild lemma map atomically: write _new, create indexes, rename over.
+  const newMap = db.collection('lexicon_lemma_map_new');
+  await newMap.drop().catch(() => {});
+  const mapDocs: Document[] = [];
+  for (const [form, keys] of lemmaMap) {
+    mapDocs.push({ form, form_loose: looseKey(form), keys: [...keys] });
+  }
+  console.log(`lemma map: ${mapDocs.length} distinct generated forms`);
+  const BATCH = 20000;
+  for (let i = 0; i < mapDocs.length; i += BATCH) {
+    await newMap.insertMany(mapDocs.slice(i, i + BATCH), { ordered: false });
+    formCount += Math.min(BATCH, mapDocs.length - i);
+    if (formCount % 100000 < BATCH) console.log(`  inserted ${formCount}/${mapDocs.length}`);
+  }
+  await newMap.createIndex({ form: 1 }, { unique: true });
+  await newMap.createIndex({ form_loose: 1 });
+  await newMap.rename('lexicon_lemma_map', { dropTarget: true });
+
+  await entriesCol.createIndex({ key: 1 }, { unique: true });
+  await entriesCol.createIndex({ key_normalized: 1 });
+  await entriesCol.createIndex({ key_loose: 1 });
+  await entriesCol.createIndex({ alt_normalized: 1 });
+
+  const finalEntries = await entriesCol.countDocuments();
+  const finalForms = await db.collection('lexicon_lemma_map').countDocuments();
+  console.log(`DONE: lexicon_entries=${finalEntries}, lexicon_lemma_map=${finalForms}`);
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lexicon/import-lsj.mjs
+++ b/scripts/lexicon/import-lsj.mjs
@@ -89,17 +89,23 @@ async function main() {
 
   // 2. Lemma map: Morpheus lemma (unicode, maybe trailing homograph digit)
   //    → LSJ keys via the shared normalizer.
+  // Dedupe fully in memory (forms collide after normalization — merge key
+  // sets), then plain insertMany. Never upsert into an unindexed collection:
+  // each upsert filter collection-scans the growing table and the load goes
+  // quadratic (~21 docs/s observed the first time).
   const newMap = db.collection('lexicon_lemma_map_grc_new');
   await newMap.drop().catch(() => {});
   const rl = readline.createInterface({ input: fs.createReadStream(LEMMA_JSONL) });
-  let mapDocs = [];
+  const byForm = new Map();
   let mapped = 0, unjoined = 0, total = 0;
   const unjoinedSample = [];
   for await (const line of rl) {
     if (!line.trim()) continue;
     total++;
     const { form, lemmas } = JSON.parse(line);
-    const keys = new Set();
+    const normForm = normGreekKey(form);
+    if (!normForm) continue;
+    const keys = byForm.get(normForm) ?? new Set();
     for (const lemma of lemmas) {
       const bare = lemma.replace(/[0-9]+$/, '');
       for (const k of keyByNorm.get(normGreekKey(bare)) ?? []) {
@@ -112,15 +118,14 @@ async function main() {
       continue;
     }
     mapped++;
-    mapDocs.push({ form: normGreekKey(form), keys: [...keys] });
-    if (mapDocs.length >= 20000) {
-      // forms can collide after normalization; last write wins is fine here
-      await newMap.bulkWrite(mapDocs.map((d) => ({ updateOne: { filter: { form: d.form }, update: { $set: d }, upsert: true } })), { ordered: false });
-      mapDocs = [];
-      if (mapped % 200000 < 20000) console.log(`lemma map ${mapped} mapped / ${unjoined} unjoined`);
-    }
+    byForm.set(normForm, keys);
   }
-  if (mapDocs.length) await newMap.bulkWrite(mapDocs.map((d) => ({ updateOne: { filter: { form: d.form }, update: { $set: d }, upsert: true } })), { ordered: false });
+  const allDocs = [...byForm.entries()].map(([form, keys]) => ({ form, keys: [...keys] }));
+  console.log(`lemma map: ${allDocs.length} distinct normalized forms (${mapped} joined / ${unjoined} unjoined of ${total})`);
+  for (let i = 0; i < allDocs.length; i += 20000) {
+    await newMap.insertMany(allDocs.slice(i, i + 20000), { ordered: false });
+    if (i % 100000 < 20000) console.log(`  inserted ${Math.min(i + 20000, allDocs.length)}/${allDocs.length}`);
+  }
   await newMap.createIndex({ form: 1 }, { unique: true });
   await newMap.rename('lexicon_lemma_map_grc', { dropTarget: true });
 

--- a/scripts/lexicon/import-lsj.mjs
+++ b/scripts/lexicon/import-lsj.mjs
@@ -34,7 +34,10 @@ const GRAVE_TO_ACUTE = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ': 'ή', 'ὶ': 'ί', '�
 export function normGreekKey(raw) {
   let s = raw.normalize('NFD').replace(/[̄̆]/g, '').normalize('NFC').toLowerCase();
   s = [...s].map((ch) => GRAVE_TO_ACUTE[ch] ?? ch).join('');
-  return s.replace(/[^\p{L}\p{N}]/gu, '');
+  // Fold final sigma into medial — positional variants of one letter, and the
+  // betacode round-trip can emit either in either position (the crunch output
+  // contains lemmas like προςέχω; keys must not care).
+  return s.replace(/ς/g, 'σ').replace(/[^\p{L}\p{N}]/gu, '');
 }
 
 async function main() {

--- a/scripts/lexicon/import-lsj.mjs
+++ b/scripts/lexicon/import-lsj.mjs
@@ -1,0 +1,135 @@
+/**
+ * Import LSJ (lsj9 JSON, CC BY 4.0) + the Morpheus form→lemma table into
+ * Mongo for Greek dictionary lookup (#3823 Phase 3).
+ *
+ * Writes:
+ *   lexicon_entries_grc  — one doc per LSJ headword (~119K): headword,
+ *                          normalized key, short def, grammar/etymology
+ *   lexicon_lemma_map_grc — corpus form → LSJ entry keys, joined from the
+ *                          regenerated Morpheus table (greek-form-lemmas
+ *                          .jsonl) with the SAME normalizer on both sides
+ *
+ * Normalization (normKey): NFD → strip length marks (macron U+0304, breve
+ * U+0306) → NFC → lowercase → grave→acute is already applied corpus-side;
+ * apply here too so both sides agree. Homograph headwords share a
+ * normalized key; the lookup returns all and ranks by having a short def.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/lexicon/import-lsj.mjs --dir _tmp-lsj9
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const dirFlag = args.indexOf('--dir');
+const DIR = dirFlag >= 0 ? args[dirFlag + 1] : '_tmp-lsj9';
+const LEMMA_JSONL = 'scripts/lexicon/output/greek-form-lemmas.jsonl';
+const MAX_KEYS_PER_FORM = 8;
+
+const GRAVE_TO_ACUTE = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ': 'ή', 'ὶ': 'ί', 'ὸ': 'ό', 'ὺ': 'ύ', 'ὼ': 'ώ', 'ἃ': 'ἅ', 'ἓ': 'ἕ', 'ἳ': 'ἵ', 'ὃ': 'ὅ', 'ὓ': 'ὕ', 'ὣ': 'ὥ', 'ἂ': 'ἄ', 'ἒ': 'ἔ', 'ἲ': 'ἴ', 'ὂ': 'ὄ', 'ὒ': 'ὔ', 'ὢ': 'ὤ', 'ᾲ': 'ᾴ', 'ῂ': 'ῄ', 'ῲ': 'ῴ' };
+
+export function normGreekKey(raw) {
+  let s = raw.normalize('NFD').replace(/[̄̆]/g, '').normalize('NFC').toLowerCase();
+  s = [...s].map((ch) => GRAVE_TO_ACUTE[ch] ?? ch).join('');
+  return s.replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI not set');
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  // 1. Entries.
+  const headwords = JSON.parse(fs.readFileSync(path.join(DIR, 'lsj9_headwords.json'), 'utf8'));
+  const shortDefs = JSON.parse(fs.readFileSync(path.join(DIR, 'lsj9_short_defs.json'), 'utf8'));
+  const entriesCol = db.collection('lexicon_entries_grc');
+  const keyByNorm = new Map(); // normalized headword (digits stripped) → entry keys
+  let ops = [];
+  let n = 0;
+  for (const h of headwords) {
+    const key = `lsj9:${h.id}`;
+    const norm = normGreekKey(h.headword);
+    if (!norm) continue;
+    const arr = keyByNorm.get(norm) ?? [];
+    arr.push(key);
+    keyByNorm.set(norm, arr);
+    ops.push({
+      updateOne: {
+        filter: { key },
+        update: {
+          $set: {
+            dict: 'lsj9',
+            key,
+            headword: h.headword,
+            key_normalized: norm,
+            grammar: h.grammar ?? null,
+            etymology: h.etymology ?? null,
+            homograph: h.homograph ?? null,
+            short_def: shortDefs[h.headword] ?? null,
+            imported_at: new Date(),
+          },
+        },
+        upsert: true,
+      },
+    });
+    if (ops.length >= 5000) {
+      await entriesCol.bulkWrite(ops, { ordered: false });
+      n += ops.length;
+      ops = [];
+      if (n % 25000 < 5000) console.log(`entries ${n}/${headwords.length}`);
+    }
+  }
+  if (ops.length) { await entriesCol.bulkWrite(ops, { ordered: false }); n += ops.length; }
+  console.log(`entries upserted: ${n}`);
+
+  // 2. Lemma map: Morpheus lemma (unicode, maybe trailing homograph digit)
+  //    → LSJ keys via the shared normalizer.
+  const newMap = db.collection('lexicon_lemma_map_grc_new');
+  await newMap.drop().catch(() => {});
+  const rl = readline.createInterface({ input: fs.createReadStream(LEMMA_JSONL) });
+  let mapDocs = [];
+  let mapped = 0, unjoined = 0, total = 0;
+  const unjoinedSample = [];
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    total++;
+    const { form, lemmas } = JSON.parse(line);
+    const keys = new Set();
+    for (const lemma of lemmas) {
+      const bare = lemma.replace(/[0-9]+$/, '');
+      for (const k of keyByNorm.get(normGreekKey(bare)) ?? []) {
+        if (keys.size < MAX_KEYS_PER_FORM) keys.add(k);
+      }
+    }
+    if (!keys.size) {
+      unjoined++;
+      if (unjoinedSample.length < 20) unjoinedSample.push(`${form} → ${lemmas.join(',')}`);
+      continue;
+    }
+    mapped++;
+    mapDocs.push({ form: normGreekKey(form), keys: [...keys] });
+    if (mapDocs.length >= 20000) {
+      // forms can collide after normalization; last write wins is fine here
+      await newMap.bulkWrite(mapDocs.map((d) => ({ updateOne: { filter: { form: d.form }, update: { $set: d }, upsert: true } })), { ordered: false });
+      mapDocs = [];
+      if (mapped % 200000 < 20000) console.log(`lemma map ${mapped} mapped / ${unjoined} unjoined`);
+    }
+  }
+  if (mapDocs.length) await newMap.bulkWrite(mapDocs.map((d) => ({ updateOne: { filter: { form: d.form }, update: { $set: d }, upsert: true } })), { ordered: false });
+  await newMap.createIndex({ form: 1 }, { unique: true });
+  await newMap.rename('lexicon_lemma_map_grc', { dropTarget: true });
+
+  await entriesCol.createIndex({ key: 1 }, { unique: true });
+  await entriesCol.createIndex({ key_normalized: 1 });
+
+  console.log(`unjoined lemma samples:\n  ${unjoinedSample.join('\n  ')}`);
+  console.log(`DONE: entries=${await entriesCol.countDocuments()} mapForms=${await db.collection('lexicon_lemma_map_grc').countDocuments()} joined=${mapped}/${total} (${((mapped / total) * 100).toFixed(1)}%)`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lexicon/morpheus-crunch.mjs
+++ b/scripts/lexicon/morpheus-crunch.mjs
@@ -51,6 +51,7 @@ const MARK = {
   '͂': '=', 'ͅ': '|', '̈': '+', '̄': '', '̆': '', // strip length marks
 };
 const LETTER_REV = Object.fromEntries(Object.entries(LETTER).map(([g, b]) => [b, g]));
+LETTER_REV.s = 'σ'; // ς overwrote σ in the reverse map; medial is the right default
 const MARK_REV = Object.fromEntries(Object.entries(MARK).filter(([, b]) => b).map(([g, b]) => [b, g]));
 
 export function toBetacode(unicode) {

--- a/scripts/lexicon/morpheus-crunch.mjs
+++ b/scripts/lexicon/morpheus-crunch.mjs
@@ -36,6 +36,10 @@ const flag = (name, dflt) => {
 };
 const MIN_COUNT = flag('min-count', 2);
 const LIMIT = flag('limit', Infinity);
+// Sharding: run N of these in parallel (emulated amd64 is slow per-process);
+// shard i takes lines where index % count === i and writes OUT.<i>.
+const SHARD_INDEX = flag('shard-index', -1);
+const SHARD_COUNT = flag('shard-count', 1);
 
 const LETTER = {
   α: 'a', β: 'b', γ: 'g', δ: 'd', ε: 'e', ζ: 'z', η: 'h', θ: 'q', ι: 'i',
@@ -78,16 +82,19 @@ export function fromBetacode(beta) {
 async function main() {
   const forms = [];
   const rl = readline.createInterface({ input: fs.createReadStream(IN) });
+  let lineNo = 0;
   for await (const line of rl) {
     const [form, countStr] = line.split('\t');
     if (Number(countStr) < MIN_COUNT) break; // file is frequency-sorted
-    forms.push(form);
+    if (SHARD_INDEX < 0 || lineNo % SHARD_COUNT === SHARD_INDEX) forms.push(form);
+    lineNo++;
     if (forms.length >= LIMIT) break;
   }
-  console.log(`${forms.length} forms to crunch (min-count ${MIN_COUNT})`);
+  const suffix = SHARD_INDEX >= 0 ? `.${SHARD_INDEX}` : '';
+  console.log(`${forms.length} forms to crunch (min-count ${MIN_COUNT}, shard ${SHARD_INDEX}/${SHARD_COUNT})`);
 
-  const out = fs.createWriteStream(OUT);
-  const skipped = fs.createWriteStream(SKIPPED);
+  const out = fs.createWriteStream(OUT + suffix);
+  const skipped = fs.createWriteStream(SKIPPED + suffix);
   const child = spawn('docker', [
     'run', '-i', '--rm', '--platform', 'linux/amd64',
     '-e', 'MORPHLIB=stemlib', 'perseidsproject/morpheus', 'bin/cruncher', '-S', '-n',
@@ -153,7 +160,7 @@ async function main() {
   await done;
   out.end();
   skipped.end();
-  console.log(`DONE: sent=${sent} withLemmas=${found} skipped=${skippedCount} → ${OUT}`);
+  console.log(`DONE: sent=${sent} withLemmas=${found} skipped=${skippedCount} → ${OUT}${suffix}`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lexicon/morpheus-crunch.mjs
+++ b/scripts/lexicon/morpheus-crunch.mjs
@@ -80,13 +80,27 @@ export function fromBetacode(beta) {
 }
 
 async function main() {
+  // Resume: forms already present in any prior output are skipped.
+  const doneForms = new Set();
+  const resumeIdx = args.indexOf('--resume');
+  if (resumeIdx >= 0) {
+    const resumeFile = args[resumeIdx + 1];
+    if (fs.existsSync(resumeFile)) {
+      const rrl = readline.createInterface({ input: fs.createReadStream(resumeFile) });
+      for await (const line of rrl) {
+        try { doneForms.add(JSON.parse(line).form); } catch { /* partial line */ }
+      }
+      console.log(`resume: ${doneForms.size} forms already crunched`);
+    }
+  }
+
   const forms = [];
   const rl = readline.createInterface({ input: fs.createReadStream(IN) });
   let lineNo = 0;
   for await (const line of rl) {
     const [form, countStr] = line.split('\t');
     if (Number(countStr) < MIN_COUNT) break; // file is frequency-sorted
-    if (SHARD_INDEX < 0 || lineNo % SHARD_COUNT === SHARD_INDEX) forms.push(form);
+    if ((SHARD_INDEX < 0 || lineNo % SHARD_COUNT === SHARD_INDEX) && !doneForms.has(form)) forms.push(form);
     lineNo++;
     if (forms.length >= LIMIT) break;
   }

--- a/scripts/lexicon/morpheus-crunch.mjs
+++ b/scripts/lexicon/morpheus-crunch.mjs
@@ -1,0 +1,159 @@
+/**
+ * Bulk Morpheus run: Greek corpus forms → form→lemma table (#3823 Phase 3).
+ *
+ * Streams the enumerated corpus forms (greek-forms.tsv, count >= --min-count,
+ * default 2 — the hapax tail is OCR noise) through ONE long-lived cruncher
+ * process inside the perseidsproject/morpheus Docker image (MPL-2.0, engine
+ * and stemlibs alike — this regenerated table is unencumbered, unlike the
+ * CC BY-NC MorpheusGreekUnicode dump).
+ *
+ * Betacode: cruncher speaks betacode, not Unicode. We NFD-decompose each
+ * form and map base letters + combining marks (smooth=`)`, rough=`(`,
+ * acute=`/`, grave=`\`, circumflex=`=`, iota subscript=`|`, diaeresis=`+`),
+ * lowercased so no `*` capital prefixes are needed; lemmas come back the
+ * same way and are reversed to NFC Unicode. Forms whose decomposition
+ * contains anything unmappable are skipped and counted, not guessed at.
+ *
+ * Output: scripts/lexicon/output/greek-form-lemmas.jsonl
+ *   {"form":"ἄνθρωπον","lemmas":["ἄνθρωπος"]}
+ * plus a .skipped.txt of unconvertible/unanalyzed forms (the honest-miss
+ * ledger — nothing silently dropped).
+ *
+ * Run: node scripts/lexicon/morpheus-crunch.mjs [--min-count 2] [--limit N]
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+import { spawn } from 'node:child_process';
+
+const IN = 'scripts/lexicon/output/greek-forms.tsv';
+const OUT = 'scripts/lexicon/output/greek-form-lemmas.jsonl';
+const SKIPPED = 'scripts/lexicon/output/greek-form-lemmas.skipped.txt';
+
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? Number(args[i + 1]) : dflt;
+};
+const MIN_COUNT = flag('min-count', 2);
+const LIMIT = flag('limit', Infinity);
+
+const LETTER = {
+  α: 'a', β: 'b', γ: 'g', δ: 'd', ε: 'e', ζ: 'z', η: 'h', θ: 'q', ι: 'i',
+  κ: 'k', λ: 'l', μ: 'm', ν: 'n', ξ: 'c', ο: 'o', π: 'p', ρ: 'r', σ: 's',
+  ς: 's', τ: 't', υ: 'u', φ: 'f', χ: 'x', ψ: 'y', ω: 'w', ϝ: 'v',
+};
+const MARK = {
+  '̓': ')', '̔': '(', '́': '/', '̀': '\\',
+  '͂': '=', 'ͅ': '|', '̈': '+', '̄': '', '̆': '', // strip length marks
+};
+const LETTER_REV = Object.fromEntries(Object.entries(LETTER).map(([g, b]) => [b, g]));
+const MARK_REV = Object.fromEntries(Object.entries(MARK).filter(([, b]) => b).map(([g, b]) => [b, g]));
+
+export function toBetacode(unicode) {
+  let out = '';
+  for (const ch of unicode.normalize('NFD').toLowerCase()) {
+    if (LETTER[ch] !== undefined) out += LETTER[ch];
+    else if (MARK[ch] !== undefined) out += MARK[ch];
+    else return null; // unmappable — skip honestly
+  }
+  return out;
+}
+
+export function fromBetacode(beta) {
+  let out = '';
+  for (const ch of beta) {
+    if (LETTER_REV[ch]) out += LETTER_REV[ch];
+    else if (MARK_REV[ch]) out += MARK_REV[ch];
+    else if (/[0-9]/.test(ch)) out += ch; // homograph number, keep
+    else if (ch === "'") out += ch;
+    else if (ch === '*') continue; // capital prefix — lookup keys are lowercase
+    else if (ch === '-') continue; // prefix separator in compound lemmas
+    else return null;
+  }
+  // final sigma
+  out = out.replace(/σ(?=$|[0-9])/g, 'ς');
+  return out.normalize('NFC');
+}
+
+async function main() {
+  const forms = [];
+  const rl = readline.createInterface({ input: fs.createReadStream(IN) });
+  for await (const line of rl) {
+    const [form, countStr] = line.split('\t');
+    if (Number(countStr) < MIN_COUNT) break; // file is frequency-sorted
+    forms.push(form);
+    if (forms.length >= LIMIT) break;
+  }
+  console.log(`${forms.length} forms to crunch (min-count ${MIN_COUNT})`);
+
+  const out = fs.createWriteStream(OUT);
+  const skipped = fs.createWriteStream(SKIPPED);
+  const child = spawn('docker', [
+    'run', '-i', '--rm', '--platform', 'linux/amd64',
+    '-e', 'MORPHLIB=stemlib', 'perseidsproject/morpheus', 'bin/cruncher', '-S', '-n',
+  ], { stdio: ['pipe', 'pipe', 'inherit'] });
+
+  const betaToForm = new Map();
+  let sent = 0, answered = 0, found = 0, skippedCount = 0;
+
+  // Reader: cruncher echoes each input line, then zero+ <NL>...</NL> lines.
+  let currentBeta = null;
+  let currentLemmas = new Set();
+  const flushCurrent = () => {
+    if (currentBeta === null) return;
+    const form = betaToForm.get(currentBeta);
+    const lemmas = [...currentLemmas].map(fromBetacode).filter(Boolean);
+    if (form && lemmas.length) {
+      out.write(JSON.stringify({ form, lemmas }) + '\n');
+      found++;
+    } else if (form) {
+      skipped.write(form + '\tno-analysis\n');
+      skippedCount++;
+    }
+    answered++;
+    if (answered % 50000 === 0) console.log(`  ${answered}/${sent} answered, ${found} with lemmas`);
+    currentBeta = null;
+    currentLemmas = new Set();
+  };
+
+  const outRl = readline.createInterface({ input: child.stdout });
+  const done = new Promise((resolve) => {
+    outRl.on('line', (line) => {
+      if (line.includes('<NL>')) {
+        // ALL analyses for one form arrive concatenated on one line:
+        // "<NL>N gh= fem gen sg...</NL><NL>V ei)mi/ imperf...</NL>".
+        // Lemma token is "form,lemma" (comma pair) or bare lemma.
+        for (const m of line.matchAll(/<NL>[A-Z]+[\s·]+(\S+?)[\s·]/g)) {
+          const pair = m[1].split(',');
+          currentLemmas.add(pair[pair.length - 1]);
+        }
+      } else if (line.trim() && betaToForm.has(line.trim())) {
+        flushCurrent();
+        currentBeta = line.trim();
+      }
+    });
+    outRl.on('close', () => { flushCurrent(); resolve(); });
+  });
+
+  // Writer with backpressure.
+  for (const form of forms) {
+    const beta = toBetacode(form);
+    if (beta === null || !beta) {
+      skipped.write(form + '\tunconvertible\n');
+      skippedCount++;
+      continue;
+    }
+    if (!betaToForm.has(beta)) betaToForm.set(beta, form);
+    if (!child.stdin.write(beta + '\n')) {
+      await new Promise((r) => child.stdin.once('drain', r));
+    }
+    sent++;
+  }
+  child.stdin.end();
+  await done;
+  out.end();
+  skipped.end();
+  console.log(`DONE: sent=${sent} withLemmas=${found} skipped=${skippedCount} → ${OUT}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lexicon/rank-grc-lemma-keys.mjs
+++ b/scripts/lexicon/rank-grc-lemma-keys.mjs
@@ -1,0 +1,60 @@
+/**
+ * Rank lexicon_lemma_map_grc candidate keys by lemma popularity (#3823).
+ *
+ * Problem (live-API spot-check): multi-candidate rows list morphologically
+ * valid but lexically absurd cohabitants first — ἐστίν surfaced εἴλω before
+ * εἰμί. Popularity = sum of corpus counts of forms attributable to exactly
+ * one key (unambiguous attribution, same discipline as the blog figure).
+ * Rows with >1 key get their keys re-sorted by that popularity, descending.
+ *
+ * Run: set env; node scripts/lexicon/rank-grc-lemma-keys.mjs
+ * Needs scripts/lexicon/output/greek-forms.tsv (corpus enumeration).
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+import { MongoClient } from 'mongodb';
+
+const G2A = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ': 'ή', 'ὶ': 'ί', 'ὸ': 'ό', 'ὺ': 'ύ', 'ὼ': 'ώ', 'ἃ': 'ἅ', 'ἓ': 'ἕ', 'ἳ': 'ἵ', 'ὃ': 'ὅ', 'ὓ': 'ὕ', 'ὣ': 'ὥ', 'ἂ': 'ἄ', 'ἒ': 'ἔ', 'ἲ': 'ἴ', 'ὂ': 'ὄ', 'ὒ': 'ὔ', 'ὢ': 'ὤ', 'ᾲ': 'ᾴ', 'ῂ': 'ῄ', 'ῲ': 'ῴ' };
+const norm = (r) => [...r.normalize('NFD').replace(/[̄̆]/g, '').normalize('NFC').toLowerCase()].map((c) => G2A[c] ?? c).join('').replace(/ς/g, 'σ').replace(/[^\p{L}\p{N}]/gu, '');
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const col = db.collection('lexicon_lemma_map_grc');
+
+const counts = new Map();
+const rl = readline.createInterface({ input: fs.createReadStream('scripts/lexicon/output/greek-forms.tsv') });
+for await (const line of rl) {
+  const [raw, c] = line.split('\t');
+  const f = norm(raw ?? '');
+  if (f) counts.set(f, (counts.get(f) ?? 0) + Number(c));
+}
+console.log(`counts loaded: ${counts.size}`);
+
+const pop = new Map();
+const multi = [];
+for await (const d of col.find({})) {
+  const keys = [...new Set(d.keys)];
+  if (keys.length === 1) {
+    const c = counts.get(d.form) ?? 0;
+    if (c) pop.set(keys[0], (pop.get(keys[0]) ?? 0) + c);
+  } else {
+    multi.push({ _id: d._id, keys: d.keys });
+  }
+}
+console.log(`popularity for ${pop.size} keys; ${multi.length} multi-key rows to re-rank`);
+
+let updated = 0;
+for (let i = 0; i < multi.length; i += 2000) {
+  const ops = multi.slice(i, i + 2000).map((d) => ({
+    updateOne: {
+      filter: { _id: d._id },
+      update: { $set: { keys: [...d.keys].sort((a, b) => (pop.get(b) ?? 0) - (pop.get(a) ?? 0)) } },
+    },
+  }));
+  const r = await col.bulkWrite(ops, { ordered: false });
+  updated += r.modifiedCount;
+  if (i % 40000 < 2000) console.log(`  ${i}/${multi.length}`);
+}
+console.log(`RANKED: ${updated} rows re-sorted`);
+await client.close();

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -44,9 +44,38 @@ export async function GET(request: NextRequest) {
   try {
     const db = await getReadDb();
     const result = await lookupLatinWord(db, word);
+    if (!result.found && result.normalized.length >= 3) {
+      // Miss telemetry: aggregated per normalized form (bounded by vocabulary,
+      // no PII, nothing automated reads it). This is the Phase-2.5 worklist —
+      // the most-tapped missing words are the next tier to build.
+      db.collection('lexicon_misses')
+        .updateOne(
+          { form: result.normalized },
+          { $inc: { count: 1 }, $set: { last_seen: new Date(), sample_query: result.query } },
+          { upsert: true }
+        )
+        .catch(() => {});
+    }
     return NextResponse.json(result, { headers: CACHE_HEADERS });
   } catch (err) {
     console.error('[lexicon/lookup] failed:', err);
+    // Same store the client-side reporter uses (application_errors), so
+    // lookup failures surface in the admin errors view instead of only in
+    // function logs. Fire-and-forget: logging must never fail the response.
+    try {
+      const db = await getReadDb();
+      db.collection('application_errors')
+        .insertOne({
+          message: `lexicon lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+          source: 'api/lexicon/lookup',
+          url: request.nextUrl.pathname + '?word=' + encodeURIComponent(word),
+          stack: err instanceof Error ? err.stack?.slice(0, 2000) : undefined,
+          timestamp: new Date(),
+        })
+        .catch(() => {});
+    } catch {
+      /* logging is best-effort */
+    }
     return NextResponse.json({ error: 'Lookup failed.' }, { status: 500 });
   }
 }

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -22,9 +22,12 @@ import { lookupGreekWord } from '@/lib/lexicon/lookup-grc';
 export const dynamic = 'force-dynamic';
 
 const CACHE_HEADERS = {
-  // max-age matters: a Cache-Control without it survives CDN purges in
-  // browser caches (see lesson on s-maxage-only headers).
-  'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+  // Browser max-age is deliberately SHORT: the lexicon dataset is young and
+  // improving, and a long browser cache pins stale misses on readers after a
+  // re-import (an hour-old miss survived the sigma-fix rejoin in testing).
+  // The CDN keeps the long TTL — deploys purge it. max-age must be present:
+  // a Cache-Control without it survives CDN purges in browser caches.
+  'Cache-Control': 'public, max-age=60, s-maxage=86400, stale-while-revalidate=604800',
   'CDN-Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
 } as const;
 

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -1,0 +1,52 @@
+/**
+ * GET /api/lexicon/lookup?word=cœlum — dictionary lookup for the parsing
+ * reader (issue #3823, Phase 1).
+ *
+ * Resolves a (possibly early modern, possibly OCR-noisy) Latin word to Lewis
+ * & Short entries via the tiered chain in src/lib/lexicon/lookup.ts:
+ * exact → variant → irregular → generated paradigm → suffix heuristic →
+ * loose orthography. Uncertain tiers return `confident: false`; a miss is a
+ * structured `found: false`, never a wrong entry dressed up as an answer.
+ *
+ * &lang=la is accepted and required to be Latin for now — the parameter
+ * exists so Greek (LSJ) can slot in later without a URL change.
+ *
+ * Anonymous, read-only, aggressively CDN-cached: word → entry is immutable
+ * short of a re-import, so cache hard and let deploys purge.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { lookupLatinWord } from '@/lib/lexicon/lookup';
+
+export const dynamic = 'force-dynamic';
+
+const CACHE_HEADERS = {
+  // max-age matters: a Cache-Control without it survives CDN purges in
+  // browser caches (see lesson on s-maxage-only headers).
+  'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+  'CDN-Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+} as const;
+
+export async function GET(request: NextRequest) {
+  const word = request.nextUrl.searchParams.get('word') ?? '';
+  const lang = request.nextUrl.searchParams.get('lang') ?? 'la';
+
+  if (lang !== 'la') {
+    return NextResponse.json(
+      { error: `Unsupported lang "${lang}" — only "la" (Latin) is available.` },
+      { status: 400 }
+    );
+  }
+  if (!word.trim() || word.length > 80) {
+    return NextResponse.json({ error: 'Provide ?word= (1–80 chars).' }, { status: 400 });
+  }
+
+  try {
+    const db = await getReadDb();
+    const result = await lookupLatinWord(db, word);
+    return NextResponse.json(result, { headers: CACHE_HEADERS });
+  } catch (err) {
+    console.error('[lexicon/lookup] failed:', err);
+    return NextResponse.json({ error: 'Lookup failed.' }, { status: 500 });
+  }
+}

--- a/src/app/api/lexicon/lookup/route.ts
+++ b/src/app/api/lexicon/lookup/route.ts
@@ -17,6 +17,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { lookupLatinWord } from '@/lib/lexicon/lookup';
+import { lookupGreekWord } from '@/lib/lexicon/lookup-grc';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,9 +32,9 @@ export async function GET(request: NextRequest) {
   const word = request.nextUrl.searchParams.get('word') ?? '';
   const lang = request.nextUrl.searchParams.get('lang') ?? 'la';
 
-  if (lang !== 'la') {
+  if (lang !== 'la' && lang !== 'grc') {
     return NextResponse.json(
-      { error: `Unsupported lang "${lang}" — only "la" (Latin) is available.` },
+      { error: `Unsupported lang "${lang}" — "la" (Latin) and "grc" (Ancient Greek) are available.` },
       { status: 400 }
     );
   }
@@ -43,7 +44,31 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = await getReadDb();
-    const result = await lookupLatinWord(db, word);
+    // Greek matches are reshaped to the Latin match schema so the popover
+    // renders both without branching (shortDef plays the first-sense role).
+    const result =
+      lang === 'grc'
+        ? await lookupGreekWord(db, word).then((r) => ({
+            query: r.query,
+            normalized: r.normalized,
+            found: r.found,
+            matches: r.matches.map((m) => ({
+              key: m.key,
+              headword: m.headword,
+              matchType: m.matchType,
+              confident: m.confident,
+              entryType: 'main',
+              partOfSpeech: m.grammar,
+              orthography: m.headword,
+              genitive: null,
+              gender: null,
+              declension: null,
+              mainNotes: m.etymology,
+              senses: m.shortDef ? [m.shortDef] : [],
+              sensesTruncated: false,
+            })),
+          }))
+        : await lookupLatinWord(db, word);
     if (!result.found && result.normalized.length >= 3) {
       // Miss telemetry: aggregated per normalized form (bounded by vocabulary,
       // no PII, nothing automated reads it). This is the Phase-2.5 worklist —
@@ -51,7 +76,7 @@ export async function GET(request: NextRequest) {
       db.collection('lexicon_misses')
         .updateOne(
           { form: result.normalized },
-          { $inc: { count: 1 }, $set: { last_seen: new Date(), sample_query: result.query } },
+          { $inc: { count: 1 }, $set: { last_seen: new Date(), sample_query: result.query, lang } },
           { upsert: true }
         )
         .catch(() => {});

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1197,7 +1197,8 @@ export default function TranslationEditor({
             not on the work's source language. Latin only for now (#3823). */}
         <LexiconTapLayer
           targetSelector='[data-reader-section="ocr"] [data-reader-panel]'
-          enabled={book.language === 'Latin' && !paired}
+          enabled={(book.language === 'Latin' || book.language === 'Greek') && !paired}
+          lang={book.language === 'Greek' ? 'grc' : 'la'}
         />
         {/* Header - Two rows on mobile, one row on desktop */}
         <header className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -33,6 +33,7 @@ import { useReaderPreferences, type ReaderTheme } from '@/hooks/useReaderPrefere
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import TraceAlignment, { type TraceStatus } from '@/components/reader/TraceAlignment';
 import LexiconTapLayer from '@/components/reader/LexiconTapLayer';
+import AlpheiosLoader from '@/components/reader/AlpheiosLoader';
 import AiBadge from '@/components/ui/AiBadge';
 import { MANUSCRIPT_OCR_FLAG } from '@/lib/marcianus-overlay.shared';
 import { usePairedEdition } from '@/hooks/usePairedEdition';
@@ -1195,9 +1196,12 @@ export default function TranslationEditor({
             language of the EDITION whose text fills that pane (book.language
             is the edition language — the OCR pane always shows edition text),
             not on the work's source language. Latin only for now (#3823). */}
+        {/* PROTOTYPE comparison (#3823): Alpheios embedded vs our popover.
+            Alpheios is on; our LexiconTapLayer is off while we evaluate. */}
+        <AlpheiosLoader enabled={(book.language === 'Latin' || book.language === 'Greek') && !paired} />
         <LexiconTapLayer
           targetSelector='[data-reader-section="ocr"] [data-reader-panel]'
-          enabled={(book.language === 'Latin' || book.language === 'Greek') && !paired}
+          enabled={false}
           lang={book.language === 'Greek' ? 'grc' : 'la'}
         />
         {/* Header - Two rows on mobile, one row on desktop */}
@@ -1811,7 +1815,9 @@ export default function TranslationEditor({
                         )}
                       </>
                     ) : ocrText ? (
-                      <div className="prose-manuscript leading-relaxed" style={{ color: 'var(--text-secondary)' }} lang={book.language === 'Latin' ? 'la' : book.language === 'German' ? 'de' : book.language === 'Arabic' ? 'ar' : book.language === 'Hebrew' ? 'he' : book.language === 'Greek' ? 'el' : book.language === 'French' ? 'fr' : book.language === 'Italian' ? 'it' : book.language === 'Dutch' ? 'nl' : undefined}>
+                      // lang: Alpheios activates on its ISO 639-2 codes (lat/grc)
+                      // for the two languages it serves; the rest keep 639-1.
+                      <div className={`prose-manuscript leading-relaxed ${book.language === 'Latin' || book.language === 'Greek' ? 'alpheios-enabled' : ''}`} style={{ color: 'var(--text-secondary)' }} lang={book.language === 'Latin' ? 'lat' : book.language === 'Greek' ? 'grc' : book.language === 'German' ? 'de' : book.language === 'Arabic' ? 'ar' : book.language === 'Hebrew' ? 'he' : book.language === 'French' ? 'fr' : book.language === 'Italian' ? 'it' : book.language === 'Dutch' ? 'nl' : undefined}>
                         <NotesRenderer text={ocrText} showNotes={showNotes} showMetadata={false} language={book.language} columns={page.columns} pageType={page.page_type} />
                       </div>
                     ) : (

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -32,6 +32,7 @@ import {
 import { useReaderPreferences, type ReaderTheme } from '@/hooks/useReaderPreferences';
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import TraceAlignment, { type TraceStatus } from '@/components/reader/TraceAlignment';
+import LexiconTapLayer from '@/components/reader/LexiconTapLayer';
 import AiBadge from '@/components/ui/AiBadge';
 import { MANUSCRIPT_OCR_FLAG } from '@/lib/marcianus-overlay.shared';
 import { usePairedEdition } from '@/hooks/usePairedEdition';
@@ -1190,6 +1191,14 @@ export default function TranslationEditor({
 
     return (
       <div className="h-screen flex flex-col" data-reader-theme={theme} style={{ background: 'var(--bg-cream)' }}>
+        {/* Tap-a-word dictionary on the original-text pane. Gate on the
+            language of the EDITION whose text fills that pane (book.language
+            is the edition language — the OCR pane always shows edition text),
+            not on the work's source language. Latin only for now (#3823). */}
+        <LexiconTapLayer
+          targetSelector='[data-reader-section="ocr"] [data-reader-panel]'
+          enabled={book.language === 'Latin' && !paired}
+        />
         {/* Header - Two rows on mobile, one row on desktop */}
         <header className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
           {/* Row 1: Back + Title ... Chapter Nav ... Page Navigator */}

--- a/src/components/reader/AlpheiosLoader.tsx
+++ b/src/components/reader/AlpheiosLoader.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+/**
+ * PROTOTYPE (#3823): load the Alpheios embedded reading tools on original-
+ * language pages, instead of our own popover. Alpheios provides dictionary
+ * entries, full morphology, inflection tables, and grammar links for Latin
+ * and Ancient Greek — the mature learner/scholar toolset (ISC license,
+ * actively maintained, https://alpheios.net).
+ *
+ * The pane it activates on must carry class="alpheios-enabled" and a lang
+ * attribute Alpheios recognizes ('lat' / 'grc'). Loads from jsDelivr CDN —
+ * fine for a dev prototype; a production ship should vendor the bundles
+ * (self-host via npm) so we're not executing third-party-mutable script.
+ */
+
+import { useEffect, useRef } from 'react';
+
+declare global {
+  interface Window {
+    AlpheiosEmbed?: {
+      importDependencies: (opts: { mode: string }) => Promise<new (opts: { clientId: string | null }) => { activate: () => void }>;
+    };
+    __alpheiosActive?: boolean;
+  }
+}
+
+export default function AlpheiosLoader({ enabled }: { enabled: boolean }) {
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || attempted.current || window.__alpheiosActive) return;
+    attempted.current = true;
+
+    if (!document.querySelector('link[data-alpheios-css]')) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = 'https://cdn.jsdelivr.net/npm/alpheios-components@latest/dist/style/style-components.min.css';
+      link.setAttribute('data-alpheios-css', '1');
+      document.head.appendChild(link);
+    }
+
+    import(/* webpackIgnore: true */ 'https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js' as string)
+      .then(() => window.AlpheiosEmbed?.importDependencies({ mode: 'cdn' }))
+      .then((Embedded) => {
+        if (!Embedded) throw new Error('AlpheiosEmbed missing');
+        new Embedded({ clientId: 'sourcelibrary-prototype' }).activate();
+        window.__alpheiosActive = true;
+      })
+      .catch((e) => console.error('[alpheios] load failed:', e));
+  }, [enabled]);
+
+  return null;
+}

--- a/src/components/reader/LexiconTapLayer.tsx
+++ b/src/components/reader/LexiconTapLayer.tsx
@@ -260,7 +260,7 @@ export default function LexiconTapLayer({ targetSelector, enabled, lang = 'la' }
       )}
       {popover.status === 'done' && !match && (
         <div className="py-3 text-sm" style={{ color: 'var(--text-muted, #6b7280)' }}>
-          No entry found in Lewis &amp; Short. Abbreviations, names, and heavily contracted early modern forms often miss.
+          No entry found in {lang === 'grc' ? 'Liddell-Scott-Jones' : 'Lewis & Short'}. Abbreviations, names, and heavily contracted forms often miss.
         </div>
       )}
 
@@ -293,7 +293,7 @@ export default function LexiconTapLayer({ targetSelector, enabled, lang = 'la' }
               </button>
             ) : <span />}
             <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted, #9ca3af)' }}>
-              <BookOpen className="w-3 h-3" /> Lewis &amp; Short
+              <BookOpen className="w-3 h-3" /> {lang === 'grc' ? 'Liddell-Scott-Jones' : 'Lewis & Short'}
             </span>
           </div>
           {alternates.length > 0 && (

--- a/src/components/reader/LexiconTapLayer.tsx
+++ b/src/components/reader/LexiconTapLayer.tsx
@@ -53,6 +53,30 @@ interface PopoverState {
 const cache = new Map<string, LookupResult>();
 const CACHE_CAP = 300;
 
+// One error report per page load, fire-and-forget, to the shared
+// application_errors intake — repeated failures (offline reader, dead
+// route) must not turn into a report storm.
+let reportedLookupError = false;
+function reportLookupError(word: string, detail: string) {
+  if (reportedLookupError) return;
+  reportedLookupError = true;
+  try {
+    fetch('/api/errors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: `lexicon popover lookup failed: ${detail}`,
+        source: 'LexiconTapLayer',
+        url: `${location.pathname} (word: ${word})`,
+        userAgent: navigator.userAgent,
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* best-effort */
+  }
+}
+
 const TIER_LABEL: Record<string, string> = {
   exact: 'dictionary form',
   variant: 'spelling variant',
@@ -165,7 +189,8 @@ export default function LexiconTapLayer({ targetSelector, enabled }: { targetSel
             setPopover((p) => (p && p.word === word ? { ...p, status: 'done', result } : p));
           }
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          reportLookupError(word, err instanceof Error ? err.message : String(err));
           if (requestSeq.current === seq) {
             setPopover((p) => (p && p.word === word ? { ...p, status: 'error' } : p));
           }

--- a/src/components/reader/LexiconTapLayer.tsx
+++ b/src/components/reader/LexiconTapLayer.tsx
@@ -138,7 +138,7 @@ function morphologyLine(m: LexiconMatch): string {
   return bits.join(' · ');
 }
 
-export default function LexiconTapLayer({ targetSelector, enabled }: { targetSelector: string; enabled: boolean }) {
+export default function LexiconTapLayer({ targetSelector, enabled, lang = 'la' }: { targetSelector: string; enabled: boolean; lang?: 'la' | 'grc' }) {
   const [popover, setPopover] = useState<PopoverState | null>(null);
   const [expanded, setExpanded] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
@@ -172,19 +172,19 @@ export default function LexiconTapLayer({ targetSelector, enabled }: { targetSel
       setExpanded(false);
       setPopover({ word, x: e.clientX, y: e.clientY, status: 'loading', result: null });
 
-      const cached = cache.get(word.toLowerCase());
+      const cached = cache.get(`${lang}:${word.toLowerCase()}`);
       if (cached) {
         setPopover({ word, x: e.clientX, y: e.clientY, status: 'done', result: cached });
         return;
       }
-      fetch(`/api/lexicon/lookup?word=${encodeURIComponent(word)}&lang=la`)
+      fetch(`/api/lexicon/lookup?word=${encodeURIComponent(word)}&lang=${lang}`)
         .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
         .then((result: LookupResult) => {
           if (cache.size >= CACHE_CAP) {
             const first = cache.keys().next().value;
             if (first !== undefined) cache.delete(first);
           }
-          cache.set(word.toLowerCase(), result);
+          cache.set(`${lang}:${word.toLowerCase()}`, result);
           if (requestSeq.current === seq) {
             setPopover((p) => (p && p.word === word ? { ...p, status: 'done', result } : p));
           }

--- a/src/components/reader/LexiconTapLayer.tsx
+++ b/src/components/reader/LexiconTapLayer.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+/**
+ * Tap-a-word dictionary lookup for the reader's original-text pane
+ * (#3823 Phase 2).
+ *
+ * Listens for clicks inside `targetSelector` and reads the tapped word
+ * straight out of the text node via caretPositionFromPoint. The OCR content
+ * is NEVER re-marked-up — no per-word <span> injection — so OCR text
+ * containing literal markup (pages transcribe real <script> tags, #3609)
+ * cannot break the page, and NotesRenderer's own rendering is untouched.
+ *
+ * Results come from GET /api/lexicon/lookup (Lewis & Short; see
+ * src/lib/lexicon/lookup.ts for the tier chain). Uncertain tiers arrive
+ * with confident:false and are rendered with an explicit hedge — an honest
+ * "no entry found" beats a wrong entry dressed up as an answer.
+ *
+ * Desktop: floating card anchored near the tap. Mobile (<lg): bottom sheet.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X, BookOpen } from 'lucide-react';
+
+interface LexiconMatch {
+  key: string;
+  headword: string;
+  matchType: string;
+  confident: boolean;
+  partOfSpeech: string | null;
+  orthography: string | null;
+  genitive: string | null;
+  gender: string | null;
+  declension: number | null;
+  senses: unknown[];
+  sensesTruncated: boolean;
+}
+
+interface LookupResult {
+  query: string;
+  normalized: string;
+  found: boolean;
+  matches: LexiconMatch[];
+}
+
+interface PopoverState {
+  word: string;
+  x: number;
+  y: number;
+  status: 'loading' | 'done' | 'error';
+  result: LookupResult | null;
+}
+
+const cache = new Map<string, LookupResult>();
+const CACHE_CAP = 300;
+
+const TIER_LABEL: Record<string, string> = {
+  exact: 'dictionary form',
+  variant: 'spelling variant',
+  irregular: 'irregular form',
+  inflected: 'inflected form',
+  loose: 'orthographic match',
+  suffix: 'best guess by ending',
+  ocr: 'possible OCR misread',
+};
+
+/** Word under (x, y): read from the text node, never from re-marked-up DOM. */
+function wordAtPoint(x: number, y: number, container: Element): string | null {
+  interface CaretPos { offsetNode: Node; offset: number }
+  type DocWithCaret = Document & {
+    caretPositionFromPoint?: (x: number, y: number) => CaretPos | null;
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  };
+  const doc = document as DocWithCaret;
+  let node: Node | null = null;
+  let offset = 0;
+  if (doc.caretPositionFromPoint) {
+    const pos = doc.caretPositionFromPoint(x, y);
+    if (pos) { node = pos.offsetNode; offset = pos.offset; }
+  } else if (doc.caretRangeFromPoint) {
+    const range = doc.caretRangeFromPoint(x, y);
+    if (range) { node = range.startContainer; offset = range.startOffset; }
+  }
+  if (!node || node.nodeType !== Node.TEXT_NODE || !container.contains(node)) return null;
+  const text = node.textContent ?? '';
+  if (!text[offset] && offset > 0) offset -= 1;
+  const isLetter = (ch: string | undefined) => !!ch && /[\p{L}̀-ͯ]/u.test(ch);
+  if (!isLetter(text[offset])) return null;
+  let start = offset;
+  let end = offset;
+  while (start > 0 && isLetter(text[start - 1])) start--;
+  while (end < text.length && isLetter(text[end])) end++;
+  const word = text.slice(start, end);
+  return word.length >= 2 && word.length <= 60 ? word : null;
+}
+
+function firstSenseText(senses: unknown[]): string {
+  for (const s of senses) {
+    if (typeof s === 'string' && s.trim()) return s;
+    if (Array.isArray(s)) {
+      const inner = firstSenseText(s);
+      if (inner) return inner;
+    }
+  }
+  return '';
+}
+
+function morphologyLine(m: LexiconMatch): string {
+  const bits: string[] = [];
+  if (m.orthography) bits.push(m.orthography);
+  if (m.genitive) bits.push(`gen. ${m.genitive}`);
+  if (m.gender) bits.push(m.gender.toLowerCase() === 'm' ? 'masc.' : m.gender.toLowerCase() === 'f' ? 'fem.' : 'neut.');
+  if (m.declension) bits.push(`${m.declension}${['', 'st', 'nd', 'rd', 'th', 'th'][m.declension]} decl.`);
+  if (m.partOfSpeech && !m.declension) bits.push(m.partOfSpeech);
+  return bits.join(' · ');
+}
+
+export default function LexiconTapLayer({ targetSelector, enabled }: { targetSelector: string; enabled: boolean }) {
+  const [popover, setPopover] = useState<PopoverState | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const requestSeq = useRef(0);
+
+  const close = useCallback(() => {
+    setPopover(null);
+    setExpanded(false);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Delegate from document: the OCR panel mounts/unmounts as the reader
+    // toggles panels, so a listener bound to the panel itself would miss a
+    // panel shown after mount.
+    const onClick = (ev: Event) => {
+      const e = ev as MouseEvent;
+      const target = e.target as Element | null;
+      const container = target?.closest?.(targetSelector);
+      if (!container) return;
+      // A real text selection in progress is not a lookup gesture.
+      const sel = window.getSelection();
+      if (sel && !sel.isCollapsed) return;
+      // Leave links, buttons, details/summary and other interactive bits alone.
+      if (target?.closest('a, button, summary, input, textarea, [role="button"]')) return;
+      const word = wordAtPoint(e.clientX, e.clientY, container);
+      if (!word) return;
+
+      const seq = ++requestSeq.current;
+      setExpanded(false);
+      setPopover({ word, x: e.clientX, y: e.clientY, status: 'loading', result: null });
+
+      const cached = cache.get(word.toLowerCase());
+      if (cached) {
+        setPopover({ word, x: e.clientX, y: e.clientY, status: 'done', result: cached });
+        return;
+      }
+      fetch(`/api/lexicon/lookup?word=${encodeURIComponent(word)}&lang=la`)
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+        .then((result: LookupResult) => {
+          if (cache.size >= CACHE_CAP) {
+            const first = cache.keys().next().value;
+            if (first !== undefined) cache.delete(first);
+          }
+          cache.set(word.toLowerCase(), result);
+          if (requestSeq.current === seq) {
+            setPopover((p) => (p && p.word === word ? { ...p, status: 'done', result } : p));
+          }
+        })
+        .catch(() => {
+          if (requestSeq.current === seq) {
+            setPopover((p) => (p && p.word === word ? { ...p, status: 'error' } : p));
+          }
+        });
+    };
+
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
+  }, [enabled, targetSelector]);
+
+  // Escape / outside-click dismiss.
+  useEffect(() => {
+    if (!popover) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && close();
+    const onDown = (e: MouseEvent) => {
+      // Both the desktop card and the mobile sheet carry data-lexicon-popover.
+      if (!(e.target as Element | null)?.closest?.('[data-lexicon-popover]')) close();
+    };
+    document.addEventListener('keydown', onKey);
+    // Delay so the opening click doesn't immediately dismiss.
+    const t = setTimeout(() => document.addEventListener('mousedown', onDown), 0);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      clearTimeout(t);
+      document.removeEventListener('mousedown', onDown);
+    };
+  }, [popover, close]);
+
+  if (!enabled || !popover) return null;
+
+  const match = popover.result?.matches?.[0] ?? null;
+  const alternates = (popover.result?.matches ?? []).slice(1, 3);
+
+  // Desktop position: clamp the card inside the viewport.
+  const CARD_W = 340;
+  const left = Math.min(Math.max(8, popover.x - CARD_W / 2), (typeof window !== 'undefined' ? window.innerWidth : 1200) - CARD_W - 8);
+  const showBelow = popover.y < (typeof window !== 'undefined' ? window.innerHeight : 800) / 2;
+
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="font-semibold text-base" style={{ color: 'var(--text-primary, #1f2937)' }}>
+              {match ? (match.orthography || match.headword) : popover.word}
+            </span>
+            {match && match.headword.toLowerCase() !== popover.word.toLowerCase() && (
+              <span className="text-xs" style={{ color: 'var(--text-muted, #6b7280)' }}>← {popover.word}</span>
+            )}
+          </div>
+          {match && (
+            <div className="text-xs mt-0.5" style={{ color: 'var(--text-muted, #6b7280)' }}>
+              {morphologyLine(match)}
+            </div>
+          )}
+        </div>
+        <button type="button" onClick={close} aria-label="Close dictionary popover" className="p-1 -m-1 shrink-0 opacity-60 hover:opacity-100">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {popover.status === 'loading' && (
+        <div className="py-3 text-sm" style={{ color: 'var(--text-muted, #6b7280)' }}>Looking up…</div>
+      )}
+      {popover.status === 'error' && (
+        <div className="py-3 text-sm" style={{ color: 'var(--text-muted, #6b7280)' }}>Lookup failed — try again.</div>
+      )}
+      {popover.status === 'done' && !match && (
+        <div className="py-3 text-sm" style={{ color: 'var(--text-muted, #6b7280)' }}>
+          No entry found in Lewis &amp; Short. Abbreviations, names, and heavily contracted early modern forms often miss.
+        </div>
+      )}
+
+      {match && (
+        <>
+          {!match.confident && (
+            <div className="mt-2 text-[11px] px-2 py-1 rounded" style={{ background: 'var(--bg-cream, #fef9ef)', color: 'var(--accent-rust, #c45d3a)' }}>
+              Uncertain match ({TIER_LABEL[match.matchType] ?? match.matchType}) — treat as a suggestion.
+            </div>
+          )}
+          <div
+            className={`mt-2 text-sm leading-relaxed ${expanded ? 'max-h-72' : 'max-h-28'} overflow-y-auto`}
+            style={{ color: 'var(--text-secondary, #374151)' }}
+          >
+            {expanded
+              ? (match.senses.filter((s) => typeof s === 'string') as string[]).map((s, i) => (
+                  <p key={i} className={i > 0 ? 'mt-2' : ''}>{s}</p>
+                ))
+              : <p>{firstSenseText(match.senses) || '(no sense text)'}</p>}
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-2">
+            {match.senses.length > 1 || match.sensesTruncated ? (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="text-xs underline underline-offset-2"
+                style={{ color: 'var(--accent-sage, #5f7d61)' }}
+              >
+                {expanded ? 'Show less' : `Full entry${match.senses.length > 1 ? ` (${match.senses.length} senses)` : ''}`}
+              </button>
+            ) : <span />}
+            <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted, #9ca3af)' }}>
+              <BookOpen className="w-3 h-3" /> Lewis &amp; Short
+            </span>
+          </div>
+          {alternates.length > 0 && (
+            <div className="mt-1 text-[11px]" style={{ color: 'var(--text-muted, #6b7280)' }}>
+              also: {alternates.map((a) => a.headword).join(', ')}
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {/* Desktop: anchored card */}
+      <div
+        ref={cardRef}
+        data-lexicon-popover
+        role="dialog"
+        aria-label={`Dictionary entry for ${popover.word}`}
+        className="hidden lg:block fixed z-[60] rounded-lg shadow-xl border p-3"
+        style={{
+          left,
+          top: showBelow ? popover.y + 14 : undefined,
+          bottom: showBelow ? undefined : window.innerHeight - popover.y + 14,
+          width: CARD_W,
+          background: 'var(--bg-paper, #ffffff)',
+          borderColor: 'var(--border-light, #e5e7eb)',
+        }}
+      >
+        {body}
+      </div>
+      {/* Mobile: bottom sheet */}
+      <div
+        data-lexicon-popover
+        role="dialog"
+        aria-label={`Dictionary entry for ${popover.word}`}
+        className="lg:hidden fixed inset-x-0 bottom-0 z-[60] rounded-t-xl shadow-[0_-4px_20px_rgba(0,0,0,0.15)] border-t p-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
+        style={{ background: 'var(--bg-paper, #ffffff)', borderColor: 'var(--border-light, #e5e7eb)' }}
+      >
+        {body}
+      </div>
+    </>
+  );
+}

--- a/src/lib/lexicon/latin-morph.ts
+++ b/src/lib/lexicon/latin-morph.ts
@@ -1,0 +1,514 @@
+/**
+ * Rule-based Latin morphology for dictionary lookup — deliberately honest
+ * about being heuristic. Two jobs:
+ *
+ *  1. Import time: generate inflected-form paradigms for Lewis & Short
+ *     entries (nouns from declension+genitive, verbs from principal parts,
+ *     adjectives from headword shape) to build the `lexicon_lemma_map`
+ *     collection. Over-generation is acceptable: every generated form maps
+ *     back to its own entry key, so junk forms are unreachable noise, not
+ *     wrong answers.
+ *
+ *  2. Query time: irregular-form table + suffix-swap candidate generation as
+ *     a fallback tier when a form isn't in the map.
+ *
+ * All inputs and outputs are NORMALIZED strings (see normalize.ts) — v→u,
+ * j→i, no diacritics. Tables below are written in normalized orthography.
+ */
+
+// ---------------------------------------------------------------------------
+// Irregular forms (query-time tier). form → lemma headwords (normalized).
+// ---------------------------------------------------------------------------
+
+const IRR: Record<string, string[]> = {};
+function irr(lemma: string, forms: string) {
+  for (const f of forms.split(/\s+/)) {
+    if (!f) continue;
+    (IRR[f] ||= []).push(lemma);
+  }
+}
+
+irr(
+  'sum',
+  `sum es est sumus estis sunt eram eras erat eramus eratis erant ero eris erit
+   erimus eritis erunt fui fuisti fuit fuimus fuistis fuerunt fueram fuerat
+   fuerant fuero fuerit fuerint sim sis sit simus sitis sint essem esses esset
+   essemus essetis essent forem fores foret forent esse fuisse fore futurus
+   futura futurum futuri futurae futuro futuram futuros futuras futurorum
+   futurarum futuris este esto`
+);
+irr(
+  'possum',
+  `possum potes potest possumus potestis possunt poteram poterat poterant
+   potero poterit poterunt potui potuit potuerunt potuerat potuerit possim
+   possit possint possem posset possent posse potuisse potens potentis potenti
+   potentem potente potentes potentium potentibus`
+);
+irr(
+  'uolo',
+  `uolo uis uult uolt uolumus uultis uolunt uolebam uolebat uolebant uolam
+   uolet uolent uolui uoluit uoluerunt uelim uelis uelit uelimus uelitis
+   uelint uellem uelles uellet uellent uelle uoluisse uolens uolentis uolenti
+   uolentem uolentes`
+);
+irr('nolo', `nolo non-uis nolumus nolunt nolebat nolui noluit nolim nolit nollem nollet nolle noli nolite nolens`);
+irr('malo', `malo mauis mauult malumus mauultis malunt malebat malui maluit malim malit mallem mallet malle`);
+irr(
+  'fero',
+  `fero fers fert ferimus fertis ferunt ferebam ferebat ferebant feram feret
+   ferent tuli tulisti tulit tulimus tulistis tulerunt tuleram tulerat tulero
+   tulerit feram ferat ferant ferrem ferret ferrent ferre tulisse ferens
+   ferentis ferenti ferentem ferentes ferentibus latus lata latum lati latae
+   lato latam latos latas latorum latarum latis feror fertur feruntur ferri
+   fer ferte`
+);
+irr(
+  'eo1',
+  `eo is it imus itis eunt ibam ibas ibat ibamus ibatis ibant ibo ibis ibit
+   ibimus ibitis ibunt ii iui iit iuit iimus ierunt iuerunt ieram ierat ierant
+   iero ierit eam eas eat eamus eatis eant irem ires iret iremus iretis irent
+   ire isse iuisse iens euntis eunti euntem euntes euntium euntibus itum itus
+   ita iturus itura iturum i ite`
+);
+irr('fio', `fio fis fit fimus fitis fiunt fiebam fiebat fiebant fiam fiet fient fiam fiat fiant fierem fieret fierent fieri factus facta factum facti factae facto factam factos factas factorum factarum factis`);
+irr('edo1', `edo edis est edimus editis edunt edi esse esum`);
+
+// Pronouns & determiners — the highest-frequency words in any Latin text.
+irr('hic', `hic haec hoc huius huic hunc hanc hi hae horum harum his hos has`);
+irr('qui1', `qui quae quod cuius cui quem quam quo qua quorum quarum quibus quos quas quicumque quaecumque quodcumque`);
+irr('quis1', `quis quid cuius cui quem quo`);
+irr('is', `is ea id eius ei eum eam eo ii ei eae eorum earum iis eis eos eas idem`);
+irr('ille', `ille illa illud illius illi illum illam illo illorum illarum illis illos illas`);
+irr('iste', `iste ista istud istius isti istum istam isto istorum istarum istis istos istas`);
+irr('ipse', `ipse ipsa ipsum ipsius ipsi ipsum ipsam ipso ipsorum ipsarum ipsis ipsos ipsas`);
+irr('idem', `idem eadem eiusdem eidem eundem eandem eodem eadem eidem eorundem earundem eisdem iisdem eosdem easdem`);
+irr('ego', `ego mei mihi me mecum nos nostri nostrum nobis nobiscum`);
+irr('tu', `tu tui tibi te tecum uos uestri uestrum uobis uobiscum`);
+irr('sui', `sui sibi se sese secum`);
+irr('nemo', `nemo neminis nemini neminem`);
+irr('quisquam', `quisquam quidquam quicquam cuiusquam cuiquam quemquam quicquid quidquid`);
+irr('nihil', `nihil nihilum nihili nihilo nil`);
+irr('duo', `duo duae duorum duarum duobus duabus duos duas`);
+irr('tres', `tres tria trium tribus`);
+irr('unus', `unus una unum unius uni unam uno`);
+irr('alius', `alius alia aliud alius alii aliud aliam alio aliorum aliarum aliis alios alias`);
+irr('uterque', `uterque utraque utrumque utriusque utrique utrumque utramque utroque`);
+irr('quisque', `quisque quaeque quodque quidque cuiusque cuique quemque quamque quoque`);
+irr('quidam', `quidam quaedam quoddam quiddam cuiusdam cuidam quendam quandam quodam quadam quorundam quarundam quibusdam quosdam quasdam`);
+
+// Irregular comparison — the classical suppletives.
+irr('bonus', `melior melioris meliori meliorem meliore meliores meliorum melioribus melius optimus optima optimum optimi optimae optimo optimam optimos optimas optimorum optimarum optimis optime`);
+irr('malus3', `peior peioris peiorem peiores peiorum peioribus peius pessimus pessima pessimum pessimi pessimae pessimo pessimis pessime`);
+irr('magnus', `maior maioris maiori maiorem maiore maiores maiorum maioribus maius maximus maxima maximum maximi maximae maximo maximam maximos maximorum maximis maxime`);
+irr('paruus', `minor minoris minorem minores minorum minoribus minus minimus minima minimum minimi minimae minimo minimis minime`);
+irr('multus', `plus pluris plura plurium pluribus plures plurimus plurima plurimum plurimi plurimae plurimo plurimis plurimum`);
+
+/** Irregular-forms lookup. Returns candidate lemma headwords (normalized). */
+export function irregularLemmas(normalizedWord: string): string[] {
+  return IRR[normalizedWord] ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Shared paradigm ending tables (normalized orthography).
+// ---------------------------------------------------------------------------
+
+const DECL_1 = ['a', 'ae', 'am', 'as', 'arum', 'is'];
+const DECL_2_MASC = ['us', 'i', 'o', 'um', 'e', 'os', 'orum', 'is'];
+const DECL_2_NEUT = ['um', 'i', 'o', 'a', 'orum', 'is'];
+const DECL_3_ENDINGS = ['is', 'i', 'em', 'e', 'es', 'um', 'ium', 'ibus', 'a', 'ia'];
+const DECL_4 = ['us', 'ui', 'um', 'u', 'uum', 'ibus'];
+const DECL_5 = ['es', 'ei', 'em', 'e', 'erum', 'ebus'];
+const ADJ_212 = ['us', 'a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is', 'e'];
+
+/**
+ * Derive oblique-stem candidates from headword + printed genitive suffix
+ * (e.g. corpus + "oris" → corpor-). Dictionary suffix conventions are not
+ * fully deterministic, so this over-generates candidates; junk stems produce
+ * junk forms that map to the right entry and are simply never queried.
+ */
+export function obliqueStems(head: string, genSuffix: string): string[] {
+  const gs = genSuffix;
+  const out = new Set<string>();
+  let tail = '';
+  if (gs.endsWith('is')) tail = gs.slice(0, -2);
+  else if (gs.endsWith('i')) tail = gs.slice(0, -1);
+  else if (gs.endsWith('us') || gs.endsWith('ei') || gs.endsWith('ae')) tail = '';
+  else return [];
+
+  // Rule 1: strip a known nominative ending, append the suffix stem-tail.
+  for (const strip of ['us', 'is', 'es', 'er', 'ir', 'or', 'en', 'on', 'o', 'x', 's', 'e', 'a', 'um', '']) {
+    if (strip && !head.endsWith(strip)) continue;
+    if (!strip && !tail) continue; // bare headword handled by caller
+    const stem = head.slice(0, head.length - strip.length) + tail;
+    if (stem.length >= 2) out.add(stem);
+  }
+  // Rule 2: printed convention "ager, gri" — replace from the last
+  // occurrence of the suffix's first letter.
+  if (tail) {
+    const idx = head.lastIndexOf(tail[0]);
+    if (idx > 0) out.add(head.slice(0, idx) + tail);
+  }
+  // Rule 3: the "suffix" is really a full genitive form ("rex, regis").
+  if (tail && gs.length >= 4 && gs[0] === head[0]) out.add(tail);
+  if (!tail) out.add(head.replace(/(us|es|ae|a|um)$/, ''));
+  return [...out];
+}
+
+/**
+ * Reverse-nominative stem guesses for 3rd-declension entries that carry no
+ * genitive in the source data (rex → reg-/rec-, corpus → corpor-, …).
+ * Over-generates; see note at top.
+ */
+export function guessThirdDeclStems(head: string): string[] {
+  const out = new Set<string>();
+  const rules: Array<[RegExp, string[]]> = [
+    [/x$/, ['g', 'c']],
+    [/as$/, ['at']],
+    [/us$/, ['or', 'er', 'ur']],
+    [/is$/, ['']],
+    [/es$/, ['', 'it']],
+    [/o$/, ['on', 'in']],
+    [/en$/, ['in']],
+    [/ut$/, ['it']],
+    [/er$/, ['r']],
+    [/or$/, ['or']],
+    [/(b|l|n|r)s$/, ['$1']],
+  ];
+  for (const [re, tails] of rules) {
+    if (!re.test(head)) continue;
+    for (const t of tails) {
+      const stem = head.replace(re, t.startsWith('$') ? '$1' : t);
+      if (stem.length >= 2 && stem !== head) out.add(stem);
+    }
+  }
+  return [...out];
+}
+
+export function nounForms(head: string, declension: number, genSuffix: string | undefined): string[] {
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+  switch (declension) {
+    case 1:
+      if (head.endsWith('a')) add(head.slice(0, -1), DECL_1);
+      break;
+    case 2:
+      if (head.endsWith('us')) add(head.slice(0, -2), DECL_2_MASC);
+      else if (head.endsWith('um')) add(head.slice(0, -2), DECL_2_NEUT);
+      else if (genSuffix) for (const s of obliqueStems(head, genSuffix)) add(s, ['i', 'o', 'um', 'orum', 'os', 'is', 'e']);
+      break;
+    case 3:
+      if (genSuffix) for (const s of obliqueStems(head, genSuffix)) add(s, DECL_3_ENDINGS);
+      else for (const s of guessThirdDeclStems(head)) add(s, DECL_3_ENDINGS);
+      break;
+    case 4:
+      if (head.endsWith('us')) add(head.slice(0, -2), DECL_4);
+      else if (head.endsWith('u')) add(head.slice(0, -1), ['u', 'us', 'ua', 'uum', 'ibus']);
+      break;
+    case 5:
+      if (head.endsWith('es')) add(head.slice(0, -2), DECL_5);
+      break;
+  }
+  return [...forms];
+}
+
+export function adjectiveForms(head: string): string[] {
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+  if (head.endsWith('us')) {
+    const stem = head.slice(0, -2);
+    add(stem, ADJ_212);
+    add(stem, ['ior', 'ioris', 'iori', 'iorem', 'iore', 'iores', 'iorum', 'ioribus', 'ius']); // comparative
+    add(stem, ['issimus', 'issima', 'issimum', 'issimi', 'issimae', 'issimo', 'issimam', 'issimis', 'issime']); // superlative
+    forms.add(stem + 'e'); // adverb
+  } else if (head.endsWith('is')) {
+    const stem = head.slice(0, -2);
+    add(stem, ['is', 'e', 'em', 'i', 'es', 'ia', 'ium', 'ibus', 'iter', 'ior', 'ioris', 'iorem', 'iores', 'issimus', 'issime']);
+  } else if (head.endsWith('er')) {
+    add(head, ['i', 'o', 'um', 'os', 'orum', 'is']);
+    // Both stem shapes: pulcher → pulchr-a, but alter → alter-a keeps the e.
+    for (const stem of [head.slice(0, -2) + 'r', head]) {
+      add(stem, ['a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is', 'e']);
+    }
+  } else if (head.endsWith('x')) {
+    // ferax, feracis — 3rd declension in -x, one termination.
+    const stem = head.slice(0, -1) + 'c';
+    add(stem, ['is', 'i', 'em', 'e', 'es', 'ia', 'ium', 'ibus', 'ior', 'ioris', 'iorem', 'iores', 'issimus', 'issima', 'issimum', 'issime', 'iter']);
+  } else if (head.endsWith('ns')) {
+    const stem = head.slice(0, -2) + 'nt';
+    add(stem, ['is', 'i', 'em', 'e', 'es', 'ium', 'ibus', 'ia', 'er']);
+  }
+  return [...forms];
+}
+
+// ---------------------------------------------------------------------------
+// Verb paradigms.
+// ---------------------------------------------------------------------------
+
+const PERFECT_ENDINGS = [
+  'i', 'isti', 'it', 'imus', 'istis', 'erunt', 'ere',
+  'eram', 'eras', 'erat', 'eramus', 'eratis', 'erant',
+  'ero', 'erit', 'erimus', 'eritis', 'erint',
+  'erim', 'eris',
+  'isse', 'issem', 'isses', 'isset', 'issemus', 'issetis', 'issent',
+];
+
+interface ConjTable {
+  active: string[];
+  passive: string[];
+  infinitives: string[];
+  imperatives: string[];
+  participleStems: string[]; // present participle: stem+ns / stem+nt-…
+  gerundStem: string; // +ndum etc.
+}
+
+// Endings are applied to the present stem (headword minus -o / -or).
+const CONJ: Record<string, ConjTable> = {
+  '1': {
+    active: ['o', 'as', 'at', 'amus', 'atis', 'ant', 'abam', 'abas', 'abat', 'abamus', 'abatis', 'abant',
+      'abo', 'abis', 'abit', 'abimus', 'abitis', 'abunt', 'em', 'es', 'et', 'emus', 'etis', 'ent',
+      'arem', 'ares', 'aret', 'aremus', 'aretis', 'arent'],
+    passive: ['or', 'aris', 'atur', 'amur', 'amini', 'antur', 'abar', 'abaris', 'abatur', 'abamur', 'abamini', 'abantur',
+      'abor', 'aberis', 'abitur', 'abimur', 'abimini', 'abuntur', 'er', 'eris', 'etur', 'emur', 'emini', 'entur',
+      'arer', 'areris', 'aretur', 'aremur', 'aremini', 'arentur'],
+    infinitives: ['are', 'ari'],
+    imperatives: ['a', 'ate', 'ator', 'antor'],
+    participleStems: ['ans|ant'],
+    gerundStem: 'and',
+  },
+  '2': {
+    // stem already ends in e (uide-)
+    active: ['o', 's', 't', 'mus', 'tis', 'nt', 'bam', 'bas', 'bat', 'bamus', 'batis', 'bant',
+      'bo', 'bis', 'bit', 'bimus', 'bitis', 'bunt', 'am', 'as', 'at', 'amus', 'atis', 'ant',
+      'rem', 'res', 'ret', 'remus', 'retis', 'rent'],
+    passive: ['or', 'ris', 'tur', 'mur', 'mini', 'ntur', 'bar', 'baris', 'batur', 'bamur', 'bamini', 'bantur',
+      'bor', 'beris', 'bitur', 'bimur', 'bimini', 'buntur', 'ar', 'aris', 'atur', 'amur', 'amini', 'antur',
+      'rer', 'reris', 'retur', 'remur', 'remini', 'rentur'],
+    infinitives: ['re', 'ri'],
+    imperatives: ['', 'te', 'tor', 'ntor'],
+    participleStems: ['ns|nt'],
+    gerundStem: 'nd',
+  },
+  '3': {
+    active: ['o', 'is', 'it', 'imus', 'itis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant',
+      'erem', 'eres', 'eret', 'eremus', 'eretis', 'erent'],
+    passive: ['or', 'eris', 'itur', 'imur', 'imini', 'untur', 'ebar', 'ebaris', 'ebatur', 'ebamur', 'ebamini', 'ebantur',
+      'ar', 'aris', 'atur', 'amur', 'amini', 'antur',
+      'erer', 'ereris', 'eretur', 'eremur', 'eremini', 'erentur'],
+    infinitives: ['ere', 'i'],
+    imperatives: ['e', 'ite', 'ito', 'itor', 'untor'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+  '3io': {
+    // stem ends in i (capi-); imperfect-subjunctive/infinitive drop it (cap-ere)
+    active: ['o', 's', 't', 'mus', 'tis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant'],
+    passive: ['or', 'tur', 'mur', 'mini', 'untur', 'ebar', 'ebatur', 'ebantur', 'ar', 'atur', 'antur'],
+    infinitives: [],
+    imperatives: ['', 'te'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+  '4': {
+    active: ['o', 's', 't', 'mus', 'tis', 'unt', 'ebam', 'ebas', 'ebat', 'ebamus', 'ebatis', 'ebant',
+      'am', 'es', 'et', 'emus', 'etis', 'ent', 'as', 'at', 'amus', 'atis', 'ant',
+      'rem', 'res', 'ret', 'remus', 'retis', 'rent'],
+    passive: ['or', 'ris', 'tur', 'mur', 'mini', 'untur', 'ebar', 'ebatur', 'ebantur', 'ar', 'atur', 'antur',
+      'rer', 'retur', 'rentur'],
+    infinitives: ['re', 'ri'],
+    imperatives: ['', 'te', 'unto'],
+    participleStems: ['ens|ent'],
+    gerundStem: 'end',
+  },
+};
+
+const PARTICIPLE_NT_ENDINGS = ['is', 'i', 'em', 'e', 'es', 'ium', 'ibus', 'ia'];
+const GERUND_ENDINGS = ['us', 'a', 'um', 'i', 'ae', 'o', 'am', 'os', 'as', 'orum', 'arum', 'is'];
+
+/**
+ * Attach an abbreviated principal-part token ("aui", "xi", "ct") to the
+ * present stem. Dictionary abbreviation conventions vary, so this returns
+ * several candidates (see over-generation note at top).
+ */
+export function principalPartStems(head: string, token: string): string[] {
+  const presStem = head.replace(/or?$/, '');
+  const out = new Set<string>();
+  if (token.length >= 4 && token[0] === head[0]) out.add(token); // full form, e.g. "uidi"
+  out.add(presStem + token);
+  if (presStem.length > 2) out.add(presStem.slice(0, -1) + token);
+  if (presStem.length > 3) out.add(presStem.slice(0, -2) + token);
+  return [...out].filter((s) => s.length >= 3);
+}
+
+export function verbForms(
+  head: string,
+  conjugation: 1 | 2 | 3 | 4,
+  perfectStems: string[],
+  supineStems: string[]
+): string[] {
+  const deponent = head.endsWith('or');
+  const presStem = head.replace(/or?$/, '');
+  const io3 = conjugation === 3 && presStem.endsWith('i');
+  const table = CONJ[io3 ? '3io' : String(conjugation)];
+  const forms = new Set<string>([head]);
+  const add = (stem: string, endings: string[]) => {
+    for (const e of endings) forms.add(stem + e);
+  };
+
+  add(presStem, table.active);
+  add(presStem, table.passive);
+  add(presStem, table.infinitives);
+  add(presStem, table.imperatives);
+  for (const p of table.participleStems) {
+    const [nom, oblique] = p.split('|');
+    forms.add(presStem + nom);
+    add(presStem + oblique, PARTICIPLE_NT_ENDINGS);
+  }
+  add(presStem + table.gerundStem, GERUND_ENDINGS);
+  if (io3) {
+    // cap-ere, cap-erem, cap-eris…
+    const short = presStem.slice(0, -1);
+    add(short, ['ere', 'erem', 'eres', 'eret', 'eremus', 'eretis', 'erent', 'eris', 'erer', 'eretur', 'i', 'e', 'ite']);
+  }
+  for (const ps of perfectStems) {
+    add(ps, PERFECT_ENDINGS);
+    // Syncopated perfects: amauisse → amasse, amauerunt → amarunt;
+    // audiuisse → audisse, audiuerunt → audierunt.
+    if (ps.endsWith('au')) {
+      add(ps.slice(0, -2), ['asse', 'assem', 'asses', 'asset', 'assemus', 'assetis', 'assent',
+        'asti', 'astis', 'arunt', 'aram', 'aras', 'arat', 'aramus', 'arant', 'aro', 'arit', 'arint']);
+    } else if (ps.endsWith('iu')) {
+      add(ps.slice(0, -1), ['sse', 'ssem', 'sset', 'ssent', 'sti', 'stis', 'erunt', 'erat', 'erant', 'ero', 'erit']);
+    }
+  }
+  for (const ss of supineStems) {
+    add(ss, GERUND_ENDINGS); // perfect participle: -us -a -um…
+    add(ss + 'ur', GERUND_ENDINGS); // future participle: -urus…
+    forms.add(ss + 'u');
+    forms.add(ss + 'um');
+  }
+  if (deponent) forms.add(head);
+  return [...forms].filter((f) => f.length >= 2);
+}
+
+// ---------------------------------------------------------------------------
+// Query-time fallback: suffix-swap candidate headwords for an unknown form.
+// ---------------------------------------------------------------------------
+
+const SUFFIX_SWAPS: Array<[string, string[]]> = [
+  ['ibus', ['', 'is', 's', 'us']],
+  ['orum', ['us', 'um', 'i']],
+  ['arum', ['a']],
+  ['erunt', ['o', 'i']],
+  ['issent', ['o']],
+  ['isset', ['o']],
+  ['isse', ['o']],
+  ['issimus', ['us', 'is']],
+  ['issima', ['us', 'is']],
+  ['issimum', ['us', 'is']],
+  ['ionis', ['io']],
+  ['ione', ['io']],
+  ['ionem', ['io']],
+  ['iones', ['io']],
+  ['ionum', ['io']],
+  ['ionibus', ['io']],
+  ['atur', ['o', 'or']],
+  ['antur', ['o', 'or']],
+  ['etur', ['eo', 'o', 'eor']],
+  ['itur', ['o', 'io']],
+  ['untur', ['o']],
+  ['abat', ['o']],
+  ['ebat', ['eo', 'o']],
+  ['abant', ['o']],
+  ['ebant', ['eo', 'o']],
+  ['auit', ['o']],
+  ['euit', ['eo']],
+  ['iuit', ['io']],
+  ['atus', ['o', 'us']],
+  ['ata', ['o', 'us']],
+  ['atum', ['o', 'us']],
+  ['ati', ['o', 'us']],
+  ['atis', ['o', 'a', 'us']],
+  ['ntis', ['ns', 'o']],
+  ['ntem', ['ns', 'o']],
+  ['ntes', ['ns', 'o']],
+  ['ntia', ['ns', 'o']],
+  ['ntium', ['ns', 'o']],
+  ['ndi', ['o', 'us']],
+  ['ndo', ['o', 'us']],
+  ['ndum', ['o', 'us']],
+  ['nda', ['o', 'us']],
+  ['are', ['o']],
+  ['ari', ['o', 'or']],
+  ['ere', ['eo', 'o']],
+  ['ire', ['io']],
+  ['amus', ['o']],
+  ['emus', ['eo', 'o']],
+  ['imus', ['o', 'io']],
+  ['atis', ['o']],
+  ['etis', ['eo', 'o']],
+  ['itis', ['o', 'io']],
+  ['ant', ['o']],
+  ['ent', ['eo', 'o']],
+  ['unt', ['o']],
+  ['iunt', ['io']],
+  ['at', ['o', 'a']],
+  ['et', ['eo', 'o']],
+  ['it', ['o', 'io', 'eo']],
+  ['as', ['o', 'a']],
+  ['es', ['o', 'eo', 'is', 'es', '']],
+  ['is', ['is', '', 's', 'us', 'o', 'a']],
+  ['ae', ['a']],
+  ['am', ['a', 'o']],
+  ['a', ['a', 'um', 'us']],
+  ['os', ['us']],
+  ['um', ['us', 'um', 'a', '']],
+  ['o', ['us', 'um', 'o']],
+  ['i', ['us', 'um', '', 'is', 'o']],
+  ['em', ['is', '', 's']],
+  ['e', ['is', 'us', '']],
+  ['u', ['us']],
+  ['us', ['us']],
+];
+
+/**
+ * Long-s OCR error variants: early modern ſ is routinely misread as f
+ * ("fpiffandi" for spissandi, "refina" for resina). Generate f→s
+ * substitution variants, bounded to 15 combinations. Lowest-confidence tier.
+ */
+export function longSVariants(word: string): string[] {
+  const positions: number[] = [];
+  for (let i = 0; i < word.length && positions.length < 4; i++) if (word[i] === 'f') positions.push(i);
+  if (!positions.length) return [];
+  const out: string[] = [];
+  for (let mask = 1; mask < 1 << positions.length; mask++) {
+    const chars = word.split('');
+    for (let b = 0; b < positions.length; b++) if (mask & (1 << b)) chars[positions[b]] = 's';
+    out.push(chars.join(''));
+  }
+  return out;
+}
+
+/** Candidate headwords for an unknown normalized form, best-guess order. */
+export function suffixSwapCandidates(word: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>([word]);
+  for (const [suffix, replacements] of SUFFIX_SWAPS) {
+    if (!word.endsWith(suffix)) continue;
+    const stem = word.slice(0, word.length - suffix.length);
+    if (stem.length < 2) continue;
+    for (const r of replacements) {
+      const cand = stem + r;
+      if (cand.length >= 2 && !seen.has(cand)) {
+        seen.add(cand);
+        out.push(cand);
+      }
+    }
+  }
+  return out;
+}

--- a/src/lib/lexicon/lookup-grc.ts
+++ b/src/lib/lexicon/lookup-grc.ts
@@ -20,7 +20,9 @@ const GRAVE_TO_ACUTE: Record<string, string> = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ'
 export function normGreekKey(raw: string): string {
   let s = raw.normalize('NFD').replace(/[̄̆]/g, '').normalize('NFC').toLowerCase();
   s = [...s].map((ch) => GRAVE_TO_ACUTE[ch] ?? ch).join('');
-  return s.replace(/[^\p{L}\p{N}]/gu, '');
+  // Fold final sigma into medial: positional variants of one letter, and the
+  // betacode round-trip can emit either in either position.
+  return s.replace(/ς/g, 'σ').replace(/[^\p{L}\p{N}]/gu, '');
 }
 
 interface GrcEntryDoc {
@@ -76,14 +78,14 @@ export async function lookupGreekWord(db: Db, rawWord: string): Promise<GrcLooku
   if (normalized.length < 1) return miss;
   const entries = db.collection<GrcEntryDoc>('lexicon_entries_grc');
 
-  const exact = await entries.find({ key_normalized: normalized }).limit(8).toArray();
+  // Both tiers fire concurrently; exact wins if it hits (one Atlas RTT, not two).
+  const [exact, mapped] = await Promise.all([
+    entries.find({ key_normalized: normalized }).limit(8).toArray(),
+    db.collection<{ form: string; keys: string[] }>('lexicon_lemma_map_grc').findOne({ form: normalized }),
+  ]);
   if (exact.length) {
     return { query, normalized, found: true, matches: rank(exact).slice(0, MAX_MATCHES).map((d) => toMatch(d, 'exact')) };
   }
-
-  const mapped = await db
-    .collection<{ form: string; keys: string[] }>('lexicon_lemma_map_grc')
-    .findOne({ form: normalized });
   if (mapped?.keys?.length) {
     const docs = await entries.find({ key: { $in: mapped.keys.slice(0, 8) } }).toArray();
     if (docs.length) {

--- a/src/lib/lexicon/lookup-grc.ts
+++ b/src/lib/lexicon/lookup-grc.ts
@@ -1,0 +1,95 @@
+import { Db } from 'mongodb';
+
+/**
+ * Greek dictionary lookup (#3823 Phase 3): LSJ 9th ed. (lsj9, CC BY 4.0)
+ * entries + a form→lemma map regenerated with the MPL-2.0 Morpheus engine
+ * over OUR corpus vocabulary (no NC-encumbered data; see
+ * scripts/lexicon/morpheus-crunch.mjs).
+ *
+ * Tiers (both confident — the map is analyzer output, not heuristics):
+ *   1. exact   — normalized form equals an LSJ headword
+ *   2. lemma   — form found in lexicon_lemma_map_grc
+ * A miss is a structured miss, same contract as Latin.
+ *
+ * normGreekKey MUST match scripts/lexicon/import-lsj.mjs (same normalizer
+ * on both sides): NFD → strip length marks → NFC → lowercase → grave→acute.
+ */
+
+const GRAVE_TO_ACUTE: Record<string, string> = { 'ὰ': 'ά', 'ὲ': 'έ', 'ὴ': 'ή', 'ὶ': 'ί', 'ὸ': 'ό', 'ὺ': 'ύ', 'ὼ': 'ώ', 'ἃ': 'ἅ', 'ἓ': 'ἕ', 'ἳ': 'ἵ', 'ὃ': 'ὅ', 'ὓ': 'ὕ', 'ὣ': 'ὥ', 'ἂ': 'ἄ', 'ἒ': 'ἔ', 'ἲ': 'ἴ', 'ὂ': 'ὄ', 'ὒ': 'ὔ', 'ὢ': 'ὤ', 'ᾲ': 'ᾴ', 'ῂ': 'ῄ', 'ῲ': 'ῴ' };
+
+export function normGreekKey(raw: string): string {
+  let s = raw.normalize('NFD').replace(/[̄̆]/g, '').normalize('NFC').toLowerCase();
+  s = [...s].map((ch) => GRAVE_TO_ACUTE[ch] ?? ch).join('');
+  return s.replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+interface GrcEntryDoc {
+  key: string;
+  headword: string;
+  key_normalized: string;
+  grammar: string | null;
+  etymology: string | null;
+  homograph: string | null;
+  short_def: string | null;
+}
+
+export interface GrcMatch {
+  key: string;
+  headword: string;
+  matchType: 'exact' | 'lemma';
+  confident: true;
+  grammar: string | null;
+  etymology: string | null;
+  shortDef: string | null;
+}
+
+export interface GrcLookupResult {
+  query: string;
+  normalized: string;
+  found: boolean;
+  matches: GrcMatch[];
+}
+
+const MAX_MATCHES = 4;
+
+/** Entries with a short def outrank bare headwords (homograph stubs). */
+function rank(docs: GrcEntryDoc[]): GrcEntryDoc[] {
+  return [...docs].sort((a, b) => Number(!!b.short_def) - Number(!!a.short_def) || a.key.localeCompare(b.key));
+}
+
+function toMatch(d: GrcEntryDoc, matchType: 'exact' | 'lemma'): GrcMatch {
+  return {
+    key: d.key,
+    headword: d.headword,
+    matchType,
+    confident: true,
+    grammar: d.grammar,
+    etymology: d.etymology,
+    shortDef: d.short_def,
+  };
+}
+
+export async function lookupGreekWord(db: Db, rawWord: string): Promise<GrcLookupResult> {
+  const query = rawWord.trim().slice(0, 80);
+  const normalized = normGreekKey(query);
+  const miss: GrcLookupResult = { query, normalized, found: false, matches: [] };
+  if (normalized.length < 1) return miss;
+  const entries = db.collection<GrcEntryDoc>('lexicon_entries_grc');
+
+  const exact = await entries.find({ key_normalized: normalized }).limit(8).toArray();
+  if (exact.length) {
+    return { query, normalized, found: true, matches: rank(exact).slice(0, MAX_MATCHES).map((d) => toMatch(d, 'exact')) };
+  }
+
+  const mapped = await db
+    .collection<{ form: string; keys: string[] }>('lexicon_lemma_map_grc')
+    .findOne({ form: normalized });
+  if (mapped?.keys?.length) {
+    const docs = await entries.find({ key: { $in: mapped.keys.slice(0, 8) } }).toArray();
+    if (docs.length) {
+      return { query, normalized, found: true, matches: rank(docs).slice(0, MAX_MATCHES).map((d) => toMatch(d, 'lemma')) };
+    }
+  }
+
+  return miss;
+}

--- a/src/lib/lexicon/lookup-grc.ts
+++ b/src/lib/lexicon/lookup-grc.ts
@@ -54,6 +54,21 @@ export interface GrcLookupResult {
 
 const MAX_MATCHES = 4;
 
+// Elided forms (apostrophe lost in normalization) → full forms, normalized.
+// Closed class: particles, prepositions, and the frequent pronoun/demonstrative
+// elisions of running Greek text. Aspirated variants (θ᾽, καθ᾽…) precede a
+// rough breathing; the expansion is the same word.
+const ELISION: Record<string, string[]> = {
+  'ἵν': ['ἵνα'], 'ἀλλ': ['ἀλλά'], 'δ': ['δέ'], 'τ': ['τε'], 'θ': ['τε'],
+  'γ': ['γε'], 'μ': ['με', 'μοι'], 'σ': ['σε'], 'οὐδ': ['οὐδέ'], 'μηδ': ['μηδέ'],
+  'κατ': ['κατά'], 'καθ': ['κατά'], 'μετ': ['μετά'], 'μεθ': ['μετά'],
+  'παρ': ['παρά'], 'ἐπ': ['ἐπί'], 'ἐφ': ['ἐπί'], 'ἀπ': ['ἀπό'], 'ἀφ': ['ἀπό'],
+  'ὑπ': ['ὑπό'], 'ὑφ': ['ὑπό'], 'δι': ['διά'], 'ἀνθ': ['ἀντί'], 'ἀντ': ['ἀντί'],
+  'ὥστ': ['ὥστε'], 'οὔτ': ['οὔτε'], 'μήτ': ['μήτε'], 'εἶτ': ['εἶτα'],
+  'ἔτ': ['ἔτι'], 'ποτ': ['ποτέ'], 'τότ': ['τότε'], 'ὅτ': ['ὅτε'],
+  'τοῦτ': ['τοῦτο'], 'ταῦτ': ['ταῦτα'], 'πάντ': ['πάντα'], 'πολλ': ['πολλά'],
+};
+
 /** Entries with a short def outrank bare headwords (homograph stubs). */
 function rank(docs: GrcEntryDoc[]): GrcEntryDoc[] {
   return [...docs].sort((a, b) => Number(!!b.short_def) - Number(!!a.short_def) || a.key.localeCompare(b.key));
@@ -79,6 +94,19 @@ export async function lookupGreekWord(db: Db, rawWord: string): Promise<GrcLooku
   const entries = db.collection<GrcEntryDoc>('lexicon_entries_grc');
 
   // Both tiers fire concurrently; exact wins if it hits (one Atlas RTT, not two).
+  // Elision: apostrophes vanish in OCR/normalization, so elided forms arrive
+  // as bare stems and misroute (ἵν → the pronoun ἕ instead of ἵνα — found by
+  // a dataset spot-check at 11K attestations). Expand the closed class first.
+  const elided = ELISION[normalized];
+  if (elided) {
+    const docs = await entries.find({ key_normalized: { $in: elided } }).limit(8).toArray();
+    if (docs.length) {
+      const order = new Map(elided.map((e, i) => [e, i]));
+      docs.sort((a, b) => (order.get(a.key_normalized) ?? 9) - (order.get(b.key_normalized) ?? 9));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'exact')) };
+    }
+  }
+
   const [exact, mapped] = await Promise.all([
     entries.find({ key_normalized: normalized }).limit(8).toArray(),
     db.collection<{ form: string; keys: string[] }>('lexicon_lemma_map_grc').findOne({ form: normalized }),

--- a/src/lib/lexicon/lookup-grc.ts
+++ b/src/lib/lexicon/lookup-grc.ts
@@ -117,7 +117,12 @@ export async function lookupGreekWord(db: Db, rawWord: string): Promise<GrcLooku
   if (mapped?.keys?.length) {
     const docs = await entries.find({ key: { $in: mapped.keys.slice(0, 8) } }).toArray();
     if (docs.length) {
-      return { query, normalized, found: true, matches: rank(docs).slice(0, MAX_MATCHES).map((d) => toMatch(d, 'lemma')) };
+      // Preserve the map's key order — it is frequency-ranked at build time
+      // (rank-grc-lemma-keys.mjs); alphabetical re-sorting is how ἐστίν once
+      // led with εἴλω instead of εἰμί.
+      const pos = new Map(mapped.keys.map((k, i) => [k, i]));
+      docs.sort((a, b) => (pos.get(a.key) ?? 99) - (pos.get(b.key) ?? 99));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'lemma')) };
     }
   }
 

--- a/src/lib/lexicon/lookup.ts
+++ b/src/lib/lexicon/lookup.ts
@@ -1,0 +1,229 @@
+import { Collection, Db } from 'mongodb';
+import { normalizeLatin, looseKey, cleanOcrToken } from './normalize';
+import { irregularLemmas, suffixSwapCandidates, longSVariants } from './latin-morph';
+
+/**
+ * Lookup chain for the parsing reader (issue #3823, Phase 1).
+ *
+ * Tiers, strongest first — the first tier that matches wins:
+ *  1. exact     — normalized form equals a headword
+ *  2. variant   — equals a recorded alternative orthography
+ *  3. irregular — hand-tabled irregular form (est → sum, tulit → fero)
+ *  4. inflected — form generated from the entry's own paradigm at import
+ *                 time (lexicon_lemma_map)
+ *  5. loose     — ae/oe/e + y/i collapsed match (coelum → caelum), a
+ *                 deterministic orthographic equivalence, so it outranks…
+ *  6. suffix    — heuristic suffix-swap candidate (labelled uncertain)
+ *  7. ocr       — long-s misread repair: f→s variants (fpiffandi →
+ *                 spissandi), re-run through tiers 1/4/5
+ *
+ * A miss is a structured miss. We never return a fuzzy "best guess" beyond
+ * tier 5/6, and those tiers carry `confident: false` so the UI can hedge.
+ */
+
+export type MatchType = 'exact' | 'variant' | 'irregular' | 'inflected' | 'loose' | 'suffix' | 'ocr';
+
+export interface LexiconMatch {
+  key: string;
+  headword: string;
+  matchType: MatchType;
+  confident: boolean;
+  entryType: string;
+  partOfSpeech: string | null;
+  orthography: string | null;
+  genitive: string | null;
+  gender: string | null;
+  declension: number | null;
+  mainNotes: string | null;
+  senses: unknown[];
+  sensesTruncated: boolean;
+}
+
+export interface LexiconLookupResult {
+  query: string;
+  normalized: string;
+  found: boolean;
+  matches: LexiconMatch[];
+}
+
+const MAX_MATCHES = 4;
+const MAX_SENSE_CHARS = 4000;
+
+interface EntryDoc {
+  key: string;
+  headword: string;
+  key_normalized: string;
+  key_loose: string;
+  alt_normalized?: string[];
+  entry_type: string;
+  part_of_speech?: string;
+  gender?: string;
+  declension?: number;
+  title_genitive?: string;
+  title_orthography?: string;
+  main_notes?: string;
+  senses?: unknown[];
+}
+
+function flattenSenseChars(senses: unknown[]): number {
+  let n = 0;
+  for (const s of senses) n += typeof s === 'string' ? s.length : flattenSenseChars(s as unknown[]);
+  return n;
+}
+
+function truncateSenses(senses: unknown[]): { senses: unknown[]; truncated: boolean } {
+  const out: unknown[] = [];
+  let used = 0;
+  for (const s of senses) {
+    const cost = typeof s === 'string' ? s.length : flattenSenseChars(s as unknown[]);
+    if (used + cost > MAX_SENSE_CHARS && out.length > 0) return { senses: out, truncated: true };
+    out.push(s);
+    used += cost;
+  }
+  return { senses: out, truncated: false };
+}
+
+function toMatch(doc: EntryDoc, matchType: MatchType): LexiconMatch {
+  const { senses, truncated } = truncateSenses(doc.senses ?? []);
+  return {
+    key: doc.key,
+    headword: doc.headword,
+    matchType,
+    confident: matchType !== 'suffix' && matchType !== 'ocr',
+    entryType: doc.entry_type,
+    partOfSpeech: doc.part_of_speech ?? null,
+    orthography: doc.title_orthography ?? null,
+    genitive: doc.title_genitive ?? null,
+    gender: doc.gender ?? null,
+    declension: doc.declension ?? null,
+    mainNotes: doc.main_notes ? doc.main_notes.slice(0, 600) : null,
+    senses,
+    sensesTruncated: truncated,
+  };
+}
+
+/** Prefer main entries and lower homonym numbers when several keys match. */
+function rankEntries(docs: EntryDoc[]): EntryDoc[] {
+  const typeRank: Record<string, number> = { main: 0, greek: 1, hapax: 2, gloss: 3, foreign: 4, spur: 5 };
+  return [...docs].sort(
+    (a, b) => (typeRank[a.entry_type] ?? 9) - (typeRank[b.entry_type] ?? 9) || a.key.localeCompare(b.key)
+  );
+}
+
+/**
+ * Pre-normalization variants tried through the whole chain, in order:
+ * the word itself; enclitic stripped (-que/-ne/-ue: veniamque → veniam);
+ * h toggled (early modern h-variance: humidum → umidum, arena → harena).
+ * These rewrite the QUERY only, so they stay consistent with the stored
+ * normalized keys (both sides of the guard keep the same normalizer).
+ */
+function queryVariants(normalized: string): string[] {
+  const out = [normalized];
+  const enclitic = normalized.match(/^(.{3,})(que|ne|ue|ce)$/);
+  if (enclitic) out.push(enclitic[1]);
+  if (normalized.startsWith('h')) out.push(normalized.slice(1));
+  else if (/^[aeiou]/.test(normalized)) out.push('h' + normalized);
+  if (enclitic && enclitic[1].startsWith('h')) out.push(enclitic[1].slice(1));
+  return out;
+}
+
+export async function lookupLatinWord(db: Db, rawWord: string): Promise<LexiconLookupResult> {
+  const query = cleanOcrToken(rawWord).slice(0, 60);
+  const normalized = normalizeLatin(query);
+  const entries = db.collection<EntryDoc>('lexicon_entries');
+  const lemmaMap = db.collection<{ form: string; form_loose?: string; keys: string[] }>('lexicon_lemma_map');
+  const miss: LexiconLookupResult = { query, normalized, found: false, matches: [] };
+  if (normalized.length < 1) return miss;
+
+  for (const variant of queryVariants(normalized)) {
+    const res = await runTiers(entries, lemmaMap, query, variant);
+    if (res) return { ...res, normalized };
+  }
+  return miss;
+}
+
+async function runTiers(
+  entries: Collection<EntryDoc>,
+  lemmaMap: Collection<{ form: string; form_loose?: string; keys: string[] }>,
+  query: string,
+  normalized: string
+): Promise<LexiconLookupResult | null> {
+  const finish = (docs: EntryDoc[], type: MatchType): LexiconLookupResult => ({
+    query,
+    normalized,
+    found: true,
+    matches: rankEntries(docs).slice(0, MAX_MATCHES).map((d) => toMatch(d, type)),
+  });
+
+  // 1. exact headword
+  const exact = await entries.find({ key_normalized: normalized }).limit(8).toArray();
+  if (exact.length) return finish(exact, 'exact');
+
+  // 2. recorded orthographic variant
+  const variant = await entries.find({ alt_normalized: normalized }).limit(8).toArray();
+  if (variant.length) return finish(variant, 'variant');
+
+  // 3. irregular forms — keep the table's order (est → sum before edo)
+  const irrLemmas = irregularLemmas(normalized);
+  if (irrLemmas.length) {
+    const docs = await entries
+      .find({ $or: [{ key_normalized: { $in: irrLemmas } }, { key: { $in: irrLemmas } }] })
+      .limit(8)
+      .toArray();
+    if (docs.length) {
+      const order = new Map(irrLemmas.map((l, i) => [l, i]));
+      const pos = (d: EntryDoc) => order.get(d.key) ?? order.get(d.key_normalized) ?? 99;
+      docs.sort((a, b) => pos(a) - pos(b));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'irregular')) };
+    }
+  }
+
+  // 4. generated paradigm map
+  const mapped = await lemmaMap.findOne({ form: normalized });
+  if (mapped?.keys?.length) {
+    const docs = await entries.find({ key: { $in: mapped.keys.slice(0, 8) } }).toArray();
+    if (docs.length) return finish(docs, 'inflected');
+  }
+
+  // 5. loose orthography (ae/oe/e, y/i collapse) — deterministic, so it
+  // outranks the suffix heuristic ("forme" is formae, not a guess at formus).
+  const loose = looseKey(normalized);
+  if (loose !== normalized) {
+    const docs = await entries.find({ key_loose: loose }).limit(8).toArray();
+    if (docs.length) return finish(docs, 'loose');
+    const mappedLoose = await lemmaMap.findOne({ form_loose: loose });
+    if (mappedLoose?.keys?.length) {
+      const docs2 = await entries.find({ key: { $in: mappedLoose.keys.slice(0, 8) } }).toArray();
+      if (docs2.length) return finish(docs2, 'loose');
+    }
+  }
+
+  // 6. suffix-swap heuristic (uncertain)
+  const candidates = suffixSwapCandidates(normalized).slice(0, 24);
+  if (candidates.length) {
+    const docs = await entries.find({ key_normalized: { $in: candidates } }).limit(8).toArray();
+    if (docs.length) {
+      // keep candidate order, not mongo order
+      const order = new Map(candidates.map((c, i) => [c, i]));
+      docs.sort((a, b) => (order.get(a.key_normalized) ?? 99) - (order.get(b.key_normalized) ?? 99));
+      return { query, normalized, found: true, matches: docs.slice(0, MAX_MATCHES).map((d) => toMatch(d, 'suffix')) };
+    }
+  }
+
+  // 7. long-s OCR repair: f→s variants through headword, paradigm map, loose.
+  const fsVariants = longSVariants(normalized);
+  if (fsVariants.length) {
+    const docs = await entries.find({ key_normalized: { $in: fsVariants } }).limit(8).toArray();
+    if (docs.length) return finish(docs, 'ocr');
+    const mappedFs = await lemmaMap.findOne({ form: { $in: fsVariants } });
+    if (mappedFs?.keys?.length) {
+      const docs2 = await entries.find({ key: { $in: mappedFs.keys.slice(0, 8) } }).toArray();
+      if (docs2.length) return finish(docs2, 'ocr');
+    }
+    const looseFs = [...new Set(fsVariants.map(looseKey))];
+    const docs3 = await entries.find({ key_loose: { $in: looseFs } }).limit(8).toArray();
+    if (docs3.length) return finish(docs3, 'ocr');
+  }
+
+  return null;
+}

--- a/src/lib/lexicon/normalize.ts
+++ b/src/lib/lexicon/normalize.ts
@@ -1,0 +1,61 @@
+/**
+ * Latin orthography normalization for dictionary lookup.
+ *
+ * Both sides of every comparison — dictionary headwords at import time and
+ * reader words at query time — MUST go through the same function. Never
+ * normalize only one side (see lesson: a guard must normalize both sides).
+ *
+ * Two tiers:
+ *  - normalizeLatin: safe, near-lossless canonical key (diacritics, ligatures,
+ *    u/v, i/j, case). Used as the primary lookup key.
+ *  - looseKey: additionally collapses ae/oe → e, which early modern printing
+ *    (coelum/caelum, foemina/femina) makes necessary. Lossier; used only as a
+ *    fallback tier so strict matches always win.
+ */
+
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+export function normalizeLatin(word: string): string {
+  return (
+    word
+      .normalize('NFD')
+      // Early modern contraction marks, BEFORE stripping combining chars.
+      // A tilde/macron over a vowel is a suspended nasal in early modern
+      // print: word-final → m ("Latinorū" → latinorum, "Cōsortiū" →
+      // consortium's final -um), mid-word tilde → m before labials
+      // ("cõbibo" → combibo) else n ("Sapiētia" → sapientia). Mid-word
+      // MACRONS are left to the generic strip — in dictionary orthography
+      // they mark length, not contraction. U+0303 = tilde, U+0304 = macron.
+      .replace(/([aeiouAEIOU])[̃̄](?=[^\p{L}̀-ͯ]|$)/gu, '$1m')
+      .replace(/([aeiouAEIOU])̃(?=[̀-ͯ]*[bpmBPM])/gu, '$1m')
+      .replace(/([aeiouAEIOU])̃/gu, '$1n')
+      .replace(COMBINING_MARKS, '') // remaining macrons, breves, accents
+      .toLowerCase()
+      .replace(/æ/g, 'ae')
+      .replace(/œ/g, 'oe')
+      .replace(/ſ/g, 's') // long s surviving in OCR
+      .replace(/j/g, 'i')
+      .replace(/v/g, 'u')
+      .replace(/w/g, 'uu')
+      // early modern tilde contractions: õ = om/on etc. NFD splits the tilde
+      // off as U+0303 (stripped above), so the base vowel survives; nothing
+      // more to do here, but the char class below drops any leftovers.
+      .replace(/[^a-z]/g, '')
+  );
+}
+
+/** Lossier key: early modern ae/oe/e and y/i conflation. */
+export function looseKey(normalized: string): string {
+  return normalized.replace(/ae/g, 'e').replace(/oe/g, 'e').replace(/y/g, 'i');
+}
+
+/**
+ * Strip punctuation and line-break hyphenation from a raw OCR token before
+ * normalization. Keeps internal letters only; returns '' for non-words.
+ */
+export function cleanOcrToken(token: string): string {
+  return token
+    .replace(/[­­-]\s*$/g, '') // trailing hyphen (line break)
+    .replace(/^[^\p{L}]+|[^\p{L}]+$/gu, '') // surrounding punctuation
+    .trim();
+}

--- a/tests/unit/lexicon-morph.test.ts
+++ b/tests/unit/lexicon-morph.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLatin, looseKey, cleanOcrToken } from '@/lib/lexicon/normalize';
+import {
+  nounForms,
+  verbForms,
+  adjectiveForms,
+  guessThirdDeclStems,
+  suffixSwapCandidates,
+  irregularLemmas,
+  longSVariants,
+} from '@/lib/lexicon/latin-morph';
+
+describe('normalizeLatin', () => {
+  it('handles early modern orthography', () => {
+    expect(normalizeLatin('cœlum')).toBe('coelum');
+    expect(normalizeLatin('Cælum')).toBe('caelum');
+    expect(normalizeLatin('ejus')).toBe('eius');
+    // Final macron reads as a suspended nasal — the early modern default in
+    // our OCR (Latinorū). The cost is dictionary-style length marks
+    // ('Vīvō' → uiuom), which effectively never appear in reader queries.
+    expect(normalizeLatin('Vīvō')).toBe('uiuom');
+    expect(normalizeLatin('āvi')).toBe('aui');
+    expect(normalizeLatin('cõmunis')).toBe('communis'); // tilde before labial → m
+  });
+  it('strips non-letters', () => {
+    expect(normalizeLatin('anno,')).toBe('anno');
+    expect(normalizeLatin('1651')).toBe('');
+  });
+  it('expands early modern contraction marks', () => {
+    expect(normalizeLatin('Latinorū')).toBe('latinorum'); // final macron → m
+    expect(normalizeLatin('conditũ')).toBe('conditum'); // final tilde → m
+    expect(normalizeLatin('Sapiẽtia')).toBe('sapientia'); // mid tilde → n
+    expect(normalizeLatin('cõbibo')).toBe('combibo'); // tilde before labial → m
+    expect(normalizeLatin('āvi')).toBe('aui'); // mid/lone macron still just strips
+  });
+  it('looseKey collapses ae/oe', () => {
+    expect(looseKey('caelum')).toBe('celum');
+    expect(looseKey('coelum')).toBe('celum');
+    expect(looseKey(normalizeLatin('cœlum'))).toBe(looseKey(normalizeLatin('cælum')));
+  });
+  it('cleanOcrToken strips punctuation and hyphenation', () => {
+    expect(cleanOcrToken('(natura)')).toBe('natura');
+    expect(cleanOcrToken('anno;')).toBe('anno');
+  });
+});
+
+describe('verbForms', () => {
+  it('conjugation 1 (amo)', () => {
+    const f = verbForms('amo', 1, ['amau'], ['amat']);
+    for (const w of ['amat', 'amamus', 'amant', 'amabat', 'amare', 'amauit', 'amatus', 'amandum', 'amans', 'amantis', 'amatur', 'amemus'])
+      expect(f, w).toContain(w);
+  });
+  it('conjugation 2 (uideo)', () => {
+    const f = verbForms('uideo', 2, ['uid'], ['uis']);
+    for (const w of ['uidet', 'uident', 'uidere', 'uidit', 'uiderunt', 'uisum', 'uidens', 'uidetur', 'uideatur'])
+      expect(f, w).toContain(w);
+  });
+  it('conjugation 3 and 3io', () => {
+    const duco = verbForms('duco', 3, ['dux'], ['duct']);
+    for (const w of ['ducit', 'ducunt', 'ducere', 'duxit', 'ductus', 'ducens', 'ducitur']) expect(duco, w).toContain(w);
+    const capio = verbForms('capio', 3, ['cep'], ['capt']);
+    for (const w of ['capit', 'capiunt', 'capere', 'cepit', 'captus', 'capiens', 'caperet']) expect(capio, w).toContain(w);
+  });
+  it('conjugation 4 (audio)', () => {
+    const f = verbForms('audio', 4, ['audiu'], ['audit']);
+    for (const w of ['audit', 'audiunt', 'audire', 'audiuit', 'auditus', 'audiens', 'auditur']) expect(f, w).toContain(w);
+  });
+});
+
+describe('nounForms', () => {
+  it('covers the five declensions', () => {
+    expect(nounForms('natura', 1, 'ae')).toEqual(expect.arrayContaining(['naturae', 'naturam', 'naturis']));
+    expect(nounForms('deus', 2, 'i')).toEqual(expect.arrayContaining(['dei', 'deorum', 'deos']));
+    expect(nounForms('corpus', 3, 'oris')).toEqual(expect.arrayContaining(['corporis', 'corpora', 'corporibus']));
+    expect(nounForms('spiritus', 4, 'us')).toEqual(expect.arrayContaining(['spiritum', 'spirituum', 'spiritibus']));
+    expect(nounForms('res', 5, 'ei')).toEqual(expect.arrayContaining(['rei', 'rerum', 'rebus']));
+  });
+  it('derives 3rd-declension stems from a full genitive (rex, regis)', () => {
+    expect(nounForms('rex', 3, 'regis')).toEqual(expect.arrayContaining(['regis', 'regem', 'regibus']));
+  });
+  it('guesses 3rd-declension stems when no genitive is given', () => {
+    expect(guessThirdDeclStems('rex')).toContain('reg');
+    expect(guessThirdDeclStems('urbs')).toContain('urb');
+    expect(guessThirdDeclStems('corpus')).toContain('corpor');
+    expect(nounForms('rex', 3, undefined)).toContain('regibus');
+  });
+});
+
+describe('adjectiveForms', () => {
+  it('1st/2nd declension with comparison', () => {
+    const f = adjectiveForms('altus');
+    for (const w of ['alta', 'altum', 'altorum', 'altior', 'altissimus', 'alte']) expect(f, w).toContain(w);
+  });
+  it('3rd declension', () => {
+    expect(adjectiveForms('omnis')).toEqual(expect.arrayContaining(['omne', 'omnia', 'omnium', 'omnibus']));
+  });
+});
+
+describe('irregularLemmas', () => {
+  it('resolves high-frequency irregular forms', () => {
+    expect(irregularLemmas('est')[0]).toBe('sum'); // sum outranks edo
+    expect(irregularLemmas('fuit')).toContain('sum');
+    expect(irregularLemmas('tulit')).toContain('fero');
+    expect(irregularLemmas('quibus')).toContain('qui1');
+    expect(irregularLemmas('melior')).toContain('bonus');
+    expect(irregularLemmas('maxime')).toContain('magnus');
+  });
+  it('returns empty for regular words', () => {
+    expect(irregularLemmas('natura')).toEqual([]);
+  });
+});
+
+describe('suffixSwapCandidates', () => {
+  it('proposes plausible headwords', () => {
+    expect(suffixSwapCandidates('philosophorum')).toContain('philosophus');
+    expect(suffixSwapCandidates('amauit')).toContain('amo');
+    expect(suffixSwapCandidates('rationis')).toContain('ratio');
+  });
+  it('never proposes sub-2-char stems', () => {
+    for (const c of suffixSwapCandidates('ibus')) expect(c.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('longSVariants', () => {
+  it('generates f→s substitutions for long-s OCR errors', () => {
+    expect(longSVariants('refina')).toContain('resina');
+    expect(longSVariants('fpiffandi')).toContain('spissandi');
+    expect(longSVariants('natura')).toEqual([]);
+  });
+  it('is bounded', () => {
+    expect(longSVariants('ffffffff').length).toBeLessThanOrEqual(15);
+  });
+});
+
+describe('syncopated perfects', () => {
+  it('amasse / amarunt from an -au perfect stem', () => {
+    const f = verbForms('amo', 1, ['amau'], ['amat']);
+    for (const w of ['amasse', 'amarunt', 'amasti']) expect(f, w).toContain(w);
+  });
+  it('audisse from an -iu perfect stem', () => {
+    expect(verbForms('audio', 4, ['audiu'], ['audit'])).toContain('audisse');
+  });
+});


### PR DESCRIPTION
Phase 2 of #3823 — the reader UI on top of the lookup API from #3840. **Stacked on #3840**; merge that first (this branch contains its commits until then, after which this diff reduces to two files).

## What readers get

On any Latin book's reader page, with the original-text pane open: tap a word → a popover shows the dictionary form (with vowel lengths), a morphology line (genitive, gender, declension), the first Lewis & Short sense, and a "Full entry" expansion. Desktop gets a floating card anchored at the tap; mobile a bottom sheet. Uncertain matches (suffix-heuristic / OCR-repair tiers) carry an explicit "treat as a suggestion" hedge, and a miss says honestly that abbreviations and contracted forms often miss.

Verified live on Drebbel's *Tractatus duo* (1628): tapping `ſubtilitate` — long s, straight off the page — resolves to *subtīlĭtas, gen. ātis, fem., 3rd decl.,* "Fineness, thinness, slenderness, minuteness," full 4-sense entry expandable.

## How (and the two traps from the issue)

- **Zero DOM mutation.** No per-word `<span>` wrapping: a click handler reads the tapped word out of the text node via `caretPositionFromPoint`. OCR text that transcribes literal markup (#3609) therefore cannot break the page, and `NotesRenderer`'s rendering is untouched.
- **Language gate is the edition's, not the work's.** The OCR pane always displays edition text, so `book.language === 'Latin'` is the correct gate (per the language-field lesson); disabled for paired Greek overlays and edit mode.
- Click delegation is document-level because the OCR panel mounts/unmounts as readers toggle panels (panel-bound listeners miss a panel shown after mount — found this live).
- Text selections and clicks on interactive elements are ignored; Escape/outside-click dismiss; ~300-entry client cache in front of the CDN-cached API.

## Out of scope

- Greek (LSJ), lemma-layer search, and linking entries to a scanned Lewis & Short (#3823 Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
