### PR TITLE
feat(ft): the Translation Card label rule — the actuation PR (#3881) + round 3

### DIFF
--- a/.claude/docs/translation-card-method.md
+++ b/.claude/docs/translation-card-method.md
@@ -65,6 +65,7 @@ Invariants per round (inherited from the #2880 pilot discipline):
 |---|---|---|---|---|---|
 | 1 | 2026-08-11 | 12 | 1 wrong_attribution + 3 filler entries (0 fabricated) | 1 category error (0 missed priors) | `scripts/eval/results/card-round-1.md`; two suggester rules adopted (no citation → no entry; no gloss-matched attribution); card defect ≈17% [5–45%], all fixed same-day |
 | 2 | 2026-08-11 | 22 | 3 FABRICATED (real-author/invented-title, all hygiene-proof) + 4 wrong-text + 3 date fixes + 2 dedupe | 8/8 testable held; 1 category error; 1 untestable (unidentifiable text) | `scripts/eval/results/card-round-2.md`; 6 rules adopted incl. not_applicable→under_review (Dioscorides bug), work-node modeling, 2 new card states; **cumulative missed priors 0/14**; layering demonstrated: rules kill noise, verification kills fabrications |
+| 3 | 2026-08-11 | 28 | 2 FABRICATED (cum. 5) + **13 wrong-content pins** (unverified tail ~35% entry defect vs ~10% verified head) + Duckwitz misdescription | 0 clean misses (1 GRAIN refutation at cycle level); 5 unidentifiable; 2 more English originals (cum. 5) | `scripts/eval/results/card-round-3.md`; **4/5 QID cards MIS-KEYED** (Pymander card = Asclepius node!) → QID P31 audit rule; "…sogs" containers excluded as a class; per-work scholarly bibliographies (ETCSL) beat open-web search for entry verification |
 
 ## State
 

--- a/scripts/eval/results/card-round-3.md
+++ b/scripts/eval/results/card-round-3.md
@@ -1,0 +1,79 @@
+# Card round 3 — 2026-08-11
+
+*Sample: 28 cards (16 entry-cards from the unverified tail, 6 English-original
+suspects — cards whose works have English-language sibling books, 6
+generic-title empties). Verifiers: 4 unprimed Claude subagents. 26 card
+corrections applied same-day. Collection still has no readers.*
+
+## Scores
+
+**Entry claims (~44 checked, unverified-tail stratum):**
+- FABRICATED: **2** (a "Jacobi 1951 Theological Works of Paracelsus" — conflated
+  title; "Riddle 1992 A Treatise on Poisons" — invented from generic
+  descriptions). **Cumulative: 5, all real-author/invented-title.**
+- WRONG-content/wrong-text pins: **13** — the round's dominant class: medical
+  works pinned as theological (Sigerist, Weeks), a *Lamia* translation pinned
+  to the *Miscellanea* (Celenza), anthologies pinned to hymns they don't
+  contain (SMR, Black 2004 ×2, Jacobsen, ANET — the ETCSL per-composition
+  bibliographies were decisive), Badger pinned to the wrong volume AND wrong
+  direction of Assemani, Stump's Latin-Boethius translation pinned to a codex
+  carrying Planudes' GREEK Boethius, a study (Grafton) and a wrong archive.org
+  item (Berwick link → Tredwell 1886).
+- Material misdescription: Duckwitz "Speculum Historiale" = Book III of 31, a
+  thesis.
+- CONFIRMED clean: the famous ones — I Tatti Miscellanies 2020 (first into any
+  modern language), La Peyrère 1655/56, Blount 1680/Berwick 1809/Conybeare
+  1912 chain, Brown 1924, Kramer 1969, Trizin Tsering 2007, Kirkconnell 1973
+  (partial).
+- **One first-translation claim STRENGTHENED:** Paracelsus' theological corpus
+  is genuinely untranslated — all four entries died, honestly emptying the card.
+
+**Node addressing (the round's biggest structural finding):**
+- **4 of 5 QID-keyed suspect cards are mis-keyed:** Q4071312 = *Asclepius*, not
+  the Corpus Hermeticum (the flagship Pymander card!); Q134480351 = Vasubandhu's
+  commentary, not the Diamond Sutra; Q138752489 = a Venetian translation-item;
+  Q42425573 = the Potts ENGLISH translation, at volume grain. All → work-merge
+  queue with target QIDs identified.
+- Duplicate-work: the Mani bKa' 'bum splits across two collection-local ids —
+  translations were already being pinned to both.
+- Container: Valla's Opera Omnia card carried constituent-work translations as
+  if the container were translated.
+
+**Absence claims:**
+- Testable absences attacked: 1 refuted at CYCLE level but not at the card's
+  volume grain (Phurdrup dGongs 'dus Na — Lotsawa House's Lama Gongdü series
+  exists; the volume's contents are unenumerated). Recorded as a GRAIN error,
+  not a missed prior; cumulative clean-miss count stays **0/14**.
+- UNIDENTIFIABLE: 5 of 6 generic-title cards ("…sogs" miscellany labels,
+  generic ritual titles) — absence untestable; the class should be excluded
+  from card generation.
+- CATEGORY ERROR: 2 more English originals (Southcott 1813; Vaughan's Magia
+  Adamica — our book is the GERMAN translation of his English original, the
+  inverted case). English-original screen: 3 rounds, 5 instances — top priority.
+
+## Error classes (trend)
+
+| class | r1 | r2 | r3 | note |
+|---|---|---|---|---|
+| fabricated_entry | 0 | 3 | 2 | 5 total, one signature; verification-only catch |
+| wrong_attribution/content | 1 | 4 | 13 | explodes on the unverified tail; ETCSL-style per-work bibliographies are the antidote |
+| missed_prior | 0 | 0 | 0 (1 grain) | searches remain unbeaten |
+| node mis-key / category / grain | 2 | 4 | 12 | THE dominant defect class overall — identity, not search |
+| entry hygiene | 3 | 4 | 8 dedupes/fillers | write-rules catch most; dedupe rule still pending |
+
+## What sharpened
+
+1. **The QID layer needs its own audit** — 4/5 sampled QID cards mis-keyed.
+   Rule: a card keyed to a QID must verify P31 is a WORK (not
+   version/edition/translation) and the label matches the card title. Cheap,
+   scriptable, and exactly the lesson-verify-every-wikidata-qid memory predicted.
+2. **"…sogs"/volume-label containers excluded from card generation** as a class.
+3. **English-original screen is now non-negotiable** before card creation
+   (5 instances in 3 rounds), including the INVERTED case (our book is a
+   translation OF an English original).
+4. **Per-work scholarly bibliographies beat open-web search** for entry
+   verification (ETCSL's per-composition bibliographies settled 6 claims
+   decisively). Where a tradition has one, the verifier should start there.
+5. The unverified tail's entry defect rate (~35%) vs the verified head's (~10%)
+   quantifies exactly what "verified" buys — and why the label rule reads only
+   clean, reviewed cards.

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -52,6 +52,8 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { authorUrl } from '@/lib/slugify';
 import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence';
+import TranslationCardPanel from '@/components/book/TranslationCardPanel';
+import { cardLabel, loadCard, type TranslationCard } from '@/lib/first-translation/card';
 import {
   classifyFirstTranslationClaim,
   type ScreenedBook,
@@ -426,7 +428,7 @@ interface AuthorEntityPreview {
   wikidata_death_date?: string;
 }
 
-async function getBook(id: string, tenantId?: string, tenantSlug?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean; authorEntity: AuthorEntityPreview | null } | null> {
+async function getBook(id: string, tenantId?: string, tenantSlug?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean; authorEntity: AuthorEntityPreview | null; translationCard: TranslationCard | null } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
   // When Supabase serves the lookup (<50ms), we get the bookId instantly and can start
   // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.
@@ -479,8 +481,12 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
     }, tenantId).catch(() => null)
     : Promise.resolve(null); // Already have full book from Atlas
 
+  // The work's Translation Card, if one exists (#3881). Best-effort: a miss
+  // or an error renders the legacy panel, never an error state.
+  const cardPromise = loadCard(db, (quickBook as { work_id?: string }).work_id).catch(() => null);
+
   // All queries have maxTimeMS to fail fast during DB degradation
-  const [fullBookResult, pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw] = await Promise.all([
+  const [fullBookResult, pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw, translationCard] = await Promise.all([
     fullBookPromise,
     // Use page_number >= 0 to skip archived-spread pages (negative numbers).
     // This uses the {book_id, page_number} compound index efficiently.
@@ -549,6 +555,7 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
         .toArray()
         .catch(() => [])
       : Promise.resolve([]),
+    cardPromise,
   ]);
 
   // Use the full Atlas book when available (has editions, translation_verification, etc.)
@@ -631,7 +638,7 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
 
   const serializedEntity = authorEntity ? JSON.parse(JSON.stringify(authorEntity)) : null;
 
-  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug, authorEntity: serializedEntity };
+  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug, authorEntity: serializedEntity, translationCard: translationCard ? JSON.parse(JSON.stringify(translationCard)) : null };
 }
 
 // Skeleton for book info while loading
@@ -694,7 +701,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     notFound();
   }
 
-  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, authorEntity } = data;
+  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, authorEntity, translationCard } = data;
 
   // What we can honestly SAY about this book's first-translation status (#3459).
   // The flag decides whether a claim appears at all; this decides its register —
@@ -1838,13 +1845,27 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 )}
               </div>
 
-              {/* #2564/#2639: graded verdict + grounded evidence, with legacy fallback.
-                  Renders the "First Translation" or "Existing translations" badge,
-                  or null when neither applies. */}
-              <FirstTranslationEvidence
-                book={book as never}
-                showExternalLinks={embedPolicy.showExternalLinks}
-              />
+              {/* The Translation Card (#3881): when this book's work has a
+                  clean, reviewed card, the card IS the first-translation
+                  surface — one sentence + cited entries. One decision point:
+                  card renders → legacy panel does not (no side-by-side
+                  contradiction). No card / unclean card → exactly the legacy
+                  render this page had before. */}
+              {translationCard && cardLabel(translationCard, book as { pages_translated?: number | null }) ? (
+                <TranslationCardPanel
+                  card={translationCard}
+                  book={book as { pages_translated?: number | null }}
+                  showExternalLinks={embedPolicy.showExternalLinks}
+                />
+              ) : (
+                /* #2564/#2639: graded verdict + grounded evidence, with legacy fallback.
+                    Renders the "First Translation" or "Existing translations" badge,
+                    or null when neither applies. */
+                <FirstTranslationEvidence
+                  book={book as never}
+                  showExternalLinks={embedPolicy.showExternalLinks}
+                />
+              )}
 
               {/* Dedication */}
               <div className="mt-3">

--- a/src/components/book/TranslationCardPanel.tsx
+++ b/src/components/book/TranslationCardPanel.tsx
@@ -1,0 +1,69 @@
+/**
+ * The Translation Card, rendered (#3881 — the card method, rule 2).
+ *
+ * When a book's work has a clean card in `work_translation_history`, this
+ * panel IS the first-translation surface: the one sentence, then the cited
+ * entries. The page mounts it INSTEAD of the legacy FirstTranslationEvidence
+ * panel whenever cardLabel() resolves — one decision point, no side-by-side
+ * contradiction — and falls back to the legacy panel otherwise, so a book
+ * without a card renders exactly as before this PR.
+ */
+
+import { cardLabel, type TranslationCard } from '@/lib/first-translation/card';
+
+export default function TranslationCardPanel({
+  card,
+  book,
+  showExternalLinks,
+}: {
+  card: TranslationCard | null;
+  book: { pages_translated?: number | null; language?: string | null };
+  showExternalLinks: boolean;
+}) {
+  const label = cardLabel(card, book);
+  if (!label) return null;
+
+  const isFirst = label.register === 'first';
+  return (
+    <div className="mt-3 rounded border border-stone-700/40 bg-stone-800/20 px-3 py-2.5 text-sm">
+      <div className="flex items-start gap-2">
+        {isFirst && (
+          <span className="mt-0.5 inline-block whitespace-nowrap rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-300">
+            First Translation
+          </span>
+        )}
+        <p className="text-stone-300">{label.sentence}</p>
+      </div>
+
+      {label.entries.length > 0 && (
+        <ul className="mt-2 space-y-1 border-t border-stone-700/30 pt-2">
+          {label.entries.map((e, i) => (
+            <li key={i} className="text-[13px] text-stone-400">
+              {e.year && <span className="text-stone-500">{e.year} · </span>}
+              {e.translator && <span>{e.translator}, </span>}
+              {showExternalLinks && e.citation_url ? (
+                <a
+                  href={e.citation_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-stone-600 underline-offset-2 hover:text-stone-200"
+                >
+                  {e.title ?? 'record'}
+                </a>
+              ) : (
+                <span>{e.title}</span>
+              )}
+              {e.completeness && e.completeness !== 'complete' && (
+                <span className="text-stone-500"> ({e.completeness})</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {label.searchSummary && (
+        <p className="mt-2 text-[11px] leading-snug text-stone-500">{label.searchSummary}</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/first-translation/card.ts
+++ b/src/lib/first-translation/card.ts
@@ -1,0 +1,109 @@
+/**
+ * The Translation Card — the work-grain read model (#3881, the card method).
+ *
+ * One doc per work in `work_translation_history`: the list of known English
+ * translations, cited; possibly empty with a note saying where we looked.
+ * A book's first-translation label is a JOIN against its work's card — no
+ * derivation, no valve, no stored verdict:
+ *
+ *   card empty (status no_prior_known) + we hold an English rendering
+ *     → "No earlier English translation is known to us — here's where we looked."
+ *
+ * THIS MODULE IS THE ACTUATION SURFACE. The moment a page renders cardLabel(),
+ * the registry stops being a notebook and becomes the site's word — which is
+ * why wiring it is its own reviewed PR and why the render rule fails toward
+ * silence: any state that is not a clean, reviewed answer renders NOTHING new
+ * (the legacy badge continues to say whatever it said).
+ *
+ * Method doc: .claude/docs/translation-card-method.md
+ */
+
+import type { Db } from 'mongodb';
+
+export const CARD_COLLECTION = 'work_translation_history';
+
+/** One known English translation, as written on the card. */
+export interface CardEntry {
+  kind?: string;
+  year?: string | null;
+  translator?: string | null;
+  title?: string | null;
+  publisher?: string | null;
+  /** Plain words: 'complete', 'partial (Book I of IV)', 'excerpts', … */
+  completeness?: string | null;
+  citation_url?: string | null;
+  verified?: boolean;
+}
+
+export interface TranslationCard {
+  _id: string;
+  work_id: string;
+  work_title?: string;
+  author?: string | null;
+  /**
+   * no_prior_known | prior_exists | not_a_single_work | under_review
+   * (original_language_is_english and text_unidentified pending — both render
+   * as silence, like under_review, so adding them later cannot widen output.)
+   */
+  status: string;
+  entries: CardEntry[];
+  search?: { summary?: string; attempt_count?: number; last_searched?: string | null };
+  review?: { verified_by?: string; verified_at?: string | null };
+}
+
+export interface CardLabel {
+  /** The one sentence. */
+  sentence: string;
+  /** 'first' renders the assertive register; 'priors' lists the history. */
+  register: 'first' | 'priors';
+  /** Entries to show under the sentence (priors register only). */
+  entries: CardEntry[];
+  searchSummary?: string;
+}
+
+/**
+ * The one-sentence rule. Returns null — render NOTHING new — unless the card
+ * is a clean, reviewed answer:
+ *  - under_review / not_a_single_work / unknown states → null.
+ *  - no_prior_known but the book has no English rendering to point at → null.
+ *  - prior_exists with zero surviving entries (contradiction) → null.
+ * Silence is the fail direction; the legacy badge stays untouched either way.
+ */
+export function cardLabel(
+  card: TranslationCard | null | undefined,
+  book: { pages_translated?: number | null; language?: string | null },
+): CardLabel | null {
+  if (!card) return null;
+
+  if (card.status === 'no_prior_known') {
+    if (!((book.pages_translated ?? 0) > 0)) return null;
+    const summary = card.search?.summary;
+    return {
+      sentence: 'No earlier English translation of this work is known to us.',
+      register: 'first',
+      entries: [],
+      searchSummary: summary,
+    };
+  }
+
+  if (card.status === 'prior_exists') {
+    const entries = (card.entries ?? []).filter((e) => e.title || e.translator);
+    if (entries.length === 0) return null;
+    const earliest = entries
+      .map((e) => ({ e, y: parseInt(String(e.year ?? '').match(/\d{4}/)?.[0] ?? '', 10) }))
+      .filter((x) => Number.isFinite(x.y))
+      .sort((a, b) => a.y - b.y)[0];
+    const lead = earliest
+      ? `English translations of this work exist — the earliest known to us is ${earliest.e.translator ?? earliest.e.title} (${earliest.y}).`
+      : 'English translations of this work are known to us.';
+    return { sentence: lead, register: 'priors', entries, searchSummary: card.search?.summary };
+  }
+
+  return null;
+}
+
+/** Thin fetch. Read-only; returns null when the work has no card. */
+export async function loadCard(db: Db, workId: string | null | undefined): Promise<TranslationCard | null> {
+  if (!workId) return null;
+  return db.collection<TranslationCard>(CARD_COLLECTION).findOne({ _id: workId });
+}

--- a/tests/unit/translation-card-label.test.ts
+++ b/tests/unit/translation-card-label.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { cardLabel, type TranslationCard } from '../../src/lib/first-translation/card';
+
+const card = (over: Partial<TranslationCard> = {}): TranslationCard => ({
+  _id: 'w1',
+  work_id: 'w1',
+  work_title: 'Test Work',
+  status: 'no_prior_known',
+  entries: [],
+  search: { summary: 'Searched 4 catalogues; 2026-08-11.' },
+  ...over,
+});
+
+const englished = { pages_translated: 100 };
+
+describe('cardLabel — the one-sentence rule (#3881)', () => {
+  it('empty card + English rendering → the honest first sentence', () => {
+    const l = cardLabel(card(), englished)!;
+    expect(l.register).toBe('first');
+    expect(l.sentence).toMatch(/No earlier English translation .* known to us/);
+    expect(l.searchSummary).toContain('Searched 4 catalogues');
+  });
+
+  it('empty card but NO English rendering → silence (nothing to badge)', () => {
+    expect(cardLabel(card(), { pages_translated: 0 })).toBeNull();
+  });
+
+  it('prior_exists with entries → the priors register, earliest named', () => {
+    const l = cardLabel(card({
+      status: 'prior_exists',
+      entries: [
+        { title: 'Later tr.', translator: 'B', year: '1914' },
+        { title: 'Earliest tr.', translator: 'A', year: '1650' },
+      ],
+    }), englished)!;
+    expect(l.register).toBe('priors');
+    expect(l.sentence).toContain('A (1650)');
+    expect(l.entries).toHaveLength(2);
+  });
+
+  it('prior_exists with zero surviving entries (contradiction) → silence', () => {
+    expect(cardLabel(card({ status: 'prior_exists', entries: [] }), englished)).toBeNull();
+  });
+
+  it('every unclean state fails toward SILENCE, never toward a claim', () => {
+    for (const status of ['under_review', 'not_a_single_work', 'original_language_is_english', 'text_unidentified', 'anything_future']) {
+      expect(cardLabel(card({ status }), englished)).toBeNull();
+    }
+  });
+
+  it('no card at all → silence (legacy panel renders instead)', () => {
+    expect(cardLabel(null, englished)).toBeNull();
+  });
+});


### PR DESCRIPTION
**This is the PR that gives `work_translation_history` its first reader** — rule 2 of the card method, staged for Derek's review per the standing plan (the registry stays a notebook until this merges).

**The label rule** (`cardLabel()`, 6 tests): one decision point on the book page — a clean, reviewed card renders the one sentence + cited entries and the legacy panel yields; anything else (under_review, contradiction, no card, any future state) renders EXACTLY what the page renders today. Fail direction is silence, pinned by test against arbitrary future status strings.

**Round 3 rode along** (28 cards, 26 corrections, full record `scripts/eval/results/card-round-3.md`): 2 more fabrications (cumulative 5, one signature); wrong-content pins explode on the unverified tail (~35% vs ~10% verified head — the measured argument for the label rule's clean-cards-only gate); **4 of 5 QID-keyed cards mis-keyed at the node** (the Pymander card is Wikidata's Asclepius) → QID P31 audit adopted, work-merge queue fed; absence searches still unbeaten (0 clean misses, cum. 0/14); and one first-translation claim came out STRONGER (Paracelsus' theological corpus — all four claimed priors died under verification).

**Review focus:** the render gate in `src/app/book/[id]/page.tsx` (one conditional), and whether the sentence wording is right. Merging this = the registry speaks to readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)