### PR TITLE
fix(ft): search-record line collapses URLs to source names

### DIFF
--- a/scripts/eval/ft-work-registry-pilot.mjs
+++ b/scripts/eval/ft-work-registry-pilot.mjs
@@ -13,11 +13,14 @@
  *                 the join would render instead (test 2: 0 after)
  *   legibility    each entry is a citable sentence a reader could check
  *
- * SAFE BY CONSTRUCTION: writes only the new `work_translation_history`
- * collection, which NOTHING reads yet — no cron, no render path, no derive.
- * (The #3776 rule: before writing to a store, ask what reads it and when it
- * next runs. Answer: nothing, never — until a reviewed PR wires the join.)
- * Dry-run by default; --apply writes; --wipe-pilot removes pilot docs.
+ * ⚠️ THIS COLLECTION IS LIVE (#3910/#3916): book pages render cards directly.
+ * Every --apply is reader-visible actuation (#3776). Two guards follow:
+ * dry-run is the default, and REVIEWED cards (review_note stamped
+ * 'card-round-N') are skipped wholesale — regeneration rebuilds entries from
+ * the append-only ledger, where spot-check-removed fabrications live forever,
+ * so overwriting a reviewed card silently restores them (happened 2026-08-11;
+ * caught in minutes, fixed by hand, guarded here). --wipe-pilot removes
+ * pilot-cast docs only.
  *
  * Usage:
  *   node --env-file=.env.production.local scripts/eval/ft-work-registry-pilot.mjs                     # pilot cast, report only
@@ -123,7 +126,23 @@ let disagreeingBefore = 0;
 let entriesTotal = 0;
 const docs = [];
 
+// REVIEWED CARDS ARE HUMAN-EDITED STATE — the regenerator must never touch
+// them. On 2026-08-11 a reseed rebuilt entries from the ledger and RESTORED
+// two spot-check-removed fabrications onto a live card (the ledger is
+// append-only, so bad priors live there forever; the card's corrections do
+// not). A card whose review_note carries a round stamp is skipped wholesale.
+const reviewed = new Set(
+  (await registry
+    .find({ review_note: { $regex: 'card-round' } }, { projection: { _id: 1 } })
+    .toArray()).map((d) => d._id),
+);
+if (reviewed.size) console.log(`Protecting ${reviewed.size} reviewed card(s) from regeneration.`);
+
 for (const workId of workList) {
+  if (reviewed.has(workId)) {
+    console.log(`  SKIP ${workId} — reviewed card (spot-check corrections present)`);
+    continue;
+  }
   const siblings = await books.find(
     { work_id: workId, visible: true },
     { projection: { id: 1, title: 1, author: 1, language: 1, is_first_translation: 1, first_translation: 1, pages_translated: 1 } },
@@ -267,7 +286,7 @@ if (APPLY) {
   for (const d of docs) {
     await registry.updateOne({ _id: d._id }, { $set: d }, { upsert: true });
   }
-  console.log(`APPLIED — ${docs.length} work_translation_history docs upserted. Nothing reads this collection yet; wiring the join is a separate, reviewed PR.`);
+  console.log(`APPLIED — ${docs.length} work_translation_history docs upserted. THIS COLLECTION IS LIVE (book pages render cards since #3910/#3916) — treat every write as reader-visible.`);
 } else {
   console.log('DRY-RUN — no writes. Re-run with --apply to seed work_translation_history.');
 }

--- a/src/lib/first-translation/card.ts
+++ b/src/lib/first-translation/card.ts
@@ -61,7 +61,16 @@ const SOURCE_NAMES: Record<string, string> = {
   open_library: 'Open Library',
   'archive.org': 'Internet Archive',
   'wikipedia.org': 'Wikipedia',
+  'en.wikipedia.org': 'Wikipedia',
   'google.com': 'Google Search',
+  'books.google.com': 'Google Books',
+  'catalog.hathitrust.org': 'HathiTrust',
+  'babel.hathitrust.org': 'HathiTrust',
+  'openlibrary.org': 'Open Library',
+  'worldcat.org': 'WorldCat',
+  'search.worldcat.org': 'WorldCat',
+  'brill.com': 'Brill',
+  'wellcomecollection.org': 'Wellcome Collection',
 };
 
 /**
@@ -72,8 +81,19 @@ const SOURCE_NAMES: Record<string, string> = {
 export function searchRecordLine(card: TranslationCard | null | undefined): string | null {
   const s = card?.search;
   if (!s || !(s.attempt_count && s.attempt_count > 0)) return null;
+  // Ledger sources mix catalogue ids with raw grounding URLs; collapse URLs
+  // to their hostname so the line reads like a source list, not a link dump.
+  const toName = (x: string): string => {
+    if (SOURCE_NAMES[x]) return SOURCE_NAMES[x];
+    try {
+      const host = new URL(x).hostname.replace(/^www\./, '');
+      return SOURCE_NAMES[host] ?? host;
+    } catch {
+      return x;
+    }
+  };
   const named = (s.sources ?? [])
-    .map((x) => SOURCE_NAMES[x] ?? x)
+    .map(toName)
     .filter((x, i, arr) => arr.indexOf(x) === i)
     .slice(0, 6);
   const when = s.last_searched


### PR DESCRIPTION
Round-4's new live-render bucket caught two issues within minutes of its first run: the search-record line rendering raw grounding URLs (fixed here — hostname collapse + display names), and a Southcott English-original card wearing the First Translation chip on production (silenced by card edit; the English-original screen for the seeder is the standing fix). Branch worktree-fix+seeder-review-guard already merged; this rides the same worktree on a new branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)