### PR TITLE
feat(ft): plain catalog voice — strip the hedging registers

### DIFF
--- a/src/components/book/FirstTranslationEvidence.tsx
+++ b/src/components/book/FirstTranslationEvidence.tsx
@@ -411,20 +411,16 @@ export default async function FirstTranslationEvidence({
   return (
     <div className="mt-3">
       <details className="group">
+        {/* Plain catalog voice (2026-08-11): one gold badge, no register split,
+            no strength/preliminary chips — the evidence footer below keeps the
+            provenance one click away. */}
         <summary
-          className={
-            isCandidateClaim
-              ? 'inline-flex items-center gap-2 px-2.5 py-1 bg-stone-700/40 text-stone-300 hover:bg-stone-700/60 text-xs font-medium rounded-full border border-stone-600/50 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden'
-              : 'inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden'
-          }
+          className="inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden"
         >
           {firstTranslationBadge(dispForLabel, book.language, inProgress, claim)}
         </summary>
         <div className="mt-2 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-xs space-y-2">
-          <div className="flex items-start justify-between gap-2">
-            <p className="text-stone-300">{firstTranslationDescription(dispForLabel, claim)}</p>
-            <StrengthChip strength={effectiveStrength} preliminary={isPreliminary} />
-          </div>
+          <p className="text-stone-300">{firstTranslationDescription(dispForLabel, claim)}</p>
           {inProgress && coverage !== null && (
             <p className="text-stone-400">{translationProgressNote(coverage)}</p>
           )}

--- a/src/components/book/TranslationCardPanel.tsx
+++ b/src/components/book/TranslationCardPanel.tsx
@@ -27,12 +27,13 @@ export default function TranslationCardPanel({
   return (
     <div className="mt-3 rounded border border-stone-700/40 bg-stone-800/20 px-3 py-2.5 text-sm">
       <div className="flex items-start gap-2">
-        {isFirst && (
+        {isFirst ? (
           <span className="mt-0.5 inline-block whitespace-nowrap rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-300">
             First Translation
           </span>
+        ) : (
+          <p className="text-stone-300">{label.sentence}</p>
         )}
-        <p className="text-stone-300">{label.sentence}</p>
       </div>
 
       {label.entries.length > 0 && (
@@ -61,9 +62,6 @@ export default function TranslationCardPanel({
         </ul>
       )}
 
-      {label.searchSummary && (
-        <p className="mt-2 text-[11px] leading-snug text-stone-500">{label.searchSummary}</p>
-      )}
     </div>
   );
 }

--- a/src/lib/first-translation-labels.ts
+++ b/src/lib/first-translation-labels.ts
@@ -3,23 +3,20 @@
  *
  * Centralizes the mapping so all UI components stay in sync.
  *
- * THE COPY RULE (#3459). "First English translation" asserts an unprovable
- * universal negative: no catalogue can establish one, it can only return
- * *nothing found*. Our reference set's measured recall is 27% — three of every
- * four known prior English translations are invisible to it — and a sampled
- * check puts the positive predictive value of a `none_found` near 50%.
+ * THE COPY RULE (revised 2026-08-11, Derek): plain catalog voice. A library
+ * catalog says "first edition" without an epistemology lecture, and everyone
+ * understands the implicit "as far as the record shows." We say "First
+ * Translation" the same way. The evidence — every search, every source, every
+ * screening decision — lives in the data (`work_translation_history`,
+ * `first_translation_attempts`) one click away for anyone who wants it; it
+ * does not live in the reader's face as a disclaimer. State the fact plainly;
+ * keep the provenance available; correct the card when someone shows us a
+ * prior. (The previous two-register system — assertive vs. hedged wording by
+ * evidence strength — read as a library afraid of its own catalog.)
  *
- * So the copy states the SEARCH, which is a bounded, dated act we actually
- * performed and can show, rather than the negative, which is a claim about the
- * world that no search supports. "No prior English translation found" is true
- * at any recall; "this is the first" is not.
- *
- * Two registers, and which one a book gets is decided by evidence strength in
- * `classifyFirstTranslationClaim`, never by the badge flag alone:
- *
- *   confirmed → strong/moderate evidence. The assertive label stands.
- *   candidate → weak or unrecorded evidence (88% of badged books, measured
- *               2026-08-07). Reports the search and its limits.
+ * The one qualifier we keep is `inProgress` (#3435): "in progress" on a
+ * barely-translated book is reader service, not epistemic hedging — it stops
+ * the bibliographic claim from implying a readable English edition exists.
  */
 
 import type { FirstTranslationClaim } from './first-translation/candidate';
@@ -28,43 +25,17 @@ type Disposition = 'confirmed_first' | 'first_from_source' | 'first_complete_tra
 
 /**
  * Returns the short badge label for a first-translation book.
- * Pass the book's language to get "First Translation from Latin" etc.
+ * Pass the book's language to get "First from Latin" etc.
  *
- * `inProgress` marks a book whose translation is real but far from complete
- * (#3435 — 244 badged books are under 10% translated). The bibliographic claim
- * is unchanged; the label stops implying a readable English edition exists.
- * "First Complete Translation" collapses to "First Translation, in progress",
- * because calling a 6%-translated book *complete* is the specific claim the
- * coverage gate exists to prevent.
- *
- * `claim` decides the register. A `candidate` never gets an assertive label,
- * however strong the disposition reads — the disposition records what a search
- * concluded, not how well it was evidenced, and conflating the two is what put
- * an unqualified "First Translation" on 5,243 weakly-evidenced books.
- *
- * ⚠️ IT DEFAULTS TO `candidate`, AND THAT DIRECTION IS THE POINT. A caller that
- * cannot supply the claim has, by definition, not established the evidence —
- * the collection, catalogue, author and exhibition cards all render from
- * `books_catalog`, which carries `ft_disposition` but no evidence strength, so
- * none of them can tell a cross-checked first from a legacy shim. Defaulting to
- * the assertive label would let every one of those surfaces assert a universal
- * negative by omission, which is precisely how this area fails (see
- * `.claude/docs/invariants/first-translation-claims.md`: every defect here
- * failed toward a confident clean negative). Opt IN to `confirmed`; never
- * inherit it.
+ * The `claim` parameter is retained for call-site compatibility but no longer
+ * changes the register: badged books get the plain catalog label.
  */
 export function firstTranslationBadge(
   disposition?: string,
   language?: string,
   inProgress?: boolean,
-  claim: FirstTranslationClaim = 'candidate',
+  _claim: FirstTranslationClaim = 'candidate',
 ): string {
-  if (claim === 'candidate') {
-    // Deliberately one label, not a family. The disposition's shades
-    // (complete / modern / from-source) are distinctions the weak evidence
-    // cannot support, so drawing them here would dress up a coin flip.
-    return inProgress ? 'No prior translation found, in progress' : 'No prior translation found';
-  }
   if (inProgress) {
     return disposition === 'first_from_source' && language
       ? `First from ${language}, in progress`
@@ -94,33 +65,22 @@ export function translationProgressNote(coverage: number): string {
 }
 
 /**
- * The expanded description shown in the book detail panel.
- *
- * For a `candidate` this is the search statement — what we looked for, and the
- * two things a reader needs in order to weigh it: that a catalogue can only
- * report absence, and that ours is thin for exactly the period most of this
- * corpus comes from. Stating the limit is not a hedge; it is the claim.
- *
- * Defaults to `candidate` for the same reason `firstTranslationBadge` does.
+ * The expanded description shown in the book detail panel. Plain catalog
+ * voice; the search record backs it one click away.
  */
 export function firstTranslationDescription(
   disposition?: string,
-  claim: FirstTranslationClaim = 'candidate',
+  _claim: FirstTranslationClaim = 'candidate',
 ): string {
-  if (claim === 'candidate') {
-    return 'We searched the catalogues for an earlier English translation of this text and found none. That is a record of the search, not proof that none exists — catalogue coverage of early printed books is thin, and an absence there is weaker evidence than a find.';
-  }
   switch (disposition as Disposition) {
-    case 'confirmed_first':
-      return 'No prior complete English translation of this text has been found.';
     case 'first_from_source':
-      return 'English translations of this work exist from another source language, but this specific text has never been translated.';
+      return 'English translations of this work exist from another source language; this is the first English translation of this text.';
     case 'first_complete_translation':
-      return 'Only partial translations or excerpts exist. This is the first complete English translation.';
+      return 'Earlier English translations were partial. This is the first complete English translation.';
     case 'first_modern_translation':
-      return 'Only antiquated translations exist. This is the first modern English translation.';
+      return 'The first modern English translation.';
     default:
-      return 'No prior English translation of this text was found.';
+      return 'The first English translation of this text.';
   }
 }
 
@@ -133,7 +93,6 @@ export function firstTranslationDescription(
  * qualifier.
  */
 export function firstTranslationClause(claim: FirstTranslationClaim): string | null {
-  if (claim === 'confirmed') return 'First English translation';
-  if (claim === 'candidate') return 'No prior English translation found';
+  if (claim === 'confirmed' || claim === 'candidate') return 'First English translation';
   return null;
 }

--- a/src/lib/first-translation/card.ts
+++ b/src/lib/first-translation/card.ts
@@ -58,7 +58,6 @@ export interface CardLabel {
   register: 'first' | 'priors';
   /** Entries to show under the sentence (priors register only). */
   entries: CardEntry[];
-  searchSummary?: string;
 }
 
 /**
@@ -77,26 +76,29 @@ export function cardLabel(
 
   if (card.status === 'no_prior_known') {
     if (!((book.pages_translated ?? 0) > 0)) return null;
-    const summary = card.search?.summary;
+    // Plain catalog voice (2026-08-11): state the fact like a catalog states
+    // "first edition". The search record backs it, one click away — not as a
+    // disclaimer in the reader's face.
     return {
-      sentence: 'No earlier English translation of this work is known to us.',
+      sentence: 'The first English translation of this work.',
       register: 'first',
       entries: [],
-      searchSummary: summary,
     };
   }
 
   if (card.status === 'prior_exists') {
     const entries = (card.entries ?? []).filter((e) => e.title || e.translator);
     if (entries.length === 0) return null;
-    const earliest = entries
+    const named = entries
       .map((e) => ({ e, y: parseInt(String(e.year ?? '').match(/\d{4}/)?.[0] ?? '', 10) }))
       .filter((x) => Number.isFinite(x.y))
-      .sort((a, b) => a.y - b.y)[0];
-    const lead = earliest
-      ? `English translations of this work exist — the earliest known to us is ${earliest.e.translator ?? earliest.e.title} (${earliest.y}).`
-      : 'English translations of this work are known to us.';
-    return { sentence: lead, register: 'priors', entries, searchSummary: card.search?.summary };
+      .sort((a, b) => a.y - b.y)
+      .slice(0, 3)
+      .map((x) => `${x.e.translator ?? x.e.title} (${x.y})`);
+    const lead = named.length
+      ? `Earlier English translations: ${named.join('; ')}.`
+      : 'Earlier English translations exist.';
+    return { sentence: lead, register: 'priors', entries };
   }
 
   return null;

--- a/tests/unit/first-translation-coverage.test.ts
+++ b/tests/unit/first-translation-coverage.test.ts
@@ -136,33 +136,34 @@ describe('firstTranslationBadge qualifies an in-progress translation', () => {
   });
 });
 
-describe('firstTranslationBadge states the search when the claim is a candidate', () => {
-  it('reports the search instead of asserting the negative', () => {
+describe('firstTranslationBadge speaks plain catalog voice in every register (2026-08-11)', () => {
+  // Policy reversal, deliberate (Derek): a catalog says "first edition" without
+  // an epistemology lecture. The claim register no longer changes the wording;
+  // provenance lives in the data, one click away, not in the label.
+  it('states the plain label regardless of claim register', () => {
     expect(firstTranslationBadge('confirmed_first', 'Latin', false, 'candidate'))
-      .toBe('No prior translation found');
+      .toBe('First Translation');
+    expect(firstTranslationBadge('confirmed_first', 'Latin', false, 'confirmed'))
+      .toBe('First Translation');
   });
 
-  it('keeps the in-progress qualifier', () => {
+  it('keeps the in-progress qualifier (reader service, not hedging)', () => {
     expect(firstTranslationBadge('confirmed_first', 'Latin', true, 'candidate'))
-      .toBe('No prior translation found, in progress');
+      .toBe('First Translation, in progress');
   });
 
-  it('does not draw distinctions the weak evidence cannot support', () => {
-    // complete / modern / from-source are gradations of a conclusion, not of the
-    // evidence behind it. Rendering them on a candidate dresses up a coin flip.
-    for (const d of ['first_complete_translation', 'first_modern_translation', 'first_from_source']) {
-      expect(firstTranslationBadge(d, 'Dutch', false, 'candidate')).toBe('No prior translation found');
-    }
+  it('draws the disposition distinctions in every register', () => {
+    expect(firstTranslationBadge('first_complete_translation', 'Dutch', false, 'candidate'))
+      .toBe('First Complete Translation');
+    expect(firstTranslationBadge('first_modern_translation', 'Dutch', false, 'candidate'))
+      .toBe('First Modern Translation');
+    expect(firstTranslationBadge('first_from_source', 'Dutch', false, 'candidate'))
+      .toBe('First from Dutch');
   });
 
-  it('DEFAULTS to the candidate register when the caller omits the claim', () => {
-    // The load-bearing default (#3459). Card surfaces render from
-    // `books_catalog`, which carries no evidence strength, so a caller that
-    // cannot supply the claim must not assert one by omission. If this ever
-    // flips to 'confirmed', every collection, catalogue and author card starts
-    // asserting a universal negative again.
-    expect(firstTranslationBadge('confirmed_first', 'Latin', false))
-      .toBe('No prior translation found');
-    expect(firstTranslationDescription('confirmed_first')).toContain('not proof');
+  it('description is plain and disclaimer-free', () => {
+    const d = firstTranslationDescription('confirmed_first');
+    expect(d).toBe('The first English translation of this text.');
+    expect(d).not.toMatch(/not proof|coin flip|weaker evidence/);
   });
 });

--- a/tests/unit/translation-card-label.test.ts
+++ b/tests/unit/translation-card-label.test.ts
@@ -14,11 +14,10 @@ const card = (over: Partial<TranslationCard> = {}): TranslationCard => ({
 const englished = { pages_translated: 100 };
 
 describe('cardLabel — the one-sentence rule (#3881)', () => {
-  it('empty card + English rendering → the honest first sentence', () => {
+  it('empty card + English rendering → the plain catalog sentence', () => {
     const l = cardLabel(card(), englished)!;
     expect(l.register).toBe('first');
-    expect(l.sentence).toMatch(/No earlier English translation .* known to us/);
-    expect(l.searchSummary).toContain('Searched 4 catalogues');
+    expect(l.sentence).toBe('The first English translation of this work.');
   });
 
   it('empty card but NO English rendering → silence (nothing to badge)', () => {
@@ -34,7 +33,7 @@ describe('cardLabel — the one-sentence rule (#3881)', () => {
       ],
     }), englished)!;
     expect(l.register).toBe('priors');
-    expect(l.sentence).toContain('A (1650)');
+    expect(l.sentence).toBe('Earlier English translations: A (1650); B (1914).');
     expect(l.entries).toHaveLength(2);
   });
 


### PR DESCRIPTION
Derek's call (2026-08-11): the two-register hedging system ('No prior translation found', 'known to us — here's where we looked', preliminary/strength chips, the catalogue-recall lecture) reads as a library afraid of its own catalog, and the epistemic asymmetry it rested on was false — 'has this been scanned?' is the same unprovable negative and nobody hedges that. Plain labels everywhere; provenance stays one click away in the evidence footer and the cards. The four tests that pinned the old policy are rewritten to pin the new one, explicitly labeled as a deliberate reversal. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)