### PR TITLE
fix(dts): stop serving raw annotation tags as document text (#3822)

### DIFF
--- a/src/app/api/dts/document/route.ts
+++ b/src/app/api/dts/document/route.ts
@@ -14,6 +14,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';import { getTenantContextFromRequest } from '@/lib/tenant-context';import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
+import { dtsPageText } from '@/lib/dts-text';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -170,9 +171,7 @@ export async function GET(request: NextRequest) {
 
     if (mediaType === 'text/html') {
       const htmlParts = pages.map((p) => {
-        const text = edition === 'translation'
-          ? (p.translation?.data || '')
-          : (p.ocr?.data || '');
+        const text = dtsPageText(edition === 'translation' ? p.translation?.data : p.ocr?.data);
         const pageNum = p.page_number;
         return `<div class="dts-page" data-ref="${pageNum}" id="p${pageNum}">\n`
           + `<h3>Page ${pageNum}</h3>\n`
@@ -194,9 +193,7 @@ export async function GET(request: NextRequest) {
 
     // Default: text/plain
     const textParts = pages.map((p) => {
-      const text = edition === 'translation'
-        ? (p.translation?.data || '')
-        : (p.ocr?.data || '');
+      const text = dtsPageText(edition === 'translation' ? p.translation?.data : p.ocr?.data);
       return `--- Page ${p.page_number} ---\n${text}`;
     });
 

--- a/src/lib/dts-text.ts
+++ b/src/lib/dts-text.ts
@@ -1,0 +1,28 @@
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+
+/**
+ * Text served by the DTS document endpoint.
+ *
+ * DTS was the one public text surface serving raw `ocr.data`/`translation.data`
+ * (#3822): `<meta>`, `<summary>`, `<image-desc>` prose — the AI's own voice,
+ * which routinely describes adjacent pages — went out as document text to
+ * scholarly consumers who will treat it as the text of the witness.
+ *
+ * Editorial wrappers are dropped content-and-all by the canonical stripper.
+ * `keepTables: true` because DTS serves the whole artifact, not an excerpt —
+ * flattening would silently destroy column structure on table-heavy pages
+ * (see .claude/docs/invariants/text-helpers-and-exports.md). Remaining
+ * annotation tags (note/term/margin/unclear/…) unwrap: content kept, markup
+ * removed. The ideal-state version maps them to TEI equivalents instead —
+ * tracked in #3822.
+ */
+export function dtsPageText(raw: string | undefined | null): string {
+  if (!raw) return '';
+  return stripEditorialWrappers(raw, { keepTables: true })
+    .replace(/<column-break\s*\/?>/gi, '\n\n')
+    .replace(/<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?\/?>/gi, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/tests/unit/dts-text.test.ts
+++ b/tests/unit/dts-text.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { dtsPageText } from '@/lib/dts-text';
+
+/**
+ * DTS is a scholarly interchange API: what it serves will be treated as the
+ * text of the witness. It must never include the AI's own voice (#3822).
+ */
+
+const OCR_PAGE = `<lang>Latin</lang>
+<page-type>text</page-type>
+<page-num>46</page-num>
+<scan-quality>good</scan-quality>
+<meta>Bleed-through from the verso is visible.</meta>
+
+<image-desc type="woodcut">A woodcut of the Vitruvian Man in a circle and square.</image-desc>
+
+Non minus quemadmodum schema rotundationis in corpore efficitur.
+
+<margin>TERTIVS</margin>
+
+| pondus | 12 |
+| mensura | 4 |
+
+<vocab>schema rotundationis, quadrata designatio</vocab>`;
+
+describe('dtsPageText', () => {
+  it('drops editorial wrapper content, keeps the witness text', () => {
+    const out = dtsPageText(OCR_PAGE);
+    expect(out).toContain('Non minus quemadmodum schema rotundationis');
+    expect(out).not.toContain('woodcut');
+    expect(out).not.toContain('Bleed-through');
+    expect(out).not.toContain('good');
+    expect(out).not.toContain('quadrata designatio');
+    expect(out).not.toContain('Latin');
+  });
+
+  it('unwraps page marks — transcription content survives, markup does not', () => {
+    const out = dtsPageText(OCR_PAGE);
+    expect(out).toContain('TERTIVS');
+    expect(out).not.toMatch(/<[a-z]/i);
+  });
+
+  it('keeps table structure (DTS serves the artifact, not an excerpt)', () => {
+    const out = dtsPageText(OCR_PAGE);
+    expect(out).toContain('| pondus | 12 |');
+  });
+
+  it('turns column breaks into paragraph breaks', () => {
+    expect(dtsPageText('left column<column-break/>right column')).toBe(
+      'left column\n\nright column'
+    );
+  });
+
+  it('does not eat prose comparisons that look tag-adjacent', () => {
+    expect(dtsPageText('where a < b and b > c holds')).toContain('a < b and b > c');
+  });
+
+  it('is safe on empty and missing input', () => {
+    expect(dtsPageText('')).toBe('');
+    expect(dtsPageText(undefined)).toBe('');
+    expect(dtsPageText(null)).toBe('');
+  });
+});


### PR DESCRIPTION
Fixes #3822 (minimal version; TEI mapping stays open there as the ideal-state follow-up).

## What

`/api/dts/document` served `ocr.data` / `translation.data` verbatim — the only public text surface bypassing `stripEditorialWrappers`. AI-authored prose (`<meta>`, `<image-desc>`, `<warning>`) went out as document text on a scholarly interchange API whose consumers will treat it as the text of the witness.

## How

New `src/lib/dts-text.ts` (`dtsPageText`), used by both the text/plain and text/html branches:

- Canonical `stripEditorialWrappers` with `keepTables: true` — DTS serves the whole artifact, so tables must keep their structure (the #3580/#3598 lesson in `text-helpers-and-exports.md`).
- `<column-break/>` becomes a paragraph break (same policy as the exports).
- Remaining annotation tags (`note`/`term`/`margin`/`unclear`/…) unwrap — content kept, markup removed. Prose comparisons (`a < b`) survive.

## Tests

`tests/unit/dts-text.test.ts`: wrapper content dropped, transcription survives unwrapping, table structure preserved, column-break handling, angle-bracket prose safety, null-safety. Full suite 2,515 green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)