### PR TITLE
feat(email): re-measured feedback-letter count + queued Ritman/reader's-letter drafts

### DIFF
--- a/public/email/feedback-2026-08/es.html
+++ b/public/email/feedback-2026-08/es.html
@@ -18,7 +18,7 @@
 
 <p style="margin: 0 0 20px;">
   Construir Source Library ha sido lo más divertido que he hecho, pero no he tenido
-  tiempo de leer los 19.420 libros que hay dentro. Si encuentras algo que se pueda
+  tiempo de leer los 22.069 libros que hay dentro. Si encuentras algo que se pueda
   mejorar, por pequeño que sea, dímelo. Puede ser la interfaz, puede ser el contenido
   de una traducción, o puede que algún dato de un libro esté mal.
 </p>

--- a/scripts/email/feedback-newsletter-2026-08.body.html
+++ b/scripts/email/feedback-newsletter-2026-08.body.html
@@ -45,7 +45,9 @@
   The letter now carries a single ask and one soft invitation to reply.
   ─────────────────────────────────────────────────────────────────────────────
 
-  BOOK COUNT — resolved 2026-08-01. Derek chose 19,420, which is the figure the
+  BOOK COUNT — resolved 2026-08-01; re-measured 2026-08-10 at send time and
+  updated to 22,069 (homepage_stats.totalBooks, refreshed that morning), per
+  the "re-measure every number" rule below. Derek chose 19,420, which was the figure the
   homepage itself shows: books that are visible AND have readable pages. 34,040
   are visible in total, but 14,620 of those have no pages yet, so the larger
   number would have overstated what a reader can actually open. It is a literal
@@ -102,7 +104,7 @@
 
 <p style="margin: 0 0 20px;">
   I&rsquo;ve had the most fun time building the Source Library, but I haven&rsquo;t
-  had the time to read all of the 19,420 books in there. If you come across something
+  had the time to read all of the 22,069 books in there. If you come across something
   that could be improved, no matter how small, please let me know. It might be in the
   UI or it might be the content of the translation or maybe some of our book data is
   wrong.

--- a/scripts/email/feedback-newsletter-2026-08.es.body.html
+++ b/scripts/email/feedback-newsletter-2026-08.es.body.html
@@ -41,7 +41,7 @@
 
 <p style="margin: 0 0 20px;">
   Construir Source Library ha sido lo más divertido que he hecho, pero no he tenido
-  tiempo de leer los 19.420 libros que hay dentro. Si encuentras algo que se pueda
+  tiempo de leer los 22.069 libros que hay dentro. Si encuentras algo que se pueda
   mejorar, por pequeño que sea, dímelo. Puede ser la interfaz, puede ser el contenido
   de una traducción, o puede que algún dato de un libro esté mal.
 </p>

--- a/scripts/email/queued/readers-letter-serpent.body.html
+++ b/scripts/email/queued/readers-letter-serpent.body.html
@@ -1,0 +1,120 @@
+<!--
+  QUEUED DRAFT — monthly reader's letter: "A fish half a foot long that stops
+  a ship" (the Olaus Magnus sea-serpent letter), with a short Ritman
+  remembrance at the top.
+
+  PROVENANCE. The serpent copy is Draft 1 from the artifact editor
+  (claude.ai/code/artifact/7a545592-...), written ~2026-07-21 and still
+  awaiting Derek's edits — it is CLAUDE'S DRAFT, not authored copy. The
+  Ritman opening was added 2026-08-10 at Derek's request as the ALTERNATIVE
+  to a standalone memorial letter (see queued/ritman-memoriam.body.html —
+  send ONE of the two, not both).
+
+  BEFORE SENDING:
+    · Derek rewrites/approves the copy (feedback_dont_change_authored_copy).
+    · If the Ritman opening stays: EFM sign-off first (Natalie Koch), same
+      gate as the standalone letter.
+    · Queue order: the feedback letter (item 1) is READY and should go first;
+      this is a reader's letter for the STANDING newsletter audience.
+    · The quote at p.861 was verified verbatim against the book in July;
+      re-check the /q/ shortlink still resolves on send day.
+
+  Facts: Ritman dates verified against the EFM In Memoriam (10 Mar 1941 –
+  5 Jun 2026). Serpent plate is the book's own page 871, served from our R2
+  (display_photo, verified 2026-08-10). Book: Historia de gentibus
+  septentrionalibus, Rome 1555, book id 699065763dc2ed39a49f155d.
+
+  Shell: 520px wrapInEmailShell (logo + h1 + footer supplied). Proof with:
+    node scripts/email/send-test.mjs \
+      scripts/email/queued/readers-letter-serpent.body.html \
+      "A fish half a foot long that stops a ship" you@example.com
+-->
+
+<p style="margin: 0 0 20px;">
+  Hey friend,
+</p>
+
+<p style="margin: 0 0 20px;">
+  Before the letter, a word of farewell. Joost Ritman, who spent seventy
+  years building the Amsterdam collection this library grows from — the
+  Bibliotheca Philosophica Hermetica, home of the
+  <a href="https://embassyofthefreemind.com" style="color:#9e4a3a;">Embassy of
+  the Free Mind</a> — passed away in June at eighty-five. Every old book you
+  open here is part of the door he held open. The best way to remember a
+  collector is to read his books, so this month, let me hand you one of the
+  strangest.
+</p>
+
+<p style="margin: 0 0 20px;">
+  In 1555 an exiled archbishop published nine hundred pages about the north.
+  Olaus Magnus had lost Sweden to the Reformation and spent his last years in
+  Rome, writing down everything he knew about a country he could not go home
+  to &mdash; its weather, its wolves, its ice, its fisheries, and, in
+  Book&nbsp;XXI, its monsters.
+</p>
+
+<a href="https://sourcelibrary.org/book/699065763dc2ed39a49f155d/page/699065763dc2ed39a49f18c4">
+  <img src="https://images.sourcelibrary.org/pages/699065763dc2ed39a49f155d/0871.jpg"
+       alt="The great serpent of Norway — woodcut, 1555"
+       style="display:block; width:100%; height:auto; border-radius:4px; margin:4px 0 8px;">
+</a>
+<p style="margin: 0 0 22px; font-size: 12px; color: #8a8780; text-align: center;">
+  De magnitudine Noruagici Serpentis &mdash; the great serpent of Norway.
+  Olaus Magnus, 1555, p.&nbsp;871.
+</p>
+
+<p style="margin: 0 0 20px;">
+  Sailors, he explains, face three terrors. Whales that spout water into the
+  hull. Birds in numbers enough to swamp a deck. And, worst of the three
+  because there is no defence against it, a fish half a foot long.
+</p>
+
+<p style="margin: 0 0 20px;">
+  It is the <em>echeneis</em> &mdash; the remora. It fastens to a hull and
+  the ship simply stops. Winds rush, storms rage, and the vessel &ldquo;seems
+  to stand as if rooted in the sea.&rdquo; Olaus quotes Ambrose, who had
+  noticed that the same little fish carries a stone in a gale to steady
+  itself &mdash; begging from pebbles the stability it hands out to ships.
+  Then he ends the chapter:
+</p>
+
+<blockquote style="margin: 0 0 20px; padding: 14px 18px; background: #f5f0e8; border-left: 4px solid #9e4a3a; border-radius: 4px;">
+  <p style="margin: 0 0 6px; font-size: 17px;">
+    And so, the impotent pride of men is mocked by such tiny creatures.
+  </p>
+  <p style="margin: 0; font-size: 13px; color: #6b6560;">
+    Olaus Magnus, <em>History of the Northern Peoples</em>, p.&nbsp;861 &middot;
+    <a href="https://sourcelibrary.org/q/BgOdTydfp39ym0o9Snt" style="color:#9e4a3a;">sourcelibrary.org/q/BgOdTydfp39ym0o9Snt</a>
+  </p>
+</blockquote>
+
+<p style="margin: 0 0 20px;">
+  Nine hundred and fifteen pages, the English beside the Latin, free to read
+  and free to quote.
+  <a href="https://sourcelibrary.org/book/historia-de-gentibus-septentrionalibus-magnus" style="color:#9e4a3a;">Start
+  at Book&nbsp;XXI</a> if you want the monsters first.
+</p>
+
+<p style="margin: 0 0 20px;">
+  I read every reply. If you find something in there, tell me what it was.
+</p>
+
+<p style="margin: 0 0 6px;">
+  &mdash; Derek
+</p>
+
+<p style="margin: 0 0 20px; font-size: 14px; color: #666;">
+  Derek Lomas, PhD &middot; Founder, Source Library &middot; a non-profit
+  initiative of the
+  <a href="https://embassyofthefreemind.com" style="color:#9e4a3a;">Embassy of
+  the Free Mind</a>
+</p>
+
+<p style="margin: 0; font-size: 13px; color: #8a8780;">
+  <strong>Also opened this month:</strong> a
+  <a href="https://sourcelibrary.org/ngrams" style="color:#9e4a3a;">word-frequency viewer</a>
+  across the whole corpus, a
+  <a href="https://sourcelibrary.org/blog/sound-laboratory" style="color:#9e4a3a;">sound laboratory</a>
+  of ten historical acoustics experiments you can play, and permanent DOIs
+  minted for the thirty-eight most-read books.
+</p>

--- a/scripts/email/queued/ritman-memoriam.body.html
+++ b/scripts/email/queued/ritman-memoriam.body.html
@@ -1,0 +1,96 @@
+<!--
+  QUEUED DRAFT — "Joost Ritman, 1941–2026" (standalone remembrance letter).
+
+  CLAUDE'S DRAFT from Derek's 2026-08-10 request. It is a starting point, not
+  authored copy — Derek should rewrite it in his own voice before it goes
+  anywhere near the composer.
+
+  BEFORE SENDING — both are hard gates, not suggestions:
+    1. EFM SIGN-OFF. This is their founder and their story. Clear the wording
+       with the Embassy (Natalie Koch, nkoch@efm.amsterdam) and, through them,
+       the family. Do not send on our judgment alone.
+    2. Derek rewrites the copy. See feedback_dont_change_authored_copy — this
+       is the inverse case: unauthored copy must not ship as if it were his.
+
+  Facts verified 2026-08-10 against the EFM's official In Memoriam
+  (embassyofthefreemind.com/news/in-memoriam-joost-r-ritman):
+    · Joost R. Ritman, 10 March 1941 – 5 June 2026
+    · founder of the Bibliotheca Philosophica Hermetica; seventy years
+      building the library and its network
+    · the Hermes epigraph quoted below is the one the EFM itself chose for
+      the In Memoriam — do not swap it for a different quote
+  The Pimander link is book 69b4cc20bb3208142d7bc47f (1472 editio princeps,
+  verified live). No collection counts are quoted anywhere in this letter, on
+  purpose — they drift, and a memorial is the wrong place for a stale number.
+
+  One ask, per .claude/docs/newsletter-queue.md: open one of his books.
+  Deliberately text-only — no plates, no screenshots. Restraint reads as
+  respect here, and any image would compete with the subject.
+
+  Shell: written for the 520px shell (wrapInEmailShell) which supplies logo,
+  <h1> from the subject, and the footer. Proof with:
+    node scripts/email/send-test.mjs \
+      scripts/email/queued/ritman-memoriam.body.html \
+      "Joost Ritman, 1941–2026" you@example.com
+-->
+
+<p style="margin: 0 0 20px;">
+  Hello Source Library friends,
+</p>
+
+<p style="margin: 0 0 20px;">
+  This letter is a quiet one. In June, Joost Ritman — the founder of the
+  Bibliotheca Philosophica Hermetica in Amsterdam, the collection at the heart
+  of this library — passed away at eighty-five.
+</p>
+
+<p style="margin: 0 0 20px;">
+  Joost began collecting as a boy and never stopped. For seventy years he
+  gathered the books of the Hermetic tradition — alchemy, mysticism, the
+  philosophy of the free mind — into one room on an Amsterdam canal, and then
+  did something collectors almost never do: he opened the door. The library
+  became the
+  <a href="https://embassyofthefreemind.com" style="color:#9e4a3a;">Embassy of
+  the Free Mind</a>, and Source Library exists so that the door he opened
+  never closes — so that his books can be read by anyone, anywhere, in any
+  language.
+</p>
+
+<p style="margin: 0 0 20px;">
+  The Embassy's farewell to him begins with a line from Hermes Trismegistus,
+  the author he built his life around:
+</p>
+
+<blockquote style="margin: 0 0 20px; padding: 14px 18px; background: #f5f0e8; border-left: 4px solid #9e4a3a; border-radius: 4px;">
+  <p style="margin: 0 0 6px; font-size: 17px;">
+    Everything is visible to one who has mind. Who contemplates himself with
+    his mind, knows himself, knows the All.
+  </p>
+  <p style="margin: 0; font-size: 13px; color: #6b6560;">
+    Corpus Hermeticum &middot; the epigraph of the Embassy's
+    <a href="https://www.embassyofthefreemind.com/news/in-memoriam-joost-r-ritman" style="color:#9e4a3a;">In Memoriam</a>
+  </p>
+</blockquote>
+
+<p style="margin: 0 0 20px;">
+  If you want to remember him the way he would have liked, read one of his
+  books. Here is the one to start with: the
+  <a href="https://sourcelibrary.org/book/69b4cc20bb3208142d7bc47f" style="color:#9e4a3a;">1472
+  first printed edition of the Pimander</a> — Hermes Trismegistus, translated
+  by Marsilio Ficino, the book that helped start a Renaissance. It sits in his
+  collection, and now it is open on your screen, in English, for free. He
+  spent his life making that sentence possible.
+</p>
+
+<p style="margin: 0 0 20px;">
+  Thank you, Joost.
+</p>
+
+<p style="margin: 0 0 6px;">
+  &mdash; Derek
+</p>
+
+<p style="margin: 0; font-size: 14px; color: #666;">
+  Derek Lomas, PhD &middot; Founder, Source Library &middot; a non-profit
+  initiative of the Embassy of the Free Mind
+</p>


### PR DESCRIPTION
One concern: the email queue.

**In scope**
- Feedback letter (`scripts/email/feedback-newsletter-2026-08.*`, hosted ES page): book count re-measured 2026-08-10 at send time, 19,420 → 22,069 (homepage_stats.totalBooks), per the queue doc's re-measure rule. The letter itself was broadcast today (Resend broadcast `77b35192`, pending contact-quota resolution).
- Two new queued drafts in `scripts/email/queued/`, both marked CLAUDE DRAFT for Derek's rewrite: a standalone Joost Ritman remembrance (hard-gated on EFM sign-off in the header comment) and the sea-serpent monthly reader's letter with a short Ritman opening. The headers say to send one of the two, not both.

**Out of scope**
- Sending anything (blocked on Resend contacts quota; broadcast already created).
- The volunteer-readers letter already queued (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)