### PR TITLE
feat(downloads): facsimile PDF as facing-page spreads with colored annotations

### DIFF
--- a/scripts/qa/render-book-pdf.ts
+++ b/scripts/qa/render-book-pdf.ts
@@ -1,0 +1,138 @@
+/**
+ * Local PDF-download QA harness.
+ *
+ * Renders the SAME generator code the download routes serve
+ * (src/lib/pdf-export.ts) against real production data, without auth or a
+ * deploy — so download-format changes can be inspected visually before they
+ * ship, and regressions reproduced from a reader report in one command.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/qa/render-book-pdf.ts <bookId> [pdf-facsimile|pdf-translation] [outPath]
+ *
+ * Output defaults to scripts/output/<bookId>-<format>.pdf (gitignored scratch).
+ * Open the PDF in a viewer that supports two-page view (Preview: View →
+ * Two Pages) to check facsimile spreads, or let Claude Read it page by page.
+ *
+ * The image path mirrors the route: canonical resolver (getPageImageUrl,
+ * display variant) → fetch → sharp resize/compress → ordered bounded stream.
+ */
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { createWriteStream, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import {
+  generatePdfFacsimileStream,
+  generatePdfTranslationStream,
+  type PdfBookInfo,
+  type PdfExportPage,
+} from '../../src/lib/pdf-export';
+import { getPageImageUrl } from '../../src/lib/page-image-url';
+import { streamOrdered } from '../../src/lib/ordered-stream';
+
+const BASE_URL = 'https://sourcelibrary.org';
+
+type QaPage = PdfExportPage & Record<string, unknown>;
+
+function pageExportImageUrl(page: QaPage): string | null {
+  const legacy =
+    (page as { compressed_photo?: string }).compressed_photo ||
+    (page as { photo?: string }).photo ||
+    null;
+  const resolved = getPageImageUrl(page as Parameters<typeof getPageImageUrl>[0], 'display') || legacy;
+  if (!resolved) return null;
+  return resolved.startsWith('/') ? `${BASE_URL}${resolved}` : resolved;
+}
+
+async function fetchFacsimilePdfImage(url: string): Promise<Buffer | null> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(60000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return await sharp(buffer)
+      .resize(1600, 1600, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: 78, mozjpeg: true })
+      .toBuffer();
+  } catch (e) {
+    console.error(`image fetch failed: ${url}`, e);
+    return null;
+  }
+}
+
+async function* streamPageImagesOrdered(validPages: QaPage[]) {
+  const stream = streamOrdered(
+    validPages,
+    page => {
+      const url = pageExportImageUrl(page);
+      return url ? fetchFacsimilePdfImage(url) : Promise.resolve(null);
+    },
+    { concurrency: 8, lookahead: 12 },
+  );
+  for await (const { item, value } of stream) {
+    yield { page: item, imageBuffer: value };
+  }
+}
+
+async function main() {
+  const [bookId, format = 'pdf-facsimile', outArg] = process.argv.slice(2);
+  if (!bookId || !['pdf-facsimile', 'pdf-translation'].includes(format)) {
+    console.error('Usage: npx tsx scripts/qa/render-book-pdf.ts <bookId> [pdf-facsimile|pdf-translation] [outPath]');
+    process.exit(1);
+  }
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set — source .env.production.local first');
+    process.exit(1);
+  }
+
+  const client = await MongoClient.connect(uri);
+  const db = client.db('bookstore');
+  const book = await db.collection('books').findOne({ id: bookId });
+  if (!book) {
+    console.error(`book ${bookId} not found`);
+    process.exit(1);
+  }
+  const pages = (await db
+    .collection('pages')
+    .find({ book_id: bookId })
+    .sort({ page_number: 1 })
+    .toArray()) as unknown as QaPage[];
+  await client.close();
+
+  console.log(`${book.title} — ${pages.length} pages, format ${format}`);
+
+  const outPath = outArg || join('scripts', 'output', `${bookId}-${format}.pdf`);
+  mkdirSync(dirname(outPath), { recursive: true });
+
+  const bookInfo: PdfBookInfo = {
+    id: book.id,
+    title: book.title,
+    display_title: book.display_title,
+    author: book.author || 'Anonymous',
+    language: book.language || 'Unknown',
+    published: book.published,
+  };
+
+  const doc =
+    format === 'pdf-facsimile'
+      ? generatePdfFacsimileStream(bookInfo, pages, {
+          baseUrl: BASE_URL,
+          hasImage: p => !!pageExportImageUrl(p),
+          streamImages: streamPageImagesOrdered,
+        })
+      : generatePdfTranslationStream(bookInfo, pages, { baseUrl: BASE_URL });
+
+  const out = createWriteStream(outPath);
+  doc.pipe(out);
+  await new Promise<void>((resolve, reject) => {
+    out.on('finish', () => resolve());
+    out.on('error', reject);
+    doc.on('error', reject);
+  });
+  console.log(`wrote ${outPath}`);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -18,7 +18,7 @@ import { markForExport } from '@/lib/provenance';
 import { getBookIndex } from '@/lib/book-index';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { Readable } from 'stream';
-import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
+import { generatePdfTranslationStream, generatePdfFacsimileStream } from '@/lib/pdf-export';
 import { markdownToHtml } from '@/lib/export-markdown-html';
 import {
   fetchAndCompressImage,
@@ -26,6 +26,7 @@ import {
   hasExportImage,
   fetchPageImagesOrdered,
   streamPageImagesOrdered,
+  fetchFacsimilePdfImage,
   generateImagesZipStream,
 } from '@/lib/export-page-images';
 
@@ -36,19 +37,6 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://sourcelibrary.org'
 // one image per page; give the function room beyond the default window. This
 // route ran on the default window until #3909 while its twin had 300s.
 export const maxDuration = 300;
-
-/**
- * Budget for the image phase, in ms. `maxDuration` on this route is 300s; we
- * stop ADDING pages at 210s so there is room to finish the page in hand, write
- * the truncation notice and the colophon, and flush.
- *
- * A big book cannot be served whole in one request (a 4,198-page book would
- * need ~40 minutes of fetching), so the choice is between an opaque timeout and
- * an honest partial edition. Per CLAUDE.md "no silent caps": if coverage is
- * bounded, say what was dropped — here in the PDF itself, so the artifact
- * carries its own provenance rather than relying on a header nobody reads.
- */
-const FACSIMILE_IMAGE_BUDGET_MS = 210_000;
 
 // Index entry structure (from book index collection)
 interface ConceptEntry {
@@ -1163,161 +1151,6 @@ p:first-of-type { text-indent: 0; }
 
     archive.finalize();
   });
-}
-
-// Generate text-only English translation PDF — see the main download route
-// for the full rationale (streamed, Unicode font, quote-integrity cleanup).
-function generatePdfTranslationStream(book: Book, pages: Page[]): PDFKit.PDFDocument {
-  const now = new Date().toISOString().split('T')[0];
-  const { doc, fonts } = createPdfDocument(book);
-
-  const translatedPages = pages.filter(p => p.translation?.data);
-
-  (async () => {
-    writePdfTitlePage(doc, fonts, book, {
-      subtitle: 'English Translation',
-      baseUrl: BASE_URL,
-      now,
-    });
-
-    doc.addPage();
-
-    for (const page of translatedPages) {
-      if (!page.translation?.data) continue;
-      const text = cleanTranslationForPdf(page.translation.data, book.id);
-      if (!text) continue;
-
-      writePdfPageHeading(doc, fonts, page.page_number);
-      writePdfBody(doc, fonts, text, { fontSize: 11, lineGap: 3 });
-      doc.moveDown(0.8);
-    }
-
-    doc.addPage();
-    writePdfColophon(doc, fonts, book, {
-      baseUrl: BASE_URL,
-      now,
-      contentLabel: 'English translation',
-      translatedCount: translatedPages.length,
-      totalCount: pages.length,
-    });
-
-    doc.end();
-  })().catch(err => {
-    console.error('pdf-translation stream failed:', err);
-    doc.destroy(err instanceof Error ? err : new Error(String(err)));
-  });
-
-  return doc;
-}
-
-// Generate facsimile PDF (page scans + translation) — see the main download
-// route for the full rationale.
-function generatePdfFacsimileStream(book: Book, pages: Page[]): PDFKit.PDFDocument {
-  const now = new Date().toISOString().split('T')[0];
-  const { doc, fonts } = createPdfDocument(book);
-
-  const validPages = pages.filter(p => pageExportImageUrl(p) || p.translation?.data);
-
-  (async () => {
-    writePdfTitlePage(doc, fonts, book, {
-      subtitle: 'Facsimile Edition — page scans with English translation',
-      baseUrl: BASE_URL,
-      now,
-    });
-
-    // Yields each page AS ITS IMAGE ARRIVES. `fetchPageImagesOrdered` awaited
-    // EVERY image before writing a byte, so the response sat silent for the
-    // whole fetch (231s on a 366-page book) and Cloudflare killed it, with
-    // every compressed image resident at once — #3597, fixed on the global
-    // route and never ported here (#3909).
-    console.log(`Streaming ${validPages.length} images for pdf-facsimile...`);
-    const startedAt = Date.now();
-    let written = 0;
-    let translated = 0;
-    let truncated = false;
-
-    const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
-    const usableHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
-
-    for await (const { page, imageBuffer } of streamPageImagesOrdered(validPages)) {
-      if (Date.now() - startedAt > FACSIMILE_IMAGE_BUDGET_MS) {
-        truncated = true;
-        break;
-      }
-      written++;
-      if (page.translation?.data) translated++;
-      doc.addPage();
-      writePdfPageHeading(doc, fonts, page.page_number);
-
-      if (imageBuffer) {
-        try {
-          doc.image(imageBuffer, { fit: [usableWidth, usableHeight * 0.6], align: 'center' });
-        } catch (e) {
-          console.error(`pdf-facsimile: failed to embed image for page ${page.page_number}:`, e);
-          doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
-          doc.fillColor('#000000');
-        }
-      } else {
-        doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
-        doc.fillColor('#000000');
-      }
-
-      if (page.translation?.data) {
-        const text = cleanTranslationForPdf(page.translation.data, book.id);
-        if (text) {
-          doc.moveDown(0.5);
-          writePdfBody(doc, fonts, text, { fontSize: 10.5, lineGap: 3 });
-        }
-      }
-    }
-
-    // A partial facsimile must say so in the artifact itself — it used to be
-    // labelled a complete "facsimile edition" with pages silently missing.
-    if (truncated) {
-      const firstMissing = validPages[written]?.page_number;
-      doc.addPage();
-      doc.font(fonts.bold).fontSize(14).text('This edition is incomplete', { align: 'center' });
-      doc.moveDown(1);
-      doc.font(fonts.regular).fontSize(11).text(
-        [
-          `This facsimile stops at page ${validPages[written - 1]?.page_number ?? written} of `
-          + `${validPages.length}. It was not truncated for editorial reasons: a single request `
-          + 'cannot fetch and lay out every page scan of a book this large within the time '
-          + 'available, so generation stopped rather than failing outright.',
-          '',
-          firstMissing !== undefined
-            ? `Pages from ${firstMissing} onward are not included here. They are all readable `
-              + `at ${BASE_URL}/book/${book.id}, and the text-only PDF and EPUB editions cover `
-              + 'the whole book.'
-            : '',
-          '',
-          'If you need the complete facsimile as a single file, please get in touch — we would '
-          + 'rather generate it for you offline than hand you a partial edition without saying so.',
-        ].filter(Boolean).join('\n'),
-        { lineGap: 3 },
-      );
-      console.warn(
-        `pdf-facsimile truncated: ${written}/${validPages.length} pages for book ${book.id} `
-        + `after ${Date.now() - startedAt}ms`,
-      );
-    }
-
-    doc.addPage();
-    writePdfColophon(doc, fonts, book, {
-      baseUrl: BASE_URL,
-      now,
-      contentLabel: truncated ? 'partial facsimile edition' : 'facsimile edition',
-      translatedCount: translated,
-      totalCount: pages.length,
-    });
-
-    doc.end();
-  })().catch(err => {
-    console.error('pdf-facsimile stream failed:', err);
-    doc.destroy(err instanceof Error ? err : new Error(String(err)));
-  });
-
-  return doc;
 }
 
 // Generate images-only EPUB (no translation, just the processed page images)
@@ -2685,8 +2518,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // ~100s origin window and die as a 524 saved as a corrupt file.
     if (isPdfTranslation || isPdfFacsimile) {
       const doc = isPdfFacsimile
-        ? generatePdfFacsimileStream(book as unknown as Book, pages as unknown as Page[])
-        : generatePdfTranslationStream(book as unknown as Book, pages as unknown as Page[]);
+        ? generatePdfFacsimileStream(book as unknown as Book, pages as unknown as Page[], {
+            baseUrl: BASE_URL,
+            hasImage: p => !!pageExportImageUrl(p as Page),
+            streamImages: ps => streamPageImagesOrdered(ps as Page[], fetchFacsimilePdfImage),
+          })
+        : generatePdfTranslationStream(book as unknown as Book, pages as unknown as Page[], {
+            baseUrl: BASE_URL,
+          });
       const suffix = isPdfFacsimile ? 'facsimile' : 'translation';
       return new Response(Readable.toWeb(doc) as unknown as ReadableStream, {
         headers: {

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -17,7 +17,7 @@ import { images } from '@/lib/api-client';
 import { markForExport } from '@/lib/provenance';
 import { getBookIndex } from '@/lib/book-index';
 import { Readable } from 'stream';
-import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
+import { generatePdfTranslationStream, generatePdfFacsimileStream } from '@/lib/pdf-export';
 import { markdownToHtml } from '@/lib/export-markdown-html';
 import {
   fetchAndCompressImage,
@@ -25,6 +25,7 @@ import {
   hasExportImage,
   fetchPageImagesOrdered,
   streamPageImagesOrdered,
+  fetchFacsimilePdfImage,
   generateImagesZipStream,
 } from '@/lib/export-page-images';
 
@@ -1145,177 +1146,6 @@ p:first-of-type { text-indent: 0; }
 
     archive.finalize();
   });
-}
-
-// Generate text-only English translation PDF: front matter, continuous
-// flowing translation text with a "PAGE N" heading before each page, then a
-// colophon. Streamed the same way as generateImagesZipStream — the returned
-// PDFDocument is itself a Readable; content is appended asynchronously after
-// the caller starts piping it to the response, so we never buffer the whole
-// document before the first byte goes out.
-function generatePdfTranslationStream(book: Book, pages: Page[]): PDFKit.PDFDocument {
-  const now = new Date().toISOString().split('T')[0];
-  const { doc, fonts } = createPdfDocument(book);
-
-  const translatedPages = pages.filter(p => p.translation?.data);
-
-  (async () => {
-    writePdfTitlePage(doc, fonts, book, {
-      subtitle: 'English Translation',
-      baseUrl: BASE_URL,
-      now,
-    });
-
-    doc.addPage();
-
-    for (const page of translatedPages) {
-      if (!page.translation?.data) continue;
-      const text = cleanTranslationForPdf(page.translation.data, book.id);
-      if (!text) continue;
-
-      writePdfPageHeading(doc, fonts, page.page_number);
-      writePdfBody(doc, fonts, text, { fontSize: 11, lineGap: 3 });
-      doc.moveDown(0.8);
-    }
-
-    doc.addPage();
-    writePdfColophon(doc, fonts, book, {
-      baseUrl: BASE_URL,
-      now,
-      contentLabel: 'English translation',
-      translatedCount: translatedPages.length,
-      totalCount: pages.length,
-    });
-
-    doc.end();
-  })().catch(err => {
-    console.error('pdf-translation stream failed:', err);
-    doc.destroy(err instanceof Error ? err : new Error(String(err)));
-  });
-
-  return doc;
-}
-
-/**
- * Budget for the image phase, in ms. `maxDuration` on this route is 300s; we
- * stop ADDING pages at 210s so there is room to finish the page in hand, write
- * the truncation notice and the colophon, and flush.
- *
- * A big book cannot be served whole in one request (a 4,198-page book would
- * need ~40 minutes of fetching), so the choice is between an opaque timeout and
- * an honest partial edition. Per CLAUDE.md "no silent caps": if coverage is
- * bounded, say what was dropped — here in the PDF itself, so the artifact
- * carries its own provenance rather than relying on a header nobody reads.
- */
-const FACSIMILE_IMAGE_BUDGET_MS = 210_000;
-
-// Generate facsimile PDF: title page, then per book page a "PAGE N" heading,
-// the page scan image, and the translation text flowing beneath it (onto
-// continuation pages as needed — pdfkit auto-paginates flowing text). Reuses
-// pageExportImageUrl() (canonical split-page-aware resolver) and
-// streamPageImagesOrdered() (bounded look-ahead, yields as images arrive).
-// Streamed the same way as generatePdfTranslationStream.
-function generatePdfFacsimileStream(book: Book, pages: Page[]): PDFKit.PDFDocument {
-  const now = new Date().toISOString().split('T')[0];
-  const { doc, fonts } = createPdfDocument(book);
-
-  // Pages with an image or a translation are worth a spread; pages with
-  // neither carry nothing to show.
-  const validPages = pages.filter(p => pageExportImageUrl(p) || p.translation?.data);
-
-  (async () => {
-    writePdfTitlePage(doc, fonts, book, {
-      subtitle: 'Facsimile Edition — page scans with English translation',
-      baseUrl: BASE_URL,
-      now,
-    });
-
-    console.log(`Streaming ${validPages.length} images for pdf-facsimile...`);
-    const startedAt = Date.now();
-    let written = 0;
-    let translated = 0;
-    let truncated = false;
-
-    const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
-    const usableHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
-
-    for await (const { page, imageBuffer } of streamPageImagesOrdered(validPages)) {
-      if (Date.now() - startedAt > FACSIMILE_IMAGE_BUDGET_MS) {
-        truncated = true;
-        break;
-      }
-      written++;
-      if (page.translation?.data) translated++;
-      doc.addPage();
-      writePdfPageHeading(doc, fonts, page.page_number);
-
-      if (imageBuffer) {
-        try {
-          doc.image(imageBuffer, { fit: [usableWidth, usableHeight * 0.6], align: 'center' });
-        } catch (e) {
-          console.error(`pdf-facsimile: failed to embed image for page ${page.page_number}:`, e);
-          doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
-          doc.fillColor('#000000');
-        }
-      } else {
-        doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
-        doc.fillColor('#000000');
-      }
-
-      if (page.translation?.data) {
-        const text = cleanTranslationForPdf(page.translation.data, book.id);
-        if (text) {
-          doc.moveDown(0.5);
-          writePdfBody(doc, fonts, text, { fontSize: 10.5, lineGap: 3 });
-        }
-      }
-    }
-
-    if (truncated) {
-      const firstMissing = validPages[written]?.page_number;
-      doc.addPage();
-      doc.font(fonts.bold).fontSize(14).text('This edition is incomplete', { align: 'center' });
-      doc.moveDown(1);
-      doc.font(fonts.regular).fontSize(11).text(
-        [
-          `This facsimile stops at page ${validPages[written - 1]?.page_number ?? written} of `
-          + `${validPages.length}. It was not truncated for editorial reasons: a single request `
-          + 'cannot fetch and lay out every page scan of a book this large within the time '
-          + 'available, so generation stopped rather than failing outright.',
-          '',
-          firstMissing !== undefined
-            ? `Pages from ${firstMissing} onward are not included here. They are all readable `
-              + `at ${BASE_URL}/book/${book.id}, and the text-only PDF and EPUB editions cover `
-              + 'the whole book.'
-            : '',
-          '',
-          'If you need the complete facsimile as a single file, please get in touch — we would '
-          + 'rather generate it for you offline than hand you a partial edition without saying so.',
-        ].filter(Boolean).join('\n'),
-        { lineGap: 3 },
-      );
-      console.warn(
-        `pdf-facsimile truncated: ${written}/${validPages.length} pages for book ${book.id} `
-        + `after ${Date.now() - startedAt}ms`,
-      );
-    }
-
-    doc.addPage();
-    writePdfColophon(doc, fonts, book, {
-      baseUrl: BASE_URL,
-      now,
-      contentLabel: truncated ? 'partial facsimile edition' : 'facsimile edition',
-      translatedCount: translated,
-      totalCount: pages.length,
-    });
-
-    doc.end();
-  })().catch(err => {
-    console.error('pdf-facsimile stream failed:', err);
-    doc.destroy(err instanceof Error ? err : new Error(String(err)));
-  });
-
-  return doc;
 }
 
 // Generate images-only EPUB (no translation, just the processed page images)
@@ -2670,8 +2500,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // book and die as a 524 saved as a corrupt file.
     if (isPdfTranslation || isPdfFacsimile) {
       const doc = isPdfFacsimile
-        ? generatePdfFacsimileStream(book as unknown as Book, pages as unknown as Page[])
-        : generatePdfTranslationStream(book as unknown as Book, pages as unknown as Page[]);
+        ? generatePdfFacsimileStream(book as unknown as Book, pages as unknown as Page[], {
+            baseUrl: BASE_URL,
+            hasImage: p => !!pageExportImageUrl(p as Page),
+            streamImages: ps => streamPageImagesOrdered(ps as Page[], fetchFacsimilePdfImage),
+          })
+        : generatePdfTranslationStream(book as unknown as Book, pages as unknown as Page[], {
+            baseUrl: BASE_URL,
+          });
       const suffix = isPdfFacsimile ? 'facsimile' : 'translation';
       return new Response(Readable.toWeb(doc) as unknown as ReadableStream, {
         headers: {

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -284,7 +284,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
           </div>
 
           {hasTranslations && hasImages && !imageRestricted && (
-            <FormatOption format="pdf-facsimile" label="Facsimile PDF" desc="Page scans + translation"
+            <FormatOption format="pdf-facsimile" label="Facsimile PDF" desc="Scan facing its translation, like the reader"
               icon={<FileType className="w-4 h-4 text-emerald-700" />}
               onDownload={handleDownload} downloading={downloading} />
           )}

--- a/src/lib/export-page-images.ts
+++ b/src/lib/export-page-images.ts
@@ -54,6 +54,27 @@ export async function fetchAndCompressImage(url: string): Promise<Buffer | null>
 }
 
 /**
+ * Facsimile-PDF image variant. Unlike fetchAndCompressImage() above (600×900
+ * grayscale — sized for e-reader screens), the facsimile PDF is a print-shaped
+ * artifact whose scan fills a full A4 page, so it keeps COLOR and real
+ * resolution. Reader feedback (2026-08-10) flagged the washed-out gray scans
+ * as part of "the layout is off." 1600px on the long edge ≈ 260 DPI on the A4
+ * text block.
+ */
+export async function fetchFacsimilePdfImage(url: string): Promise<Buffer | null> {
+  try {
+    const buffer = await images.fetchBuffer(url, { timeout: 60000 });
+    return await sharp(buffer)
+      .resize(1600, 1600, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: 78, mozjpeg: true })
+      .toBuffer();
+  } catch (error) {
+    console.error(`Failed to fetch/process facsimile image: ${url}`, error);
+    return null;
+  }
+}
+
+/**
  * Resolve a page's export image via the canonical resolver (R2 display variant
  * first). `photo` is the SOURCE-provider URL — often a slow Internet Archive
  * fetch, and on split-from-spread pages it is the WRONG IMAGE ENTIRELY: the
@@ -166,12 +187,13 @@ export function generateImagesZipStream(pages: Page[]): archiver.Archiver {
 
 export async function* streamPageImagesOrdered(
   validPages: Page[],
+  fetchImage: (url: string) => Promise<Buffer | null> = fetchAndCompressImage,
 ): AsyncGenerator<{ page: Page; imageBuffer: Buffer | null }> {
   const stream = streamOrdered(
     validPages,
     page => {
       const url = pageExportImageUrl(page);
-      return url ? fetchAndCompressImage(url) : Promise.resolve(null);
+      return url ? fetchImage(url) : Promise.resolve(null);
     },
     { concurrency: 8, lookahead: 12 },
   );

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -14,6 +14,7 @@
 import PDFDocument from 'pdfkit';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { normalizeAnnotationSpans } from '@/lib/normalize-annotation-spans';
 import { registerPdfFonts, type PdfFontNames } from '@/lib/pdf-fonts';
 
 export const PDF_MARGINS = { top: 72, bottom: 72, left: 72, right: 72 };
@@ -28,17 +29,44 @@ const PDF_METADATA_TAGS =
 const PDF_METADATA_TAG_RE = new RegExp(`<(${PDF_METADATA_TAGS})>[\\s\\S]*?<\\/\\1>`, 'gi');
 
 /**
- * Flatten the inline annotation tags translation text carries, for a plain-
- * flowing PDF text run. Conceptually mirrors `markdownToHtml()`'s tag
- * handling: gloss/term/unclear/insert keep their content; note/margin keep
- * their content bracketed (the plain-text convention used elsewhere in these
- * exports); page-physical metadata tags are dropped entirely.
- *
- * Call this AFTER stripEditorialWrappers() + markForExport() — see
- * `cleanTranslationForPdf` below, which is the entry point every caller
- * should use.
+ * Inline annotation tags that survive cleaning and render as COLORED runs in
+ * the PDF, matching the reader's chip colors (`NOTE_TAG_STYLES` in
+ * src/lib/style-constants.ts, light theme). A paying reader asked for exactly
+ * this — "I like the colour coding of text when you are providing context
+ * within the translation, can we keep that?" (feedback, 2026-08-10) — so the
+ * PDF keeps the same semantic color language as the site. Italic doubles the
+ * signal so the distinction survives grayscale printing.
  */
-function flattenTagsForPdf(text: string): string {
+export const PDF_ANNOTATION_STYLES: Record<
+  string,
+  { color: string; italic: boolean; suffix?: string }
+> = {
+  note: { color: '#9e7c3c', italic: true }, // editorial note — gold
+  'image-desc': { color: '#9e7c3c', italic: true }, // AI image description — gold
+  margin: { color: '#5e6d52', italic: false }, // marginal note in original — sage
+  insert: { color: '#5e6d52', italic: false }, // later insertion — sage
+  gloss: { color: '#7c5db5', italic: false }, // gloss/annotation in original — violet
+  term: { color: '#7c5db5', italic: true }, // technical term — violet
+  unclear: { color: '#78716c', italic: true, suffix: '?' }, // uncertain reading — gray
+};
+
+const ANNOTATION_TAG_NAMES = Object.keys(PDF_ANNOTATION_STYLES).join('|');
+// Open tags may carry attributes (<image-desc size="large">) — allow and drop them.
+const ANNOTATION_RUN_RE = new RegExp(
+  `<(${ANNOTATION_TAG_NAMES})(?:\\s[^>]*)?>([\\s\\S]*?)<\\/\\1>`,
+  'gi'
+);
+
+/**
+ * Normalize the inline markup translation text carries, KEEPING the annotation
+ * tags above (they become colored runs at render time) and flattening or
+ * dropping everything else.
+ *
+ * Call order matters: runs AFTER stripEditorialWrappers() and BEFORE
+ * markForExport() — see `cleanTranslationForPdf` below, the entry point every
+ * caller should use.
+ */
+function normalizeTagsForPdf(text: string): string {
   let out = text;
 
   // Markdown image syntax + bare URLs don't render as inline images/links in
@@ -46,15 +74,14 @@ function flattenTagsForPdf(text: string): string {
   out = out.replace(/!\[.*?\]\(.*?\)/g, '');
   out = out.replace(/https?:\/\/[^\s)]+/g, '');
 
-  // Inline glosses — keep content plain.
-  out = out.replace(/<gloss>([\s\S]*?)<\/gloss>/gi, '$1');
-  out = out.replace(/<term>([\s\S]*?)<\/term>/gi, '$1');
-  out = out.replace(/<unclear>([\s\S]*?)<\/unclear>/gi, '$1?');
-  out = out.replace(/<insert>([\s\S]*?)<\/insert>/gi, '$1');
-
-  // Marginal annotations — keep content, bracket it.
-  out = out.replace(/<note>([\s\S]*?)<\/note>/gi, '[$1]');
-  out = out.replace(/<margin>([\s\S]*?)<\/margin>/gi, '[$1]');
+  // Legacy bracket syntax → XML, so one render path handles both vintages.
+  out = out.replace(/\[\[image:\s*[\s\S]*?\]\]/gi, '');
+  out = out.replace(/\[\[(notes?):\s*([\s\S]*?)\]\]/gi, '<note>$2</note>');
+  out = out.replace(/\[\[margin:\s*([\s\S]*?)\]\]/gi, '<margin>$1</margin>');
+  out = out.replace(/\[\[gloss:\s*([\s\S]*?)\]\]/gi, '<gloss>$1</gloss>');
+  out = out.replace(/\[\[insert:\s*([\s\S]*?)\]\]/gi, '<insert>$1</insert>');
+  out = out.replace(/\[\[unclear:\s*([\s\S]*?)\]\]/gi, '<unclear>$1</unclear>');
+  out = out.replace(/\[\[term:\s*([\s\S]*?)\]\]/gi, '<term>$1</term>');
 
   out = out.replace(/<column-break\s*\/?>/gi, '\n\n');
   out = out.replace(/<page-break\s*\/?>/gi, '');
@@ -62,11 +89,29 @@ function flattenTagsForPdf(text: string): string {
   // Page-physical metadata tags — drop entirely (content and all).
   out = out.replace(PDF_METADATA_TAG_RE, '');
 
-  // Safety net for any unrecognized tag: strip the markup, keep the content —
-  // real page text should never be silently eaten by an unhandled tag.
-  out = out.replace(/<\/?[a-z][a-z0-9-]*\s*\/?>/gi, '');
+  // Rewrite annotation spans into balanced, non-nested, single-paragraph tag
+  // pairs (#2709) — the same pass the reader runs. The lazy pairing regex in
+  // parseStyledLines() below needs well-formed spans or a nested note strands
+  // the outer note's tail as body text.
+  out = normalizeAnnotationSpans(out);
+
+  // Safety net for any OTHER tag: strip the markup, keep the content — real
+  // page text should never be silently eaten by an unhandled tag. Annotation
+  // tags are exempted (they carry the color styling through to render time).
+  out = out.replace(/<\/?([a-z][a-z0-9-]*)(?:\s[^>]*)?\/?>/gi, (m, name) =>
+    PDF_ANNOTATION_STYLES[String(name).toLowerCase()] ? m : ''
+  );
 
   return out.trim();
+}
+
+/** Strip annotation tags, keeping their content — for contexts that can't
+ * carry color (table cells, plain-text fallbacks). `unclear` keeps its "?". */
+export function stripAnnotationTags(text: string): string {
+  return text.replace(ANNOTATION_RUN_RE, (_, name, content) => {
+    const style = PDF_ANNOTATION_STYLES[String(name).toLowerCase()];
+    return style?.suffix ? `${content}${style.suffix}` : content;
+  });
 }
 
 /**
@@ -74,9 +119,10 @@ function flattenTagsForPdf(text: string): string {
  *   1. stripEditorialWrappers() — removes AI page-description wrapper blocks
  *      (never verbatim source, see CLAUDE.md "Quote & snippet integrity") and
  *      flattens markdown markup (headers/bold/italic/tables/->centered<-).
- *   2. markForExport() — invisible zero-width provenance mark (same as every
+ *   2. normalizeTagsForPdf() — legacy brackets → XML, metadata tags dropped,
+ *      annotation spans normalized and KEPT (rendered as colored runs).
+ *   3. markForExport() — invisible zero-width provenance mark (same as every
  *      other download format).
- *   3. flattenTagsForPdf() — inline annotation tags → plain text.
  */
 export function cleanTranslationForPdf(raw: string, bookId: string): string {
   if (!raw) return '';
@@ -86,8 +132,7 @@ export function cleanTranslationForPdf(raw: string, bookId: string): string {
   // PDF table instead. (40% of pages in a manuscript like Kitab al-Bulhan are
   // calendar/abjad tables, so this is not an edge case.)
   const stripped = stripEditorialWrappers(raw, { keepTables: true });
-  const marked = markForExport(stripped, bookId);
-  return flattenTagsForPdf(marked);
+  return markForExport(normalizeTagsForPdf(stripped), bookId);
 }
 
 /** A run of page text: either flowing prose or a GFM table. */
@@ -186,10 +231,50 @@ export function splitScriptRuns(text: string): Array<{ arabic: boolean; text: st
   return runs;
 }
 
+/** One render unit: a piece of a single visual line with one annotation style.
+ * `style` is null for body text, else a key of PDF_ANNOTATION_STYLES. */
+export interface StyledRun {
+  style: string | null;
+  text: string;
+}
+
 /**
- * Write a string that may mix Latin and Arabic, switching face per run.
+ * Split cleaned page text into LINES of styled runs. Annotation spans become
+ * styled runs (their tags consumed); everything else is body text. A span
+ * whose content wraps across newlines is split so that the line-scoped
+ * `continued` chaining below still works — style carries across the split.
  *
- * Two facts force this, both verified by rendering (2026-08-03):
+ * Exported for testing — `writePdfBody()` is the normal entry point.
+ */
+export function parseStyledLines(text: string): StyledRun[][] {
+  const runs: StyledRun[] = [];
+  let last = 0;
+  ANNOTATION_RUN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ANNOTATION_RUN_RE.exec(text)) !== null) {
+    if (m.index > last) runs.push({ style: null, text: text.slice(last, m.index) });
+    const style = m[1].toLowerCase();
+    const suffix = PDF_ANNOTATION_STYLES[style]?.suffix ?? '';
+    runs.push({ style, text: m[2] + suffix });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) runs.push({ style: null, text: text.slice(last) });
+
+  const lines: StyledRun[][] = [[]];
+  for (const run of runs) {
+    run.text.split('\n').forEach((piece, i) => {
+      if (i > 0) lines.push([]);
+      if (piece) lines[lines.length - 1].push({ style: run.style, text: piece });
+    });
+  }
+  return lines;
+}
+
+/**
+ * Write a string that may mix Latin and Arabic AND carry colored annotation
+ * runs, switching face and fill color per run.
+ *
+ * Script-splitting facts, both verified by rendering (2026-08-03):
  *  - Noto Serif has NO Arabic glyphs, so Arabic inside translation glosses
  *    (`<note>original: "دري اللون"…`) rendered as .notdef boxes — 97 of 366
  *    pages on Kitab al-Bulhan.
@@ -200,47 +285,50 @@ export function splitScriptRuns(text: string): Array<{ arabic: boolean; text: st
  * shapes the letters and orders the words correctly but DROPS the inter-word
  * spaces ("قارعت الاثنين" → "الاثنينقارعت"), which silently alters the text —
  * unacceptable in an edition that gets cited. With it, spacing is correct.
+ *
+ * Continuation is scoped to ONE LINE. `continued: true` resumes at the
+ * current x, and an embedded "\n" inside a continued run does not reset it —
+ * so a single chain over multi-line text indents every line after the first
+ * to wherever the previous run happened to end. (Caught by rendering the full
+ * book: page 195 showed "hoping? for God's mercy" starting mid-measure.)
+ * parseStyledLines() pre-splits on newlines so each chain covers one line.
  */
-function writeScriptAwareText(
+function writeStyledText(
   doc: PDFKit.PDFDocument,
   fonts: PdfFontNames,
   text: string,
   opts: { fontSize: number; lineGap?: number },
 ): void {
   const { fontSize, lineGap = 3 } = opts;
-  // No Arabic, or no Arabic face bundled: one plain call. When the face is
-  // missing we deliberately keep the .notdef boxes rather than dropping the
-  // text — a visible gap is honest, silently-deleted source is not.
-  if (!fonts.arabic || !ARABIC_RE.test(text)) {
-    doc.font(fonts.regular).fontSize(fontSize).text(text, { lineGap });
-    return;
-  }
-  // Continuation is scoped to ONE LINE. `continued: true` resumes at the
-  // current x, and an embedded "\n" inside a continued run does not reset it —
-  // so a single chain over multi-line text indents every line after the first
-  // to wherever the previous run happened to end. (Caught by rendering the full
-  // book: page 195 showed "hoping? for God's mercy" starting mid-measure.)
-  // Splitting per line keeps each line starting at the margin, matching the
-  // plain `doc.text(text)` path above.
-  const lines = text.split('\n');
-  lines.forEach(line => {
-    if (!line) {
-      doc.font(fonts.regular).fontSize(fontSize).text(' ', { lineGap });
-      return;
+  for (const line of parseStyledLines(text)) {
+    if (line.length === 0) {
+      doc.font(fonts.regular).fontSize(fontSize).fillColor('#000000').text(' ', { lineGap });
+      continue;
     }
-    const runs = splitScriptRuns(line);
-    runs.forEach((run, i) => {
+    // Flatten [annotation runs] × [script runs] into one draw list for the line.
+    const draws: Array<{ style: string | null; arabic: boolean; text: string }> = [];
+    for (const run of line) {
+      // When the Arabic face is missing we deliberately keep the .notdef boxes
+      // rather than dropping the text — a visible gap is honest,
+      // silently-deleted source is not.
+      const scriptRuns = fonts.arabic ? splitScriptRuns(run.text) : [{ arabic: false, text: run.text }];
+      for (const s of scriptRuns) draws.push({ style: run.style, arabic: s.arabic, text: s.text });
+    }
+    draws.forEach((d, i) => {
+      const ann = d.style ? PDF_ANNOTATION_STYLES[d.style] : undefined;
+      const face = d.arabic ? fonts.arabic! : ann?.italic ? fonts.italic : fonts.regular;
       doc
-        .font(run.arabic ? fonts.arabic! : fonts.regular)
+        .font(face)
         .fontSize(fontSize)
-        .text(run.text, {
+        .fillColor(ann?.color ?? '#000000')
+        .text(d.text, {
           lineGap,
-          continued: i < runs.length - 1,
-          ...(run.arabic ? { features: ['rtla'] } : {}),
+          continued: i < draws.length - 1,
+          ...(d.arabic ? { features: ['rtla'] } : {}),
         });
     });
-  });
-  doc.font(fonts.regular).fontSize(fontSize);
+  }
+  doc.font(fonts.regular).fontSize(fontSize).fillColor('#000000');
 }
 
 /**
@@ -261,9 +349,11 @@ export function writePdfBody(
 
   for (const block of splitPdfBlocks(text)) {
     if (block.kind === 'text') {
-      writeScriptAwareText(doc, fonts, block.text, { fontSize, lineGap });
+      writeStyledText(doc, fonts, block.text, { fontSize, lineGap });
       continue;
     }
+    // Table cells can't carry per-run color — unwrap annotation tags there.
+    block.rows = block.rows.map(r => r.map(stripAnnotationTags));
     if (!canTable) {
       // Keep the pipes — unaligned, but the column each value belongs to is
       // still recoverable, unlike a flattened run.
@@ -367,9 +457,10 @@ export function writePdfTitlePage(
 }
 
 /** Small "Page N" heading before a page's content, matching the other
- * export formats' rust-colored page markers. */
-export function writePdfPageHeading(doc: PDFKit.PDFDocument, fonts: PdfFontNames, pageNumber: number): void {
-  doc.font(fonts.bold).fontSize(9).fillColor('#8b0000').text(`PAGE ${pageNumber}`);
+ * export formats' rust-colored page markers. `label` distinguishes the two
+ * halves of a facsimile spread ("PAGE 12" scan / "PAGE 12 · ENGLISH" text). */
+export function writePdfPageHeading(doc: PDFKit.PDFDocument, fonts: PdfFontNames, pageNumber: number, label?: string): void {
+  doc.font(fonts.bold).fontSize(9).fillColor('#8b0000').text(`PAGE ${pageNumber}${label ? ` · ${label}` : ''}`);
   doc.fillColor('#000000');
   doc.moveDown(0.25);
 }
@@ -416,4 +507,246 @@ export function writePdfColophon(
     "Preserving humanity's wisdom for the digital age.",
   ];
   doc.text(lines.filter((l): l is string => l !== null).join('\n'), { lineGap: 4 });
+}
+
+// ─── Full-document generators ────────────────────────────────────────────
+//
+// Both PDF download formats live here (not in the route files) so the main
+// route, the tenant twin, and the local QA harness
+// (scripts/qa/render-book-pdf.ts) share ONE implementation. Image fetching
+// stays with the caller, injected as an async-iterable streamer — each route
+// keeps its own resolver/fetcher per the existing per-route pattern.
+
+/** Minimal page shape the generators need. */
+export interface PdfExportPage {
+  page_number: number;
+  translation?: { data?: string } | null;
+}
+
+/** Ordered, bounded-lookahead image streamer — see streamPageImagesOrdered()
+ * in the download routes for the canonical implementation. */
+export type PageImageStream<P extends PdfExportPage> = (
+  pages: P[]
+) => AsyncIterable<{ page: P; imageBuffer: Buffer | null }>;
+
+/**
+ * Budget for the facsimile image phase, in ms. `maxDuration` on the download
+ * routes is 300s; we stop ADDING pages at 210s so there is room to finish the
+ * page in hand, write the truncation notice and the colophon, and flush.
+ *
+ * A big book cannot be served whole in one request (a 4,198-page book would
+ * need ~40 minutes of fetching), so the choice is between an opaque timeout and
+ * an honest partial edition. Per CLAUDE.md "no silent caps": if coverage is
+ * bounded, say what was dropped — here in the PDF itself, so the artifact
+ * carries its own provenance rather than relying on a header nobody reads.
+ */
+export const FACSIMILE_IMAGE_BUDGET_MS = 210_000;
+
+/**
+ * Text-only English translation PDF: front matter, continuous flowing
+ * translation text with a "PAGE N" heading before each page, then a colophon.
+ * The returned PDFDocument is itself a Readable; content is appended
+ * asynchronously after the caller starts piping it to the response, so we
+ * never buffer the whole document before the first byte goes out.
+ */
+export function generatePdfTranslationStream<P extends PdfExportPage>(
+  book: PdfBookInfo,
+  pages: P[],
+  opts: { baseUrl: string },
+): PDFKit.PDFDocument {
+  const now = new Date().toISOString().split('T')[0];
+  const { doc, fonts } = createPdfDocument(book);
+
+  const translatedPages = pages.filter(p => p.translation?.data);
+
+  (async () => {
+    writePdfTitlePage(doc, fonts, book, {
+      subtitle: 'English Translation',
+      baseUrl: opts.baseUrl,
+      now,
+    });
+
+    doc.addPage();
+
+    for (const page of translatedPages) {
+      if (!page.translation?.data) continue;
+      const text = cleanTranslationForPdf(page.translation.data, book.id);
+      if (!text) continue;
+
+      writePdfPageHeading(doc, fonts, page.page_number);
+      writePdfBody(doc, fonts, text, { fontSize: 11, lineGap: 3 });
+      doc.moveDown(0.8);
+    }
+
+    doc.addPage();
+    writePdfColophon(doc, fonts, book, {
+      baseUrl: opts.baseUrl,
+      now,
+      contentLabel: 'English translation',
+      translatedCount: translatedPages.length,
+      totalCount: pages.length,
+    });
+
+    doc.end();
+  })().catch(err => {
+    console.error('pdf-translation stream failed:', err);
+    doc.destroy(err instanceof Error ? err : new Error(String(err)));
+  });
+
+  return doc;
+}
+
+/**
+ * Facsimile PDF as FACING PAGES, like the site reader: each book page becomes
+ * a full-page scan on a LEFT (verso) page and its English translation on the
+ * facing RIGHT (recto) page. Reader feedback (2026-08-10) asked for exactly
+ * the site's layout — "one page with the scan beside one page of translation."
+ *
+ * Mechanics:
+ *  - The document catalog's /PageLayout is set to TwoPageRight, so PDF viewers
+ *    that honor it (Acrobat, Preview's Two Pages mode) open with the title
+ *    page alone on the right — like a book cover — and every following spread
+ *    as scan-left / translation-right.
+ *  - Physical page parity is maintained with blank filler pages: a long
+ *    translation flows onto continuation pages, and without a filler the NEXT
+ *    scan would drift onto a right-hand page, breaking every spread after it
+ *    (the Loeb problem). Scans always land on even physical pages.
+ *  - Streamed like generatePdfTranslationStream — pipe immediately.
+ */
+export function generatePdfFacsimileStream<P extends PdfExportPage>(
+  book: PdfBookInfo,
+  pages: P[],
+  opts: {
+    baseUrl: string;
+    /** Does this page have a scan image the streamer can fetch? */
+    hasImage: (p: P) => boolean;
+    streamImages: PageImageStream<P>;
+    imageBudgetMs?: number;
+  },
+): PDFKit.PDFDocument {
+  const now = new Date().toISOString().split('T')[0];
+  const budgetMs = opts.imageBudgetMs ?? FACSIMILE_IMAGE_BUDGET_MS;
+  const { doc, fonts } = createPdfDocument(book);
+
+  // Spread view: title page alone on the right, then scan-left/text-right
+  // pairs. pdfkit has no public API for the catalog's /PageLayout; writing the
+  // entry on the root dictionary is the accepted workaround and degrades to
+  // nothing (viewer default) if a viewer ignores it.
+  const catalog = (doc as unknown as { _root?: { data?: Record<string, unknown> } })._root;
+  if (catalog?.data) catalog.data.PageLayout = 'TwoPageRight';
+
+  // Pages with an image or a translation are worth a spread; pages with
+  // neither carry nothing to show.
+  const validPages = pages.filter(p => opts.hasImage(p) || p.translation?.data);
+
+  (async () => {
+    // Physical page counter — page 1 exists from the constructor; every
+    // addPage() fires 'pageAdded'.
+    let physical = 1;
+    doc.on('pageAdded', () => { physical++; });
+
+    writePdfTitlePage(doc, fonts, book, {
+      subtitle: 'Facsimile Edition — page scans facing their English translation',
+      baseUrl: opts.baseUrl,
+      now,
+    });
+
+    console.log(`Streaming ${validPages.length} images for pdf-facsimile...`);
+    const startedAt = Date.now();
+    let written = 0;
+    let translated = 0;
+    let truncated = false;
+
+    const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+    const usableHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
+    // Room left for the scan under its "PAGE N" heading.
+    const scanHeight = usableHeight - 24;
+
+    for await (const { page, imageBuffer } of opts.streamImages(validPages)) {
+      if (Date.now() - startedAt > budgetMs) {
+        truncated = true;
+        break;
+      }
+      written++;
+      if (page.translation?.data) translated++;
+
+      // The scan must sit on an EVEN physical page (left of the spread under
+      // TwoPageRight). If the next page would be odd — the previous
+      // translation ran long — insert one blank filler page.
+      if ((physical + 1) % 2 !== 0) doc.addPage();
+
+      doc.addPage();
+      writePdfPageHeading(doc, fonts, page.page_number);
+      if (imageBuffer) {
+        try {
+          doc.image(imageBuffer, { fit: [usableWidth, scanHeight], align: 'center' });
+        } catch (e) {
+          console.error(`pdf-facsimile: failed to embed image for page ${page.page_number}:`, e);
+          doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
+          doc.fillColor('#000000');
+        }
+      } else {
+        doc.font(fonts.italic).fontSize(10).fillColor('#999999').text('[Image unavailable]');
+        doc.fillColor('#000000');
+      }
+
+      doc.addPage();
+      writePdfPageHeading(doc, fonts, page.page_number, 'ENGLISH');
+      const text = page.translation?.data
+        ? cleanTranslationForPdf(page.translation.data, book.id)
+        : '';
+      if (text) {
+        writePdfBody(doc, fonts, text, { fontSize: 10.5, lineGap: 3 });
+      } else {
+        doc.font(fonts.italic).fontSize(10).fillColor('#999999')
+          .text('No translation available for this page.');
+        doc.fillColor('#000000');
+      }
+    }
+
+    if (truncated) {
+      const firstMissing = validPages[written]?.page_number;
+      doc.addPage();
+      doc.font(fonts.bold).fontSize(14).text('This edition is incomplete', { align: 'center' });
+      doc.moveDown(1);
+      doc.font(fonts.regular).fontSize(11).text(
+        [
+          `This facsimile stops at page ${validPages[written - 1]?.page_number ?? written} of `
+          + `${validPages.length}. It was not truncated for editorial reasons: a single request `
+          + 'cannot fetch and lay out every page scan of a book this large within the time '
+          + 'available, so generation stopped rather than failing outright.',
+          '',
+          firstMissing !== undefined
+            ? `Pages from ${firstMissing} onward are not included here. They are all readable `
+              + `at ${opts.baseUrl}/book/${book.id}, and the text-only PDF and EPUB editions cover `
+              + 'the whole book.'
+            : '',
+          '',
+          'If you need the complete facsimile as a single file, please get in touch — we would '
+          + 'rather generate it for you offline than hand you a partial edition without saying so.',
+        ].filter(Boolean).join('\n'),
+        { lineGap: 3 },
+      );
+      console.warn(
+        `pdf-facsimile truncated: ${written}/${validPages.length} pages for book ${book.id} `
+        + `after ${Date.now() - startedAt}ms`,
+      );
+    }
+
+    doc.addPage();
+    writePdfColophon(doc, fonts, book, {
+      baseUrl: opts.baseUrl,
+      now,
+      contentLabel: truncated ? 'partial facsimile edition' : 'facsimile edition',
+      translatedCount: translated,
+      totalCount: pages.length,
+    });
+
+    doc.end();
+  })().catch(err => {
+    console.error('pdf-facsimile stream failed:', err);
+    doc.destroy(err instanceof Error ? err : new Error(String(err)));
+  });
+
+  return doc;
 }

--- a/tests/unit/download-route-parity.test.ts
+++ b/tests/unit/download-route-parity.test.ts
@@ -57,9 +57,15 @@ describe('download routes: shared export machinery', () => {
 
     it(`${rel} labels a truncated facsimile as partial`, () => {
       // "No silent caps": a bounded export must say what was dropped, in the
-      // artifact itself.
-      expect(src).toContain('partial facsimile edition');
-      expect(src).toContain('This edition is incomplete');
+      // artifact itself. The truncation notice lives in the SHARED facsimile
+      // generator (src/lib/pdf-export.ts) — the route must build its PDFs
+      // through it, not re-implement one beside the call site (the same rule
+      // as the image helpers above).
+      expect(src).toContain('generatePdfFacsimileStream');
+      expect(src).not.toMatch(/function\s+generatePdfFacsimileStream\s*\(/);
+      const pdfLib = read('src/lib/pdf-export.ts');
+      expect(pdfLib).toContain('partial facsimile edition');
+      expect(pdfLib).toContain('This edition is incomplete');
     });
 
     it(`${rel} does not filter book_indexes by a field it does not have`, () => {

--- a/tests/unit/export-table-preservation.test.ts
+++ b/tests/unit/export-table-preservation.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
-import { splitPdfBlocks, cleanTranslationForPdf, splitScriptRuns, writePdfBody } from '@/lib/pdf-export';
+import { splitPdfBlocks, cleanTranslationForPdf, splitScriptRuns, writePdfBody, parseStyledLines, stripAnnotationTags } from '@/lib/pdf-export';
 import { loadPdfFonts } from '@/lib/pdf-fonts';
 import { pipeTableToHtml } from '@/lib/markdown-table-html';
 
@@ -159,6 +159,7 @@ describe('mixed-script runs', () => {
     const fakeDoc = {
       font() { return this; },
       fontSize() { return this; },
+      fillColor() { return this; },
       text(t: string, o?: { continued?: boolean }) {
         calls.push({ text: t, continued: !!o?.continued });
         return this;
@@ -181,6 +182,48 @@ describe('mixed-script runs', () => {
     expect(joined).toContain('hoping for mercy');
     expect(joined).toContain('third line');
     expect(joined).toContain('دري اللون');
+  });
+});
+
+describe('annotation color runs (PDF path)', () => {
+  it('keeps annotation tags through cleaning so they can render as colored runs', () => {
+    const out = cleanTranslationForPdf(
+      'Body text <note>an editorial note</note> more <term>khawass</term> end.',
+      'test-book-id'
+    );
+    expect(out).toContain('<note>');
+    expect(out).toContain('<term>');
+  });
+
+  it('converts legacy bracket tags to XML annotation tags', () => {
+    const out = cleanTranslationForPdf('Text [[gloss: a gloss]] tail.', 'test-book-id');
+    expect(out).toContain('<gloss>a gloss</gloss>');
+  });
+
+  it('parseStyledLines splits body and annotation runs, appending ? to unclear', () => {
+    const lines = parseStyledLines('before <unclear>reading</unclear> after');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toEqual([
+      { style: null, text: 'before ' },
+      { style: 'unclear', text: 'reading?' },
+      { style: null, text: ' after' },
+    ]);
+  });
+
+  it('carries a span style across an embedded newline, one run per line', () => {
+    const lines = parseStyledLines('<note>first line\nsecond line</note>');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEqual([{ style: 'note', text: 'first line' }]);
+    expect(lines[1]).toEqual([{ style: 'note', text: 'second line' }]);
+  });
+
+  it('accepts attributes on annotation open tags', () => {
+    const lines = parseStyledLines('<image-desc size="large">an engraving</image-desc>');
+    expect(lines[0][0]).toEqual({ style: 'image-desc', text: 'an engraving' });
+  });
+
+  it('stripAnnotationTags unwraps content for colorless contexts (table cells)', () => {
+    expect(stripAnnotationTags('a <gloss>b</gloss> c <unclear>d</unclear>')).toBe('a b c d?');
   });
 });
 


### PR DESCRIPTION
## Why

Reader feedback via /support (2026-08-10, a signed-in reader finalizing work with our PDFs): *"the layout is off. Are you able to make the required changes so they export as they are displayed on the website: One page with the scan beside one page of translation. I also like the colour coding of text when you are providing context within the translation - can we keep that?"*

Both asks are exactly right — the old `pdf-facsimile` squeezed a 600×900 **grayscale** (EPUB-sized) scan into the top 60% of each page with translation text crammed beneath, and flattened every annotation to plain black text.

## What

**Facing-page facsimile.** Each book page becomes a spread: full-page **color** scan (1600px, ~260 DPI) on the left, translation on the right. Blank filler pages keep parity when a translation overflows (the Loeb problem), and the PDF catalog's `/PageLayout TwoPageRight` opens the title page alone like a cover, then scan-left/text-right in any viewer's two-page mode.

**Annotation colors.** `note`/`image-desc` (gold italic), `margin`/`insert` (sage), `gloss`/`term` (violet), `unclear` (gray italic + ?) — same palette as the reader's `NOTE_TAG_STYLES`, in both `pdf-facsimile` and `pdf-translation`. Spans are normalized via `normalizeAnnotationSpans` (#2709) before run-parsing; legacy `[[bracket:]]` syntax converts; table cells unwrap tags (no color in cells).

**Refactor for testability.** Both generators moved from the two route files into `src/lib/pdf-export.ts` with image streaming injected per-route (routes keep their fetchers, per the existing pattern). The tenant route now streams images with bounded lookahead instead of buffering all of them (same #3597 rationale as the main route).

**QA harness.** `scripts/qa/render-book-pdf.ts` renders either format locally against prod data — reproduce a reader report or inspect a change visually in one command, no auth/deploy needed.

## Verified by rendering

- 16pp Latin disputation (1577): title page, spreads pair correctly, parity filler after a long translation, gold/violet/sage runs, colophon.
- 366pp Kitab al-Bulhan text PDF: Arabic script runs shaped correctly, GFM tables as real PDF tables, 441 output pages, no crash.
- Unit tests extended for run parsing (style across newlines, unclear '?', attributes, cell unwrapping) — 24 pass; `tsc --noEmit` clean.

## Out of scope

- EPUB facsimile keeps its 600×900 grayscale variant (e-reader constraints).
- No new download format keys; `pdf-facsimile` changed in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)