### PR TITLE
docs(invariants): commons provenance pairing rule (#3838) + handoff

### DIFF
--- a/.claude/docs/invariants/paired-artifacts.md
+++ b/.claude/docs/invariants/paired-artifacts.md
@@ -18,3 +18,23 @@ Each time, two artifacts produced by **different code at different times** were 
 - **Ordering matters as much as mapping.** OCR that runs *before* archival reads the source URL; OCR that runs *after* reads the archived image. If those disagree, a book OCR'd in two passes gets pages transcribed **twice** while their neighbours are never transcribed at all — real duplicate text and real gaps that re-archiving alone cannot repair (see #3362's ordering hazard).
 
 Full postmortem: `.claude/handoffs/2026-07-27-bulk-jp2-leaf-offset.md`.
+
+---
+
+**The same shape on artwork provenance fields (#3838, 2026-08-10):** on artwork
+docs, `commons_title`, `commons_url`, and `commons_sha1` are written by
+different code at different times and are NOT guaranteed to name the same
+Commons file. The image-upgrade path (`image_upgrade_source: "Commons
+alternate"`, May–June 2026) re-points `commons_title` at a higher-quality
+duplicate file without refreshing `commons_url` or `commons_sha1` — measured
+2026-08-10, **440** of ~11.2K true-Commons artwork docs disagree. Inside that
+set, sha1 equality compares the wrong file: 362 of 367 apparent "sha1
+divergences" were this, not wrong images (dHash confirmed the served images
+match the upgraded file). So: **never use `commons_sha1` equality (dedup #3037,
+integrity checks) without first checking that `commons_title` and `commons_url`
+name the same file**, or test membership of the stored sha1 in the file's
+*version history* (batchable: `prop=imageinfo&iiprop=sha1&iilimit=20`). And
+never refresh a stale sha1 without dHash-verifying our stored image against the
+newly named file first — an unverified refresh fabricates provenance.
+`source_ids.commons` (the canonical post-redirect title, written 2026-08-09/10)
+is the authoritative pointer; `fetchCommonsSource` prefers it.

--- a/.claude/handoffs/2026-08-10-artwork-source-ids.md
+++ b/.claude/handoffs/2026-08-10-artwork-source-ids.md
@@ -1,0 +1,63 @@
+# Artwork provenance backfill — issue #3838 delivered end-to-end
+
+**Sessions 2026-08-09 → 2026-08-10.** Structured `source_ids` coverage went from
+627 docs (2.5%) to **24,010 / 24,819 (96.7%)**, with the 591 pointer-less residue
+marked `source_unrecoverable: true` (99.1% accounted for). All PRs merged, all
+writes verified in Mongo, UI change verified in prod HTML.
+
+## What shipped (all merged)
+
+- **#3849** `backfill-commons-source-ids.mjs` — item 1: 11,239 true-Commons docs
+  got `source_ids.commons` (canonical post-redirect File: title) + full
+  `commons_sha1` coverage. Batched 50 titles/request → zero 429s.
+- **#3856** `backfill-provider-source-ids.mjs` — Met objectIDs (289) +
+  Rijksmuseum object numbers (1,868) extracted from the museums' own URLs
+  hiding in `commons_url`/`source_url`.
+- **#3864** — item 4 bulk: the "10,188 no-signal" docs were 93% recoverable via
+  `commons_page_title`/`commons_full_url`; 9,457 written, canonical
+  `commons_url` added where missing.
+- **#3868** — Rijksmuseum fetcher (keyless Linked Art chain: objectNumber
+  search → object → VisualItem → DigitalObject → iiif.micr.io) and NGA fetcher
+  (opendata `published_images.csv` via `--nga-images-csv`) wired into
+  `artwork-image-integrity.mjs` (`--rijks-sample`, default 100); NGA matcher
+  (`backfill-nga-source-ids.mjs`, 390/590 strict matches); identifier lanes
+  (94 Met Egyptian-art + 47 Rijksmuseum KOG from `image_source.identifier`);
+  591 marked `source_unrecoverable` (detector shows `unrecoverable-marked`).
+- **#3873** — UI: artwork page Source button + Digital Source row fall back
+  `commons_url` → `source_url` → museum-record URL from `source_ids`.
+  Verified live on an NGA page and a URL-less Rijksmuseum page.
+
+## Key findings (recorded on the issue)
+
+- **commons_sha1 ≠ the file the doc points at, for 440 docs**: the image-upgrade
+  path (`image_upgrade_source: "Commons alternate"`) re-points `commons_title`
+  without refreshing `commons_sha1`/`commons_url`. 362/367 "sha1 divergences"
+  were this, not wrong images. Never use sha1 equality inside that set without
+  first checking title/url agreement (affects dedup #3037 + item-5 sweep).
+- **2 new confirmed wrong-image records** (smoke test): `69dfe0046a68cb6a2e358396`
+  (cleveland, dist 24), `2c2840822ab4a93692ad6529` (met, dist 17) → repair queue
+  (`repair-artwork-images.mjs`).
+- **Met API 403s after ~60 rapid requests** at the audit's concurrency 4/250ms —
+  the Met section needs its own throttle before an exhaustive sweep is
+  trustworthy.
+- NGA ambiguities (195) are two-impression pairs — disambiguate by dHash against
+  each candidate's IIIF image (report:
+  `scripts/output/nga-source-ids-backfill-2026-08-10.json`).
+
+## Open follow-ups (all listed on #3838, which stays OPEN)
+
+1. Met-section throttle, then the full item-5 corpus sweep
+   (`--nga-images-csv` needs the opendata CSVs; copies were in the scratchpad,
+   re-download from github.com/NationalGalleryOfArt/opendata).
+2. The 2 repair-queue mismatches above.
+3. dHash-disambiguation of the 195 NGA pairs; dHash-verify-then-refresh of the
+   440 stale-sha1 docs (never refresh unverified).
+4. Manual click-check of one NGA link (nga.gov blocks curl; pattern is Wikidata
+   P4683's formatter): https://www.nga.gov/collection/art-object-page.11.html —
+   if 404, swap the pattern in `museumRecordLink` (ArtworkInfo.tsx).
+
+## Reports (local, untracked, in `scripts/output/`)
+
+`commons-source-ids-backfill-2026-08-{09,10}.json`, `sha1-divergent-triage`,
+`sha1-history-check`, `provider-source-ids-backfill-2026-08-{09,10}.json`,
+`nga-source-ids-backfill-2026-08-10.json`, `artwork-image-integrity-2026-08-10.json`.


### PR DESCRIPTION
Gnite ratchet from the #3838 sessions: the `commons_title`/`commons_url`/`commons_sha1` desync (440 docs; 362/367 apparent sha1 divergences explained by the image-upgrade path) is the paired-artifacts shape, so the rule lands in that invariant doc. Plus the session handoff.

No code changes. Refs #3838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)