### PR TITLE
fix(ft): mount the Translation Card in the standard layout (#3881)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1348,6 +1348,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             <PlusToggle />
           </summary>
           <div className="px-4 pb-4 md:px-6 md:pb-6">
+            {translationCard && cardLabel(translationCard, book as { pages_translated?: number | null }) && (
+              <TranslationCardPanel
+                card={translationCard}
+                book={book as { pages_translated?: number | null }}
+                showExternalLinks={embedPolicy.showExternalLinks}
+              />
+            )}
             <BookBiblioPanel book={book} pagesCount={totalPages} showExternalLinks={embedPolicy.showExternalLinks} />
             {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (
               <Suspense fallback={null}><RelatedEditions


### PR DESCRIPTION
#3910's mount sat in BookInfo's **embed-only** return — the standard site layout never renders it, so the card was invisible on every real book page (the documented 2026-08-04 embed-only-branch trap, faithfully recreated by me). One-hunk fix: mount inside the standard layout's Bibliographic information section; embed mount unchanged. Locally verified against prod data — both registers render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)