### PR TITLE
docs: the Translation Card method (#3881)

### DIFF
--- a/.claude/docs/translation-card-method.md
+++ b/.claude/docs/translation-card-method.md
@@ -63,7 +63,7 @@ Invariants per round (inherited from the #2880 pilot discipline):
 
 | Round | Date | Cards | Entry-card errors | Empty-card errors | Notes |
 |---|---|---|---|---|---|
-| 1 | 2026-08-11 | (in flight) | | | pilot-cast cards; first calibration |
+| 1 | 2026-08-11 | 12 | 1 wrong_attribution + 3 filler entries (0 fabricated) | 1 category error (0 missed priors) | `scripts/eval/results/card-round-1.md`; two suggester rules adopted (no citation → no entry; no gloss-matched attribution); card defect ≈17% [5–45%], all fixed same-day |
 
 ## State
 

--- a/.claude/docs/translation-card-method.md
+++ b/.claude/docs/translation-card-method.md
@@ -1,0 +1,77 @@
+# The Translation Card — method
+
+*The target state of the first-translation system (#3881, superseding the
+book-grain machinery). This page is deliberately short: if the method stops
+fitting on it, the method has failed its own test.*
+
+## The card
+
+Every work gets one card: the list of known English translations, cited.
+
+> **De architectura** — English: Newton 1771; Morgan 1914.
+> **Pymander** — English: Everard 1650.
+> **Colliget** — English: *none known to us* (searched LoC, ESTC, the web — Aug 2026).
+
+Store: `work_translation_history` (Mongo, one doc per `work_id`). An entry is a
+year, a translator, a title, a citation URL, and any qualifier written in plain
+words ("partial, chs. 1–3"). An empty list carries a note saying where we
+looked. That's the whole schema that matters.
+
+## The three rules
+
+1. **One list per work.** Editions inherit; containers decompose into their
+   constituent works' cards.
+2. **One sentence on the site.** List empty + we hold an English rendering →
+   *"No earlier English translation is known to us — here's where we looked."*
+   That sentence IS the label; it links to the card.
+3. **One process.** Anyone — instrument or human — proposes an entry **with a
+   citation**. A reviewer merges it. Nothing lands unreviewed on a card that
+   changes what readers see.
+
+The search instruments (catalogue sweeps, grounded search, Claude
+verification) are entry *suggesters*. The attempts ledger is the evidence
+archive behind cards. Neither is part of the concept a reader needs.
+
+## Sharpening: pilot rounds + spot checks
+
+The method improves by measurement, not by adding machinery. Each round:
+
+1. **Sample cards** — stratified: cards with entries vs empty cards, Western vs
+   catalogue-blind traditions. Empty cards are the risk (an absence claim);
+   entry cards fail differently (fabricated or mis-attributed citations).
+2. **Verify independently** — one subagent per card, UNPRIMED (it gets the work,
+   not our card), different model family than what wrote the entries:
+   - entry cards: does the cited translation actually exist as described
+     (open the citation; check translator/year/completeness)?
+   - empty cards: try to REFUTE — find any English translation the card missed.
+3. **Score** — card error rate per stratum with Wilson CIs; every error
+   classified: `fabricated_entry` / `wrong_attribution` / `missed_prior` /
+   `wrong_work_identity` / `stale_search_note`.
+4. **Fix what the round found** (cards are cheap to correct — that's the point),
+   and fix the *suggester* that produced the error class.
+5. **Record** the round in `scripts/eval/results/card-round-<N>.md` and append
+   to the running error-rate table below.
+
+Invariants per round (inherited from the #2880 pilot discipline):
+- The verifier is **unprimed** — never fed our card.
+- **No reader-visible change from a round** — corrections to cards are ordinary
+  reviewed edits, not bulk writes.
+- The **random slice is mandatory** — spot checks include cards nobody suspects,
+  or correlated error hides.
+
+## Running error rate
+
+| Round | Date | Cards | Entry-card errors | Empty-card errors | Notes |
+|---|---|---|---|---|---|
+| 1 | 2026-08-11 | (in flight) | | | pilot-cast cards; first calibration |
+
+## State
+
+- Seeded: 919 verified-layer works, 1,730 cited entries, 62 sibling-disagreement
+  sets exposed (PRs #3890, #3891). Canary: Q1232238 caught wrong at seed —
+  `under_review`.
+- Readers of the collection: **none yet.** The label rule (rule 2) ships as its
+  own reviewed PR — that is the moment the registry becomes actuating.
+- The book-grain machinery (verdicts, derive, valve) remains in place and
+  untouched until the card replaces it; then it is deleted, not migrated
+  (#3881 passes 3–6).

--- a/scripts/eval/ft-work-registry-pilot.mjs
+++ b/scripts/eval/ft-work-registry-pilot.mjs
@@ -20,8 +20,9 @@
  * Dry-run by default; --apply writes; --wipe-pilot removes pilot docs.
  *
  * Usage:
- *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs           # report only
- *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs --apply   # seed the collection
+ *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs                     # pilot cast, report only
+ *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs --apply             # seed the pilot cast
+ *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs --all-verified --apply   # phase 1: EVERY verified-layer work
  */
 import fs from 'fs';
 import path from 'path';
@@ -32,6 +33,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
 const APPLY = process.argv.includes('--apply');
 const WIPE = process.argv.includes('--wipe-pilot');
+const ALL_VERIFIED = process.argv.includes('--all-verified');
 const NOW = new Date().toISOString();
 
 /**
@@ -100,13 +102,24 @@ if (WIPE) {
   process.exit(0);
 }
 
+// Phase 1 (#3881): --all-verified seeds EVERY work with a verified-layer
+// resolution, not just the hand-picked cast. Same safety: only the unread
+// collection is written; a wrong seed is visible (test 2 canary), not active.
+const workList = ALL_VERIFIED
+  ? await books.distinct('work_id', {
+      'first_translation.resolver': { $in: ['tier2_agent', 'human'] },
+      work_id: { $exists: true, $nin: [null, ''] },
+    })
+  : PILOT_WORKS;
+console.log(`Seeding ${workList.length} work(s) (${ALL_VERIFIED ? 'ALL verified-layer' : 'pilot cast'})`);
+
 const report = { generated_at: NOW, works: [], totals: {} };
 let totalSiblings = 0;
 let disagreeingBefore = 0;
 let entriesTotal = 0;
 const docs = [];
 
-for (const workId of PILOT_WORKS) {
+for (const workId of workList) {
   const siblings = await books.find(
     { work_id: workId, visible: true },
     { projection: { id: 1, title: 1, author: 1, language: 1, is_first_translation: 1, first_translation: 1, pages_translated: 1 } },
@@ -179,7 +192,8 @@ for (const workId of PILOT_WORKS) {
       basis_attempt_id: ft.best_attempt_id ?? null,
       seeded_from_book: verifiedBook.id,
     },
-    pilot: true,
+    pilot: !ALL_VERIFIED,
+    seeded_from: ALL_VERIFIED ? 'phase1-verified-layer' : 'pilot-cast',
     seeded_at: NOW,
   });
 

--- a/scripts/eval/results/card-round-1.md
+++ b/scripts/eval/results/card-round-1.md
@@ -1,0 +1,68 @@
+# Card round 1 — 2026-08-11
+
+*Method: `.claude/docs/translation-card-method.md`. Sample: 12 cards from the
+919-card phase-1 seed (6 with entries, 6 empty), random within strata, drawn
+2026-08-11. Verifiers: 4 independent Claude subagents (subscription), unprimed
+on the absence side. All card corrections applied same-day as reviewed edits
+(review notes carry `card-round-1 2026-08-11`); nothing reader-visible changed
+(the collection has no readers yet).*
+
+## Scores
+
+**Entry cards (6 cards, 14 checkable entry claims):**
+- CONFIRMED with resolving records: 8 (incl. one title correction — Leeser 1848)
+- Reclassified honestly: 1 (De Quincey 1824 = abridged free adaptation of
+  Buhle, his own words: "abstracted, re-arranged… improved")
+- WRONG attribution: 1 — the Gangtey card pinned Reynolds 1989 to the wrong
+  text entirely (Reynolds translates Karma Lingpa's *gcer mthong rang grol*;
+  the generator glossed the Tibetan title into English and grabbed the
+  best-known "Self-Liberation…" translation). **The AI-conflation signature:
+  a title gloss + a famous nearby work.**
+- Filler/unverifiable-as-written: 3 entries across 2 cards ("Cyranides
+  (various)", "Partial translations of the introduction", "None (complete
+  edition)") — extraction noise, not knowledge.
+- FABRICATED: **0**
+
+**Empty cards (6):**
+- Absence HELD under genuine refutation attempts: 5 of 6 — including two
+  title-trap exclusions the verifiers caught (Kirton 1576 = Innocent III, not
+  Arévalo; Wagenseil's *Tela Ignea Satanae* ≠ Grynaeus) and one constituent
+  caveat added (Neyphug phur dbang vs Boord's byang gter translations).
+- CATEGORY ERROR: 1 — Samuel Parker 1666 is an English original (EEBO A56390);
+  the card should never have existed. Book-grain verdict also wrong.
+- Missed priors: **0**
+- Bonus metadata catch: the Ferdinand II "proclamation" is an anonymous
+  partisan pamphlet — author field wrong on the book record.
+
+## Error classes (per method doc)
+
+| class | count | where the fix goes |
+|---|---|---|
+| fabricated_entry | 0 | — |
+| wrong_attribution | 1 | card fixed; suggester rule: NEVER pin an entry via an English gloss of the title — require the prior's own identity to match |
+| missed_prior | 0 | — |
+| wrong_work_identity / category | 2 (Parker; Ferdinand author field) | cards fixed; book-grain records need the same fix (English-original screen; author correction) |
+| entry hygiene (filler / uncited) | 3 entries | cards fixed; suggester rule: no citation → no entry (placeholder text is not an entry) |
+
+Card-level defect rate (substantive): 2/12 ≈ 17% (Wilson 95% ≈ [5%, 45%] — round
+2 should grow n before quoting this anywhere).
+
+## What sharpened
+
+1. **Suggester rule (adopted):** an entry requires its own citation — no
+   placeholder text, no gloss-matched attributions. Both round-1 entry defects
+   die under this one rule.
+2. **Write-time consistency check (to add):** status `no_prior_known` with a
+   non-empty entries list is a contradiction — reject at write.
+3. **English-original screen** belongs before card creation (the Parker class) —
+   `english-source-detect.mjs` exists for exactly this.
+4. **The searches themselves are good.** Round 1 found zero missed priors and
+   zero fabrications — consistent with the paper's finding that failures are
+   identity/hygiene, not search competence. The card model concentrates
+   exactly there, which is the point.
+
+## Next round
+
+Round 2: n=24 (grow the CI), stratified the same way + include 4 cards from the
+62 sibling-disagreement set, and run the two new write-time rules on the
+proposals before verifiers see them (measure how much the rules alone catch).


### PR DESCRIPTION
One-page method doc for the card model — the card, the three rules, the spot-check sharpening loop with its per-round invariants (unprimed verifier, mandatory random slice, no reader-visible changes from a round), and the running error-rate table that round results append to. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)