### PR TITLE
feat(quote): serve the romanized layer for non-Latin scripts (#3828)

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -483,6 +483,19 @@ const QUOTE_TIP =
   "> [exact translation text, verbatim]\n" +
   "> — [Author], p. [N]. [citation_link]";
 
+// Three-layer apparatus for non-Latin scripts (#3828). Appended only when the
+// page actually carries a romanization, so a Latin-script quote is never told
+// about a field that isn't there.
+const ROMANIZED_TIP =
+  "This page is in a non-Latin script and carries all three layers. Render as:\n" +
+  "> [original, verbatim]\n" +
+  "> [romanized]\n" +
+  "> [translation, verbatim]\n" +
+  "> — [Author], p. [N]. [citation_link]\n" +
+  "The `romanized` field is AI-generated reading apparatus, not a transcription — " +
+  "never present it as the text printed on the page, and quote from `original` or " +
+  "`translation` when quoting the source itself.";
+
 export async function getQuote(args: {
   book_id: string;
   page: number;
@@ -490,7 +503,13 @@ export async function getQuote(args: {
   const params = new URLSearchParams({ page: String(args.page) });
   const result = await apiGet(`/books/${args.book_id}/quote`, params) as Record<string, unknown>;
 
-  return { ...withCitationLink(result), tip: QUOTE_TIP };
+  const quote = result.quote as Record<string, unknown> | undefined;
+  const romanized = typeof quote?.romanized === "string" && quote.romanized.length > 0;
+
+  return {
+    ...withCitationLink(result),
+    tip: romanized ? `${QUOTE_TIP}\n\n${ROMANIZED_TIP}` : QUOTE_TIP,
+  };
 }
 
 type ImageSource = "gallery" | "artworks" | "all";

--- a/mcp-server/src/cli.ts
+++ b/mcp-server/src/cli.ts
@@ -395,6 +395,14 @@ async function run() {
             console.log(`\n${bold("Original")}`);
             console.log(wrap(original as string, 80, 2));
           }
+          // Non-Latin scripts carry a third layer (#3828). Labelled as
+          // apparatus, not transcription — a reader scanning this output must
+          // not mistake it for what is printed on the leaf.
+          const romanized = quote?.romanized || q.romanized;
+          if (romanized) {
+            console.log(`\n${bold("Romanized")} ${dim("(AI reading aid, not a transcription)")}`);
+            console.log(wrap(romanized as string, 80, 2));
+          }
           if (cit?.url) console.log(`\n${cyan(cit.url as string)}`);
           return;
         }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -376,7 +376,7 @@ const TOOLS: Tool[] = [
     name: "get_quote",
     title: "Get Quote",
     description:
-      "Get the exact translated text of a single page for quoting. Returns the verbatim translation, original OCR text, and a formatted citation. ALWAYS use this tool before putting text in quotation marks — copy the exact text from the response, do not paraphrase or reconstruct from memory. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote and its page number. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]",
+      "Get the exact translated text of a single page for quoting. Returns the verbatim translation, original OCR text, and a formatted citation. ALWAYS use this tool before putting text in quotation marks — copy the exact text from the response, do not paraphrase or reconstruct from memory. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote and its page number. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]\nNON-LATIN SCRIPTS: where the page is Greek, Hebrew, Arabic, Sanskrit, Cyrillic and so on, the response also carries romanized — the romanization of the original — so the citation can be shown in three layers: original → romanized → translation → citation_link. It is AI-generated reading apparatus, not a transcription; quote the source from original or translation, never from romanized. Absent on Latin-script pages and on non-Latin pages not yet romanized.",
     annotations: { title: "Get Quote", readOnlyHint: true },
     inputSchema: {
       type: "object" as const,

--- a/public/api/openapi.json
+++ b/public/api/openapi.json
@@ -449,6 +449,10 @@
                 "type": "string",
                 "description": "Original language text (Latin, German, etc.)"
               },
+              "romanized": {
+                "type": "string",
+                "description": "Romanization of the original, for non-Latin scripts (Greek, Hebrew, Arabic, Cyrillic, Sanskrit…). AI-generated reading apparatus, not a transcription — quote the source from original or translation. Present only where the page carries a romanization current with its OCR; omitted when include_original=false."
+              },
               "page": {
                 "type": "integer"
               },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -138,8 +138,14 @@ GET /books/{book_id}/quote?page={page_number}
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | page | number | Page number (required) |
-| include_original | boolean | Include original language text (default true) |
+| include_original | boolean | Include original language text — and, for non-Latin scripts, its romanization (default true) |
 | include_context | boolean | Include adjacent pages for context |
+
+For pages in a non-Latin script (Greek, Hebrew, Arabic, Cyrillic, Sanskrit…) the
+quote also carries `romanized`, so a citation can be shown in three layers:
+original → romanized → translation. The romanization is AI-generated reading
+apparatus, not a transcription — quote the source from `original` or
+`translation`, never from `romanized`.
 
 **Example:**
 ```

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -6,6 +6,7 @@ import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { romanizedForQuote } from '@/lib/romanization';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -31,6 +32,13 @@ interface QuoteResponse {
   quote: {
     translation: string;
     original?: string;
+    /**
+     * Romanization of the original for non-Latin scripts (#3828) — AI-derived
+     * apparatus, never a transcription, hence `romanized` and not
+     * `original_romanized`. Served only when the page carries a
+     * transliteration that is still current against its OCR.
+     */
+    romanized?: string;
     page: number;
     book_id: string;
     book_title: string;
@@ -255,6 +263,12 @@ export async function GET(request: NextRequest, context: RouteContext) {
     // Include original text if requested
     if (includeOriginal && page.ocr?.data) {
       response.quote.original = stripEditorialWrappers(page.ocr.data).trim();
+      // …and, for non-Latin scripts, its romanization — the third layer of the
+      // citation (#3828). Rides the same flag as `original`: it is a reading of
+      // the original, so a caller that asked for translation only should not
+      // get the source text back in Latin letters.
+      const romanized = romanizedForQuote(page);
+      if (romanized) response.quote.romanized = romanized;
     }
 
     // Include context (adjacent pages) if requested

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -6,6 +6,7 @@ import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { romanizedForQuote } from '@/lib/romanization';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { withApiAuth } from '@/lib/api-auth';
@@ -19,6 +20,13 @@ interface QuoteResponse {
   quote: {
     translation: string;
     original?: string;
+    /**
+     * Romanization of the original for non-Latin scripts (#3828) — AI-derived
+     * apparatus, never a transcription, hence `romanized` and not
+     * `original_romanized`. Served only when the page carries a
+     * transliteration that is still current against its OCR.
+     */
+    romanized?: string;
     page: number;
     book_id: string;
     book_title: string;
@@ -124,6 +132,12 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
     // Include original text if requested
     if (includeOriginal && page.ocr?.data) {
       response.quote.original = stripEditorialWrappers(page.ocr.data).trim();
+      // …and, for non-Latin scripts, its romanization — the third layer of the
+      // citation (#3828). Rides the same flag as `original`: it is a reading of
+      // the original, so a caller that asked for translation only should not
+      // get the source text back in Latin letters.
+      const romanized = romanizedForQuote(page);
+      if (romanized) response.quote.romanized = romanized;
     }
 
     // Include context (adjacent pages) if requested

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -402,6 +402,24 @@ const QUOTE_TIP =
   '> [exact translation text, verbatim]\n' +
   '> — [Author], p. [N]. [citation_link]';
 
+// Three-layer apparatus for non-Latin scripts (#3828). Only emitted when a
+// page actually carries a romanization, so a caller quoting a Latin book is
+// never told about a field that isn't there.
+const ROMANIZED_TIP =
+  'This page is in a non-Latin script and carries all three layers. Render as:\n' +
+  '> [original, verbatim]\n' +
+  '> [romanized]\n' +
+  '> [translation, verbatim]\n' +
+  '> — [Author], p. [N]. [citation_link]\n' +
+  'The `romanized` field is AI-generated reading apparatus, not a transcription — ' +
+  'never present it as the text printed on the page, and quote from `original` or ' +
+  '`translation` when quoting the source itself.';
+
+function hasRomanized(result: Record<string, unknown>): boolean {
+  const quote = result.quote as Record<string, unknown> | undefined;
+  return typeof quote?.romanized === 'string' && quote.romanized.length > 0;
+}
+
 async function getQuote(args: Record<string, unknown>) {
   const params = new URLSearchParams({ page: String(args.page) });
   // The quote API has always accepted this; the MCP tool never passed it, so
@@ -430,6 +448,7 @@ async function getQuote(args: Record<string, unknown>) {
   // get_book_text: one page is a citation, hundreds is a corpus pull.
   if (quote && typeof quote.translation === 'string') quote.translation = stripProvenanceMarks(quote.translation);
   if (quote && typeof quote.original === 'string') quote.original = stripProvenanceMarks(quote.original);
+  if (quote && typeof quote.romanized === 'string') quote.romanized = stripProvenanceMarks(quote.romanized);
   const ctx = result.context as Record<string, unknown> | undefined;
   if (ctx) {
     for (const k of ['previous_page', 'next_page']) {
@@ -442,7 +461,7 @@ async function getQuote(args: Record<string, unknown>) {
     ...withCitationLink(result),
     continuity,
     ...(hint ? { continuity_hint: hint } : {}),
-    tip: QUOTE_TIP,
+    tip: hasRomanized(result) ? `${QUOTE_TIP}\n\n${ROMANIZED_TIP}` : QUOTE_TIP,
   };
 }
 
@@ -479,6 +498,7 @@ async function getQuotes(args: Record<string, unknown>) {
         );
         if (q && typeof q.translation === 'string') q.translation = stripProvenanceMarks(q.translation);
         if (q && typeof q.original === 'string') q.original = stripProvenanceMarks(q.original);
+        if (q && typeof q.romanized === 'string') q.romanized = stripProvenanceMarks(q.romanized);
         const hint = continuityHint(continuity, page);
         return { ...withCitationLink(result), continuity, ...(hint ? { continuity_hint: hint } : {}) };
       } catch (err) {
@@ -489,11 +509,13 @@ async function getQuotes(args: Record<string, unknown>) {
     })
   );
 
+  const anyRomanized = settled.some((s) => hasRomanized(s as Record<string, unknown>));
+
   return {
     book_id: bookId,
     pages_requested: pageNums,
     quotes: settled,
-    tip: QUOTE_TIP,
+    tip: anyRomanized ? `${QUOTE_TIP}\n\n${ROMANIZED_TIP}` : QUOTE_TIP,
   };
 }
 
@@ -731,7 +753,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_quote',
     title: 'Get Quote',
-    description: 'READ PIPELINE step 3 — CITE. Get the exact verbatim text of a single page plus its citation apparatus. ALWAYS use before putting text in quotation marks. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]\nPAGE BREAKS: this corpus is paginated from physical leaves, and nearly one prose page-boundary in five has a sentence running across it — sometimes a word split by a hyphen ("…our move-" / "movements…"). A page that opens or breaks off mid-sentence still reads as complete prose and still carries a perfectly valid citation, so check the continuity field on every response BEFORE quoting: if continues_on_next or continues_from_previous is true, call again with context: true and quote the whole sentence. Quoting a fragment as though it were the author\'s complete thought is a misattribution even when the page number is right. For several pages of one book at once, use get_quotes.',
+    description: 'READ PIPELINE step 3 — CITE. Get the exact verbatim text of a single page plus its citation apparatus. ALWAYS use before putting text in quotation marks. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]\nPAGE BREAKS: this corpus is paginated from physical leaves, and nearly one prose page-boundary in five has a sentence running across it — sometimes a word split by a hyphen ("…our move-" / "movements…"). A page that opens or breaks off mid-sentence still reads as complete prose and still carries a perfectly valid citation, so check the continuity field on every response BEFORE quoting: if continues_on_next or continues_from_previous is true, call again with context: true and quote the whole sentence. Quoting a fragment as though it were the author\'s complete thought is a misattribution even when the page number is right.\nNON-LATIN SCRIPTS: where the page is Greek, Hebrew, Arabic, Sanskrit, Cyrillic and so on, the response also carries romanized — the romanization of the original — so the citation can be shown in three layers: original → romanized → translation → citation_link. It is AI-generated reading apparatus, not a transcription; quote the source from original or translation, never from romanized. Absent on Latin-script pages and on non-Latin pages not yet romanized.\nFor several pages of one book at once, use get_quotes.',
     annotations: { title: 'Get Quote', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -759,7 +781,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_quotes',
     title: 'Get Quotes (batch)',
-    description: 'READ PIPELINE step 3 — CITE, in batch. Get verbatim text + citation_link for SEVERAL pages of a single book in one round-trip, to assemble a multi-passage dossier. Specify either pages (an explicit array, e.g. [12, 40, 41]) or an inclusive from/to range. Max 25 pages per call. Each entry carries its own citation_link to present alongside the quote.',
+    description: 'READ PIPELINE step 3 — CITE, in batch. Get verbatim text + citation_link for SEVERAL pages of a single book in one round-trip, to assemble a multi-passage dossier. Specify either pages (an explicit array, e.g. [12, 40, 41]) or an inclusive from/to range. Max 25 pages per call. Each entry carries its own citation_link to present alongside the quote, and — on non-Latin-script pages that have one — a romanized layer to show between the original and the translation (AI apparatus, not a transcription).',
     annotations: { title: 'Get Quotes (batch)', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,

--- a/src/lib/romanization.ts
+++ b/src/lib/romanization.ts
@@ -1,0 +1,89 @@
+/**
+ * The romanized layer of a page (issue #3828).
+ *
+ * A Greek, Hebrew, Arabic or Sanskrit page is only half-readable to a scholar
+ * who cannot sound out the script, so a quote of one wants three layers:
+ * the original, its romanization, and the translation. The romanization
+ * already exists in the data — `pages.transliteration.data`, written by the
+ * transliteration machinery (#3125) — but until now only the alignment route
+ * read it. This helper is the shared read path for every surface that serves
+ * it as apparatus alongside a quote.
+ *
+ * PROVENANCE: the romanization is AI-derived layer-2 apparatus, NOT a
+ * transcription. It is served under the field name `romanized` (never
+ * `original_romanized`) precisely so no consumer can mistake it for the
+ * verbatim original — see the tag-registry distinction in #3825.
+ *
+ * STALENESS: `transliteration.source_ocr_hash` pins the romanization to the
+ * OCR text it was produced from. If the page has since been re-OCR'd or
+ * hand-corrected, the stored romanization romanizes words that are no longer
+ * on the page we are about to serve — apparatus that disagrees with the
+ * original beside it is worse than no apparatus, so we omit it. Writers use
+ * two different hash functions (djb2 in the transliterate routes,
+ * `pipeline-orchestrator.mjs` and `batch-transliterate.mjs`; md5 in
+ * `scripts/workers/transliterate-greek.mjs`), so the check dispatches on hash
+ * shape and fails OPEN when the stored hash is absent or unrecognized — an
+ * unverifiable romanization is still served, only a provably stale one is not.
+ */
+
+import { createHash } from 'crypto';
+import { stripEditorialWrappers } from './strip-editorial-wrappers';
+import type { Page } from './types';
+
+/**
+ * The non-cryptographic hash used by the transliterate API routes,
+ * `scripts/workers/pipeline-orchestrator.mjs` and
+ * `scripts/batch/batch-transliterate.mjs`. Kept byte-identical to those
+ * copies — changing it here silently invalidates every stored hash.
+ */
+export function djb2Hash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  return hash.toString(16);
+}
+
+/**
+ * Does the stored romanization still describe this OCR text? True when the
+ * hash is missing or in an unrecognized format (fail open — see module note).
+ */
+export function isRomanizationCurrent(
+  storedHash: string | undefined | null,
+  ocrText: string | undefined | null
+): boolean {
+  if (!storedHash || typeof storedHash !== 'string') return true;
+  if (!ocrText) return true;
+  // md5 (transliterate-greek.mjs) is 32 hex chars; djb2 is at most 8 plus a
+  // possible leading '-'. Nothing else writes this field.
+  if (/^[a-f0-9]{32}$/i.test(storedHash)) {
+    return createHash('md5').update(ocrText).digest('hex') === storedHash;
+  }
+  if (/^-?[a-f0-9]{1,8}$/i.test(storedHash)) {
+    return djb2Hash(ocrText) === storedHash;
+  }
+  return true;
+}
+
+type RomanizablePage = Pick<Page, 'ocr' | 'transliteration'>;
+
+/**
+ * The romanized text to serve alongside a quote, or `undefined` when there is
+ * none worth serving (absent, blank, or stale against the current OCR).
+ *
+ * Stripped through the same editorial-wrapper pipeline as `original`: the
+ * romanization is produced from raw `ocr.data`, wrapper blocks and all, so it
+ * can carry romanized `<meta>`/`<scan-quality>` prose that is not source text
+ * (the #2232 misquote family, one alphabet removed).
+ */
+export function romanizedForQuote(page: RomanizablePage | null | undefined): string | undefined {
+  const data = page?.transliteration?.data;
+  if (!data || typeof data !== 'string') return undefined;
+  if (!isRomanizationCurrent(page?.transliteration?.source_ocr_hash, page?.ocr?.data)) {
+    return undefined;
+  }
+  const stripped = stripEditorialWrappers(data).trim();
+  return stripped ? stripped : undefined;
+}

--- a/tests/unit/quote-romanized.test.ts
+++ b/tests/unit/quote-romanized.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { djb2Hash, isRomanizationCurrent, romanizedForQuote } from '@/lib/romanization';
+
+/**
+ * The romanized layer of a quote (#3828).
+ *
+ * A Greek page quoted as three layers — original, romanization, translation —
+ * only works if the middle layer is a romanization of the SAME words as the
+ * top one. `pages.transliteration.source_ocr_hash` is what makes that
+ * checkable, and it is written by two different hash functions across the
+ * writers (djb2 in the transliterate routes / orchestrator / batch script,
+ * md5 in scripts/workers/transliterate-greek.mjs), so the reader has to
+ * recognize both shapes and fail open on anything else.
+ */
+describe('romanizedForQuote', () => {
+  const OCR = 'Ἐν ἀρχῇ ἦν ὁ λόγος';
+  const ROMAN = 'En archē ēn ho logos';
+
+  const page = (t: Record<string, unknown> | undefined, ocr = OCR) =>
+    ({ ocr: { data: ocr }, transliteration: t }) as Parameters<typeof romanizedForQuote>[0];
+
+  it('serves a romanization whose djb2 hash matches the current OCR', () => {
+    expect(romanizedForQuote(page({ data: ROMAN, source_ocr_hash: djb2Hash(OCR) }))).toBe(ROMAN);
+  });
+
+  it('serves a romanization whose md5 hash matches (transliterate-greek.mjs writer)', () => {
+    const md5 = createHash('md5').update(OCR).digest('hex');
+    expect(romanizedForQuote(page({ data: ROMAN, source_ocr_hash: md5 }))).toBe(ROMAN);
+  });
+
+  it('omits a romanization that is stale against re-OCR\'d text', () => {
+    // The page was re-OCR'd after transliteration: the stored romanization
+    // spells words no longer printed on the page we are about to serve.
+    const stale = { data: ROMAN, source_ocr_hash: djb2Hash('completely different text') };
+    expect(romanizedForQuote(page(stale))).toBeUndefined();
+  });
+
+  it('fails open when no hash was stored', () => {
+    expect(romanizedForQuote(page({ data: ROMAN }))).toBe(ROMAN);
+  });
+
+  it('returns undefined when absent or blank', () => {
+    expect(romanizedForQuote(page(undefined))).toBeUndefined();
+    expect(romanizedForQuote(page({ data: '' }))).toBeUndefined();
+    expect(romanizedForQuote(page({ data: '   \n ' }))).toBeUndefined();
+  });
+
+  it('strips editorial wrappers — a romanized <meta> block is still not source text', () => {
+    // The romanization is produced from raw ocr.data, envelope and all, so the
+    // OCR page-metadata envelope can arrive romanized. Serving it would quote
+    // words that are not on the page (the #2232 misquote class).
+    const withEnvelope = `<language>Greek</language>\n<scan-quality>good</scan-quality>\n${ROMAN}`;
+    expect(romanizedForQuote(page({ data: withEnvelope }))).toBe(ROMAN);
+  });
+
+  it('treats an unrecognized hash shape as unverifiable, not stale', () => {
+    expect(isRomanizationCurrent('sha256:whatever-this-is', OCR)).toBe(true);
+  });
+
+  it('djb2Hash stays byte-identical to the writers\' copies', () => {
+    // Same algorithm as scripts/workers/pipeline-orchestrator.mjs,
+    // scripts/batch/batch-transliterate.mjs and the transliterate routes.
+    const reference = (str: string) => {
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        hash = ((hash << 5) - hash) + str.charCodeAt(i);
+        hash |= 0;
+      }
+      return hash.toString(16);
+    };
+    for (const s of [OCR, ROMAN, '', 'a', 'ζ'.repeat(500)]) {
+      expect(djb2Hash(s)).toBe(reference(s));
+    }
+  });
+});


### PR DESCRIPTION
Closes #3828.

A Greek page quoted with only original + translation asks a reader who cannot sound out the script to take the translation on faith. The third layer already exists in the data — `pages.transliteration.data` (#3125) — but until now only the alignment route read it. Coverage measured on the issue (2026-08-09): **231,401 of 473,248 OCR'd Greek pages** carry a transliteration, so **serve-when-present** (option (a) in the issue) makes half the Greek corpus three-layer with no new spend.

## What changed

**Quote routes (+ tenant twin)** — additive `romanized` field on `quote`, stripped through the same editorial-wrapper pipeline as `original`. It rides the existing `include_original` flag: the romanization is a reading *of the original*, so a caller that asked for translation only should not get the source text back in Latin letters.

**`src/lib/romanization.ts`** (new) — the shared read path, so the next surface that wants the layer doesn't re-derive the rules:

- **Wrapper stripping.** The romanization is produced from raw `ocr.data`, envelope and all, so it can carry a *romanized* `<language>`/`<scan-quality>` block. 4% of a 600-page sample did. Serving that is the #2232 misquote class, one alphabet removed.
- **Staleness.** `transliteration.source_ocr_hash` pins the romanization to the OCR it was made from; if the page has since been re-OCR'd, the stored romanization spells words no longer on the leaf, and apparatus that disagrees with the original beside it is worse than no apparatus. Two writers use **two different hash functions** — djb2 in the transliterate routes / `pipeline-orchestrator.mjs` / `batch-transliterate.mjs`, md5 in `scripts/workers/transliterate-greek.mjs` — and both are live in the data (448 djb2 / 152 md5 in that same sample). A single-format check would have silently dropped a quarter of the corpus as "stale", so the check dispatches on hash shape and **fails open** on anything absent or unrecognized: only a *provably* stale romanization is withheld.

**MCP `get_quote` / `get_quotes`** — both the hosted route (`src/app/api/mcp/route.ts`) and the npm server pass `romanized` through and gain render guidance for the three-layer form (original → romanized → translation → citation_link), emitted **only** when the page actually carries one, so a Latin-script caller is never told about a field that isn't there. Both say plainly that it is AI-derived apparatus and that the source must be quoted from `original` or `translation` — the layer-2 distinction of #3825, which is also why the field is `romanized` and not `original_romanized`.

**Docs** — `public/api/openapi.json` and `public/llms.txt`.

## Verification

Ran against the live DB through a local dev server, Demosthenes *Orationes* Vol. I (`6a08a92f50cb4ea746a0b71b`):

- p.60 / p.120 return Greek `original`, its `romanized` reading (`kai ta mikra S; kai kata m. AF hic et omnes Tim.`…), and the English `translation`
- `include_original=false` returns translation only — no `original`, no `romanized`
- a Latin-script control book returns `original` and no `romanized`

8 new unit tests (`tests/unit/quote-romanized.test.ts`) cover both hash formats, staleness, fail-open, blank/absent, wrapper stripping, and pin `djb2Hash` byte-identical to the writers' copies. Full suite: 2,509 passing. `tsc --noEmit` clean in both the app and `mcp-server`.

## Out of scope

- **The backfill** — now tracked in #3861. Sizing it turned out to matter: the gap is **1,167,293 pages, not ~242K** (that figure counted Greek only, and Greek at 49.5% is the *best*-covered script; Tibetan, Chinese, Korean, Hebrew and Arabic are at or near zero). Measured cost is $0.00071/page, so the whole thing is ~$1.6K — the blocker is that all three transliteration writers hardcode `gemini-3.1-flash-lite` while `getModelForBook` sends every non-Latin script to full flash, which is the entire population transliteration runs on.
- **The reader UI.** This PR serves the layer over the API and MCP only; showing it in the reader is a separate design question.
- **No `mcp-server` version bump / publish** — the npm package ships on its own cadence, and its CHANGELOG is already behind `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

