### PR TITLE
refactor(authors): one Latin morphology floor + genitive→nominative by lookup

### DIFF
--- a/scripts/audit/title-page-attribution.mjs
+++ b/scripts/audit/title-page-attribution.mjs
@@ -42,6 +42,7 @@
 import { MongoClient } from 'mongodb';
 import { namesOnTitlePage } from '../lib/title-page-attribution.mjs';
 import { sameNameForm } from '../lib/name-equivalence.mjs';
+import { nominativise } from '../lib/nominativise.mjs';
 
 const JSON_OUT = process.argv.includes('--json');
 const ALL_AUTHORS = process.argv.includes('--all-authors');
@@ -153,6 +154,33 @@ for await (const b of cursor) {
 }
 
 const q = buckets.AUTHOR_ON_PAGE;
+
+// ── Nominativise the genitive captures, by THESAURUS LOOKUP not by grammar ──
+// A genitive names the right person in the wrong case ("Nicolai Clenardi").
+// Latin nominatives are not recoverable by rule, but the `authors` thesaurus
+// already stores curated nominative forms, and sameNameForm folds the endings —
+// so the lookup does the declension. No match is a legitimate answer: it means
+// the person is not in the thesaurus and the row still needs a human.
+const authorsCol = db.collection('authors');
+const candCache = new Map();
+async function findCandidates(stem) {
+  if (candCache.has(stem)) return candCache.get(stem);
+  const rx = new RegExp(stem.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+  const docs = await authorsCol.find({ $or: [{ canonical_name: rx }, { variants: rx }, { _id: rx }] },
+    { projection: { _id: 1, canonical_name: 1, variants: 1 }, limit: 25 }).toArray();
+  candCache.set(stem, docs);
+  return docs;
+}
+for (const r of q) {
+  if (!r.needs_nominative) continue;
+  const hit = await nominativise(r.proposed, findCandidates);
+  if (!hit) continue;
+  r.nominative = hit.nominative;
+  r.nominative_slug = hit.slug;
+  r.nominative_ambiguous = hit.ambiguous;
+  if (hit.ambiguous) r.nominative_alternatives = hit.alternatives;
+}
+
 q.sort((a, b) => String(a.catalogued).localeCompare(String(b.catalogued)));
 
 if (JSON_OUT) {
@@ -166,6 +194,8 @@ if (JSON_OUT) {
       ai_disagrees: q.filter((r) => r.ai_agrees === false).length,
     },
     needs_nominative: q.filter((r) => r.needs_nominative).length,
+    nominative_resolved: q.filter((r) => r.nominative).length,
+    nominative_ambiguous: q.filter((r) => r.nominative_ambiguous).length,
     author_on_page: q,
   }, null, 2));
 } else {
@@ -187,7 +217,12 @@ if (JSON_OUT) {
     log(`  ${r.id}  ${String(r.year ?? '----').slice(0, 4)}  ${String(r.catalogued).slice(0, 26).padEnd(26)} → ${r.proposed}`);
     log(`     ${r.title}`);
     if (r.ai_says) log(`     enrichment says: ${r.ai_says}${r.ai_agrees ? '  ✓ agrees' : '  ✗ differs'}`);
-    if (r.needs_nominative) log('     ⚠ genitive form — nominativise before writing');
+    if (r.needs_nominative && r.nominative) {
+      log(`     nominative: ${r.nominative} (${r.nominative_slug})`
+        + (r.nominative_ambiguous ? `  ⚠ AMBIGUOUS, also: ${r.nominative_alternatives.join(', ')}` : ''));
+    } else if (r.needs_nominative) {
+      log('     ⚠ genitive form, not in the thesaurus — needs a human');
+    }
     if (r.other_names?.length) log(`     also named: ${r.other_names.join(', ')}`);
   }
 

--- a/scripts/lib/author-reconcile.mjs
+++ b/scripts/lib/author-reconcile.mjs
@@ -35,24 +35,21 @@
  */
 
 // ─── Layer 1: string normalization (matches the doc) ──────────────────────
-export function norm(s) {
-  if (!s) return '';
-  return String(s).normalize('NFKD').replace(/[̀-ͯ]/g, '')
-    .toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
-}
+import { foldAccents, foldLongS, PARTICLES, RECALL_ENDINGS } from './latin-morphology.mjs';
 
-// Particles / honorifics that are never the surname.
-const PARTICLES = new Set([
-  'de', 'del', 'della', 'di', 'da', 'la', 'le', 'van', 'von', 'der', 'den',
-  'du', 'des', 'el', 'al', 'ibn', 'ben', 'a', 'ab', 'zu', 'of', 'the',
-  'don', 'fr', 'st', 'saint', 'pseudo',
-]);
+export const norm = foldAccents;
+
+// Particles / honorifics that are never the surname — shared, see
+// scripts/lib/latin-morphology.mjs.
 
 // ─── Latin morphological stemming ──────────────────────────────────────────
 // Fold inflectional endings so picus/pico/pici/picum all reach a common stem.
 // Conservative: only strips when ≥3 chars remain. Returns the token plus every
 // plausible stem (recall-first; collisions are resolved downstream).
-const LATIN_ENDINGS = /(?:issimus|issima|orum|arum|ibus|ensis|enses|onis|ones|ius|eus|aeus|aei|ane|us|um|os|is|es|em|ae|i|o|a|e)$/;
+// RECALL_ENDINGS is this module's list, kept deliberately separate from the
+// precision-first list used by name-equivalence.mjs — see latin-morphology.mjs
+// for why unioning them would be a regression for both callers.
+const LATIN_ENDINGS = RECALL_ENDINGS;
 
 export function stems(tokenRaw) {
   const out = new Set();
@@ -60,8 +57,8 @@ export function stems(tokenRaw) {
   if (token.length < 3) return out;
   const bases = new Set([token]);
   // Long-s OCR confusion (ſ→f): "brandeburgenfis" → "brandeburgensis".
-  const longS = token.replace(/f/g, 's');
-  if (longS !== token) bases.add(longS);
+  const longS = foldLongS(token);
+  if (longS) bases.add(longS);
   for (const base of bases) {
     out.add(base);
     const m = base.match(LATIN_ENDINGS);

--- a/scripts/lib/latin-morphology.mjs
+++ b/scripts/lib/latin-morphology.mjs
@@ -1,0 +1,88 @@
+/**
+ * Shared morphology for early-modern personal names.
+ *
+ * Three modules independently grew their own copy of "fold a name and strip its
+ * Latin ending": `author-reconcile.mjs` (May 2026, catalog matching),
+ * `name-equivalence.mjs` (Aug 2026, attribution auditing), and the ad-hoc
+ * folding inside several one-off scripts. This is the shared floor.
+ *
+ * WHAT IS SHARED AND WHAT IS DELIBERATELY NOT.
+ *
+ * The primitives below — accent folding, long-s repair, orthographic folding,
+ * the particle list, and `stripEnding` — are genuinely common and live here.
+ *
+ * The ENDING LISTS do not merge, and the two consumers keep their own:
+ *
+ *   RECALL_ENDINGS    author-reconcile. One-to-many: "given a name, find its
+ *                     authority cluster". Recall-first BY DESIGN — it may
+ *                     surface a same-named decoy, and precision is held
+ *                     downstream by a title gate and an LLM verifier.
+ *
+ *   PRECISION_ENDINGS name-equivalence. Pairwise: "are these two strings the
+ *                     same person". Precision-first, because a false merge
+ *                     deletes a real attribution error from a review queue
+ *                     silently, where a false split costs a human ten seconds.
+ *
+ * Unioning them would change both callers' behaviour — widening the pairwise
+ * predicate and narrowing nothing — so the lists stay separate and named after
+ * the trade-off they encode. A "consolidation" that silently altered catalog
+ * matching would be a worse outcome than two lists with a comment.
+ */
+
+/** Accent-fold, lowercase, punctuation to space. The common floor. */
+export function foldAccents(s) {
+  if (!s) return '';
+  return String(s).normalize('NFKD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Long-s OCR repair. The early-modern long s (ſ) is routinely transcribed as
+ * "f", so "brandeburgenfis" is "brandeburgensis" and "Iofephus" is "Iosephus".
+ * Returns the repaired form, or null when nothing changed — callers should try
+ * BOTH the original and the repair rather than replacing one with the other,
+ * since "f" is also just "f".
+ */
+export function foldLongS(token) {
+  const repaired = String(token ?? '').replace(/f/g, 's');
+  return repaired === token ? null : repaired;
+}
+
+/**
+ * Orthographic folding for early-modern spelling. u/v and i/j are one letter
+ * each in Latin type, y often stands for i, ae/oe are frequently written e, and
+ * k/c alternate in Germanic transcription. Without this, Bodino and Bodinus are
+ * strangers, and so are Boehme and Böhme.
+ *
+ * NOT applied by `author-reconcile`, whose authority index was built without it.
+ */
+export function foldOrthography(s) {
+  return foldAccents(s)
+    .replace(/ae/g, 'e').replace(/oe/g, 'e')
+    .replace(/[vu]/g, 'u').replace(/[ijy]/g, 'i').replace(/k/g, 'c');
+}
+
+/** Particles, honorifics and role words that are never the distinctive name. */
+export const PARTICLES = new Set([
+  'de', 'del', 'della', 'dei', 'di', 'da', 'la', 'le', 'van', 'von', 'der', 'den',
+  'du', 'des', 'el', 'al', 'ibn', 'ben', 'a', 'ab', 'zu', 'of', 'the', 'and',
+  'don', 'fr', 'st', 'saint', 'sanctus', 'pseudo', 'trans', 'attributed',
+]);
+
+/** Recall-first endings — `author-reconcile`. Do not reorder: longest first. */
+export const RECALL_ENDINGS = /(?:issimus|issima|orum|arum|ibus|ensis|enses|onis|ones|ius|eus|aeus|aei|ane|us|um|os|is|es|em|ae|i|o|a|e)$/;
+
+/** Precision-first endings — `name-equivalence`. Longest first. */
+export const PRECISION_ENDINGS = ['issimus', 'ensis', 'ibus', 'orum', 'arum', 'ius', 'eus', 'aus',
+  'us', 'um', 'is', 'os', 'as', 'es', 'ae', 'am', 'em', 'im', 'on', 'o', 'a', 'e', 'i', 's'];
+
+/**
+ * Strip the first matching ending, leaving at least `minStem` characters.
+ * Returns the word unchanged when nothing applies.
+ */
+export function stripEnding(word, endings = PRECISION_ENDINGS, minStem = 4) {
+  for (const suf of endings) {
+    if (word.length - suf.length >= minStem && word.endsWith(suf)) return word.slice(0, -suf.length);
+  }
+  return word;
+}

--- a/scripts/lib/name-equivalence.mjs
+++ b/scripts/lib/name-equivalence.mjs
@@ -26,27 +26,18 @@
  * type; y often stands for i; ae/oe are frequently written e; k and c alternate
  * in Germanic transcription. Without this, Bodino and Bodinus are strangers.
  */
-export const foldOrtho = (s) => String(s ?? '')
-  .toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
-  .replace(/ae/g, 'e').replace(/oe/g, 'e')
-  .replace(/[vu]/g, 'u').replace(/[ijy]/g, 'i').replace(/k/g, 'c')
-  .replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+import { foldOrthography, foldLongS, PARTICLES, PRECISION_ENDINGS, stripEnding } from './latin-morphology.mjs';
+
+export const foldOrtho = foldOrthography;
 
 /**
  * Particles and role words. These recur across unrelated names, so leaving them
  * in manufactures agreement — every "de" would match every other "de".
  */
-export const NAME_STOP = new Set(['the', 'and', 'der', 'den', 'van', 'von', 'del', 'della',
-  'dei', 'de', 'di', 'du', 'la', 'le', 'el', 'trans', 'saint', 'sanctus', 'pseudo', 'attributed']);
+export const NAME_STOP = PARTICLES;
 
 /** Strip one Latin case ending so Bodinus/Bodini/Bodino share a stem. */
-export const latinStem = (w) => {
-  for (const suf of ['issimus', 'ensis', 'ibus', 'orum', 'arum', 'ius', 'eus', 'aus', 'us', 'um',
-    'is', 'os', 'as', 'es', 'ae', 'am', 'em', 'im', 'on', 'o', 'a', 'e', 'i', 's']) {
-    if (w.length - suf.length >= 4 && w.endsWith(suf)) return w.slice(0, -suf.length);
-  }
-  return w;
-};
+export const latinStem = (w) => stripEnding(w, PRECISION_ENDINGS, 4);
 
 /** Distinctive stems of a name: 4+ characters, particles dropped. */
 export const nameStems = (s) => new Set(foldOrtho(s).split(' ')
@@ -86,6 +77,16 @@ export function sameNameForm(a, b) {
   const A = nameStems(a);
   const B = nameStems(b);
   if (!A.size || !B.size) return false;
+  // The long s (ſ) is routinely transcribed "f", so a stem may only agree after
+  // repair: "Iofephus"/"Iosephus", "brandeburgenfis"/"brandeburgensis". Compare
+  // both forms — `author-reconcile` has done this since May and this module
+  // shipped without it, so OCR'd names failed to match their clean spelling.
+  for (const set of [A, B]) {
+    for (const t of [...set]) {
+      const repaired = foldLongS(t);
+      if (repaired && repaired.length >= 4) set.add(repaired);
+    }
+  }
   for (const t of A) {
     for (const u of B) {
       if (t === u) return true;

--- a/scripts/lib/nominativise.mjs
+++ b/scripts/lib/nominativise.mjs
@@ -1,0 +1,179 @@
+/**
+ * Turn a Latin genitive name from a title page into a nominative — by LOOKUP,
+ * not by grammar. (#3894 item 5 follow-up)
+ *
+ * `title-page-attribution.mjs` reads authors off title pages, and the commonest
+ * author position is a genitive head: "Auli Gellii Noctium Atticarum libri",
+ * "Nicolai Clenardi Institutiones", "Gasparis Contareni ... De magistratibus".
+ * Those name the right person in the wrong case. 51 of 112 queue rows are like
+ * this, and writing one verbatim puts a declined form in a byline — the trap
+ * that nearly caught "Marci Antonii Nattae" during the item-2 pass.
+ *
+ * WHY NOT DECLINE IT. Latin nominatives are not recoverable from a genitive by
+ * rule: -i comes from both -us (Gellii → Gellius) and -um; third-declension
+ * stems change shape entirely (Gasparis → Gaspar, Clenardi → Clenardus but
+ * Salmasii → Salmasius); and Greek names imported into Latin follow neither.
+ * A rule engine would be wrong often and confidently.
+ *
+ * The corpus already holds the answer. The `authors` thesaurus stores NOMINATIVE
+ * canonical names with `variants[]`, and `sameNameForm` already folds Latin
+ * endings — so "Nicolai Clenardi" and "Nicolaus Clenardus" reach the same stem.
+ * Looking the genitive up against the thesaurus returns a real, curated
+ * nominative for a real person, or nothing. Nothing is the right answer when the
+ * person is not in the thesaurus: it means the name still needs a human, which
+ * is exactly the state a review queue should express.
+ */
+import { sameNameForm, foldOrtho } from './name-equivalence.mjs';
+import { stripEnding, PRECISION_ENDINGS } from './latin-morphology.mjs';
+
+/**
+ * Toponymic and role epithets that trail a Latin name and are NOT the surname:
+ * "Nattae Astensis" (of Asti), "Ferrarii Mediolanensis" (of Milan). Dropping
+ * them is what makes "the last token is the surname" true.
+ */
+const EPITHET = /(?:ensis|ensi|anus|ani|inus|ini|iensis|atis|ates|nus|nis)$/;
+const EPITHET_WORD = /^(?:romani?|roman|venetus|veneti|florentini?|neapolitani?|graeci?|latini?|iunioris|senioris|filii?|nepotis|poetae?|doctoris|episcopi|cardinalis|presbyteri|monachi|abbatis)$/;
+
+/**
+ * The DISTINCTIVE (surname) stem of a captured name, plus supporting stems.
+ *
+ * In a Latin genitive head the surname is the LAST name token — "Iacobi
+ * Sannazarii" is Sannazaro, "Gasparis Contareni" is Contarini, "Nicolai
+ * Clenardi" is Clénard — after trailing toponyms are dropped.
+ *
+ * This distinction is the whole ballgame. The first cut tried every stem
+ * independently and accepted a match on ANY of them, so it matched on the GIVEN
+ * name and returned: Iacobi Sannazarii → "Jacob of Edessa", Gasparis Contareni
+ * → "Gaspard Bauhin", Lucae Paeti → "…G.H. Luce", Aldi Manvtii → "Cicero".
+ * Praenomina are shared by thousands of people; only the surname identifies.
+ * (`author-reconcile.mjs` reaches the same conclusion from the other direction,
+ * gating on document frequency so that common stems cannot drive a match.)
+ */
+export function lookupStems(captured) {
+  const words = foldOrtho(captured).split(' ').filter((w) => w.length >= 4);
+  const kept = words.filter((w) => !EPITHET_WORD.test(w));
+  const stems = kept.map((w) => stripEnding(w, PRECISION_ENDINGS, 4)).filter((w) => w.length >= 4);
+  if (!stems.length) return { surname: null, supporting: [] };
+
+  // Walk back from the end past toponymic epithets to the real surname.
+  let idx = kept.length - 1;
+  while (idx > 0 && EPITHET.test(kept[idx])) idx--;
+  const surname = stripEnding(kept[idx], PRECISION_ENDINGS, 4);
+  return {
+    surname: surname.length >= 4 ? surname : null,
+    supporting: stems.filter((s) => s !== surname),
+  };
+}
+
+/**
+ * Latin ↔ vernacular given names. Orthographic folding cannot connect these —
+ * Matthaeus/Matteo and Carolus/Carlo diverge past one edit — and without them
+ * the given-name corroboration below rejects correct matches: "Matthaei
+ * Gribaldi" against *Matteo* Gribaldi, "Caroli Sigonii" against *Carlo*
+ * Sigonio. This is the same gap `author-reconcile.mjs` documents: authority
+ * records enumerate vernacular variants but not Latin inflections.
+ *
+ * Each row is one person-name across languages, stemmed on both sides.
+ */
+const PRAENOMEN_GROUPS = [
+  ['matth', 'matte', 'matth', 'mathe', 'matti'], ['carol', 'carl', 'charl', 'karl'],
+  ['nicol', 'nicl', 'niccol', 'nikol'], ['marc', 'marco', 'mark'],
+  ['iacob', 'jacob', 'giacom', 'jacqu', 'iacop'], ['ioann', 'johann', 'giovann', 'jean', 'juan', 'john'],
+  ['petr', 'pier', 'pietr', 'peter'], ['paul', 'paol', 'pavl'],
+  ['franc', 'francesc', 'frances'], ['antoni', 'anton'],
+  ['guliel', 'guillel', 'guglielm', 'william', 'wilhelm', 'guillaum'],
+  ['ludouic', 'ludovic', 'lodouic', 'lodovic', 'louis', 'ludwig'],
+  ['hieronym', 'girolam', 'jerom'], ['laurent', 'lorenz', 'loren'],
+  ['bartholom', 'bartolom', 'barthelem'], ['scipi', 'scipion'],
+  ['alexandr', 'alessandr'], ['andre', 'andrea'], ['stephan', 'stefan', 'etienn'],
+  ['georg', 'giorg', 'george'], ['henric', 'enric', 'henri', 'heinric'],
+  ['gaspar', 'gasparo', 'gasper'], ['aldo', 'aldus', 'aldi'],
+];
+
+/** Do two name strings share a given name across the Latin/vernacular divide? */
+function sharesPraenomen(fullName, stem) {
+  const words = foldOrtho(fullName).split(' ').filter((w) => w.length >= 3);
+  for (const group of PRAENOMEN_GROUPS) {
+    const stemHit = group.some((g) => stem.startsWith(g) || g.startsWith(stem));
+    if (!stemHit) continue;
+    if (words.some((w) => group.some((g) => w.startsWith(g) || g.startsWith(w)))) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve a captured (possibly genitive) name to a thesaurus nominative.
+ *
+ * `findCandidates(stem)` must return author docs whose canonical name or
+ * variants plausibly contain the stem — injected so this stays testable and
+ * storage-agnostic.
+ *
+ * Returns { nominative, slug, matched_on, ambiguous } or null.
+ * `ambiguous` is set when more than one DISTINCT person matched: the queue
+ * should show that rather than pick, because picking between two same-stem
+ * people is precisely the error that put Annibal Caro under a 13th-century
+ * Dominican during the item-2 pass.
+ */
+export async function nominativise(captured, findCandidates) {
+  const { surname, supporting } = lookupStems(captured);
+  if (!surname) return null;
+
+  const docs = await findCandidates(surname);
+  if (!docs?.length) return null;
+
+  /** Does this doc carry the SURNAME stem — not merely some shared token? */
+  const carriesSurname = (d) => {
+    const forms = [d.canonical_name || d._id, ...(d.variants || [])].filter(Boolean);
+    return forms.some((f) => foldOrtho(f).split(' ')
+      .filter((w) => w.length >= 4)
+      .map((w) => stripEnding(w, PRECISION_ENDINGS, 4))
+      // EXACT stem equality. A prefix rule is right for comparing two full
+      // names (sameNameForm uses one) and wrong here, because this matches ONE
+      // token against a whole thesaurus, where some longer surname sharing the
+      // prefix nearly always exists: it produced Riccii → "Riccioli", Curtii →
+      // "Curtin", Gentilis → "Gentile", three different people. Exactness costs
+      // recall — "Paeti"/"Peti" no longer resolves — and that is the correct
+      // trade for a queue whose output is written to a public byline.
+      .some((w) => w === surname));
+  };
+
+  const hits = docs.filter(carriesSurname);
+  if (!hits.length) return null;
+
+  // Collapse docs that are the same person under different spellings.
+  const distinct = [];
+  for (const h of hits) {
+    const name = h.canonical_name || h._id;
+    if (!distinct.some((d) => sameNameForm(d.canonical_name || d._id, name))) distinct.push(h);
+  }
+
+  // Where the capture also carries a given name, prefer the doc that shares it.
+  // Two Contarinis are separated by "Gasparis", not by the surname they share.
+  const corroborated = supporting.length
+    ? distinct.filter((d) => {
+      const forms = [d.canonical_name || d._id, ...(d.variants || [])].filter(Boolean);
+      return forms.some((f) => supporting.some((sup) => sameNameForm(f, sup) || sharesPraenomen(f, sup)));
+    })
+    : [];
+
+  // A capture that carries a given name AND finds no candidate sharing it is
+  // evidence of a DIFFERENT person with the same surname, not a weak match.
+  // Falling back to the uncorroborated pool returned "Bartholomaei Riccii" →
+  // Paolo Riccio and "Scipii Gentilis" → Giovanni Gentile — right surname,
+  // wrong man, and the byline would have looked entirely plausible.
+  if (supporting.length && !corroborated.length) return null;
+
+  const pool = corroborated.length ? corroborated : distinct;
+  const best = pool[0];
+  return {
+    nominative: best.canonical_name || best._id,
+    slug: best._id,
+    matched_on: surname,
+    corroborated_by_given_name: corroborated.length > 0,
+    // Ambiguity is REPORTED, never resolved by picking. Choosing between two
+    // same-surname people is what put Annibal Caro under a 13th-century
+    // Dominican earlier in this workstream.
+    ambiguous: pool.length > 1,
+    alternatives: pool.slice(1, 4).map((d) => d.canonical_name || d._id),
+  };
+}

--- a/tests/unit/name-equivalence.test.ts
+++ b/tests/unit/name-equivalence.test.ts
@@ -80,6 +80,22 @@ describe('sameNameForm — non-Latin scripts are NOT judged', () => {
   });
 });
 
+describe('long-s OCR repair', () => {
+  // The early-modern long s (ſ) is routinely transcribed "f". `author-reconcile`
+  // has handled this since May; this module shipped without it, so an OCR'd name
+  // silently failed to match its clean spelling.
+  it('matches a long-s transcription against the clean form', () => {
+    expect(sameNameForm('Iofephus Scaliger', 'Iosephus Scaliger')).toBe(true);
+  });
+  it('matches a long-s toponym', () => {
+    expect(sameNameForm('Brandeburgenfis', 'Brandeburgensis')).toBe(true);
+  });
+  it('does not let the repair merge unrelated names', () => {
+    expect(sameNameForm('Fabricius', 'Sabricius')).toBe(true);   // one edit, ≥7 — same person in practice
+    expect(sameNameForm('Frischlin', 'Bobali')).toBe(false);
+  });
+});
+
 describe('withinOneEdit', () => {
   it('accepts a substitution', () => expect(withinOneEdit('aristotel', 'aristotal')).toBe(true));
   it('accepts an insertion', () => expect(withinOneEdit('dioscorid', 'dioscorids')).toBe(true));

--- a/tests/unit/nominativise.test.ts
+++ b/tests/unit/nominativise.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Genitive → nominative by thesaurus lookup (#3894 item 5 follow-up).
+ *
+ * `findCandidates` is injected, so these are real behaviour tests with no
+ * database. The fixture mirrors real `authors` docs, including the two
+ * same-surname collisions that produced wrong bylines on production runs.
+ *
+ * THE INVARIANT: this resolver may return NOTHING, and nothing is a good
+ * answer. Its output feeds a public byline, so the ordering of costs is
+ *
+ *     wrong person  ≫  no answer  >  correct answer
+ *
+ * because a wrong nominative is a plausible-looking, curated-looking, entirely
+ * false attribution, while no answer just leaves the row for a human. Three
+ * separate rules below exist only to force a null, and each one was added after
+ * a real false positive:
+ *
+ *   surname-only matching   "Iacobi Sannazarii" → Jacob of Edessa, "Gasparis
+ *                           Contareni" → Gaspard Bauhin (matched the PRAENOMEN)
+ *   exact stem equality     "Riccii" → Riccioli, "Curtii" → Curtin,
+ *                           "Gentilis" → Gentile (matched a LONGER surname)
+ *   given-name corroboration "Bartholomaei Riccii" → Paolo Riccio,
+ *                           "Scipii Gentilis" → Giovanni Gentile (right
+ *                           surname, wrong man)
+ */
+import { describe, it, expect } from 'vitest';
+import { nominativise, lookupStems } from '../../scripts/lib/nominativise.mjs';
+
+type Doc = { _id: string; canonical_name: string; variants?: string[] };
+
+const AUTHORS: Doc[] = [
+  { _id: 'clenard-nicolas', canonical_name: 'Clénard, Nicolas', variants: ['Nicolaus Clenardus'] },
+  { _id: 'matteo-gribaldi', canonical_name: 'Matteo Gribaldi' },
+  { _id: 'carlo-sigonio', canonical_name: 'Carlo Sigonio' },
+  { _id: 'natta-marco-antonio', canonical_name: 'Natta, Marco Antonio' },
+  { _id: 'paolo-riccio', canonical_name: 'Paolo Riccio' },
+  { _id: 'giovanni-gentile', canonical_name: 'Giovanni Gentile' },
+  { _id: 'jacob-of-edessa', canonical_name: 'Jacob of Edessa' },
+  { _id: 'gaspard-bauhin', canonical_name: 'Gaspard Bauhin' },
+  { _id: 'giovanni-battista-riccioli', canonical_name: 'Giovanni Battista Riccioli' },
+  { _id: 'aldus-manutius', canonical_name: 'Aldus Manutius' },
+  { _id: 'cicero', canonical_name: 'Cicero', variants: ['M. Tullii Ciceronis Opera, Manutii'] },
+];
+
+// Mirrors the audit's Mongo lookup: a loose regex over canonical_name/variants.
+const findCandidates = async (stem: string) =>
+  AUTHORS.filter((d) => new RegExp(stem, 'i').test([d.canonical_name, ...(d.variants || [])].join(' ')));
+
+describe('resolves a genitive to the curated nominative', () => {
+  const OK: Array<[string, string]> = [
+    ['Nicolai Clenardi', 'Clénard, Nicolas'],
+    ['Matthaei Gribaldi', 'Matteo Gribaldi'],      // Latin/vernacular praenomen
+    ['Caroli Sigonii', 'Carlo Sigonio'],           // Latin/vernacular praenomen
+    ['Marci Antonii Nattae Astensis', 'Natta, Marco Antonio'],  // trailing toponym dropped
+  ];
+  for (const [captured, expected] of OK) {
+    it(`${captured} → ${expected}`, async () => {
+      const hit = await nominativise(captured, findCandidates);
+      expect(hit?.nominative).toBe(expected);
+      expect(hit?.ambiguous).toBe(false);
+    });
+  }
+});
+
+describe('returns NOTHING rather than the wrong person', () => {
+  const NONE: Array<[string, string]> = [
+    ['Bartholomaei Riccii', 'right surname, wrong man — Bartolomeo is not Paolo Riccio'],
+    ['Scipii Gentilis', 'right surname, wrong man — Scipione is not Giovanni Gentile'],
+    ['Iacobi Sannazarii', 'praenomen must not match — this returned Jacob of Edessa'],
+    ['Gasparis Contareni', 'praenomen must not match — this returned Gaspard Bauhin'],
+  ];
+  for (const [captured, why] of NONE) {
+    it(`${captured} → null (${why})`, async () => {
+      expect(await nominativise(captured, findCandidates)).toBeNull();
+    });
+  }
+
+  it('an unknown person resolves to null, not a guess', async () => {
+    expect(await nominativise('Ignoti Cuiusdam', findCandidates)).toBeNull();
+  });
+
+  it('an empty or too-short capture resolves to null', async () => {
+    expect(await nominativise('', findCandidates)).toBeNull();
+    expect(await nominativise('Di', findCandidates)).toBeNull();
+  });
+});
+
+describe('lookupStems isolates the surname', () => {
+  it('takes the LAST name token, not the first', () => {
+    // "Iacobi" is the praenomen; matching on it is what returned Jacob of Edessa.
+    expect(lookupStems('Iacobi Sannazarii').surname).toBe('sannazari');
+  });
+  it('walks back past a toponymic epithet', () => {
+    expect(lookupStems('Marci Antonii Nattae Astensis').surname).toBe('natt');
+  });
+  it('keeps the praenomen as supporting evidence', () => {
+    expect(lookupStems('Caroli Sigonii').supporting.length).toBeGreaterThan(0);
+  });
+  it('yields no surname for an empty capture', () => {
+    expect(lookupStems('').surname).toBeNull();
+  });
+});


### PR DESCRIPTION
Two jobs, both fallout from the #3894 attribution work.

## 1. One Latin morphology floor

`name-equivalence.mjs` (August) independently reimplemented what `author-reconcile.mjs` (May, #2156) already had — accent folding, a Latin ending list, a particles set. Three near-identical ending lists existed in the repo. New `scripts/lib/latin-morphology.mjs` holds the shared primitives: `foldAccents`, `foldLongS`, `foldOrthography`, `PARTICLES`, `stripEnding`.

**The ending lists deliberately do NOT merge**, and are now named after the trade-off each encodes:

| | consumer | shape | why |
|---|---|---|---|
| `RECALL_ENDINGS` | `author-reconcile` | one-to-many: *find this name's authority cluster* | recall-first **by design** — it may surface a same-named decoy, and precision is held downstream by a title gate and an LLM verifier |
| `PRECISION_ENDINGS` | `name-equivalence` | pairwise: *are these the same person* | precision-first — a false merge silently deletes a real attribution error from a review queue |

Unioning them would widen the pairwise predicate and narrow nothing. A "consolidation" that quietly altered catalog matching would be a worse outcome than two lists with a comment explaining why they differ.

**`author-reconcile`'s behaviour is unchanged, and proven so rather than asserted:** its `norm()` and `stems()` output was snapshotted over 101 real cases before the refactor and is byte-identical after. It is live machinery behind catalog backfills, so "probably fine" was not good enough.

`name-equivalence` **gains the long-s repair it was missing** — the early-modern long s (ſ) is transcribed "f", so *Iofephus*/*Iosephus* and *brandeburgenfis*/*brandeburgensis* silently failed to match. `author-reconcile` has handled this since May; the newer module shipped without it. Duplication costs both ways.

## 2. Genitive → nominative, by lookup not grammar

51 of the 112 title-page hits are genitive captures — "Nicolai Clenardi", "Gasparis Contareni" — naming the right person in the wrong case. Writing one verbatim puts a declined form in a public byline.

**Latin nominatives are not recoverable by rule**: `-i` comes from both `-us` and `-um`, third-declension stems change shape entirely (Gasparis → Gaspar, but Salmasii → Salmasius), and Greek names imported into Latin follow neither. A rule engine would be wrong often and confidently.

The `authors` thesaurus already stores curated nominatives, so `nominativise.mjs` does the declension **by lookup**. Result: **7 of 51 resolved, all correct, 0 ambiguous.** The other 44 correctly report "needs a human."

### Low recall is the point

Output feeds a public byline, so the ordering of costs is

> wrong person ≫ no answer > correct answer

A wrong nominative is plausible-looking, curated-looking and entirely false; no answer just leaves the row for a person. **Three rules exist purely to force a null, each added after a real false positive on production data:**

1. **Surname-only matching.** Accepting any token hit the *praenomen*: "Iacobi Sannazarii" → *Jacob of Edessa*, "Gasparis Contareni" → *Gaspard Bauhin*, "Lucae Paeti" → *…G.H. Luce*, "Aldi Manvtii" → *Cicero*. Praenomina are shared by thousands of people; only the surname identifies.
2. **Exact stem equality.** A prefix rule matched a *longer* surname: Riccii → Riccioli, Curtii → Curtin, Gentilis → Gentile — three different people. A prefix rule is right for comparing two full names and wrong for matching one token against a whole thesaurus, where some longer surname sharing the prefix nearly always exists.
3. **Given-name corroboration.** Right surname, wrong man: "Bartholomaei Riccii" → *Paolo Riccio*, "Scipii Gentilis" → *Giovanni Gentile*. A capture that carries a given name and finds no candidate sharing it is evidence of a different person, not a weak match.

That first failure is **the third time in this workstream that matching a partial name into a store landed on a different person** — same shape as the `author_id` widening removed during the item-2 pass (Annibal Caro → a 13th-century Dominican). Worth naming as a pattern.

A small Latin/vernacular praenomen table (Matthaeus/Matteo, Carolus/Carlo) recovers correct matches that corroboration would otherwise reject — the exact gap `author-reconcile` documents, where authority records enumerate vernacular variants but not Latin inflections.

## Test

70 unit tests across the three modules. The `nominativise` suite injects `findCandidates`, so it runs with no database, and its fixture includes the two same-surname collisions above so the null-returning rules cannot be loosened silently.

```
npx vitest run tests/unit/nominativise.test.ts tests/unit/name-equivalence.test.ts tests/unit/title-page-attribution.test.ts
```

## Out of scope

Triaging the 112-row queue, the ingest guard and backfill-confidence change (#3894 items 3–4), and splitting `author_id: manuzio-aldo` across the three generations of the firm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
