### PR TITLE
fix(export): port the tenant download route back to the shared image path (#3909)

### DIFF
--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -15,14 +15,40 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { images } from '@/lib/api-client';
 import { markForExport } from '@/lib/provenance';
+import { getBookIndex } from '@/lib/book-index';
 import { resolveTenantId } from '@/lib/tenant-context';
-import { getPageImageUrl } from '@/lib/page-image-url';
 import { Readable } from 'stream';
 import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
 import { markdownToHtml } from '@/lib/export-markdown-html';
+import {
+  fetchAndCompressImage,
+  pageExportImageUrl,
+  hasExportImage,
+  fetchPageImagesOrdered,
+  streamPageImagesOrdered,
+  generateImagesZipStream,
+} from '@/lib/export-page-images';
 
 // Base URL for source links - update when we have a custom domain
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://sourcelibrary.org';
+
+// Image-heavy formats (facsimile/images EPUBs, images-zip) fetch + recompress
+// one image per page; give the function room beyond the default window. This
+// route ran on the default window until #3909 while its twin had 300s.
+export const maxDuration = 300;
+
+/**
+ * Budget for the image phase, in ms. `maxDuration` on this route is 300s; we
+ * stop ADDING pages at 210s so there is room to finish the page in hand, write
+ * the truncation notice and the colophon, and flush.
+ *
+ * A big book cannot be served whole in one request (a 4,198-page book would
+ * need ~40 minutes of fetching), so the choice is between an opaque timeout and
+ * an honest partial edition. Per CLAUDE.md "no silent caps": if coverage is
+ * bounded, say what was dropped — here in the PDF itself, so the artifact
+ * carries its own provenance rather than relying on a header nobody reads.
+ */
+const FACSIMILE_IMAGE_BUDGET_MS = 210_000;
 
 // Index entry structure (from book index collection)
 interface ConceptEntry {
@@ -874,37 +900,6 @@ function getTextSizeClass(text: string): string {
 }
 
 // Image dimensions for fixed-layout EPUB
-const IMAGE_WIDTH = 600;
-const IMAGE_HEIGHT = 900;
-
-// Fetch and process image for EPUB embedding
-// Uses minimal processing: grayscale + normalize (auto contrast)
-async function fetchAndCompressImage(url: string): Promise<Buffer | null> {
-  try {
-    const buffer = await images.fetchBuffer(url, { timeout: 60000 });
-
-    // Process with sharp: resize, grayscale, normalize, compress
-    const processed = await sharp(buffer)
-      .resize(IMAGE_WIDTH, IMAGE_HEIGHT, {
-        fit: 'inside',
-        withoutEnlargement: true
-      })
-      .grayscale()
-      .normalize()  // Auto contrast stretch
-      .jpeg({
-        quality: 75,
-        mozjpeg: true
-      })
-      .toBuffer();
-
-    console.log(`Image processed: ${url.slice(-30)} -> ${(processed.length / 1024).toFixed(1)}KB`);
-    return processed;
-  } catch (error) {
-    console.error(`Failed to fetch/process image: ${url}`, error);
-    return null;
-  }
-}
-
 // Generate facsimile EPUB: original page image on left, translation on right
 async function generateFacsimileEpubDownload(
   book: Book,
@@ -914,8 +909,10 @@ async function generateFacsimileEpubDownload(
   const bookTitle = book.display_title || book.title;
   const bookId = `urn:uuid:${book.id}`;
 
-  // Collect pages with photo and translation
-  const validPages = pages.filter(p => p.translation?.data && (p.photo || p.compressed_photo));
+  // Collect pages with photo and translation. Resolves through the canonical
+  // resolver — reading `photo` directly exports the uncropped spread on
+  // split-from-spread pages, i.e. the wrong image, silently (#3909).
+  const validPages = pages.filter(p => p.translation?.data && hasExportImage(p));
 
   return new Promise(async (resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -1087,14 +1084,11 @@ p:first-of-type { text-indent: 0; }
     `, 'Title Page', 'page-right');
     archive.append(titlePage, { name: 'OEBPS/title.xhtml' });
 
-    // Fetch and compress all images first (async)
+    // Fetch with BOUNDED concurrency. This was an unbounded Promise.all over
+    // every page — hundreds of simultaneous image fetches on a large book
+    // (#3909); the global route has used the bounded helper since #3597.
     console.log(`Fetching ${validPages.length} images for facsimile EPUB...`);
-    const imagePromises = validPages.map(async (page) => {
-      const imageUrl = page.compressed_photo || page.photo;
-      const imageBuffer = await fetchAndCompressImage(imageUrl);
-      return { page, imageBuffer };
-    });
-    const pageImages = await Promise.all(imagePromises);
+    const pageImages = await fetchPageImagesOrdered(validPages);
 
     // Add images and content pages
     for (const { page, imageBuffer } of pageImages) {
@@ -1171,70 +1165,6 @@ p:first-of-type { text-indent: 0; }
   });
 }
 
-// Generate ZIP of all page images
-async function generateImagesZip(
-  book: Book,
-  pages: Page[]
-): Promise<Buffer> {
-  const validPages = pages.filter(p => p.photo || p.compressed_photo);
-
-  return new Promise(async (resolve, reject) => {
-    const chunks: Buffer[] = [];
-    const archive = archiver('zip', { zlib: { level: 6 } });
-
-    archive.on('data', (chunk: Buffer) => chunks.push(chunk));
-    archive.on('end', () => resolve(Buffer.concat(chunks)));
-    archive.on('error', reject);
-
-    // Fetch and add each image
-    console.log(`Fetching ${validPages.length} images for ZIP...`);
-    for (const page of validPages) {
-      const imageUrl = page.compressed_photo || page.photo;
-      const imageBuffer = await fetchAndCompressImage(imageUrl);
-      if (imageBuffer) {
-        const paddedNum = String(page.page_number).padStart(4, '0');
-        archive.append(imageBuffer, { name: `page-${paddedNum}.jpg` });
-      }
-    }
-
-    archive.finalize();
-  });
-}
-
-// Resolve a page's export image via the canonical resolver (R2 display variant
-// first — `photo` is the SOURCE-provider URL, often a slow Internet Archive
-// fetch, and on split-from-spread pages it is the wrong image entirely). Added
-// alongside the PDF formats below — the rest of this file's image formats
-// predate this resolver and still use the legacy `photo || compressed_photo`
-// priority (out of scope to change here; tracked separately).
-function pageExportImageUrl(page: Page): string | null {
-  const legacy = (page as { compressed_photo?: string }).compressed_photo || page.photo || null;
-  const resolved = getPageImageUrl(page, 'display') || legacy;
-  if (!resolved) return null;
-  return resolved.startsWith('/') ? `${BASE_URL}${resolved}` : resolved;
-}
-
-// Prefetch page images with BOUNDED concurrency, preserving page order — see
-// the identical helper (and its rationale) in the main
-// src/app/api/books/[id]/download/route.ts.
-async function fetchPageImagesOrdered(
-  validPages: Page[],
-  concurrency = 8,
-): Promise<{ page: Page; imageBuffer: Buffer | null }[]> {
-  const results: { page: Page; imageBuffer: Buffer | null }[] = new Array(validPages.length);
-  let next = 0;
-  async function worker() {
-    while (next < validPages.length) {
-      const i = next++;
-      const page = validPages[i];
-      const url = pageExportImageUrl(page);
-      results[i] = { page, imageBuffer: url ? await fetchAndCompressImage(url) : null };
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(concurrency, validPages.length) }, worker));
-  return results;
-}
-
 // Generate text-only English translation PDF — see the main download route
 // for the full rationale (streamed, Unicode font, quote-integrity cleanup).
 function generatePdfTranslationStream(book: Book, pages: Page[]): PDFKit.PDFDocument {
@@ -1295,13 +1225,27 @@ function generatePdfFacsimileStream(book: Book, pages: Page[]): PDFKit.PDFDocume
       now,
     });
 
-    console.log(`Fetching ${validPages.length} images for pdf-facsimile (streaming)...`);
-    const pageImages = await fetchPageImagesOrdered(validPages);
+    // Yields each page AS ITS IMAGE ARRIVES. `fetchPageImagesOrdered` awaited
+    // EVERY image before writing a byte, so the response sat silent for the
+    // whole fetch (231s on a 366-page book) and Cloudflare killed it, with
+    // every compressed image resident at once — #3597, fixed on the global
+    // route and never ported here (#3909).
+    console.log(`Streaming ${validPages.length} images for pdf-facsimile...`);
+    const startedAt = Date.now();
+    let written = 0;
+    let translated = 0;
+    let truncated = false;
 
     const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
     const usableHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
 
-    for (const { page, imageBuffer } of pageImages) {
+    for await (const { page, imageBuffer } of streamPageImagesOrdered(validPages)) {
+      if (Date.now() - startedAt > FACSIMILE_IMAGE_BUDGET_MS) {
+        truncated = true;
+        break;
+      }
+      written++;
+      if (page.translation?.data) translated++;
       doc.addPage();
       writePdfPageHeading(doc, fonts, page.page_number);
 
@@ -1327,12 +1271,43 @@ function generatePdfFacsimileStream(book: Book, pages: Page[]): PDFKit.PDFDocume
       }
     }
 
+    // A partial facsimile must say so in the artifact itself — it used to be
+    // labelled a complete "facsimile edition" with pages silently missing.
+    if (truncated) {
+      const firstMissing = validPages[written]?.page_number;
+      doc.addPage();
+      doc.font(fonts.bold).fontSize(14).text('This edition is incomplete', { align: 'center' });
+      doc.moveDown(1);
+      doc.font(fonts.regular).fontSize(11).text(
+        [
+          `This facsimile stops at page ${validPages[written - 1]?.page_number ?? written} of `
+          + `${validPages.length}. It was not truncated for editorial reasons: a single request `
+          + 'cannot fetch and lay out every page scan of a book this large within the time '
+          + 'available, so generation stopped rather than failing outright.',
+          '',
+          firstMissing !== undefined
+            ? `Pages from ${firstMissing} onward are not included here. They are all readable `
+              + `at ${BASE_URL}/book/${book.id}, and the text-only PDF and EPUB editions cover `
+              + 'the whole book.'
+            : '',
+          '',
+          'If you need the complete facsimile as a single file, please get in touch — we would '
+          + 'rather generate it for you offline than hand you a partial edition without saying so.',
+        ].filter(Boolean).join('\n'),
+        { lineGap: 3 },
+      );
+      console.warn(
+        `pdf-facsimile truncated: ${written}/${validPages.length} pages for book ${book.id} `
+        + `after ${Date.now() - startedAt}ms`,
+      );
+    }
+
     doc.addPage();
     writePdfColophon(doc, fonts, book, {
       baseUrl: BASE_URL,
       now,
-      contentLabel: 'facsimile edition',
-      translatedCount: pageImages.filter(p => p.page.translation?.data).length,
+      contentLabel: truncated ? 'partial facsimile edition' : 'facsimile edition',
+      translatedCount: translated,
       totalCount: pages.length,
     });
 
@@ -1354,7 +1329,7 @@ async function generateImagesOnlyEpubDownload(
   const bookTitle = book.display_title || book.title;
   const bookId = `urn:uuid:${book.id}`;
 
-  const validPages = pages.filter(p => p.photo || p.compressed_photo);
+  const validPages = pages.filter(hasExportImage);
 
   return new Promise(async (resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -1467,12 +1442,11 @@ body { background: #1a1a1a; display: flex; align-items: center; justify-content:
 </html>`;
     archive.append(titlePage, { name: 'OEBPS/title.xhtml' });
 
-    // Fetch images and create pages
+    // Fetch images (bounded concurrency — the serial loop here took >100s on
+    // a ~126-page book and Cloudflare 524'd the response) and create pages
     console.log(`Fetching ${validPages.length} images for images-only EPUB...`);
-    for (const page of validPages) {
-      const imageUrl = page.compressed_photo || page.photo;
-      const imageBuffer = await fetchAndCompressImage(imageUrl);
-
+    const pageImages = await fetchPageImagesOrdered(validPages);
+    for (const { page, imageBuffer } of pageImages) {
       if (imageBuffer) {
         archive.append(imageBuffer, { name: `OEBPS/images/img-${page.page_number}.jpg` });
       }
@@ -2692,11 +2666,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Handle images ZIP download
     if (isImagesZip) {
-      const zipBuffer = await generateImagesZip(
-        book as unknown as Book,
-        pages as unknown as Page[]
-      );
-      return new Response(new Uint8Array(zipBuffer), {
+      // Streamed, not buffered: a buffered zip emits zero bytes for the whole
+      // build, and a big book crossed Cloudflare's ~100s origin window and died
+      // as a 524 that readers saved as a corrupt .zip (#3909).
+      const archive = generateImagesZipStream(pages as unknown as Page[]);
+      return new Response(Readable.toWeb(archive) as unknown as ReadableStream, {
         headers: {
           'Content-Type': 'application/zip',
           'Content-Disposition': `attachment; filename="${safeTitle}-images.zip"`,
@@ -2775,11 +2749,20 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           edition = editions[0] || null;
         }
 
-        // Get book index from dedicated collection (or inline fallback)
-        const indexData = await db.collection('book_indexes').findOne(
-          { book_id: (book as unknown as Book).id, tenantId },
-          { projection: { _id: 0, book_id: 0, tenantId: 0 } }
-        );
+        // Get book index via the shared accessor (dedicated collection, with the
+        // legacy inline `book.index` fallback).
+        //
+        // This was an inline `findOne({ book_id, tenantId })`, and `book_indexes`
+        // documents carry NO tenantId — 0 of 18,273 corpus-wide (measured
+        // 2026-08-11) — so the filter matched nothing and the scholarly EPUB has
+        // shipped without its index on every tenant subdomain since the route was
+        // written. It failed silently because a missing index is indistinguishable
+        // from a book that has none.
+        //
+        // Dropping the filter does not widen access: `book` above was already
+        // fetched with `{ id, tenantId }`, so tenant ownership is established
+        // before we get here, and `book_indexes` is keyed 1:1 on that book_id.
+        const indexData = await getBookIndex((book as unknown as Book).id);
         if (indexData) {
           const idx = indexData as unknown as {
             vocabulary?: ConceptEntry[];

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -16,11 +16,17 @@ import { join } from 'path';
 import { images } from '@/lib/api-client';
 import { markForExport } from '@/lib/provenance';
 import { getBookIndex } from '@/lib/book-index';
-import { getPageImageUrl } from '@/lib/page-image-url';
 import { Readable } from 'stream';
 import { createPdfDocument, writePdfTitlePage, writePdfPageHeading, writePdfColophon, cleanTranslationForPdf, writePdfBody } from '@/lib/pdf-export';
 import { markdownToHtml } from '@/lib/export-markdown-html';
-import { streamOrdered } from '@/lib/ordered-stream';
+import {
+  fetchAndCompressImage,
+  pageExportImageUrl,
+  hasExportImage,
+  fetchPageImagesOrdered,
+  streamPageImagesOrdered,
+  generateImagesZipStream,
+} from '@/lib/export-page-images';
 
 // Base URL for source links - update when we have a custom domain
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://sourcelibrary.org';
@@ -879,108 +885,6 @@ function getTextSizeClass(text: string): string {
 }
 
 // Image dimensions for fixed-layout EPUB
-const IMAGE_WIDTH = 600;
-const IMAGE_HEIGHT = 900;
-
-// Fetch and process image for EPUB embedding
-// Uses minimal processing: grayscale + normalize (auto contrast)
-async function fetchAndCompressImage(url: string): Promise<Buffer | null> {
-  try {
-    const buffer = await images.fetchBuffer(url, { timeout: 60000 });
-
-    // Process with sharp: resize, grayscale, normalize, compress
-    const processed = await sharp(buffer)
-      .resize(IMAGE_WIDTH, IMAGE_HEIGHT, {
-        fit: 'inside',
-        withoutEnlargement: true
-      })
-      .grayscale()
-      .normalize()  // Auto contrast stretch
-      .jpeg({
-        quality: 75,
-        mozjpeg: true
-      })
-      .toBuffer();
-
-    console.log(`Image processed: ${url.slice(-30)} -> ${(processed.length / 1024).toFixed(1)}KB`);
-    return processed;
-  } catch (error) {
-    console.error(`Failed to fetch/process image: ${url}`, error);
-    return null;
-  }
-}
-
-// Resolve a page's export image via the canonical resolver (R2 display variant
-// first — `photo` is the SOURCE-provider URL, often a slow Internet Archive
-// fetch, and on split-from-spread pages it is the wrong image entirely).
-// Falls back to the legacy field priority this route used historically.
-function pageExportImageUrl(page: Page): string | null {
-  const legacy = (page as { compressed_photo?: string }).compressed_photo || page.photo || null;
-  const resolved = getPageImageUrl(page, 'display') || legacy;
-  if (!resolved) return null;
-  return resolved.startsWith('/') ? `${BASE_URL}${resolved}` : resolved;
-}
-
-// Prefetch page images with BOUNDED concurrency, preserving page order.
-// Serial fetching made a ~126-page book take >100s of response silence, so
-// Cloudflare cut the connection (HTTP 524) and readers saved the CF error
-// page as a corrupt .zip/.epub (footer feedback, 2026-07-02). Unbounded
-// Promise.all is the opposite failure: hundreds of concurrent image fetches.
-async function fetchPageImagesOrdered(
-  validPages: Page[],
-  concurrency = 8,
-): Promise<{ page: Page; imageBuffer: Buffer | null }[]> {
-  const results: { page: Page; imageBuffer: Buffer | null }[] = new Array(validPages.length);
-  let next = 0;
-  async function worker() {
-    while (next < validPages.length) {
-      const i = next++;
-      const page = validPages[i];
-      const url = pageExportImageUrl(page);
-      results[i] = { page, imageBuffer: url ? await fetchAndCompressImage(url) : null };
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(concurrency, validPages.length) }, worker));
-  return results;
-}
-
-/**
- * Ordered image fetch that yields each page AS IT ARRIVES, keeping only a
- * bounded look-ahead window resident.
- *
- * `fetchPageImagesOrdered()` above awaits EVERY image before returning, which
- * gives the streamed PDF two problems that only appear at real book sizes
- * (measured on a 366-page book, #3597):
- *
- *  - Nothing is written for the whole fetch (231s locally). The response
- *    "streams", but the producer blocks before emitting a body, so the
- *    connection sits silent and Cloudflare's ~100s window kills it long before
- *    `maxDuration` would.
- *  - Every compressed image is resident at once (74MB), and peak RSS hit 707MB
- *    against Vercel's 1024MB default. 6,987 visible books are LARGER than that
- *    test book, so this is the common case, not the tail.
- *
- * Yielding in order with a `lookahead` cap fixes both: the first page is
- * written as soon as one image lands, and at most `lookahead` buffers are held.
- * Each yielded buffer is dropped from the window so it can be collected once
- * the caller has embedded it.
- */
-async function* streamPageImagesOrdered(
-  validPages: Page[],
-): AsyncGenerator<{ page: Page; imageBuffer: Buffer | null }> {
-  const stream = streamOrdered(
-    validPages,
-    page => {
-      const url = pageExportImageUrl(page);
-      return url ? fetchAndCompressImage(url) : Promise.resolve(null);
-    },
-    { concurrency: 8, lookahead: 12 },
-  );
-  for await (const { item, value } of stream) {
-    yield { page: item, imageBuffer: value };
-  }
-}
-
 // Generate facsimile EPUB: original page image on left, translation on right
 async function generateFacsimileEpubDownload(
   book: Book,
@@ -1241,45 +1145,6 @@ p:first-of-type { text-indent: 0; }
 
     archive.finalize();
   });
-}
-
-// Generate ZIP of all page images
-// Returns a live archiver stream so the response starts flowing immediately.
-// Buffering the whole zip meant zero bytes for the full build time; big books
-// crossed Cloudflare's ~100s origin window and died with a 524.
-function generateImagesZipStream(book: Book, pages: Page[]): archiver.Archiver {
-  const validPages = pages.filter(p => pageExportImageUrl(p));
-  const archive = archiver('zip', { zlib: { level: 6 } });
-
-  (async () => {
-    console.log(`Fetching ${validPages.length} images for ZIP (streaming)...`);
-    // Sliding window: ~8 fetches in flight, appended strictly in page order.
-    const inFlight: (Promise<Buffer | null> | undefined)[] = new Array(validPages.length);
-    let started = 0;
-    const startNext = () => {
-      if (started >= validPages.length) return;
-      const i = started++;
-      const url = pageExportImageUrl(validPages[i]);
-      inFlight[i] = url ? fetchAndCompressImage(url) : Promise.resolve(null);
-    };
-    for (let k = 0; k < Math.min(8, validPages.length); k++) startNext();
-
-    for (let i = 0; i < validPages.length; i++) {
-      const imageBuffer = await inFlight[i];
-      inFlight[i] = undefined;
-      startNext();
-      if (imageBuffer) {
-        const paddedNum = String(validPages[i].page_number).padStart(4, '0');
-        archive.append(imageBuffer, { name: `page-${paddedNum}.jpg` });
-      }
-    }
-    await archive.finalize();
-  })().catch(err => {
-    console.error('images-zip stream failed:', err);
-    archive.destroy(err instanceof Error ? err : new Error(String(err)));
-  });
-
-  return archive;
 }
 
 // Generate text-only English translation PDF: front matter, continuous
@@ -2788,10 +2653,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Handle images ZIP download
     if (isImagesZip) {
-      const archive = generateImagesZipStream(
-        book as unknown as Book,
-        pages as unknown as Page[]
-      );
+      const archive = generateImagesZipStream(pages as unknown as Page[]);
       return new Response(Readable.toWeb(archive) as unknown as ReadableStream, {
         headers: {
           'Content-Type': 'application/zip',

--- a/src/lib/export-page-images.ts
+++ b/src/lib/export-page-images.ts
@@ -1,0 +1,181 @@
+import archiver from 'archiver';
+import sharp from 'sharp';
+import { images } from '@/lib/api-client';
+import { getPageImageUrl } from '@/lib/page-image-url';
+import { streamOrdered } from '@/lib/ordered-stream';
+import type { Page } from '@/lib/types';
+
+/**
+ * Page-image resolution and fetching for the download exports.
+ *
+ * This lived in BOTH download routes (`/api/books/[id]/download` and its tenant
+ * twin), and the twins drifted: fixes landed on the global route and were ported
+ * to the tenant one only at the call site that motivated them, leaving three of
+ * four tenant image formats on the legacy path for months (#3909). The failure
+ * was silent in both directions — a wrong image is still a valid JPEG, and a
+ * serial fetch is just slow until Cloudflare cuts it.
+ *
+ * The mechanics here are tenant-independent: what differs between the two routes
+ * is which books they may serve, not how an image is resolved or fetched. Import
+ * these; do not re-implement them beside a call site.
+ */
+
+const IMAGE_WIDTH = 600;
+const IMAGE_HEIGHT = 900;
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://sourcelibrary.org';
+
+/**
+ * Fetch and process an image for EPUB/PDF embedding.
+ * Minimal processing: resize, grayscale, normalize (auto contrast), compress.
+ */
+export async function fetchAndCompressImage(url: string): Promise<Buffer | null> {
+  try {
+    const buffer = await images.fetchBuffer(url, { timeout: 60000 });
+
+    const processed = await sharp(buffer)
+      .resize(IMAGE_WIDTH, IMAGE_HEIGHT, {
+        fit: 'inside',
+        withoutEnlargement: true
+      })
+      .grayscale()
+      .normalize()  // Auto contrast stretch
+      .jpeg({
+        quality: 75,
+        mozjpeg: true
+      })
+      .toBuffer();
+
+    console.log(`Image processed: ${url.slice(-30)} -> ${(processed.length / 1024).toFixed(1)}KB`);
+    return processed;
+  } catch (error) {
+    console.error(`Failed to fetch/process image: ${url}`, error);
+    return null;
+  }
+}
+
+/**
+ * Resolve a page's export image via the canonical resolver (R2 display variant
+ * first). `photo` is the SOURCE-provider URL — often a slow Internet Archive
+ * fetch, and on split-from-spread pages it is the WRONG IMAGE ENTIRELY: the
+ * uncropped spread rather than the single page the reader sees. Falls back to
+ * the legacy field priority the routes used historically.
+ *
+ * Every export format must resolve through here. Reading `photo ||
+ * compressed_photo` directly at a call site is the #3909 bug, and it does not
+ * announce itself — the export succeeds and simply contains the wrong picture.
+ */
+export function pageExportImageUrl(page: Page): string | null {
+  const legacy = (page as { compressed_photo?: string }).compressed_photo || page.photo || null;
+  const resolved = getPageImageUrl(page, 'display') || legacy;
+  if (!resolved) return null;
+  return resolved.startsWith('/') ? `${BASE_URL}${resolved}` : resolved;
+}
+
+/** True when a page has an image any export format can embed. */
+export function hasExportImage(page: Page): boolean {
+  return pageExportImageUrl(page) !== null;
+}
+
+/**
+ * Prefetch page images with BOUNDED concurrency, preserving page order.
+ *
+ * Serial fetching made a ~126-page book take >100s of response silence, so
+ * Cloudflare cut the connection (HTTP 524) and readers saved the CF error page
+ * as a corrupt .zip/.epub (footer feedback, 2026-07-02). Unbounded Promise.all
+ * is the opposite failure: hundreds of concurrent image fetches.
+ */
+export async function fetchPageImagesOrdered(
+  validPages: Page[],
+  concurrency = 8,
+): Promise<{ page: Page; imageBuffer: Buffer | null }[]> {
+  const results: { page: Page; imageBuffer: Buffer | null }[] = new Array(validPages.length);
+  let next = 0;
+  async function worker() {
+    while (next < validPages.length) {
+      const i = next++;
+      const page = validPages[i];
+      const url = pageExportImageUrl(page);
+      results[i] = { page, imageBuffer: url ? await fetchAndCompressImage(url) : null };
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, validPages.length) }, worker));
+  return results;
+}
+
+/**
+ * Ordered image fetch that yields each page AS IT ARRIVES, keeping only a
+ * bounded look-ahead window resident.
+ *
+ * `fetchPageImagesOrdered()` above awaits EVERY image before returning, which
+ * gives a streamed response two problems that only appear at real book sizes
+ * (measured on a 366-page book, #3597):
+ *
+ *  - Nothing is written for the whole fetch (231s locally). The response
+ *    "streams", but the producer blocks before emitting a body, so the
+ *    connection sits silent and Cloudflare's ~100s window kills it long before
+ *    `maxDuration` would.
+ *  - Every compressed image is resident at once (74MB), and peak RSS hit 707MB
+ *    against Vercel's 1024MB default. 6,987 visible books are LARGER than that
+ *    test book, so this is the common case, not the tail.
+ *
+ * Yielding in order with a `lookahead` cap fixes both: the first page is written
+ * as soon as one image lands, and at most `lookahead` buffers are held.
+ */
+/**
+ * ZIP of all page images.
+ *
+ * Returns a LIVE archiver stream so the response starts flowing immediately.
+ * Buffering the whole zip meant zero bytes for the full build time; big books
+ * crossed Cloudflare's ~100s origin window and died with a 524, and the reader
+ * saved the Cloudflare error page as a corrupt `.zip`.
+ */
+export function generateImagesZipStream(pages: Page[]): archiver.Archiver {
+  const validPages = pages.filter(hasExportImage);
+  const archive = archiver('zip', { zlib: { level: 6 } });
+
+  (async () => {
+    console.log(`Fetching ${validPages.length} images for ZIP (streaming)...`);
+    // Sliding window: ~8 fetches in flight, appended strictly in page order.
+    const inFlight: (Promise<Buffer | null> | undefined)[] = new Array(validPages.length);
+    let started = 0;
+    const startNext = () => {
+      if (started >= validPages.length) return;
+      const i = started++;
+      const url = pageExportImageUrl(validPages[i]);
+      inFlight[i] = url ? fetchAndCompressImage(url) : Promise.resolve(null);
+    };
+    for (let k = 0; k < Math.min(8, validPages.length); k++) startNext();
+
+    for (let i = 0; i < validPages.length; i++) {
+      const imageBuffer = await inFlight[i];
+      inFlight[i] = undefined;
+      startNext();
+      if (imageBuffer) {
+        const paddedNum = String(validPages[i].page_number).padStart(4, '0');
+        archive.append(imageBuffer, { name: `page-${paddedNum}.jpg` });
+      }
+    }
+    await archive.finalize();
+  })().catch(err => {
+    console.error('images-zip stream failed:', err);
+    archive.destroy(err instanceof Error ? err : new Error(String(err)));
+  });
+
+  return archive;
+}
+
+export async function* streamPageImagesOrdered(
+  validPages: Page[],
+): AsyncGenerator<{ page: Page; imageBuffer: Buffer | null }> {
+  const stream = streamOrdered(
+    validPages,
+    page => {
+      const url = pageExportImageUrl(page);
+      return url ? fetchAndCompressImage(url) : Promise.resolve(null);
+    },
+    { concurrency: 8, lookahead: 12 },
+  );
+  for await (const { item, value } of stream) {
+    yield { page: item, imageBuffer: value };
+  }
+}

--- a/tests/unit/download-route-parity.test.ts
+++ b/tests/unit/download-route-parity.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { pageExportImageUrl, hasExportImage } from '@/lib/export-page-images';
+import type { Page } from '@/lib/types';
+
+const ROUTES = [
+  'src/app/api/books/[id]/download/route.ts',
+  'src/app/api/[tenant]/books/[id]/download/route.ts',
+];
+
+const read = (rel: string) => readFileSync(path.join(process.cwd(), rel), 'utf8');
+
+/**
+ * #3909. The two download routes are near-twins that are NOT parity-tested, and
+ * they drifted: fixes landed on the global route and were ported to the tenant
+ * one only at the call site that motivated them. Three of four tenant image
+ * formats sat on the legacy path for months.
+ *
+ * Every failure in that set was SILENT — a wrong image is still a valid JPEG, a
+ * serial fetch is just slow until Cloudflare cuts it, and a missing book index
+ * looks exactly like a book that has none. So these guards pin the properties
+ * whose violation produces no error, not the ones a test would catch anyway.
+ */
+describe('download routes: shared export machinery', () => {
+  for (const rel of ROUTES) {
+    const src = read(rel);
+
+    it(`${rel} resolves export images through the canonical resolver`, () => {
+      // The #3909 bug shape: reading the raw fields at a call site. `photo` is
+      // the SOURCE-provider URL and on split-from-spread pages it is the
+      // uncropped spread — a different picture than the reader sees.
+      expect(src).not.toMatch(/p\.photo\s*\|\|\s*p\.compressed_photo/);
+      expect(src).not.toMatch(/page\.compressed_photo\s*\|\|\s*page\.photo/);
+      expect(src).toContain("from '@/lib/export-page-images'");
+    });
+
+    it(`${rel} does not define the image helpers locally`, () => {
+      expect(src).not.toMatch(/function\s+pageExportImageUrl\s*\(/);
+      expect(src).not.toMatch(/function\s+fetchPageImagesOrdered\s*\(/);
+      expect(src).not.toMatch(/function\s+fetchAndCompressImage\s*\(/);
+    });
+
+    it(`${rel} gives image-heavy formats room beyond the default window`, () => {
+      // Image formats fetch + recompress one image per page. The tenant route
+      // ran on the default window until #3909.
+      expect(src).toMatch(/export const maxDuration = 300;/);
+    });
+
+    it(`${rel} streams the images zip rather than buffering it`, () => {
+      // A buffered zip emits zero bytes for the whole build; big books crossed
+      // Cloudflare's ~100s origin window and died as a 524 that readers saved
+      // as a corrupt .zip.
+      expect(src).toContain('generateImagesZipStream');
+      expect(src).not.toMatch(/await\s+generateImagesZip\s*\(/);
+    });
+
+    it(`${rel} labels a truncated facsimile as partial`, () => {
+      // "No silent caps": a bounded export must say what was dropped, in the
+      // artifact itself.
+      expect(src).toContain('partial facsimile edition');
+      expect(src).toContain('This edition is incomplete');
+    });
+
+    it(`${rel} does not filter book_indexes by a field it does not have`, () => {
+      // Measured 2026-08-11: 0 of 18,273 book_indexes documents carry tenantId,
+      // so this filter matched nothing and the scholarly EPUB silently shipped
+      // with no index on every tenant subdomain.
+      expect(src).not.toMatch(/book_id:[^)]*tenantId[^)]*\}\s*,?\s*\n?\s*\{\s*projection/);
+      expect(src).not.toMatch(/collection\('book_indexes'\)/);
+    });
+  }
+});
+
+describe('pageExportImageUrl', () => {
+  const page = (fields: Partial<Page>) => fields as Page;
+
+  it('prefers the R2 display variant over the source-provider photo', () => {
+    const url = pageExportImageUrl(page({
+      display_photo: 'https://cdn.example.org/r2/display.jpg',
+      photo: 'https://archive.org/download/foo/page.jp2',
+    }));
+    expect(url).toBe('https://cdn.example.org/r2/display.jpg');
+  });
+
+  it('falls back to the legacy fields when nothing resolves', () => {
+    const url = pageExportImageUrl(page({ compressed_photo: 'https://cdn.example.org/small.jpg' }));
+    expect(url).toBe('https://cdn.example.org/small.jpg');
+  });
+
+  it('returns null when a page has no image at all', () => {
+    expect(pageExportImageUrl(page({}))).toBeNull();
+    expect(hasExportImage(page({}))).toBe(false);
+  });
+
+  it('absolutises a site-relative resolver result so an export can fetch it', () => {
+    const url = pageExportImageUrl(page({
+      photo: 'https://archive.org/download/foo/page.jp2',
+      cropped_photo: '/api/image?src=x',
+    }));
+    if (url?.startsWith('/')) throw new Error('relative URL leaked to the fetcher');
+    expect(url === null || /^https?:\/\//.test(url)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3909.

## Corrections to the issue I filed

Working it turned up three errors in my own report, all worth stating because two of them change what the fix is.

1. **The tenant route was not missing the helpers.** `pageExportImageUrl` and `fetchPageImagesOrdered` were both defined in it, added alongside the PDF formats — with a comment saying the other image formats "still use the legacy priority (out of scope to change here; tracked separately)". The drift is not an absent helper, it is **which call sites were converted**: 1 of 4 image formats.
2. **The facsimile EPUB was not fetching serially** — it used an unbounded `Promise.all` over every page, which is the *opposite* failure and the one `fetchPageImagesOrdered`'s own comment warns about. images-zip and images-only EPUB were the serial ones.
3. **Item 5 was not a "maintenance hazard", it was a live silent defect** — see below. I under-rated it because I reasoned from the shape of the code instead of checking the data.

## The defects, all of which failed silently

| # | format | what it did | why nobody noticed |
|---|---|---|---|
| 1 | facsimile EPUB, images-zip, images-only EPUB | resolved from raw `photo`/`compressed_photo` | on split-from-spread pages `photo` is the **uncropped spread** — the export succeeds with a valid JPEG of the wrong thing |
| 2 | scholarly EPUB | `book_indexes.findOne({ book_id, tenantId })` | **0 of 18,273** `book_indexes` docs carry `tenantId` (measured 2026-08-11), so the filter matched nothing and the EPUB shipped with no index — indistinguishable from a book that has none |
| 3 | facsimile EPUB | unbounded `Promise.all` over every page | slow/OOM, not an error |
| 4 | images-zip, images-only EPUB | serial `await` per image | >100s silence on a ~126-page book → Cloudflare 524 → reader saves the CF error page as a corrupt `.zip` |
| 5 | images-zip | buffered the whole archive before responding | same 524 window |
| 6 | pdf-facsimile | awaited **every** image before writing a byte | the #3597 failure: 231s of silence on a 366-page book, 707MB peak RSS against a 1024MB limit |
| 7 | the route itself | no `export const maxDuration` | ran on the default window while its twin had 300s |
| 8 | pdf-facsimile | no truncation notice; colophon always said "facsimile edition" | a partial export presented as complete — the "no silent caps" rule |

Defect 2 is the one I'd flag for review attention: it is not a drift at all, it is a filter that has never matched since the route was written.

On dropping that `tenantId` filter — it does not widen access. `book` is fetched with `{ id, tenantId }` earlier in the handler, so tenant ownership is established before the index lookup, and `book_indexes` is keyed 1:1 on `book_id`. The shared `getBookIndex` accessor also brings the legacy inline-`book.index` fallback the inline query lacked.

## Approach

Porting four patches would have left the same structure that produced the drift. Instead the tenant-independent mechanics move to **`src/lib/export-page-images.ts`** (`fetchAndCompressImage`, `pageExportImageUrl`, `hasExportImage`, `fetchPageImagesOrdered`, `streamPageImagesOrdered`, `generateImagesZipStream`), imported by both routes. What actually differs between them is *which books they may serve*, not how an image is resolved or fetched.

Remaining twin drift: **388 → 175 lines**, and what is left is genuine tenant scoping.

## Tests

`tests/unit/download-route-parity.test.ts` — a whole-file parity assert is still not available, so these pin the properties whose violation produces **no error**: no raw-field resolution, no locally-redefined helpers, `maxDuration` present, zip streamed not buffered, truncation labelled, no `book_indexes` filter on a field that does not exist.

**All eight guards were run against the pre-fix file and confirmed firing** — a guard that has never seen its bug is decoration.

- Full suite: 2653 passed / 186 files.
- `npx tsc --noEmit` clean, eslint clean on new files.

## Scope

**Out:** making the tenant route a thin wrapper that injects a `tenantId` filter and delegates — the real structural fix, but a much larger change than this correctness one, and it wants its own review. The 175 remaining diff lines are the material for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
