### PR TITLE
feat(curation): BPH holdings filter on identity review

### DIFF
--- a/src/app/api/admin/edition-keepers/route.ts
+++ b/src/app/api/admin/edition-keepers/route.ts
@@ -27,12 +27,20 @@ export const GET = withInnerCircleAuth(async (request) => {
   const limit = Math.min(parseInt(url.searchParams.get('limit') || '30', 10) || 30, 100);
   const skip = Math.max(parseInt(url.searchParams.get('skip') || '0', 10) || 0, 0);
 
+  const bphOnly = url.searchParams.get('bph') === '1';
+
   const db = await getDb();
   const queue = db.collection('edition_keeper_queue');
 
   const filter: Record<string, unknown> = { status };
   if (bucket === 'human') filter.bucket = { $in: HUMAN_BUCKETS };
   else if (bucket !== 'all') filter.bucket = bucket;
+  if (bphOnly) {
+    const bphIds = await db.collection('books').distinct('id', {
+      $or: [{ held_by: 'bph' }, { 'image_source.provider': 'bph' }],
+    });
+    filter['members.id'] = { $in: bphIds };
+  }
 
   const [rows, total, statusCounts, bucketCounts] = await Promise.all([
     queue.find(filter).sort({ ft_flag: -1, _id: 1 }).skip(skip).limit(limit).toArray(),
@@ -51,7 +59,7 @@ export const GET = withInnerCircleAuth(async (request) => {
         { projection: {
           _id: 0, id: 1, title: 1, author: 1, slug: 1, language: 1, year: 1, visible: 1,
           pages_count: 1, pages_ocr: 1, pages_translated: 1, is_first_translation: 1,
-          'image_source.provider': 1,
+          'image_source.provider': 1, held_by: 1,
           image_thumb: 1, image_display: 1, thumbnail: 1, thumbnail_blob: 1,
         } }
       ).toArray()
@@ -84,6 +92,8 @@ export const GET = withInnerCircleAuth(async (request) => {
         ocr: (live?.pages_ocr as number) || 0,
         translated: (live?.pages_translated as number) || 0,
         ft: live?.is_first_translation === true,
+        bph: Array.isArray(live?.held_by) ? (live!.held_by as string[]).includes('bph')
+          : ((live?.image_source as Record<string, string>)?.provider) === 'bph',
         provider: ((live?.image_source as Record<string, string>)?.provider) || '',
         thumb: live ? getBookThumbnailUrl(live as Parameters<typeof getBookThumbnailUrl>[0], 'thumb') : null,
       };

--- a/src/app/api/admin/work-merges/route.ts
+++ b/src/app/api/admin/work-merges/route.ts
@@ -23,10 +23,17 @@ interface WorkSide {
   workId: string;
   nBooks: number;
   nVisible: number;
+  bph: boolean;
   languages: string[];
   yearMin: number | null;
   yearMax: number | null;
   samples: { id: string; title: string; slug: string; visible: boolean; thumb: string | null }[];
+}
+
+function isBphBook(b: Record<string, unknown>): boolean {
+  const held = b.held_by;
+  if (Array.isArray(held) && held.includes('bph')) return true;
+  return ((b.image_source as Record<string, string>)?.provider) === 'bph';
 }
 
 function summarizeSide(workId: string, books: Record<string, unknown>[]): WorkSide {
@@ -50,6 +57,7 @@ function summarizeSide(workId: string, books: Record<string, unknown>[]): WorkSi
     workId,
     nBooks: books.length,
     nVisible: books.filter((b) => b.visible === true).length,
+    bph: books.some(isBphBook),
     languages: [...langs].sort(),
     yearMin: years.length ? Math.min(...years) : null,
     yearMax: years.length ? Math.max(...years) : null,
@@ -77,6 +85,7 @@ export const GET = withInnerCircleAuth(async (request) => {
   const skip = Math.max(parseInt(url.searchParams.get('skip') || '0', 10) || 0, 0);
   const verdict = url.searchParams.get('verdict');
   const author = url.searchParams.get('author');
+  const bphOnly = url.searchParams.get('bph') === '1';
 
   const db = await getDb();
   const queue = db.collection('work_merge_queue');
@@ -85,6 +94,17 @@ export const GET = withInnerCircleAuth(async (request) => {
   if (verdict === 'none') filter['llm'] = { $exists: false };
   else if (verdict) filter['llm.verdict'] = verdict;
   if (author) filter['evidence.author'] = { $regex: author.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
+
+  // BPH lane (#3846 follow-up): pairs where either side holds a BPH/EFM book.
+  // held_by is the canonical holdings marker; provider catches early imports
+  // that predate held_by backfill.
+  const BPH_BOOK = { $or: [{ held_by: 'bph' }, { 'image_source.provider': 'bph' }] };
+  if (bphOnly) {
+    const bphWids = await db.collection('books').distinct('work_id', {
+      ...BPH_BOOK, work_id: { $exists: true, $nin: [null, ''] },
+    });
+    filter.$or = [{ a: { $in: bphWids } }, { b: { $in: bphWids } }];
+  }
 
   const [rows, total, statusCounts] = await Promise.all([
     queue.find(filter).sort({ 'evidence.author': 1, _id: 1 }).skip(skip).limit(limit).toArray(),
@@ -99,6 +119,7 @@ export const GET = withInnerCircleAuth(async (request) => {
         { projection: {
           _id: 0, id: 1, work_id: 1, title: 1, slug: 1, language: 1, year: 1, visible: 1,
           pages_count: 1, image_thumb: 1, image_display: 1, thumbnail: 1, thumbnail_blob: 1,
+          held_by: 1, 'image_source.provider': 1,
         } }
       ).toArray()
     : [];

--- a/src/app/curation/identity-review/page.tsx
+++ b/src/app/curation/identity-review/page.tsx
@@ -17,6 +17,7 @@ interface WorkSide {
   workId: string;
   nBooks: number;
   nVisible: number;
+  bph: boolean;
   languages: string[];
   yearMin: number | null;
   yearMax: number | null;
@@ -42,6 +43,7 @@ interface MergeItem {
 interface KeeperMember {
   id: string;
   found: boolean;
+  bph: boolean;
   title: string;
   author: string;
   slug: string;
@@ -92,6 +94,7 @@ function WorkSideCard({ side, isSuggested }: { side: WorkSide; isSuggested: bool
         <a href={`/work/${encodeURIComponent(side.workId)}`} target="_blank" rel="noopener noreferrer" className="text-xs font-mono text-accent-rust hover:underline truncate">
           {side.workId}
         </a>
+        {side.bph && <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 whitespace-nowrap">BPH</span>}
         {isSuggested && <span className="text-[10px] uppercase tracking-wide text-emerald-700 whitespace-nowrap">suggested keep</span>}
       </div>
       <div className="text-xs text-stone-500 mb-2">
@@ -113,7 +116,7 @@ function WorkSideCard({ side, isSuggested }: { side: WorkSide; isSuggested: bool
   );
 }
 
-function WorkMergesTab() {
+function WorkMergesTab({ bph }: { bph: boolean }) {
   const [status, setStatus] = useState<Status>('pending');
   const [verdict, setVerdict] = useState<string>('');
   const [items, setItems] = useState<MergeItem[]>([]);
@@ -129,6 +132,7 @@ function WorkMergesTab() {
     try {
       const params = new URLSearchParams({ status, limit: String(LIMIT), skip: String(skip) });
       if (verdict) params.set('verdict', verdict);
+      if (bph) params.set('bph', '1');
       const res = await fetch(`/api/admin/work-merges?${params}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
@@ -140,8 +144,9 @@ function WorkMergesTab() {
     } finally {
       setLoading(false);
     }
-  }, [status, verdict, skip]);
+  }, [status, verdict, skip, bph]);
 
+  useEffect(() => { setSkip(0); }, [bph]);
   useEffect(() => { load(); }, [load]);
 
   async function act(item: MergeItem, action: 'approve' | 'reject', winner?: string) {
@@ -240,7 +245,7 @@ function WorkMergesTab() {
   );
 }
 
-function EditionKeepersTab() {
+function EditionKeepersTab({ bph }: { bph: boolean }) {
   const [status, setStatus] = useState<Status>('pending');
   const [bucket, setBucket] = useState<string>('human');
   const [items, setItems] = useState<KeeperItem[]>([]);
@@ -256,6 +261,7 @@ function EditionKeepersTab() {
     setLoading(true);
     try {
       const params = new URLSearchParams({ status, bucket, limit: String(LIMIT), skip: String(skip) });
+      if (bph) params.set('bph', '1');
       const res = await fetch(`/api/admin/edition-keepers?${params}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
@@ -268,8 +274,9 @@ function EditionKeepersTab() {
     } finally {
       setLoading(false);
     }
-  }, [status, bucket, skip]);
+  }, [status, bucket, skip, bph]);
 
+  useEffect(() => { setSkip(0); }, [bph]);
   useEffect(() => { load(); }, [load]);
 
   async function act(item: KeeperItem, action: 'keep' | 'dismiss', keeperId?: string) {
@@ -337,6 +344,7 @@ function EditionKeepersTab() {
                         {m.provider}{m.language ? ` · ${m.language}` : ''}{m.year ? ` · ${m.year}` : ''}
                         {!m.visible && <span className="text-rose-600"> · hidden</span>}
                         {m.ft && <span className="text-purple-600"> · FT</span>}
+                        {m.bph && <span className="text-amber-700"> · BPH</span>}
                       </div>
                     </div>
                   </div>
@@ -379,6 +387,11 @@ function EditionKeepersTab() {
 
 export default function IdentityReviewPage() {
   const [tab, setTab] = useState<'merges' | 'keepers'>('merges');
+  // ?bph=1 opens the page scoped to BPH/EFM holdings (shareable link for
+  // partner-collection reviewers). Client page, so location is available.
+  const [bph, setBph] = useState<boolean>(() =>
+    typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('bph') === '1'
+  );
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-10">
@@ -393,16 +406,20 @@ export default function IdentityReviewPage() {
         the <em>unsure</em> lane, not everything.
       </p>
 
-      <div className="flex gap-2 mb-6 border-b border-stone-200">
+      <div className="flex items-center gap-2 mb-6 border-b border-stone-200">
         {([['merges', 'Work merges'], ['keepers', 'Edition keepers']] as const).map(([key, label]) => (
           <button key={key} onClick={() => setTab(key)}
             className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === key ? 'border-accent-rust text-accent-rust' : 'border-transparent text-stone-500 hover:text-stone-800'}`}>
             {label}
           </button>
         ))}
+        <label className="ml-auto flex items-center gap-2 text-sm text-stone-600 cursor-pointer pb-1">
+          <input type="checkbox" checked={bph} onChange={(e) => setBph(e.target.checked)} />
+          BPH holdings only
+        </label>
       </div>
 
-      {tab === 'merges' ? <WorkMergesTab /> : <EditionKeepersTab />}
+      {tab === 'merges' ? <WorkMergesTab bph={bph} /> : <EditionKeepersTab bph={bph} />}
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #3846/#3871: scope the identity-review queues to BPH/EFM holdings so a partner-collection reviewer (Paul Dijstelberge) can be handed `/curation/identity-review?bph=1` and land directly on the Ritman collection's own books.

- `bph=1` on both APIs filters to pairs/clusters touching a BPH book (`held_by: 'bph'`, falling back to `image_source.provider` for pre-backfill imports). Measured today: **136 of 1,940 merge pairs, 84 of 311 keeper clusters**.
- Page toggle ("BPH holdings only") initialized from the URL param; BPH chips on work sides and cluster members in the unscoped view; pagination resets on scope change.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)