### PR TITLE
fix(export): notes-off deleted transcription and left dangling term chips (#3870)

### DIFF
--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -19,7 +19,7 @@ import { resolveTenantId } from '@/lib/tenant-context';
 import { getPageImageUrl } from '@/lib/page-image-url';
 import { Readable } from 'stream';
 import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
-import { pipeTableToHtml } from '@/lib/markdown-table-html';
+import { markdownToHtml } from '@/lib/export-markdown-html';
 
 // Base URL for source links - update when we have a custom domain
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://sourcelibrary.org';
@@ -160,90 +160,6 @@ function generateTxtDownload(book: Book, pages: Page[], format: 'translation' | 
   lines.push('═'.repeat(60));
 
   return lines.join('\n');
-}
-
-// Convert markdown-like text to basic HTML for EPUB
-function markdownToHtml(text: string, opts?: { stripNotes?: boolean }): string {
-  // First, remove image markdown syntax (can't embed in simple EPUB)
-  let html = text.replace(/!\[.*?\]\(.*?\)/g, '');
-
-  // Remove any standalone URLs
-  html = html.replace(/https?:\/\/[^\s\)]+/g, '');
-
-  // Strip notes/margin/gloss entirely when requested (scholarly EPUB — they clutter the reading flow)
-  if (opts?.stripNotes) {
-    html = html.replace(/<note>[\s\S]*?<\/note>/gi, '');
-    html = html.replace(/<margin>[\s\S]*?<\/margin>/gi, '');
-    html = html.replace(/<gloss>[\s\S]*?<\/gloss>/gi, '');
-    html = html.replace(/\[\[notes?:\s*.*?\]\]/gi, '');
-  }
-
-  // Convert XML annotation tags to styled aside/span blocks BEFORE escaping HTML
-  // These are our custom tags that should become actual HTML elements
-  html = html.replace(/<note>([\s\S]*?)<\/note>/gi, '[[NOTE_PLACEHOLDER:$1]]');
-  html = html.replace(/<margin>([\s\S]*?)<\/margin>/gi, '[[MARGIN_PLACEHOLDER:$1]]');
-  html = html.replace(/<gloss>([\s\S]*?)<\/gloss>/gi, '[[GLOSS_PLACEHOLDER:$1]]');
-  html = html.replace(/<term>([\s\S]*?)<\/term>/gi, '[[TERM_PLACEHOLDER:$1]]');
-  html = html.replace(/<unclear>([\s\S]*?)<\/unclear>/gi, '[[UNCLEAR_PLACEHOLDER:$1]]');
-  // Strip <insert> tags (keep content) and <column-break/> markers
-  html = html.replace(/<insert>([\s\S]*?)<\/insert>/gi, '$1');
-  html = html.replace(/<column-break\s*\/?>/gi, '');
-  // Strip ->...<- centering markers (OCR convention for centered text)
-  html = html.replace(/->/g, '').replace(/<-/g, '');
-  // Remove metadata tags (hidden)
-  html = html.replace(/<(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>[\s\S]*?<\/(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>/gi, '');
-  html = html.replace(/<(?:column-break|page-break)\s*\/?>/gi, '');
-
-  // Escape HTML entities
-  html = html
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-
-  // Convert placeholders to inline styled elements (no line breaks)
-  html = html.replace(/\[\[NOTE_PLACEHOLDER:(.*?)\]\]/gi, '<span class="note">[$1]</span>');
-  html = html.replace(/\[\[MARGIN_PLACEHOLDER:(.*?)\]\]/gi, '<span class="margin">[$1]</span>');
-  html = html.replace(/\[\[GLOSS_PLACEHOLDER:(.*?)\]\]/gi, '<span class="gloss">$1</span>');
-  html = html.replace(/\[\[TERM_PLACEHOLDER:(.*?)\]\]/gi, '<em class="term">$1</em>');
-  html = html.replace(/\[\[UNCLEAR_PLACEHOLDER:(.*?)\]\]/gi, '<span class="unclear">$1?</span>');
-
-  // Convert legacy [[notes: ...]] to inline
-  html = html.replace(/\[\[notes?:\s*(.*?)\]\]/gi, '<span class="note">[$1]</span>');
-
-  // Convert headers (must be done before paragraph wrapping)
-  html = html.replace(/^### (.+)$/gm, '\n<h3>$1</h3>\n');
-  html = html.replace(/^## (.+)$/gm, '\n<h2>$1</h2>\n');
-  html = html.replace(/^# (.+)$/gm, '\n<h1>$1</h1>\n');
-
-  // Convert bold and italic
-  html = html.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>');
-  html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-  html = html.replace(/\*(.*?)\*/g, '<em>$1</em>');
-
-  // Split by double newlines to create paragraphs
-  const blocks = html.split(/\n\n+/);
-
-  // Process each block
-  html = blocks.map(block => {
-    block = block.trim();
-    if (!block) return '';
-    // Don't wrap headers in paragraphs
-    if (block.startsWith('<h')) {
-      return block;
-    }
-    // GFM pipe tables become real tables, not pipe-soup inside a <p>.
-    const table = pipeTableToHtml(block);
-    if (table) return table;
-    // Replace single newlines with breaks within paragraphs
-    block = block.replace(/\n/g, '<br/>');
-    return `<p>${block}</p>`;
-  }).filter(b => b).join('\n');
-
-  // Clean up empty paragraphs and whitespace issues
-  html = html.replace(/<p>\s*<\/p>/g, '');
-  html = html.replace(/<p><br\/><\/p>/g, '');
-
-  return html || '<p></p>';
 }
 
 // Custom CSS for EPUB styling

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -19,7 +19,7 @@ import { getBookIndex } from '@/lib/book-index';
 import { getPageImageUrl } from '@/lib/page-image-url';
 import { Readable } from 'stream';
 import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
-import { pipeTableToHtml } from '@/lib/markdown-table-html';
+import { markdownToHtml } from '@/lib/export-markdown-html';
 import { streamOrdered } from '@/lib/ordered-stream';
 
 // Base URL for source links - update when we have a custom domain
@@ -165,90 +165,6 @@ function generateTxtDownload(book: Book, pages: Page[], format: 'translation' | 
   lines.push('═'.repeat(60));
 
   return lines.join('\n');
-}
-
-// Convert markdown-like text to basic HTML for EPUB
-function markdownToHtml(text: string, opts?: { stripNotes?: boolean }): string {
-  // First, remove image markdown syntax (can't embed in simple EPUB)
-  let html = text.replace(/!\[.*?\]\(.*?\)/g, '');
-
-  // Remove any standalone URLs
-  html = html.replace(/https?:\/\/[^\s\)]+/g, '');
-
-  // Strip notes/margin/gloss entirely when requested (scholarly EPUB — they clutter the reading flow)
-  if (opts?.stripNotes) {
-    html = html.replace(/<note>[\s\S]*?<\/note>/gi, '');
-    html = html.replace(/<margin>[\s\S]*?<\/margin>/gi, '');
-    html = html.replace(/<gloss>[\s\S]*?<\/gloss>/gi, '');
-    html = html.replace(/\[\[notes?:\s*.*?\]\]/gi, '');
-  }
-
-  // Convert XML annotation tags to styled aside/span blocks BEFORE escaping HTML
-  // These are our custom tags that should become actual HTML elements
-  html = html.replace(/<note>([\s\S]*?)<\/note>/gi, '[[NOTE_PLACEHOLDER:$1]]');
-  html = html.replace(/<margin>([\s\S]*?)<\/margin>/gi, '[[MARGIN_PLACEHOLDER:$1]]');
-  html = html.replace(/<gloss>([\s\S]*?)<\/gloss>/gi, '[[GLOSS_PLACEHOLDER:$1]]');
-  html = html.replace(/<term>([\s\S]*?)<\/term>/gi, '[[TERM_PLACEHOLDER:$1]]');
-  html = html.replace(/<unclear>([\s\S]*?)<\/unclear>/gi, '[[UNCLEAR_PLACEHOLDER:$1]]');
-  // Strip <insert> tags (keep content) and <column-break/> markers
-  html = html.replace(/<insert>([\s\S]*?)<\/insert>/gi, '$1');
-  html = html.replace(/<column-break\s*\/?>/gi, '');
-  // Strip ->...<- centering markers (OCR convention for centered text)
-  html = html.replace(/->/g, '').replace(/<-/g, '');
-  // Remove metadata tags (hidden)
-  html = html.replace(/<(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>[\s\S]*?<\/(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>/gi, '');
-  html = html.replace(/<(?:column-break|page-break)\s*\/?>/gi, '');
-
-  // Escape HTML entities
-  html = html
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-
-  // Convert placeholders to inline styled elements (no line breaks)
-  html = html.replace(/\[\[NOTE_PLACEHOLDER:(.*?)\]\]/gi, '<span class="note">[$1]</span>');
-  html = html.replace(/\[\[MARGIN_PLACEHOLDER:(.*?)\]\]/gi, '<span class="margin">[$1]</span>');
-  html = html.replace(/\[\[GLOSS_PLACEHOLDER:(.*?)\]\]/gi, '<span class="gloss">$1</span>');
-  html = html.replace(/\[\[TERM_PLACEHOLDER:(.*?)\]\]/gi, '<em class="term">$1</em>');
-  html = html.replace(/\[\[UNCLEAR_PLACEHOLDER:(.*?)\]\]/gi, '<span class="unclear">$1?</span>');
-
-  // Convert legacy [[notes: ...]] to inline
-  html = html.replace(/\[\[notes?:\s*(.*?)\]\]/gi, '<span class="note">[$1]</span>');
-
-  // Convert headers (must be done before paragraph wrapping)
-  html = html.replace(/^### (.+)$/gm, '\n<h3>$1</h3>\n');
-  html = html.replace(/^## (.+)$/gm, '\n<h2>$1</h2>\n');
-  html = html.replace(/^# (.+)$/gm, '\n<h1>$1</h1>\n');
-
-  // Convert bold and italic
-  html = html.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>');
-  html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-  html = html.replace(/\*(.*?)\*/g, '<em>$1</em>');
-
-  // Split by double newlines to create paragraphs
-  const blocks = html.split(/\n\n+/);
-
-  // Process each block
-  html = blocks.map(block => {
-    block = block.trim();
-    if (!block) return '';
-    // Don't wrap headers in paragraphs
-    if (block.startsWith('<h')) {
-      return block;
-    }
-    // GFM pipe tables become real tables, not pipe-soup inside a <p>.
-    const table = pipeTableToHtml(block);
-    if (table) return table;
-    // Replace single newlines with breaks within paragraphs
-    block = block.replace(/\n/g, '<br/>');
-    return `<p>${block}</p>`;
-  }).filter(b => b).join('\n');
-
-  // Clean up empty paragraphs and whitespace issues
-  html = html.replace(/<p>\s*<\/p>/g, '');
-  html = html.replace(/<p><br\/><\/p>/g, '');
-
-  return html || '<p></p>';
 }
 
 // Custom CSS for EPUB styling

--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -10,6 +10,7 @@ import { isRTLLanguage } from '@/lib/types';
 import { NOTE_TAG_STYLES } from '@/lib/style-constants';
 import { cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
 import { normalizeAnnotationSpans } from '@/lib/normalize-annotation-spans';
+import { applyNotesOff } from '@/lib/notes-off';
 
 /**
  * Page types where the entire "translation" is AI-generated description (no
@@ -308,57 +309,13 @@ function preprocessBracketTags(text: string, showNotes: boolean): string {
   return result;
 }
 
-// Handle <term> vocabulary chips when notes are hidden.
-// A trailing glossary entry is a line of nothing but <term>+<note> pairs
-// (e.g. `<term>bite</term> <note>original: "morsus."</note>`). With notes off the
-// <note> renders as null, leaving the term chip dangling with no definition —
-// remove those lines whole. But the same pair also occurs INLINE mid-sentence
-// (`a <term>scheme of roundness</term> <note>original: "schema rotundationis"</note>
-// is produced`), where the term IS the translation of the word: deleting the pair
-// there deletes sentence content (#3811). So only whole glossary lines are dropped;
-// every other <term> is unwrapped to plain text (its <note>, if any, is removed
-// downstream by stripAiAnnotations). A <term> followed by a <gloss> keeps the term
-// and drops only the AI's rendering of it, otherwise the unwrapped gloss reads as
-// a duplicate.
-function preprocessTerms(text: string, showNotes: boolean): string {
-  if (showNotes) return text;
-  const pair = '<term>[^\\n]*?<\\/term>\\s*<note>[^\\n]*?<\\/note>';
-  const glossaryLine = new RegExp(`^[\\s*\\->#\\d.]*(?:${pair}[\\s.,;:]*)+[\\s*]*$`, 'i');
-  return text
-    .split('\n')
-    .filter(line => !glossaryLine.test(line))
-    .join('\n')
-    .replace(/(<term>[\s\S]*?<\/term>)\s*<gloss>[\s\S]*?<\/gloss>/gi, '$1')
-    .replace(/<term>([\s\S]*?)<\/term>/gi, '$1');
-}
-
-// Tags that mark text physically present on the page (a marginal note in the
-// original, a scribal insertion, an uncertain reading) as opposed to <note>/
-// <image-desc>, which are the AI's own commentary. Turning Notes off must never
-// delete a page mark's content — that is transcription, and on pages whose text
-// is mostly labels (maps, diagrams, plates) deleting it empties the page.
-// Unwrap them instead: the words stay, the highlight chip goes.
-const PAGE_MARK_TAGS = 'margin|gloss|insert|unclear';
-
-function unwrapPageMarks(text: string, showNotes: boolean): string {
-  if (showNotes) return text;
-  return text.replace(
-    new RegExp(`<(${PAGE_MARK_TAGS})(?:\\s[^>]*)?>([\\s\\S]*?)<\\/\\1>`, 'gi'),
-    '$2'
-  );
-}
-
-// The AI's own commentary — the only thing the Notes toggle should hide.
-// Removed here rather than left to the component's `showNotes ? … : null`
-// branches so that one pass decides what "notes off" means: whatever survives
-// this function is page text. Runs after unwrapPageMarks, so a note nested
-// inside a page mark is already flattened into it by normalizeAnnotationSpans.
-function stripAiAnnotations(text: string, showNotes: boolean): string {
-  if (showNotes) return text;
-  return text
-    .replace(/<(note|image-desc)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi, '')
-    .replace(/\n{3,}/g, '\n\n');
-}
+// What "notes off" means — the dangling-term rule, the page-mark unwrap, and the
+// AI-annotation strip — now lives in @/lib/notes-off so the reader and the
+// exports share one definition. It had been re-implemented on five surfaces and
+// drifted: #3811 fixed the reader deleting translated words, and the EPUB/HTML
+// download was still doing it (plus deleting page-mark content) months later
+// (#3870). Read the doc comments there; this component only decides WHEN to
+// apply it, never what it does.
 
 // On description-only pages (illustrations, diagrams, etc.) the entire "translation"
 // is AI-generated description. The model wraps some of it in <note>/<image-desc> and
@@ -897,10 +854,9 @@ export function prepareNotesMarkdown(
     (DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
       DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '')) &&
     !hasBodyTextOutsideNotes(withNormalizedSpans);
-  // Drop dangling vocabulary chips when notes are off (see preprocessTerms).
-  const withTerms = preprocessTerms(withNormalizedSpans, showNotes);
-  // Keep transcribed page marks when notes are off; drop only the AI's commentary.
-  const withPageMarks = stripAiAnnotations(unwrapPageMarks(withTerms, showNotes), showNotes);
+  // Notes off: drop dangling vocabulary chips, keep transcribed page marks, drop
+  // only the AI's commentary. One shared definition — see @/lib/notes-off.
+  const withPageMarks = showNotes ? withNormalizedSpans : applyNotesOff(withNormalizedSpans);
   // On description-only pages, render the whole AI description uniformly (no half-highlighting).
   const withDescription = isDescriptionOnly && showNotes ? unwrapDescriptionNotes(withPageMarks) : withPageMarks;
   const withGreek = preprocessLatexGreek(withDescription);

--- a/src/lib/export-markdown-html.ts
+++ b/src/lib/export-markdown-html.ts
@@ -1,0 +1,103 @@
+import { pipeTableToHtml } from '@/lib/markdown-table-html';
+import { applyNotesOff } from '@/lib/notes-off';
+
+/**
+ * Convert a page's markdown-like text to the basic HTML the EPUB/HTML exports embed.
+ *
+ * This lived, character-for-character, in BOTH download routes
+ * (`/api/books/[id]/download` and its tenant twin `/api/[tenant]/books/[id]/download`).
+ * They are not parity-tested and have measurably drifted elsewhere — 388 diff lines
+ * as of #3870, with the tenant copy missing the split-page image resolver, the
+ * bounded-concurrency prefetch and the zip streaming. Duplicated text markup is the
+ * same hazard with a quieter failure: a served-text fix lands on one subdomain and
+ * not the other, and nothing reports it. Import this; do not paste it back.
+ *
+ * Note ordering: tags become placeholders BEFORE HTML entities are escaped, then
+ * come back as real elements after — otherwise the escape pass would eat our own
+ * markup along with the page's stray angle brackets.
+ */
+export function markdownToHtml(text: string, opts?: { stripNotes?: boolean }): string {
+  // First, remove image markdown syntax (can't embed in simple EPUB)
+  let html = text.replace(/!\[.*?\]\(.*?\)/g, '');
+
+  // Remove any standalone URLs
+  html = html.replace(/https?:\/\/[^\s\)]+/g, '');
+
+  // Notes off (scholarly EPUB): the AI's commentary goes, the transcription stays.
+  // This used to delete <margin>/<gloss> CONTENT along with the note, and to leave
+  // <term> chips dangling with no definition once their <note> was gone — the two
+  // halves of #3870, and the same class of defect as #3811 in the reader. The rule
+  // is shared with the reader (@/lib/notes-off) precisely so the export cannot
+  // drift from it again; do not re-inline these regexes here.
+  if (opts?.stripNotes) {
+    html = applyNotesOff(html);
+    html = html.replace(/\[\[notes?:\s*.*?\]\]/gi, '');
+  }
+
+  // Convert XML annotation tags to styled aside/span blocks BEFORE escaping HTML
+  // These are our custom tags that should become actual HTML elements
+  html = html.replace(/<note>([\s\S]*?)<\/note>/gi, '[[NOTE_PLACEHOLDER:$1]]');
+  html = html.replace(/<margin>([\s\S]*?)<\/margin>/gi, '[[MARGIN_PLACEHOLDER:$1]]');
+  html = html.replace(/<gloss>([\s\S]*?)<\/gloss>/gi, '[[GLOSS_PLACEHOLDER:$1]]');
+  html = html.replace(/<term>([\s\S]*?)<\/term>/gi, '[[TERM_PLACEHOLDER:$1]]');
+  html = html.replace(/<unclear>([\s\S]*?)<\/unclear>/gi, '[[UNCLEAR_PLACEHOLDER:$1]]');
+  // Strip <insert> tags (keep content) and <column-break/> markers
+  html = html.replace(/<insert>([\s\S]*?)<\/insert>/gi, '$1');
+  html = html.replace(/<column-break\s*\/?>/gi, '');
+  // Strip ->...<- centering markers (OCR convention for centered text)
+  html = html.replace(/->/g, '').replace(/<-/g, '');
+  // Remove metadata tags (hidden)
+  html = html.replace(/<(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>[\s\S]*?<\/(?:lang|language|page-num|page-type|folio|sig|header|meta|warning|abbrev|vocab|summary|keywords|columns|detected-images|blockquote)>/gi, '');
+  html = html.replace(/<(?:column-break|page-break)\s*\/?>/gi, '');
+
+  // Escape HTML entities
+  html = html
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  // Convert placeholders to inline styled elements (no line breaks)
+  html = html.replace(/\[\[NOTE_PLACEHOLDER:(.*?)\]\]/gi, '<span class="note">[$1]</span>');
+  html = html.replace(/\[\[MARGIN_PLACEHOLDER:(.*?)\]\]/gi, '<span class="margin">[$1]</span>');
+  html = html.replace(/\[\[GLOSS_PLACEHOLDER:(.*?)\]\]/gi, '<span class="gloss">$1</span>');
+  html = html.replace(/\[\[TERM_PLACEHOLDER:(.*?)\]\]/gi, '<em class="term">$1</em>');
+  html = html.replace(/\[\[UNCLEAR_PLACEHOLDER:(.*?)\]\]/gi, '<span class="unclear">$1?</span>');
+
+  // Convert legacy [[notes: ...]] to inline
+  html = html.replace(/\[\[notes?:\s*(.*?)\]\]/gi, '<span class="note">[$1]</span>');
+
+  // Convert headers (must be done before paragraph wrapping)
+  html = html.replace(/^### (.+)$/gm, '\n<h3>$1</h3>\n');
+  html = html.replace(/^## (.+)$/gm, '\n<h2>$1</h2>\n');
+  html = html.replace(/^# (.+)$/gm, '\n<h1>$1</h1>\n');
+
+  // Convert bold and italic
+  html = html.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>');
+  html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\*(.*?)\*/g, '<em>$1</em>');
+
+  // Split by double newlines to create paragraphs
+  const blocks = html.split(/\n\n+/);
+
+  // Process each block
+  html = blocks.map(block => {
+    block = block.trim();
+    if (!block) return '';
+    // Don't wrap headers in paragraphs
+    if (block.startsWith('<h')) {
+      return block;
+    }
+    // GFM pipe tables become real tables, not pipe-soup inside a <p>.
+    const table = pipeTableToHtml(block);
+    if (table) return table;
+    // Replace single newlines with breaks within paragraphs
+    block = block.replace(/\n/g, '<br/>');
+    return `<p>${block}</p>`;
+  }).filter(b => b).join('\n');
+
+  // Clean up empty paragraphs and whitespace issues
+  html = html.replace(/<p>\s*<\/p>/g, '');
+  html = html.replace(/<p><br\/><\/p>/g, '');
+
+  return html || '<p></p>';
+}

--- a/src/lib/notes-off.ts
+++ b/src/lib/notes-off.ts
@@ -1,0 +1,81 @@
+/**
+ * "Notes off" — the one definition of what disappears when a reader turns
+ * annotations off, shared by the reader and every export.
+ *
+ * The editorial markup splits into two families, and the whole rule turns on
+ * the distinction:
+ *
+ *   - **Page marks** (`<margin>`, `<gloss>`, `<insert>`, `<unclear>`) mark text
+ *     that is physically present on the page — a marginal note in the original,
+ *     a scribal insertion, an uncertain reading. That is transcription. Notes
+ *     off must never delete their content; it unwraps them, so the words stay
+ *     and only the highlight chip goes. On pages whose text is mostly labels
+ *     (maps, diagrams, plates) deleting them empties the page.
+ *   - **AI annotations** (`<note>`, `<image-desc>`) are our own commentary, and
+ *     are the only thing the toggle should actually hide.
+ *
+ * `<term>` sits across the line and needs the glossary-line rule below.
+ *
+ * This module exists because the rule was implemented independently on five
+ * surfaces (reader, EPUB download ×2, PDF, Typst — census in #3825) and drifted:
+ * #3811 fixed the reader deleting translated words, and #3870 found the EPUB/HTML
+ * download still doing the same thing plus deleting page-mark content outright.
+ * Every surface that honours a notes-off flag must call `applyNotesOff` rather
+ * than hand-rolling the regexes again.
+ */
+
+/** Tags marking text physically on the page, as opposed to AI commentary. */
+export const PAGE_MARK_TAGS = 'margin|gloss|insert|unclear';
+
+/**
+ * Handle `<term>` vocabulary chips when notes are hidden.
+ *
+ * A trailing glossary entry is a line of nothing but `<term>`+`<note>` pairs
+ * (e.g. `<term>bite</term> <note>original: "morsus."</note>`). With notes off the
+ * `<note>` disappears, leaving the term chip dangling with no definition — remove
+ * those lines whole. But the same pair also occurs INLINE mid-sentence
+ * (`a <term>scheme of roundness</term> <note>original: "schema rotundationis"</note>
+ * is produced`), where the term IS the translation of the word: deleting the pair
+ * there deletes sentence content (#3811). So only whole glossary lines are dropped;
+ * every other `<term>` is unwrapped to plain text (its `<note>`, if any, is removed
+ * by `stripAiAnnotations`). A `<term>` followed by a `<gloss>` keeps the term and
+ * drops only the AI's rendering of it, otherwise the unwrapped gloss reads as a
+ * duplicate.
+ */
+export function preprocessTerms(text: string): string {
+  const pair = '<term>[^\\n]*?<\\/term>\\s*<note>[^\\n]*?<\\/note>';
+  const glossaryLine = new RegExp(`^[\\s*\\->#\\d.]*(?:${pair}[\\s.,;:]*)+[\\s*]*$`, 'i');
+  return text
+    .split('\n')
+    .filter(line => !glossaryLine.test(line))
+    .join('\n')
+    .replace(/(<term>[\s\S]*?<\/term>)\s*<gloss>[\s\S]*?<\/gloss>/gi, '$1')
+    .replace(/<term>([\s\S]*?)<\/term>/gi, '$1');
+}
+
+/** Unwrap page marks: keep the transcribed words, drop the chip. */
+export function unwrapPageMarks(text: string): string {
+  return text.replace(
+    new RegExp(`<(${PAGE_MARK_TAGS})(?:\\s[^>]*)?>([\\s\\S]*?)<\\/\\1>`, 'gi'),
+    '$2'
+  );
+}
+
+/**
+ * Remove the AI's own commentary — the only thing the notes toggle hides.
+ * Runs after `unwrapPageMarks`, so a note nested inside a page mark has already
+ * been flattened into it.
+ */
+export function stripAiAnnotations(text: string): string {
+  return text
+    .replace(/<(note|image-desc)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi, '')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * The full notes-off transform, in the order the reader applies it. Whatever
+ * survives is page text.
+ */
+export function applyNotesOff(text: string): string {
+  return stripAiAnnotations(unwrapPageMarks(preprocessTerms(text)));
+}

--- a/tests/unit/notes-off.test.ts
+++ b/tests/unit/notes-off.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { applyNotesOff, preprocessTerms, unwrapPageMarks, stripAiAnnotations } from '@/lib/notes-off';
+import { markdownToHtml } from '@/lib/export-markdown-html';
+
+/**
+ * What "notes off" means, pinned once (#3870, following #3811).
+ *
+ * The distinction the whole rule turns on: page marks (<margin>, <gloss>,
+ * <insert>, <unclear>) are TRANSCRIPTION and must survive with their content;
+ * <note>/<image-desc> are the AI's own commentary and are the only thing that
+ * disappears. Both download routes had it backwards for margins.
+ */
+describe('notes-off rule', () => {
+  it('keeps the content of page marks, dropping only the chip', () => {
+    const out = applyNotesOff('The <margin>The level</margin> of the wall');
+    expect(out).toBe('The The level of the wall');
+    expect(out).toContain('The level');
+  });
+
+  it('keeps a plate page that is nothing but marginal labels', () => {
+    // A map whose text is all cartouche labels: deleting page-mark content
+    // empties the page entirely.
+    const map = '<margin>Mare Germanicum</margin>\n<insert>Oceanus</insert>\n<unclear>Frisia</unclear>';
+    expect(applyNotesOff(map).replace(/\s+/g, ' ').trim())
+      .toBe('Mare Germanicum Oceanus Frisia');
+  });
+
+  it('removes AI commentary and its content', () => {
+    expect(applyNotesOff('Body text <note>original: "corpus."</note> continues'))
+      .toBe('Body text  continues');
+    expect(applyNotesOff('<image-desc>An engraving of a lion</image-desc>')).toBe('');
+  });
+
+  it('drops a whole glossary line, chip and all', () => {
+    const text = 'Real sentence.\n<term>bite</term> <note>original: "morsus."</note>';
+    expect(applyNotesOff(text)).toBe('Real sentence.');
+  });
+
+  it('keeps an inline term+note pair as sentence content (#3811)', () => {
+    // The term IS the translation of the word here — deleting the pair deletes
+    // words the reader needs.
+    const text = 'a <term>scheme of roundness</term> <note>original: "schema rotundationis"</note> is produced';
+    const out = applyNotesOff(text);
+    expect(out).toContain('scheme of roundness');
+    expect(out).not.toContain('schema rotundationis');
+  });
+
+  it('drops a <gloss> that merely re-renders a preceding <term>', () => {
+    expect(preprocessTerms('<term>aqua</term> <gloss>water</gloss>')).toBe('aqua');
+  });
+
+  it('flattens a note nested inside a page mark rather than keeping its text', () => {
+    expect(applyNotesOff('<margin>Chilon <note>a sage</note></margin>')).toBe('Chilon ');
+  });
+
+  it('handles page-mark tags carrying attributes', () => {
+    expect(unwrapPageMarks('<margin side="left">note text</margin>')).toBe('note text');
+  });
+
+  it('collapses the blank-line pileup left by removed annotations', () => {
+    expect(stripAiAnnotations('a\n\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('is a no-op on text with no editorial markup', () => {
+    expect(applyNotesOff('Plain page text, unmarked.')).toBe('Plain page text, unmarked.');
+  });
+});
+
+describe('EPUB/HTML export honours the same rule', () => {
+  it('keeps marginal transcription in a stripNotes export (#3870)', () => {
+    const html = markdownToHtml('The <margin>The level</margin> of the wall', { stripNotes: true });
+    expect(html).toContain('The level');
+  });
+
+  it('leaves no dangling term chip when its note is gone (#3870)', () => {
+    const html = markdownToHtml('Real sentence.\n<term>bite</term> <note>original: "morsus."</note>', { stripNotes: true });
+    expect(html).not.toContain('bite');
+    expect(html).toContain('Real sentence.');
+  });
+
+  it('still renders notes and margins as chips when notes are on', () => {
+    const html = markdownToHtml('Body <note>a note</note> and <margin>a margin</margin>', { stripNotes: false });
+    expect(html).toContain('<span class="note">[a note]</span>');
+    expect(html).toContain('<span class="margin">[a margin]</span>');
+  });
+
+  it('escapes stray angle brackets in page text without eating its own markup', () => {
+    const html = markdownToHtml('5 < 6 and <note>x</note>', { stripNotes: false });
+    expect(html).toContain('5 &lt; 6');
+    expect(html).toContain('<span class="note">');
+  });
+});
+
+/**
+ * Drift guard. The two download routes are twins that are NOT parity-tested and
+ * HAVE diverged (388 diff lines as of #3870 — the tenant copy is missing the
+ * split-page image resolver, the bounded-concurrency prefetch and the zip
+ * streaming). Whole-file parity is therefore not assertable; what this pins is
+ * that neither route re-implements the text markup locally, which is how the
+ * notes-off bug survived in the export for months after the reader was fixed.
+ */
+describe('download routes share one markup implementation', () => {
+  const routes = [
+    'src/app/api/books/[id]/download/route.ts',
+    'src/app/api/[tenant]/books/[id]/download/route.ts',
+  ];
+
+  for (const rel of routes) {
+    const src = readFileSync(path.join(process.cwd(), rel), 'utf8');
+
+    it(`${rel} imports markdownToHtml instead of defining it`, () => {
+      expect(src).toContain("from '@/lib/export-markdown-html'");
+      expect(src).not.toMatch(/function\s+markdownToHtml\s*\(/);
+    });
+
+    it(`${rel} does not delete page-mark content locally`, () => {
+      // The exact shape of the #3870 bug: a regex removing <margin>/<gloss>
+      // together with everything inside it.
+      expect(src).not.toMatch(/<(?:margin|gloss)>\[\\s\\S\]\*\?<\\\/(?:margin|gloss)>\/gi,\s*''/);
+    });
+  }
+});


### PR DESCRIPTION
Closes #3870.

## The bug

`markdownToHtml`'s `stripNotes` branch in both download routes did this:

```
html.replace(/<margin>[\s\S]*?<\/margin>/gi, '')   // deletes the CONTENT
html.replace(/<gloss>[\s\S]*?<\/gloss>/gi, '')     // deletes the CONTENT
// ...and <term> survived downstream as <em>, its <note> already gone
```

Two user-visible defects:

1. **Dangling term chips** (what the issue reported) — a trailing glossary entry
   `<term>bite</term> <note>original: "morsus."</note>` exported as a bare italic
   "bite" with no definition.
2. **Deleted transcription** (found while verifying, not in the issue as filed, and
   the worse of the two) — `<margin>`/`<gloss>` mark text *physically present on the
   page*. The reader was fixed for exactly this in #3811 ("turning Notes off must
   never delete a page mark's content — that is transcription"). The export was
   still doing it. On a plate or map page whose text is mostly cartouche labels, the
   scholarly EPUB came out empty.

Measured against the old implementation before writing the fix:

| input | old output |
|---|---|
| `The <margin>The level</margin> of the wall` | `The  of the wall` |
| `Real sentence.\n<term>bite</term> <note>…</note>` | `Real sentence.\n<em class="term">bite</em> ` |
| `<margin>Mare Germanicum</margin>\n<insert>Oceanus</insert>` | `\n<insert>Oceanus</insert>` |

## The cause, and what actually fixes it

The rule for what "notes off" means was implemented independently on five surfaces
(reader, EPUB ×2, PDF, Typst — census in #3825), so #3811's fix reached one of them.
Fixing the regexes in place would have left four copies and the same drift.

- **`src/lib/notes-off.ts`** — one definition of the rule (glossary-line drop,
  page-mark unwrap, AI-annotation strip), imported by the reader and both exports.
  `NotesRenderer` now only decides *when* to apply it, never what it does.
- **`src/lib/export-markdown-html.ts`** — the 86-line `markdownToHtml` was duplicated
  character-for-character in both download routes. Extracted, not tested-for-parity.

## On the parity test the issue asked for

The issue says the twins are "byte-identical". **They are not, and haven't been for a
while** — 388 diff lines, and the tenant copy is the one missing fixes: the canonical
`getPageImageUrl` display-variant resolver (so split-from-spread pages export the
*wrong image* on partner subdomains), the bounded-concurrency prefetch (the
Cloudflare 524 fix), images-zip streaming, and the PDF facsimile truncation notice.
A whole-file parity assert would just fail on all of that.

So the guard here is narrower and honest about it: the test asserts neither route
*defines* `markdownToHtml` or re-inlines a page-mark-deleting regex. The image-path
drift is a real reader-facing bug on the BPH/EFM subdomains, out of scope for this
PR, and filed separately rather than folded in.

## Scope

**In:** the notes-off rule, the two EPUB/HTML export paths, the shared extraction, tests.

**Out:** PDF and Typst export paths (they never delete page-mark content —
`pdf-export.ts` unwraps `<term>` and brackets `<margin>` — so they carry the drift
risk but not the bug; folding them in would mix a refactor into a fix). The
tenant-twin image drift, filed separately. #3698's unbalanced-`<margin>` validator,
which is a write-boundary concern.

## Verification

- 18 new tests; the three behavioural ones were **run against the old implementation
  first and confirmed failing** — a guard that only passes after the fix proves nothing.
- Full suite: 2613 passed / 184 files.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
