### PR TITLE
feat(ft): one ledger, one queue (#3881 passes 1-2)

### DIFF
--- a/.claude/docs/invariants/first-translation-claims.md
+++ b/.claude/docs/invariants/first-translation-claims.md
@@ -8,6 +8,8 @@
 
 "First English translation" asserts an **unprovable universal negative**. No search establishes one; a catalogue returns only *nothing found*. The fix (#3459) is to stop asserting the negative and publish the **search**: a bounded, dated, reproducible act recorded in `search_efforts` — proposition, reference set with per-source snapshot dates and declared gaps, every query verbatim, every candidate **with its screening reason**, and the git SHA that produced it.
 
+**ONE LEDGER (#3881): `first_translation_attempts` is the canonical evidence ledger.** Every search by every instrument lands there as one row; `search_efforts` is the tier-1 **detail archive** behind it (same relationship `first_translation_transcripts` has to rung-2 rows — ledger row lean, deep artifact behind `transcript_ref`). The sweep dual-writes via `effortToAttempt()` in `scripts/lib/search-effort.mjs`; `not_searchable` efforts deliberately never enter the ledger ("we could not ask" must not read as "we asked"). Read `search_efforts` only through `latestEffortPerBook()`; do not add a second ledger, and a new instrument writes attempts, not a new collection.
+
 **Full doc: `.claude/docs/first-translation-reference-set.md`** — the evidence
 layer, its measured reliability, and the invariants below in detail.
 

--- a/.claude/skills/ft-verify/SKILL.md
+++ b/.claude/skills/ft-verify/SKILL.md
@@ -22,6 +22,17 @@ limit. Context: issue #2564; `.claude/docs/ft-verification-runbook.md`.
   single-pass verdict.
 
 ## Inputs
+**Build the worklist from the LEDGER, never from a per-run report file** (#3881 pass 2 —
+`ft-ladder-*.json` files are run reports; they overwrite each other and go stale):
+
+    set -a; source .env.production.local; set +a
+    npx tsx scripts/eval/ft-rung3-queue.ts --out=queue.json          # full, bucket-prioritized
+    npx tsx scripts/eval/ft-rung3-queue.ts --bucket=demote_candidate --out=demotes.json
+
+Buckets arrive verification-priority ordered: `demote_candidate` (a claimed complete prior
+against a live badge — verify these FIRST), `uncertain`, `needs_review`, `hard_class`,
+`undocumented_absence`.
+
 A set of flips, each with: `book_id`, `work` (title), `author`, `lang`, and a **direction**:
 - `demote` — Stage 1 said *a prior exists* → verify the prior is REAL and COMPLETE.
 - `promote` — Stage 1 said *first / no prior* → try to REFUTE by FINDING a prior.

--- a/scripts/eval/ft-ladder.ts
+++ b/scripts/eval/ft-ladder.ts
@@ -365,20 +365,15 @@ async function main() {
   console.log(`  rung-3 (claude) queue: ${rung3Queue.length} | rung-4 (human) queue: ${rung4Queue.length}`);
   if (RUN) console.log(`  rung-2 spend: $${spent.toFixed(4)} of $${BUDGET} budget${spent >= BUDGET ? '  ← BUDGET EXHAUSTED, queue truncated' : ''}`);
 
+  // RUN REPORTS, not queues (#3881 pass 2). Timestamped so same-day runs never
+  // clobber each other. The canonical rung-3/-4 worklist is rebuilt from the
+  // ledger at any moment by scripts/eval/ft-rung3-queue.ts — never feed these
+  // files to ft-verify.
   fs.mkdirSync(OUT_DIR, { recursive: true });
-  const reportPath = path.join(OUT_DIR, `ft-ladder-${DATE}.json`);
-  fs.writeFileSync(reportPath, JSON.stringify({ date: RUN_DATE, queue: QUEUE, model: MODEL, prompt_version: SKEPTIC_PROMPT_VERSION, spent_usd: spent, rows }, null, 1));
-  console.log(`\nWrote ${reportPath}`);
-  if (rung3Queue.length) {
-    const p = path.join(OUT_DIR, `ft-ladder-rung3-queue-${DATE}.json`);
-    fs.writeFileSync(p, JSON.stringify(rung3Queue, null, 1));
-    console.log(`Wrote ${p} — feed to the ft-verify skill (Claude subagents).`);
-  }
-  if (rung4Queue.length) {
-    const p = path.join(OUT_DIR, `ft-ladder-rung4-human-${DATE}.json`);
-    fs.writeFileSync(p, JSON.stringify(rung4Queue, null, 1));
-    console.log(`Wrote ${p} — policy holds for Derek.`);
-  }
+  const RUN_STAMP = RUN_DATE.replace(/[:.]/g, '-');
+  const reportPath = path.join(OUT_DIR, `ft-ladder-report-${RUN_STAMP}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({ date: RUN_DATE, queue: QUEUE, model: MODEL, prompt_version: SKEPTIC_PROMPT_VERSION, spent_usd: spent, rows, rung3: rung3Queue, rung4: rung4Queue }, null, 1));
+  console.log(`\nWrote ${reportPath} (run report — the canonical queue is \`npx tsx scripts/eval/ft-rung3-queue.ts\`).`);
 
   if (APPLY && (rung1Applied || rung2Logged)) {
     console.log(`\n⚠ ACTUATION NOTICE: ingested ${rung1Applied + rung2Logged} row(s) into first_translation_attempts `

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -36,7 +36,8 @@ import readline from 'readline';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
-import { buildSearchEffort, SCREEN, VERDICT } from '../lib/search-effort.mjs';
+import { buildSearchEffort, effortToAttempt, SCREEN, VERDICT } from '../lib/search-effort.mjs';
+import { appendAttempt } from '../lib/ft-attempt-log.mjs';
 import {
   titleTokens as toks,
   bookTitleTokens,
@@ -847,6 +848,19 @@ await withMongo(async (db) => {
     written += res.upsertedCount + res.modifiedCount + res.matchedCount;
   }
   console.log(`APPLIED — ${written} search_efforts upserted (no badge was changed).`);
+
+  // ONE LEDGER (#3881 pass 1): every searchable effort also lands in
+  // `first_translation_attempts` as one compact row — the canonical ledger the
+  // derive/reconcile pipeline reads. search_efforts stays as the detail
+  // archive behind transcript_ref. Idempotent per effort ($setOnInsert).
+  // ACTUATION (#3776): the 05:30 derive reads these rows. They resolve to
+  // tier1_catalog, which the reconcile valve does not admit — no badge moves.
+  let ledgered = 0;
+  for (const e of efforts) {
+    const attempt = effortToAttempt(e);
+    if (attempt && await appendAttempt(db, attempt)) ledgered++;
+  }
+  console.log(`LEDGER — ${ledgered} attempt row(s) appended to first_translation_attempts (searchable efforts only; the 05:30 derive will read them).`);
 },
 /**
  * `noTimeout` is REQUIRED — this walks a whole cohort (5,947 badged / 10,126

--- a/scripts/eval/ft-rung3-queue.ts
+++ b/scripts/eval/ft-rung3-queue.ts
@@ -1,0 +1,147 @@
+/**
+ * ft-rung3-queue.ts — build the rung-3 (Claude ft-verify) worklist from the
+ * LEDGER, not from per-run report files (#3881 pass 2).
+ *
+ * The per-run `ft-ladder-rung3-queue-<date>.json` files overwrite each other
+ * and go stale the moment another run happens — the 2026-08-10 run briefly
+ * left a version polluted with 1,749 quota-error books. The ledger
+ * (`first_translation_attempts`) plus the books collection can answer the
+ * queue question at any moment, so this builder IS the queue; the ladder's
+ * JSON output is a run report, not an input to anything.
+ *
+ * Buckets, in verification-priority order (all recomputed, none read from
+ * report files):
+ *
+ *   demote_candidate     a skeptic search found a COMPLETE prior against a live
+ *                        badge — only rung 3+ may earn the resolver that moves
+ *                        the badge, so these verify first.
+ *   uncertain            the skeptic could not decide.
+ *   needs_review         the stored verdict itself demands adjudication
+ *                        (remember: needs_review DEMOTES at reconcile).
+ *   hard_class           pre-search structural signals (container, liturgy,
+ *                        archival document …) — recomputed via the same screen
+ *                        the ladder uses; these books have no useful skeptic row
+ *                        by design.
+ *   undocumented_absence a "none found" whose search trail is below the
+ *                        documented bar (<3 queries or <2 sources) — absence
+ *                        that still needs a real search behind it.
+ *
+ * Books already resolved by the badge-moving tier (resolver tier2_agent or
+ * human) are excluded — re-verifying them is duplicate spend.
+ *
+ * Read-only. Writes nothing to Mongo.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/eval/ft-rung3-queue.ts                  # summary + counts
+ *   npx tsx scripts/eval/ft-rung3-queue.ts --out=queue.json # full worklist
+ *   npx tsx scripts/eval/ft-rung3-queue.ts --bucket=demote_candidate --out=demotes.json
+ */
+import fs from 'fs';
+import { getDb } from '@/lib/mongodb';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+// @ts-expect-error — plain .mjs module without type declarations (tsx resolves it)
+import { screenDemoteCandidate } from '../lib/ft-demote-screen.mjs';
+
+const arg = (name: string) => process.argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
+const OUT = arg('out');
+const BUCKET = arg('bucket');
+
+/** The skeptic's own "documented search" bar (skeptic.ts): ≥3 queries AND ≥2 sources. */
+const documented = (a: FirstTranslationAttempt) =>
+  (a.queries?.length ?? 0) >= 3 && (a.sources_checked?.length ?? 0) >= 2;
+
+interface QueueRow {
+  book_id: string;
+  work?: string;
+  author?: string;
+  lang?: string;
+  bucket: 'demote_candidate' | 'uncertain' | 'needs_review' | 'hard_class' | 'undocumented_absence';
+  reasons: string[];
+  claimed_priors?: FirstTranslationAttempt['priors'];
+  transcript_ref?: string;
+}
+
+async function main() {
+  const db = await getDb();
+  const books = db.collection('books');
+  const attemptsCol = db.collection<FirstTranslationAttempt>('first_translation_attempts');
+
+  // Scope: the badged-weak universe plus stored needs_review — the books whose
+  // public claim is not yet evidence-backed.
+  const scope = await books.find(
+    {
+      visible: true,
+      language: { $nin: [null, 'en', 'eng', 'English', 'english'] },
+      $or: [
+        { is_first_translation: true },
+        { 'first_translation.verdict': 'needs_review' },
+      ],
+    },
+    { projection: { _id: 0, id: 1, title: 1, author: 1, language: 1, first_translation: 1, translation_verification: 1 } },
+  ).toArray();
+
+  const rows: QueueRow[] = [];
+  const counts: Record<string, number> = {};
+  const push = (r: QueueRow) => {
+    rows.push(r);
+    counts[r.bucket] = (counts[r.bucket] ?? 0) + 1;
+  };
+
+  for (const b of scope) {
+    const ft = b.first_translation as { resolver?: string; verdict?: string; evidence_strength?: string } | undefined;
+    // Already resolved by the badge-moving tier — do not re-pay.
+    if (ft?.resolver === 'tier2_agent' || ft?.resolver === 'human') continue;
+
+    const base = { book_id: b.id as string, work: b.title as string, author: b.author as string, lang: b.language as string };
+
+    // Pre-search hard classes never get a useful skeptic row by design.
+    const screen = screenDemoteCandidate(b) as { signals: Array<{ code: string }> };
+    const hardSignals = (screen.signals ?? []).map((s) => s.code);
+    if (hardSignals.length) {
+      push({ ...base, bucket: 'hard_class', reasons: hardSignals });
+      continue;
+    }
+
+    const attempts = await attemptsCol
+      .find({ book_id: b.id as string, prompt_version: { $regex: 'skeptic' } })
+      .sort({ date: -1 })
+      .limit(5)
+      .toArray();
+    const latest = attempts[0];
+
+    const demote = attempts.find((a) => a.verdict === 'complete_prior_found');
+    if (demote) {
+      push({ ...base, bucket: 'demote_candidate', reasons: ['complete_prior_found_needs_tier2'], claimed_priors: demote.priors, transcript_ref: demote.transcript_ref });
+      continue;
+    }
+    if (latest?.verdict === 'uncertain') {
+      push({ ...base, bucket: 'uncertain', reasons: ['rung2_uncertain'], transcript_ref: latest.transcript_ref });
+      continue;
+    }
+    if (ft?.verdict === 'needs_review') {
+      push({ ...base, bucket: 'needs_review', reasons: ['stored_verdict_needs_review'], transcript_ref: latest?.transcript_ref });
+      continue;
+    }
+    if (latest && latest.result === 'none' && !documented(latest)) {
+      push({ ...base, bucket: 'undocumented_absence', reasons: ['absence_below_documented_bar'], transcript_ref: latest.transcript_ref });
+    }
+    // A documented absence needs no rung-3 visit: the evidence is honest and on file.
+  }
+
+  const order: QueueRow['bucket'][] = ['demote_candidate', 'uncertain', 'needs_review', 'hard_class', 'undocumented_absence'];
+  rows.sort((a, b) => order.indexOf(a.bucket) - order.indexOf(b.bucket) || a.book_id.localeCompare(b.book_id));
+  const out = BUCKET ? rows.filter((r) => r.bucket === BUCKET) : rows;
+
+  console.log(`rung-3 queue (from the ledger, ${new Date().toISOString()}):`);
+  for (const k of order) console.log(`  ${k.padEnd(22)} ${String(counts[k] ?? 0).padStart(5)}`);
+  console.log(`  total ${rows.length}${BUCKET ? ` | emitted bucket=${BUCKET}: ${out.length}` : ''}`);
+
+  if (OUT) {
+    fs.writeFileSync(OUT, JSON.stringify({ generated_at: new Date().toISOString(), counts, rows: out }, null, 1));
+    console.log(`Wrote ${OUT}`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lib/search-effort.mjs
+++ b/scripts/lib/search-effort.mjs
@@ -237,3 +237,71 @@ export function renderEffortSummary(effort) {
       return `Inconclusive — candidates remain unscreened. ${scope}`;
   }
 }
+
+/**
+ * effortToAttempt — the ONE-LEDGER bridge (#3881 pass 1).
+ *
+ * `first_translation_attempts` is the canonical evidence ledger; this
+ * collection is the tier-1 DETAIL ARCHIVE behind it (the same relationship
+ * `first_translation_transcripts` has to rung-2 skeptic rows: ledger row lean,
+ * deep artifact separate). Every searchable effort therefore also lands in the
+ * ledger as one compact attempt row, produced here, with `transcript_ref`
+ * pointing back at the effort for the full queries/candidates/screening record.
+ *
+ * NOT_SEARCHABLE efforts return null on purpose: "we could not ask" must never
+ * enter the ledger, where downstream readers treat a row as "we asked" — the
+ * exact conflation the invariant doc forbids.
+ */
+export function effortToAttempt(effort) {
+  if (!effort || effort.verdict === VERDICT.NOT_SEARCHABLE) return null;
+
+  const candidates = effort.candidates ?? [];
+  const priorRows = candidates.filter((c) => c.screen === SCREEN.PRIOR);
+  const partialRows = candidates.filter((c) => c.screen === SCREEN.PARTIAL);
+  const citeUrl = (c) => {
+    const id = c.identifiers ?? {};
+    if (id.lccn) return `https://lccn.loc.gov/${id.lccn}`;
+    if (id.estc_id) return `http://estc.bl.uk/${id.estc_id}`;
+    if (id.wikidata_edition) return `https://www.wikidata.org/wiki/${id.wikidata_edition}`;
+    return undefined;
+  };
+  const toPrior = (c, completeness) => ({
+    english_title: c.title,
+    pub_year: c.year != null ? String(c.year) : undefined,
+    publisher: c.publisher,
+    completeness,
+    source_url: citeUrl(c),
+  });
+
+  const found = effort.verdict === VERDICT.PRIOR_FOUND || effort.verdict === VERDICT.ONLY_PARTIAL_FOUND;
+  return {
+    // Deterministic: an effort maps to exactly one attempt, so re-ingesting a
+    // generation is idempotent under appendAttempt's $setOnInsert.
+    attempt_id: `${effort.book_id}:tier1_catalog:${effort.effort_id}`,
+    book_id: effort.book_id,
+    work_id: effort.work_id ?? null,
+    date: new Date(effort.run_at).toISOString(),
+    method: 'tier1_catalog',
+    match_key: effort.work_id ? 'work_id' : 'author_title',
+    sources_checked: (effort.reference_set?.sources ?? []).map((s) => s.id),
+    queries: (effort.queries ?? []).map((q) => `[${q.source}] ${q.query} → ${q.result_count ?? 0}`),
+    result: found ? 'found' : 'none',
+    verdict: effort.verdict,
+    found_refs: priorRows.concat(partialRows)
+      .map((c) => c.identifiers?.lccn ?? c.identifiers?.estc_id ?? c.identifiers?.wikidata_edition)
+      .filter(Boolean),
+    priors: [
+      ...priorRows.map((c) => toPrior(c, 'complete')),
+      ...partialRows.map((c) => toPrior(c, 'partial')),
+    ],
+    // A positive sighting in a curated catalogue is strong; catalogue-tier
+    // absence is weak BY MEASUREMENT (32.1% recall) — never higher.
+    evidence_strength: effort.verdict === VERDICT.PRIOR_FOUND ? 'strong'
+      : effort.verdict === VERDICT.ONLY_PARTIAL_FOUND ? 'moderate'
+      : 'weak',
+    notes: renderEffortSummary(effort),
+    prompt_version: `ft-reference-set-search/${effort.reference_set?.version ?? 'unknown'}@${effort.code_version ?? 'unknown'}`,
+    transcript_ref: effort.effort_id,
+    _src: 'search_efforts',
+  };
+}

--- a/tests/unit/search-effort-to-attempt.test.ts
+++ b/tests/unit/search-effort-to-attempt.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { effortToAttempt, VERDICT, SCREEN } from '../../scripts/lib/search-effort.mjs';
+
+const baseEffort = (over = {}) => ({
+  effort_id: 'e1',
+  book_id: 'b1',
+  work_id: 'w1',
+  run_at: '2026-08-10T00:00:00.000Z',
+  verdict: VERDICT.NONE_FOUND,
+  reference_set: { version: 'v9', sources: [{ id: 'loc' }, { id: 'estc' }] },
+  queries: [{ source: 'loc', query: 'author:"X"', result_count: 3 }],
+  candidates: [],
+  counts: { queries: 1, records_returned: 3, candidates_screened: 0, by_screen: {} },
+  code_version: 'abc1234',
+  ...over,
+});
+
+describe('effortToAttempt — the one-ledger bridge (#3881)', () => {
+  it('not_searchable maps to NOTHING: "we could not ask" must never enter the ledger', () => {
+    expect(effortToAttempt(baseEffort({ verdict: VERDICT.NOT_SEARCHABLE }))).toBeNull();
+  });
+
+  it('none_found maps to a weak absence row with the search trail attached', () => {
+    const a = effortToAttempt(baseEffort());
+    expect(a.result).toBe('none');
+    expect(a.evidence_strength).toBe('weak'); // catalogue-only recall is 32.1% — never higher
+    expect(a.method).toBe('tier1_catalog');
+    expect(a.sources_checked).toEqual(['loc', 'estc']);
+    expect(a.queries[0]).toContain('author:"X"');
+    expect(a.transcript_ref).toBe('e1');
+    // Deterministic id: re-ingesting a generation is idempotent under $setOnInsert.
+    expect(a.attempt_id).toBe('b1:tier1_catalog:e1');
+  });
+
+  it('prior_found maps to a strong found row with a citable prior', () => {
+    const a = effortToAttempt(baseEffort({
+      verdict: VERDICT.PRIOR_FOUND,
+      candidates: [{
+        screen: SCREEN.PRIOR, title: 'The Works, Englished', year: 1650,
+        identifiers: { lccn: '55004252' },
+      }],
+    }));
+    expect(a.result).toBe('found');
+    expect(a.evidence_strength).toBe('strong');
+    expect(a.found_refs).toEqual(['55004252']);
+    expect(a.priors[0].source_url).toBe('https://lccn.loc.gov/55004252');
+    expect(a.priors[0].completeness).toBe('complete');
+  });
+
+  it('only_partial_found is a found row whose priors are marked partial (supports first_complete, does not defeat)', () => {
+    const a = effortToAttempt(baseEffort({
+      verdict: VERDICT.ONLY_PARTIAL_FOUND,
+      candidates: [{ screen: SCREEN.PARTIAL, title: 'Selections', year: 1890, identifiers: { estc_id: 'S1234' } }],
+    }));
+    expect(a.result).toBe('found');
+    expect(a.evidence_strength).toBe('moderate');
+    expect(a.priors[0].completeness).toBe('partial');
+  });
+
+  it('screened-out candidates (different work, wrong language) contribute no priors', () => {
+    const a = effortToAttempt(baseEffort({
+      candidates: [
+        { screen: SCREEN.DIFFERENT_WORK, title: 'Other', identifiers: { lccn: 'x' } },
+        { screen: SCREEN.WRONG_LANGUAGE, title: 'French tr.', identifiers: { lccn: 'y' } },
+      ],
+    }));
+    expect(a.priors).toEqual([]);
+    expect(a.found_refs).toEqual([]);
+    expect(a.result).toBe('none');
+  });
+});


### PR DESCRIPTION
First two passes of the simplification plan (#3881), as amended by the self-review.

**Pass 1 — one ledger.** `first_translation_attempts` is canonical; `search_efforts` becomes the tier-1 detail archive behind `transcript_ref` (the same relationship `first_translation_transcripts` has to rung-2 rows). The sweep dual-writes via a new `effortToAttempt()` bridge — deterministic ids (idempotent re-ingest), citable priors, absence capped at weak by the measured 32.1% catalogue recall, and `not_searchable` deliberately excluded ('we could not ask' must never read as 'we asked'). Invariant doc updated with the no-second-ledger rule. No backfill of historical efforts in this PR — that is a separate, flagged actuation decision.

**Pass 2 — one queue.** `ft-rung3-queue.ts` rebuilds the rung-3 worklist from the ledger at any moment, bucket-prioritized; the ladder's per-run JSONs are demoted to one timestamped run report (no same-day clobber — the 2026-08-10 incident where a queue file was briefly polluted with 1,749 quota-error books cannot recur); ft-verify's skill doc sources its worklist from the builder.

**Live-verified (read-only):** the ledger-backed queue is 3,494 books (deduped), badge-threatening head 427 (376 demote candidates + 51 uncertain) — the per-run files double-counted across runs.

Verification: tsc clean; full unit suite green (2,437) + 5 new tests pinning the bridge.

Part of #3881 (passes 3-6 to follow separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)