### PR TITLE
feat(ft): search record on click + the unresearched line (#3881)

### DIFF
--- a/scripts/eval/ft-work-registry-pilot.mjs
+++ b/scripts/eval/ft-work-registry-pilot.mjs
@@ -195,6 +195,20 @@ for (const workId of workList) {
   totalSiblings += siblings.length;
   entriesTotal += entries.length;
 
+  // The reader-facing search record (#3881 provenance disclosure): which
+  // sources every attempt on this work's books consulted, and when the most
+  // recent search ran — across ALL attempts, not just the ones that found
+  // something.
+  const allAttempts = await attempts
+    .find({ book_id: { $in: bookIds } }, { projection: { sources_checked: 1, date: 1 } })
+    .toArray();
+  const sourceSet = new Set();
+  let lastSearched = null;
+  for (const a of allAttempts) {
+    for (const s of a.sources_checked ?? []) if (s) sourceSet.add(String(s));
+    if (a.date && (!lastSearched || String(a.date) > String(lastSearched))) lastSearched = a.date;
+  }
+
   docs.push({
     _id: workId,
     work_id: workId,
@@ -204,8 +218,9 @@ for (const workId of workList) {
     entries,
     search: {
       summary: `Verified at book grain by ${ft.resolver}; verdict ${ft.verdict} (${ft.evidence_strength}). Seeded from the attempts ledger.`,
-      attempt_count: await attempts.countDocuments({ book_id: { $in: bookIds } }),
-      last_searched: found[0]?.date ?? null,
+      sources: [...sourceSet].sort(),
+      attempt_count: allAttempts.length,
+      last_searched: lastSearched,
     },
     review: {
       verified_by: ft.resolver,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -52,7 +52,7 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { authorUrl } from '@/lib/slugify';
 import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence';
-import TranslationCardPanel from '@/components/book/TranslationCardPanel';
+import TranslationCardPanel, { TranslationHistoryUnresearched } from '@/components/book/TranslationCardPanel';
 import { cardLabel, loadCard, type TranslationCard } from '@/lib/first-translation/card';
 import {
   classifyFirstTranslationClaim,
@@ -1348,12 +1348,24 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             <PlusToggle />
           </summary>
           <div className="px-4 pb-4 md:px-6 md:pb-6">
-            {translationCard && cardLabel(translationCard, book as { pages_translated?: number | null }) && (
+            {translationCard && cardLabel(translationCard, book as { pages_translated?: number | null }) ? (
               <TranslationCardPanel
                 card={translationCard}
                 book={book as { pages_translated?: number | null }}
                 showExternalLinks={embedPolicy.showExternalLinks}
               />
+            ) : (
+              // A catalog states its own coverage: a translated, non-English
+              // book with neither a card nor a book-grain verdict has simply
+              // not been researched — say so, or silence reads as "checked,
+              // nothing found" (#3881).
+              !translationCard
+              && !(book as { first_translation?: { verdict?: string } }).first_translation?.verdict
+              && !book.is_first_translation
+              && (book.pages_translated ?? 0) > 0
+              && book.language
+              && !['English', 'english', 'en', 'eng'].includes(book.language)
+              && <TranslationHistoryUnresearched />
             )}
             <BookBiblioPanel book={book} pagesCount={totalPages} showExternalLinks={embedPolicy.showExternalLinks} />
             {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (

--- a/src/components/book/TranslationCardPanel.tsx
+++ b/src/components/book/TranslationCardPanel.tsx
@@ -1,15 +1,13 @@
 /**
  * The Translation Card, rendered (#3881 — the card method, rule 2).
  *
- * When a book's work has a clean card in `work_translation_history`, this
- * panel IS the first-translation surface: the one sentence, then the cited
- * entries. The page mounts it INSTEAD of the legacy FirstTranslationEvidence
- * panel whenever cardLabel() resolves — one decision point, no side-by-side
- * contradiction — and falls back to the legacy panel otherwise, so a book
- * without a card renders exactly as before this PR.
+ * Plain catalog voice: collapsed, the panel is the label alone — the badge
+ * ("First Translation") or the earlier-translations line. Expanded, it is the
+ * RECORD: the cited entries and the search line (what was consulted, when).
+ * Provenance one click away, never a disclaimer in the reader's face.
  */
 
-import { cardLabel, type TranslationCard } from '@/lib/first-translation/card';
+import { cardLabel, searchRecordLine, type TranslationCard } from '@/lib/first-translation/card';
 
 export default function TranslationCardPanel({
   card,
@@ -24,44 +22,73 @@ export default function TranslationCardPanel({
   if (!label) return null;
 
   const isFirst = label.register === 'first';
+  const record = searchRecordLine(card);
+
   return (
-    <div className="mt-3 rounded border border-stone-700/40 bg-stone-800/20 px-3 py-2.5 text-sm">
-      <div className="flex items-start gap-2">
-        {isFirst ? (
-          <span className="mt-0.5 inline-block whitespace-nowrap rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-300">
-            First Translation
-          </span>
-        ) : (
-          <p className="text-stone-300">{label.sentence}</p>
-        )}
-      </div>
+    <div className="mt-3">
+      <details className="group">
+        <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+          {isFirst ? (
+            <span className="inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors">
+              First Translation
+            </span>
+          ) : (
+            <span className="text-sm text-stone-300 hover:text-stone-100 transition-colors">
+              {label.sentence}
+            </span>
+          )}
+        </summary>
 
-      {label.entries.length > 0 && (
-        <ul className="mt-2 space-y-1 border-t border-stone-700/30 pt-2">
-          {label.entries.map((e, i) => (
-            <li key={i} className="text-[13px] text-stone-400">
-              {e.year && <span className="text-stone-500">{e.year} · </span>}
-              {e.translator && <span>{e.translator}, </span>}
-              {showExternalLinks && e.citation_url ? (
-                <a
-                  href={e.citation_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline decoration-stone-600 underline-offset-2 hover:text-stone-200"
-                >
-                  {e.title ?? 'record'}
-                </a>
-              ) : (
-                <span>{e.title}</span>
-              )}
-              {e.completeness && e.completeness !== 'complete' && (
-                <span className="text-stone-500"> ({e.completeness})</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+        <div className="mt-2 rounded border border-stone-700/40 bg-stone-800/20 px-3 py-2.5 text-sm">
+          {isFirst && (
+            <p className="text-stone-300">The first English translation of this work.</p>
+          )}
 
+          {label.entries.length > 0 && (
+            <ul className={`space-y-1 ${isFirst ? 'mt-2 border-t border-stone-700/30 pt-2' : ''}`}>
+              {label.entries.map((e, i) => (
+                <li key={i} className="text-[13px] text-stone-400">
+                  {e.year && <span className="text-stone-500">{e.year} · </span>}
+                  {e.translator && <span>{e.translator}, </span>}
+                  {showExternalLinks && e.citation_url ? (
+                    <a
+                      href={e.citation_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline decoration-stone-600 underline-offset-2 hover:text-stone-200"
+                    >
+                      {e.title ?? 'record'}
+                    </a>
+                  ) : (
+                    <span>{e.title}</span>
+                  )}
+                  {e.completeness && e.completeness !== 'complete' && (
+                    <span className="text-stone-500"> ({e.completeness})</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {record && (
+            <p className="mt-2 text-[11px] leading-snug text-stone-500">{record}</p>
+          )}
+        </div>
+      </details>
     </div>
+  );
+}
+
+/**
+ * The one quiet line for a book whose translation history has not been
+ * researched — so silence never reads as "checked, nothing found". Rendered
+ * by the page only for translated, non-English books with neither a card nor
+ * any book-grain verdict.
+ */
+export function TranslationHistoryUnresearched() {
+  return (
+    <p className="mt-3 text-[12px] text-stone-500">
+      Translation history: not yet researched.
+    </p>
   );
 }

--- a/src/lib/first-translation/card.ts
+++ b/src/lib/first-translation/card.ts
@@ -47,8 +47,44 @@ export interface TranslationCard {
    */
   status: string;
   entries: CardEntry[];
-  search?: { summary?: string; attempt_count?: number; last_searched?: string | null };
+  search?: { summary?: string; sources?: string[]; attempt_count?: number; last_searched?: string | null };
   review?: { verified_by?: string; verified_at?: string | null };
+}
+
+/** Reader display names for the source ids the ledger records. */
+const SOURCE_NAMES: Record<string, string> = {
+  loc: 'Library of Congress',
+  estc: 'ESTC',
+  wikidata: 'Wikidata',
+  translation_catalogs: 'translation catalogues',
+  translation_classification: 'internal classification',
+  open_library: 'Open Library',
+  'archive.org': 'Internet Archive',
+  'wikipedia.org': 'Wikipedia',
+  'google.com': 'Google Search',
+};
+
+/**
+ * One factual line about the search behind a card — for the expanded view of
+ * the panel, never as a disclaimer beside the label. Returns null when the
+ * card records no search (nothing to show is better than an empty boast).
+ */
+export function searchRecordLine(card: TranslationCard | null | undefined): string | null {
+  const s = card?.search;
+  if (!s || !(s.attempt_count && s.attempt_count > 0)) return null;
+  const named = (s.sources ?? [])
+    .map((x) => SOURCE_NAMES[x] ?? x)
+    .filter((x, i, arr) => arr.indexOf(x) === i)
+    .slice(0, 6);
+  const when = s.last_searched
+    ? new Date(s.last_searched).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+    : null;
+  const bits = [
+    `${s.attempt_count} recorded ${s.attempt_count === 1 ? 'search' : 'searches'}`,
+    named.length ? `sources include ${named.join(', ')}` : null,
+    when ? `most recent ${when}` : null,
+  ].filter(Boolean);
+  return `Search record: ${bits.join(' · ')}.`;
 }
 
 export interface CardLabel {


### PR DESCRIPTION
Answers Derek's two review questions: (1) the card panel expands to show the search record — cited entries + one factual line from the ledger (sources consulted, count, most recent date; seeder now stores the source union); (2) translated non-English books with no card and no verdict say **'Translation history: not yet researched.'** so silence never impersonates a clean search. Plain voice throughout — the record is available on click, never a disclaimer beside the label. Reseed follows merge to populate sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)