### PR TITLE
docs: AI Models — flash-lite does not ground; cap preview thinking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ it makes needs a person. Related: `.claude/docs/invariants/first-translation-cla
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
 - OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
+- **Grounded search: flash-lite does NOT ground** (0/189 measured 2026-08-10 — empty `groundingMetadata` while the prose claims "extensive searches"). Use `gemini-3-flash-preview` with an explicit positive `thinkingBudget` (512 → 6/6 grounded, ~$0.003/book; unbounded ≈ $0.19/book; `-1` silently suppresses grounding). Verify groundedness from `queries[]` on written rows, never from response prose.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
 ## Conditional invariants — read the one matching what you're touching


### PR DESCRIPTION
One-line addition to the AI Models section from the measured #3778 ladder findings: flash-lite returns empty groundingMetadata on grounded-search calls (0/189) while claiming searches in prose; flash-preview grounds reliably and cheaply only with an explicit positive thinkingBudget. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)