### PR TITLE
fix(eval): ladder rung-0 skip is model-aware (#3778)

### DIFF
--- a/scripts/eval/ft-ladder.ts
+++ b/scripts/eval/ft-ladder.ts
@@ -65,6 +65,15 @@ const IDS = arg('ids')?.split(',').map((s) => s.trim()).filter(Boolean);
 const LIMIT = parseInt(arg('limit') ?? '0', 10);
 const MODEL = arg('model') ?? 'gemini-3.1-flash-lite';
 const BUDGET = parseFloat(arg('budget-usd') ?? '0');
+/**
+ * Explicit positive thinking cap (tokens). Unset → the API default (dynamic).
+ * NEVER pass -1: `thinkingBudget: -1` silently SUPPRESSES grounding on
+ * flash-preview (the §8 hazard in the FT paper). A positive cap bounds the
+ * dominant cost driver — unbounded thinking ran ~$0.19/book on preview vs
+ * ~$0.002 for lean calls (measured 2026-08-10).
+ */
+const THINKING = arg('thinking-budget');
+const THINKING_BUDGET = THINKING !== undefined ? Math.max(0, parseInt(THINKING, 10) || 0) : undefined;
 const CONC = parseInt(arg('concurrency') ?? '4', 10);
 const TRANSCRIPTS = 'first_translation_transcripts'; // pure archive: no automated job reads it (#3778)
 
@@ -189,7 +198,10 @@ async function main() {
         const ai = new GoogleGenAI({ apiKey: nextKey() });
         const resp = await ai.models.generateContent({
           model: MODEL, contents: prompt,
-          config: { tools: [{ googleSearch: {} }], temperature: 0.1 },
+          config: {
+            tools: [{ googleSearch: {} }], temperature: 0.1,
+            ...(THINKING_BUDGET !== undefined ? { thinkingConfig: { thinkingBudget: THINKING_BUDGET } } : {}),
+          },
         });
         const gm = (resp.candidates?.[0] as { groundingMetadata?: { webSearchQueries?: string[]; groundingChunks?: Array<{ web?: { uri?: string; title?: string } }> } })?.groundingMetadata ?? {};
         const u = resp.usageMetadata ?? {};

--- a/scripts/eval/ft-ladder.ts
+++ b/scripts/eval/ft-ladder.ts
@@ -225,7 +225,12 @@ async function main() {
         row.outcome = `resolved:${stored.verdict} (resolver=${stored.resolver})`; continue;
       }
       const attempts = await attemptsCol.find({ book_id: b.id }).sort({ date: -1 }).limit(20).toArray();
-      if (attempts.some((a) => a.prompt_version === SKEPTIC_PROMPT_VERSION)) {
+      // Model-aware: the instrument is (prompt_version, model), not the prompt
+      // alone. gemini-3.1-flash-lite answers this prompt WITHOUT grounding
+      // (empty groundingMetadata on all 189 rows of the 2026-08-10 batch), and
+      // a prompt-only skip would let those ungrounded rows permanently block a
+      // grounded re-run on a model that actually searches.
+      if (attempts.some((a) => a.prompt_version === SKEPTIC_PROMPT_VERSION && a.model === MODEL)) {
         row.outcome = 'already_searched_this_prompt_version'; continue;
       }
 


### PR DESCRIPTION
Two fixes found live during the approved badged-weak ladder run:

1. **Model-aware rung-0 skip** — flash-lite does not ground on the skeptic prompt (189/189 rows with empty grounding metadata), and the prompt-version-only skip would let those ungrounded rows permanently block a grounded re-run under flash-preview. Skip now requires same prompt_version AND same model.
2. **--thinking-budget flag** — measured: lite grounds 0/189; preview with unbounded thinking grounds inconsistently at ~$0.19/book; preview with thinkingBudget 512 grounds 6/6 (11-26 queries/book) at $0.0029/book avg. Explicit positive caps only; -1 is never passed (it suppresses grounding — the paper's §8 hazard).

With these, the full ~4.9K-book queue projects to ~$15, not ~$580. The escalation router had already refused to trust the ungrounded absences, so no bad evidence settled anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)