### PR TITLE
feat(audit): Rijksmuseum + NGA source fetchers (#3838 items 2/3/5)

### DIFF
--- a/scripts/audit/artwork-image-integrity.mjs
+++ b/scripts/audit/artwork-image-integrity.mjs
@@ -95,7 +95,7 @@ const books = db.collection('books');
 const PROJECTION = {
   _id: 1, id: 1, slug: 1, title: 1, author: 1, resource_type: 1,
   source_url: 1, commons_url: 1, commons_title: 1, source_ids: 1,
-  dedup_date: 1, dedup_reason: 1, visible: 1, hidden: 1,
+  dedup_date: 1, dedup_reason: 1, visible: 1, hidden: 1, source_unrecoverable: 1,
   thumbnail: 1, thumbnail_blob: 1, archived_full_url: 1, image_thumb: 1,
   image_width: 1, image_height: 1,
 };
@@ -111,7 +111,12 @@ async function checkOne(doc) {
   const provider = detectProvider(doc);
   const base = { id: doc.id || String(doc._id), slug: doc.slug, title: doc.title, provider };
 
-  if (!provider) return { ...base, status: 'no-source' };
+  if (!provider) {
+    // source_unrecoverable is the deliberate "we checked, there is no
+    // machine-verifiable pointer" marker (#3838 item 4) — distinct from an
+    // unexpected coverage gap.
+    return { ...base, status: doc.source_unrecoverable ? 'unrecoverable-marked' : 'no-source' };
+  }
   if (provider === 'wellcome') {
     return { ...base, status: 'unverifiable', detail: 'wellcome not integrated' };
   }

--- a/scripts/audit/artwork-image-integrity.mjs
+++ b/scripts/audit/artwork-image-integrity.mjs
@@ -37,8 +37,12 @@
  *     R2 thumb (scripts/lib/dhash.mjs); Hamming distance >= HASH_DIFF (16,
  *     see scripts/lib/page-alignment.mjs) is a confirmed mismatch, <= 12 is
  *     a match, the small band between is "ambiguous" (kept, not auto-fixed).
- *   - rijksmuseum / nga / wellcome: NOT integrated (see
- *     scripts/lib/artwork-sources.mjs header) — reported as `unverifiable`.
+ *   - rijksmuseum: dHash via the keyless Linked Art chain (4 requests/doc,
+ *     so sampled — --rijks-sample, default 100, 0 to skip).
+ *   - nga: dHash via opendata IIIF, exhaustive, only when
+ *     --nga-images-csv=<path to published_images.csv> is provided
+ *     (no live API); otherwise `unverifiable`.
+ *   - wellcome: NOT integrated — reported as `unverifiable`.
  *   - no recognizable source at all: reported as `no-source`.
  *
  * SCOPE (per #3815 instructions — full sweep of ~24.8K docs is too slow)
@@ -62,7 +66,10 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 import { computeDHash } from '../lib/dhash.mjs';
 import { hammingHex, HASH_MATCH, HASH_DIFF } from '../lib/page-alignment.mjs';
-import { detectProvider, fetchSourceFor, fetchImageBuffer } from '../lib/artwork-sources.mjs';
+import { detectProvider, fetchSourceFor, fetchImageBuffer, loadNgaImagesCsvSync } from '../lib/artwork-sources.mjs';
+
+let NGA_IMAGES = null; // assigned in main() when --nga-images-csv is given
+
 
 const args = process.argv.slice(2);
 const argVal = (name, def) => {
@@ -70,6 +77,8 @@ const argVal = (name, def) => {
   return i >= 0 ? args[i + 1] : def;
 };
 const SAMPLE = parseInt(argVal('--sample', '300'), 10);
+const RIJKS_SAMPLE = parseInt(argVal('--rijks-sample', '100'), 10); // 4 requests/doc — sample, don't sweep
+const NGA_IMAGES_CSV = argVal('--nga-images-csv', null);
 const COMMONS_CAP = parseInt(argVal('--commons-cap', '0'), 10) || Infinity; // 0 = no cap
 const JSON_OUT = argVal('--json', null);
 const CONCURRENCY = parseInt(argVal('--concurrency', '4'), 10);
@@ -103,11 +112,14 @@ async function checkOne(doc) {
   const base = { id: doc.id || String(doc._id), slug: doc.slug, title: doc.title, provider };
 
   if (!provider) return { ...base, status: 'no-source' };
-  if (provider === 'rijksmuseum' || provider === 'nga' || provider === 'wellcome') {
-    return { ...base, status: 'unverifiable', detail: `${provider} not integrated` };
+  if (provider === 'wellcome') {
+    return { ...base, status: 'unverifiable', detail: 'wellcome not integrated' };
+  }
+  if (provider === 'nga' && !NGA_IMAGES) {
+    return { ...base, status: 'unverifiable', detail: 'nga needs --nga-images-csv (opendata published_images.csv)' };
   }
 
-  const src = await fetchSourceFor(provider, doc);
+  const src = await fetchSourceFor(provider, doc, { ngaImages: NGA_IMAGES });
   if (!src.ok) return { ...base, status: 'source-error', detail: src.error };
 
   if (provider === 'cleveland') {
@@ -181,6 +193,11 @@ function shuffle(arr) {
 async function main() {
   console.log('=== Artwork image integrity sweep (#3815) ===\n');
 
+  if (NGA_IMAGES_CSV) {
+    NGA_IMAGES = loadNgaImagesCsvSync(NGA_IMAGES_CSV, fs);
+    console.log(`NGA published_images loaded: ${NGA_IMAGES.size} objects\n`);
+  }
+
   const allResults = [];
 
   // ── Cleveland: exhaustive, cheap ──────────────────────────────────────
@@ -206,6 +223,28 @@ async function main() {
   ).toArray();
   console.log(`\nAIC: ${aicDocs.length} docs (exhaustive, dHash)`);
   allResults.push(...await runBatch(aicDocs, 'aic'));
+
+  // ── Rijksmuseum: random sample (Linked Art chain = 4 requests/doc) ─────
+  if (RIJKS_SAMPLE > 0) {
+    const rijksIds = await books.find(
+      { resource_type: { $exists: true }, 'source_ids.rijksmuseum': { $exists: true } },
+      { projection: { _id: 1 } }
+    ).toArray();
+    const rijksSampleIds = shuffle(rijksIds).slice(0, RIJKS_SAMPLE).map(d => d._id);
+    const rijksDocs = await books.find({ _id: { $in: rijksSampleIds } }, { projection: PROJECTION }).toArray();
+    console.log(`\nRijksmuseum (random sample of ${rijksIds.length} with source_ids): ${rijksDocs.length} docs, dHash`);
+    allResults.push(...await runBatch(rijksDocs, 'rijksmuseum'));
+  }
+
+  // ── NGA: exhaustive when the opendata images CSV is provided ───────────
+  if (NGA_IMAGES) {
+    const ngaDocs = await books.find(
+      { resource_type: { $exists: true }, 'source_ids.nga': { $exists: true } },
+      { projection: PROJECTION }
+    ).toArray();
+    console.log(`\nNGA: ${ngaDocs.length} docs (exhaustive, dHash via opendata IIIF)`);
+    allResults.push(...await runBatch(ngaDocs, 'nga'));
+  }
 
   // ── Commons: dedup-touched exhaustive + random sample of the rest ─────
   const commonsQuery = { resource_type: { $exists: true }, commons_url: /commons\.wikimedia\.org/i };

--- a/scripts/lib/artwork-sources.mjs
+++ b/scripts/lib/artwork-sources.mjs
@@ -6,14 +6,18 @@
  * function returns the museum/Commons API's OWN account of what image
  * belongs to a given doc — never derived from our own slug or R2 keys.
  *
- * Provider coverage (2026-08-09): Cleveland, Met, AIC, and true Wikimedia
- * Commons file pages are supported. Rijksmuseum's public collection API
- * returns 410 Gone (deprecated, no working replacement found in a quick
- * check) and NGA's open data is a static CSV dump, not a live API — both
- * are reported as `unverifiable` rather than guessed at. ~1,892 Rijksmuseum
- * + ~590 NGA artwork docs are therefore NOT covered by this integrity check;
- * a follow-up would need a Rijksmuseum API key (dead endpoint otherwise) or
- * NGA's bulk opendata CSVs.
+ * Provider coverage (2026-08-10): Cleveland, Met, AIC, true Wikimedia
+ * Commons file pages, Rijksmuseum, and NGA.
+ *
+ * Rijksmuseum (#3838 item 2): the old www.rijksmuseum.nl/api is 410 Gone,
+ * but the Linked Art stack on data.rijksmuseum.nl resolves WITHOUT a key:
+ * objectNumber search → HumanMadeObject → shows[0] VisualItem →
+ * digitally_shown_by[0] DigitalObject → IIIF access point (iiif.micr.io,
+ * arbitrary sizes). Four requests per doc — sample, don't sweep blindly.
+ *
+ * NGA (#3838 item 3): no live API. fetchNgaSource needs the opendata
+ * published_images.csv preloaded into a Map (see loadNgaImagesCsv) —
+ * callers without it get `unverifiable`, never a guess.
  */
 
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org) bot';
@@ -30,6 +34,9 @@ export function detectProvider(doc) {
   if (doc.source_ids?.cleveland) return 'cleveland';
   if (doc.source_ids?.met) return 'met';
   if (doc.source_ids?.aic) return 'aic';
+  if (doc.source_ids?.rijksmuseum) return 'rijksmuseum';
+  if (doc.source_ids?.nga) return 'nga';
+  if (doc.source_ids?.commons) return 'commons';
   const link = sourceLink(doc);
   if (!link) return null;
   let host;
@@ -38,8 +45,8 @@ export function detectProvider(doc) {
   if (/metmuseum\.org$/i.test(host)) return 'met';
   if (/artic\.edu$/i.test(host)) return 'aic';
   if (/commons\.wikimedia\.org$/i.test(host)) return 'commons';
-  if (/rijksmuseum\.nl$/i.test(host)) return 'rijksmuseum'; // unverifiable — see header
-  if (/nga\.gov$/i.test(host)) return 'nga';                // unverifiable — see header
+  if (/rijksmuseum\.nl$/i.test(host)) return 'rijksmuseum';
+  if (/nga\.gov$/i.test(host)) return 'nga'; // verifiable only with the opendata CSV — see header
   if (/wellcomecollection\.org$/i.test(host)) return 'wellcome'; // not yet integrated
   return null;
 }
@@ -119,7 +126,10 @@ export async function fetchAicSource(doc) {
 export async function fetchCommonsSource(doc) {
   const link = sourceLink(doc);
   let fileTitle = null;
-  if (doc.commons_title && /^File:/i.test(doc.commons_title)) fileTitle = doc.commons_title;
+  // source_ids.commons is the canonical post-redirect title written by the
+  // #3838 backfill — prefer it when present.
+  if (doc.source_ids?.commons && /^File:/i.test(doc.source_ids.commons)) fileTitle = doc.source_ids.commons;
+  if (!fileTitle && doc.commons_title && /^File:/i.test(doc.commons_title)) fileTitle = doc.commons_title;
   if (!fileTitle && link) {
     const decoded = decodeURIComponent(link);
     const m = decoded.match(/File:([^&?#]+)/i);
@@ -135,12 +145,104 @@ export async function fetchCommonsSource(doc) {
   return { ok: true, imageUrl: info.thumburl || info.url, fullImageUrl: info.url, width: info.width, height: info.height };
 }
 
-export async function fetchSourceFor(provider, doc) {
+/**
+ * Rijksmuseum via the keyless Linked Art chain (#3838 item 2). `source_ids.
+ * rijksmuseum` is the museum's own object number (e.g. RP-P-OB-1482).
+ * Cross-checks that the resolved record's Identifier equals the requested
+ * object number before trusting its image.
+ */
+export async function fetchRijksmuseumSource(doc) {
+  const objnum = doc.source_ids?.rijksmuseum;
+  if (!objnum) return { ok: false, error: 'no source_ids.rijksmuseum' };
+  const ld = { 'Accept': 'application/ld+json' };
+  const search = await getJson(`https://data.rijksmuseum.nl/search/collection?objectNumber=${encodeURIComponent(objnum)}`);
+  if (!search.ok) return search;
+  const objId = search.json.orderedItems?.[0]?.id;
+  if (!objId) return { ok: false, error: `object number ${objnum} not found in Linked Art search` };
+
+  const getLd = async (url) => {
+    const res = await fetch(url, { headers: { 'User-Agent': UA, ...ld }, signal: AbortSignal.timeout(15000) });
+    if (!res.ok) return null;
+    return res.json();
+  };
+  const obj = await getLd(objId);
+  if (!obj) return { ok: false, error: `could not dereference ${objId}` };
+  const identifiers = (obj.identified_by || []).filter(i => i.type === 'Identifier').map(i => i.content);
+  if (identifiers.length && !identifiers.includes(objnum)) {
+    return { ok: false, error: `resolved record identifies as ${identifiers.join('/')}, not ${objnum}` };
+  }
+  const title = (obj.identified_by || []).find(i => i.type === 'Name')?.content || null;
+  const visualId = (obj.shows || [])[0]?.id;
+  if (!visualId) return { ok: false, error: 'no VisualItem on object' };
+  const visual = await getLd(visualId);
+  const digitalId = (visual?.digitally_shown_by || [])[0]?.id;
+  if (!digitalId) return { ok: false, error: 'no DigitalObject on VisualItem' };
+  const digital = await getLd(digitalId);
+  const fullImageUrl = (digital?.access_point || [])[0]?.id;
+  if (!fullImageUrl) return { ok: false, error: 'no access_point on DigitalObject' };
+  // micr.io serves IIIF Image API paths — swap /full/max/ for a cheap 800px rendition.
+  const imageUrl = fullImageUrl.replace('/full/max/', '/full/800,/');
+  return { ok: true, title, imageUrl, fullImageUrl };
+}
+
+/**
+ * NGA has no live API — the caller must preload the opendata
+ * published_images.csv (objectid → iiif thumb/full URLs) and pass the Map.
+ */
+export function loadNgaImagesCsvSync(path, fsMod) {
+  // RFC-4180 scan — assistivetext fields contain quoted commas AND newlines,
+  // so a line/comma split silently misaligns every row after the first one.
+  const text = fsMod.readFileSync(path, 'utf8');
+  const rows = [];
+  let fields = [], cur = '', inQ = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQ) {
+      if (ch === '"') { if (text[i + 1] === '"') { cur += '"'; i++; } else inQ = false; }
+      else cur += ch;
+    } else if (ch === '"') inQ = true;
+    else if (ch === ',') { fields.push(cur); cur = ''; }
+    else if (ch === '\n') { fields.push(cur.replace(/\r$/, '')); rows.push(fields); fields = []; cur = ''; }
+    else cur += ch;
+  }
+  if (cur || fields.length) { fields.push(cur); rows.push(fields); }
+  const header = rows[0];
+  const iOid = header.indexOf('depictstmsobjectid');
+  const iIiif = header.indexOf('iiifurl');
+  const iThumb = header.indexOf('iiifthumburl');
+  const iSeq = header.indexOf('sequence');
+  const map = new Map();
+  for (let r = 1; r < rows.length; r++) {
+    const f = rows[r];
+    const oid = f[iOid];
+    if (!oid) continue;
+    if (map.has(oid) && f[iSeq] !== '0') continue; // prefer the primary image
+    map.set(oid, { iiifurl: f[iIiif], thumb: f[iThumb] });
+  }
+  return map;
+}
+
+export async function fetchNgaSource(doc, ctx = {}) {
+  const id = doc.source_ids?.nga;
+  if (!id) return { ok: false, error: 'no source_ids.nga' };
+  const img = ctx.ngaImages?.get(String(id));
+  if (!ctx.ngaImages) return { ok: false, error: 'nga images csv not loaded (pass ctx.ngaImages)' };
+  if (!img?.iiifurl) return { ok: false, error: `no published image for NGA object ${id}` };
+  return {
+    ok: true,
+    imageUrl: img.thumb || `${img.iiifurl}/full/!800,800/0/default.jpg`,
+    fullImageUrl: `${img.iiifurl}/full/max/0/default.jpg`,
+  };
+}
+
+export async function fetchSourceFor(provider, doc, ctx = {}) {
   switch (provider) {
     case 'cleveland': return fetchClevelandSource(doc);
     case 'met': return fetchMetSource(doc);
     case 'aic': return fetchAicSource(doc);
     case 'commons': return fetchCommonsSource(doc);
+    case 'rijksmuseum': return fetchRijksmuseumSource(doc);
+    case 'nga': return fetchNgaSource(doc, ctx);
     default: return { ok: false, error: `provider '${provider}' not integrated (see file header)` };
   }
 }

--- a/scripts/maintenance/backfill-nga-source-ids.mjs
+++ b/scripts/maintenance/backfill-nga-source-ids.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Match the NGA-provider artwork docs against the National Gallery of Art
+ * open-data catalog and write `source_ids.nga` (#3838, item 3).
+ *
+ * The 590 `image_source.provider: "nga"` docs carry no structured source
+ * pointer at all — `image_source.identifier` is an internal import counter
+ * ("nga-11"), not an NGA id. NGA has no live public API; the authoritative
+ * source is their open-data CSV dump (github.com/NationalGalleryOfArt/opendata).
+ *
+ * Matching is deliberately STRICT — a wrong id is worse than none (#3815):
+ *   1. normalized(title) + normalized(attribution) must hit exactly ONE
+ *      catalog object (attribution or attributioninverted, doc title or
+ *      display_title);
+ *   2. fallback: normalized title unique in the whole catalog AND the
+ *      attribution contains the author's last name.
+ * Anything ambiguous or unmatched is reported, never guessed. Existing
+ * `source_ids.nga` values are never overwritten.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-nga-source-ids.mjs \
+ *     --objects-csv=/path/to/objects.csv \
+ *     [--images-csv=/path/to/published_images.csv] [--dry-run]
+ *
+ * CSVs: curl -sL -o objects.csv https://raw.githubusercontent.com/NationalGalleryOfArt/opendata/main/data/objects.csv
+ *       (published_images.csv likewise; optional — only used to report IIIF
+ *       coverage of the matches for the item-5 fetcher.)
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import readline from 'readline';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const argVal = (name) => process.argv.find(a => a.startsWith(`${name}=`))?.split('=').slice(1).join('=');
+const OBJECTS_CSV = argVal('--objects-csv');
+const IMAGES_CSV = argVal('--images-csv');
+if (!OBJECTS_CSV) { console.error('--objects-csv=... required'); process.exit(2); }
+
+// Minimal RFC-4180 CSV line stream: handles quoted fields, embedded commas,
+// escaped quotes, and newlines inside quotes.
+async function* csvRows(path) {
+  const rl = readline.createInterface({ input: fs.createReadStream(path), crlfDelay: Infinity });
+  let pending = '';
+  for await (const line of rl) {
+    pending = pending ? pending + '\n' + line : line;
+    // A row is complete when it contains an even number of unescaped quotes.
+    if (((pending.match(/"/g) || []).length % 2) !== 0) continue;
+    const fields = [];
+    let cur = '', inQ = false;
+    for (let i = 0; i < pending.length; i++) {
+      const ch = pending[i];
+      if (inQ) {
+        if (ch === '"') { if (pending[i + 1] === '"') { cur += '"'; i++; } else inQ = false; }
+        else cur += ch;
+      } else if (ch === '"') inQ = true;
+      else if (ch === ',') { fields.push(cur); cur = ''; }
+      else cur += ch;
+    }
+    fields.push(cur);
+    pending = '';
+    yield fields;
+  }
+}
+
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+async function main() {
+  if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(2); }
+
+  console.log('Loading NGA objects catalog…');
+  const byTitleAttr = new Map(); // norm(title)|norm(attr) -> Set(objectid)
+  const byTitle = new Map();     // norm(title) -> [{objectid, attribution}]
+  let header = null, nRows = 0;
+  for await (const row of csvRows(OBJECTS_CSV)) {
+    if (!header) { header = row; continue; }
+    const get = (name) => row[header.indexOf(name)];
+    const objectid = get('objectid');
+    const title = get('title');
+    if (!objectid || !title) continue;
+    nRows++;
+    const nt = norm(title);
+    const attrs = [get('attribution'), get('attributioninverted')].filter(Boolean);
+    for (const a of attrs) {
+      const k = `${nt}|${norm(a)}`;
+      if (!byTitleAttr.has(k)) byTitleAttr.set(k, new Set());
+      byTitleAttr.get(k).add(objectid);
+    }
+    if (!byTitle.has(nt)) byTitle.set(nt, []);
+    byTitle.get(nt).push({ objectid, attribution: attrs[0] || '' });
+  }
+  console.log(`${nRows} catalog objects loaded`);
+
+  let iiifByObject = null;
+  if (IMAGES_CSV) {
+    iiifByObject = new Set();
+    let ih = null;
+    for await (const row of csvRows(IMAGES_CSV)) {
+      if (!ih) { ih = row; continue; }
+      const oid = row[ih.indexOf('depictstmsobjectid')];
+      if (oid) iiifByObject.add(oid);
+    }
+    console.log(`${iiifByObject.size} objects have published IIIF images`);
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+  const docs = await books.find(
+    { resource_type: { $exists: true }, 'image_source.provider': 'nga', 'source_ids.nga': { $exists: false } },
+    { projection: { _id: 1, id: 1, slug: 1, title: 1, display_title: 1, author: 1 } }
+  ).toArray();
+  console.log(`${docs.length} NGA docs without source_ids.nga\n`);
+
+  const stats = { matched: 0, matchedFallback: 0, ambiguous: 0, unmatched: 0, withIiif: 0 };
+  const problems = [];
+  const ops = [];
+
+  for (const doc of docs) {
+    const titles = [...new Set([doc.title, doc.display_title].filter(Boolean))];
+    const na = norm(doc.author);
+    let hit = null, how = null;
+
+    const exact = new Set();
+    for (const t of titles) {
+      const s = byTitleAttr.get(`${norm(t)}|${na}`);
+      if (s) for (const id of s) exact.add(id);
+    }
+    if (exact.size === 1) { hit = [...exact][0]; how = 'title+attribution'; }
+    else if (exact.size > 1) { stats.ambiguous++; problems.push({ id: doc.id || String(doc._id), slug: doc.slug, why: 'ambiguous', candidates: [...exact] }); continue; }
+    else {
+      // Fallback: unique title in the whole catalog + last-name check.
+      const lastName = norm((doc.author || '').trim().split(/\s+/).pop());
+      const cands = titles.flatMap(t => byTitle.get(norm(t)) || []);
+      const uniq = [...new Map(cands.map(c => [c.objectid, c])).values()];
+      if (uniq.length === 1 && lastName && norm(uniq[0].attribution).includes(lastName)) {
+        hit = uniq[0].objectid; how = 'unique-title+lastname';
+      } else if (uniq.length > 1) { stats.ambiguous++; problems.push({ id: doc.id || String(doc._id), slug: doc.slug, why: 'ambiguous-title-only', candidates: uniq.map(u => u.objectid).slice(0, 8) }); continue; }
+      else { stats.unmatched++; problems.push({ id: doc.id || String(doc._id), slug: doc.slug, why: 'no-match', title: doc.title, author: doc.author }); continue; }
+    }
+
+    if (how === 'title+attribution') stats.matched++; else stats.matchedFallback++;
+    if (iiifByObject?.has(hit)) stats.withIiif++;
+    ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { 'source_ids.nga': hit } } } });
+  }
+
+  if (ops.length && !DRY_RUN) {
+    const r = await books.bulkWrite(ops, { ordered: false });
+    console.log(`bulkWrite modified ${r.modifiedCount}`);
+  }
+
+  console.log('\n━━━ SUMMARY ━━━');
+  console.log(JSON.stringify(stats, null, 2));
+  const outPath = `scripts/output/nga-source-ids-backfill-${new Date().toISOString().slice(0, 10)}.json`;
+  fs.mkdirSync('scripts/output', { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify({ generated_at: new Date().toISOString(), dry_run: DRY_RUN, stats, problems }, null, 2));
+  console.log(`Report → ${outPath}`);
+  await client.close();
+}
+
+main().catch(e => { console.error('Fatal:', e); process.exit(1); });

--- a/scripts/maintenance/backfill-provider-source-ids.mjs
+++ b/scripts/maintenance/backfill-provider-source-ids.mjs
@@ -104,6 +104,45 @@ async function main() {
     console.log(`${provider}: ${stats[provider].scoped} scoped, ${stats[provider].written} ${DRY_RUN ? 'would write' : 'written'}, ${stats[provider].unparsed} unparsed`);
   }
 
+  // Second lane: some importer generations wrote the museum's own id into
+  // image_source.identifier with no URL anywhere (Met Egyptian-art batch:
+  // numeric objectID; Rijksmuseum KOG batch: object number). Both id shapes
+  // spot-verified against the live APIs 2026-08-10 (#3838).
+  for (const [provider, idRe] of [
+    ['met', /^\d{4,}$/],
+    ['rijksmuseum', RIJKS_OBJNUM],
+  ]) {
+    const query = {
+      resource_type: { $exists: true },
+      [`source_ids.${provider}`]: { $exists: false },
+      'image_source.provider': provider,
+      'image_source.identifier': { $exists: true, $nin: [null, ''] },
+    };
+    const docs = await books.find(query, {
+      projection: { _id: 1, id: 1, slug: 1, 'image_source.identifier': 1 },
+    }).limit(LIMIT || 0).toArray();
+    const key = `${provider}-identifier`;
+    stats[key] = { scoped: docs.length, written: 0, unparsed: 0 };
+
+    const ops = [];
+    for (const doc of docs) {
+      const ident = (doc.image_source?.identifier || '').trim();
+      if (!idRe.test(ident)) {
+        stats[key].unparsed++;
+        unparsed.push({ provider: key, id: doc.id || String(doc._id), slug: doc.slug, invalid: ident });
+        continue;
+      }
+      ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { [`source_ids.${provider}`]: ident } } } });
+    }
+    if (ops.length && !DRY_RUN) {
+      const r = await books.bulkWrite(ops, { ordered: false });
+      stats[key].written = r.modifiedCount;
+    } else {
+      stats[key].written = ops.length;
+    }
+    console.log(`${key}: ${stats[key].scoped} scoped, ${stats[key].written} ${DRY_RUN ? 'would write' : 'written'}, ${stats[key].unparsed} unparsed`);
+  }
+
   if (unparsed.length) {
     console.log(`\n${unparsed.length} unparsed URL(s):`);
     for (const u of unparsed.slice(0, 15)) console.log(`  [${u.provider}] ${u.slug} — ${u.url}${u.invalid ? ` (extracted "${u.invalid}" failed validation)` : ''}`);


### PR DESCRIPTION
## What

Closes the two unverifiable-provider gaps in `scripts/lib/artwork-sources.mjs` and wires them into the integrity detector:

- **Rijksmuseum** — the old API is 410 Gone, but the Linked Art stack resolves **without a key**: `data.rijksmuseum.nl/search/collection?objectNumber=…` → object → VisualItem → DigitalObject → IIIF access point. The fetcher cross-checks the resolved record's own Identifier against the requested object number before trusting its image. 4 requests/doc → the audit **samples** (`--rijks-sample`, default 100). Smoke test: 4/4 sampled docs dHash-match.
- **NGA** — no live API; `fetchNgaSource` reads the opendata `published_images.csv` via a proper RFC-4180 loader (naive comma/line splits silently misalign on quoted multi-line `assistivetext` — caught in testing when object 11 'lost' its image). Audit flag: `--nga-images-csv`. Without the CSV, NGA reports `unverifiable`, never a guess.
- `detectProvider` now routes by `source_ids.rijksmuseum/nga/commons`, and `fetchCommonsSource` prefers the canonical `source_ids.commons` title from the #3838 backfill.
- Includes `backfill-nga-source-ids.mjs` (already run 2026-08-10: 390/590 written; 195 two-impression ambiguities + 5 no-matches reported).

## Found during smoke test

- **2 new confirmed mismatches** (cleveland dist 24, met dist 17) → repair queue, will report on #3838.
- The **Met API 403s** after ~60 rapid requests (all 537 source-errors in the test were `met | HTTP 403`) — pre-existing audit behavior at concurrency 4/250ms, not introduced here. The Met section needs its own throttle; noting on #3838 rather than bundling into this PR.

## Out of scope

Met throttling fix; the full item-5 corpus sweep (runs after merge); `source_unrecoverable` tail marking.

Refs #3838

🤖 Generated with [Claude Code](https://claude.com/claude-code)