### PR TITLE
feat(eval): Suda-SOL benchmark pipeline → scripts/eval/suda-sol (#3884)

### DIFF
--- a/scripts/eval/suda-sol/README.md
+++ b/scripts/eval/suda-sol/README.md
@@ -1,0 +1,48 @@
+# Suda–SOL parallel benchmark pipeline
+
+Tooling for the Suda On Line alignment benchmark — issue **#3884**, research note
+[/blog/suda-benchmark](https://sourcelibrary.org/blog/suda-benchmark).
+
+Aligns our AI translation of Bekker's 1854 *Suidae Lexicon* (book
+`69a99ce86c7545e2236e12de`) with the Suda On Line's ~31k scholar-vetted entries,
+producing per-entry Adler IDs, cross-family fidelity gold labels, and a
+categorical quality census.
+
+## Data location
+
+All scripts read/write `$SOL_DATA_DIR` (default `scripts/output/sol-harvest/`,
+untracked). The data is NOT in this repo: the SOL mirror and every file derived
+from it carry SOL's **CC BY-NC-SA** license and must not be committed to this
+AGPL repository. Snapshot backup: `root@46.224.122.120:/root/backups/sol-harvest-2026-08-11.tar.gz`.
+
+## Pipeline (run in order; each stage is resumable/idempotent)
+
+| stage | script | output | notes |
+|---|---|---|---|
+| 1. mirror SOL | `harvest.mjs` (nohup, ~9h @3req/s) | `raw/<letter>/<n>.html` | polite crawl, skips existing files |
+| 2. parse | `parse-sol.py` | `sol.jsonl` | Betacode→Unicode; incl. Adler's Greek per entry |
+| 3. segment | `segment-bekker.mjs` (needs `MONGODB_URI`) | `bekker-entries.jsonl` | paragraph candidates from page OCR |
+| 4. align | `align.py` | `aligned.jsonl`, `align-report.json` | see invariants below |
+| 5. gold pilot | `make-pilot.mjs` → Claude subagents per `judge-instructions.md` → `summarize-pilot.py` | `pilot/`, `gold-labels-merged.jsonl` | cross-family judges ONLY (see below) |
+| 6. judge validation | `validate-lite.mjs` (needs `GEMINI_API_KEY`) | `lite-verdicts/` | κ vs gold before trusting any cheap judge |
+| 7. census | `census.mjs` (needs both keys) | `census-verdicts/`, `census.jsonl` | categorical checks only, grouped per page (~$1) |
+
+## Invariants learned the hard way (don't relearn them)
+
+- **Bekker alphabetized; Adler/SOL is antistoichic.** The aligner must re-sort SOL
+  alphabetically or the αι/ει/οι letter-groups score 0%.
+- **Adler numbers do not follow Bekker's print order within homonym groups**
+  (seven consecutive Δίδυμος entries). Disambiguate by trigram similarity against
+  Adler's Greek, never by order.
+- **Never grade fidelity against SOL's English directly** — Bekker≠Adler edition
+  differences appeared in 42/49 sampled entries. Both Greek texts must arbitrate.
+- **Never use a judge from the translator's model family for fidelity.** Measured
+  κ=0.107 (both gemini-lite and gemini-flash-preview miss ~90% of catalogued
+  Gemini-translation errors, zero false positives). Same-family models validated
+  only for categorical flags (misalignment, recitation), and every flag they
+  raise is a candidate requiring cross-family verification.
+- **maxOutputTokens + responseMimeType json**: page-grouped census calls must
+  assert the returned array length equals the entry count; two pages needed a
+  retry for shape/JSON errors.
+
+Full evaluation trail, numbers, and release plan: #3884.

--- a/scripts/eval/suda-sol/align.py
+++ b/scripts/eval/suda-sol/align.py
@@ -1,0 +1,195 @@
+# Align Bekker OCR paragraphs to SOL/Adler entries — v2. Issue #3884.
+# v2 changes: (1) SOL sequence sorted strictly alphabetically (Bekker alphabetized;
+# Adler kept antistoichic -iota groups, which zeroed alphaiota/epsiloniota/omicroniota
+# in v1); (2) interior-split pass — unmatched SOL headwords found mid-paragraph split
+# the paragraph (OCR runs short glosses together).
+# Outputs: aligned.jsonl (one row per SOL entry) + align-report.json
+import json, unicodedata, bisect
+from pathlib import Path
+import os
+
+D = Path(os.environ.get("SOL_DATA_DIR", "scripts/output/sol-harvest"))
+
+def norm(s):
+    s = s.replace("*", "")
+    s = unicodedata.normalize("NFD", s)
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    return s.lower().replace("ς", "σ").strip(" .,·:;'\"?!()[]<>“”‘’")
+
+def lev_le(a, b, k):
+    if abs(len(a) - len(b)) > k: return False
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i] + [0] * len(b)
+        for j, cb in enumerate(b, 1):
+            cur[j] = min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (ca != cb))
+        if min(cur) > k: return False
+        prev = cur
+    return prev[-1] <= k
+
+def fuzzy(a, b):
+    return (len(a) > 3 and a[0] == b[0]
+            and lev_le(a, b, 1 if len(a) < 8 else 2))
+
+sol = [json.loads(l) for l in open(D / "sol.jsonl")]
+for r in sol:
+    r["_hw"] = norm(r["headword_unicode"].split()[0]) if r["headword_unicode"] else ""
+    letter, num = r["adler_id"].split(",")
+    r["_num"] = int(num)
+# strict alphabetical; homonym groups keep Adler order
+sol.sort(key=lambda r: (r["_hw"], r["_num"]))
+sol_hw = [r["_hw"] for r in sol]
+sol_pos = {}
+for i, h in enumerate(sol_hw):
+    if h: sol_pos.setdefault(h, []).append(i)
+
+raw = [json.loads(l) for l in open(D / "bekker-entries.jsonl")]
+units = []
+for r in raw:
+    words = r["text"].split()
+    units.append({"orig_seq": r["seq"], "words": words,
+                  "toks": [norm(w) for w in words],
+                  "scan_page": r["scan_page"], "printed_page": r["printed_page"],
+                  "margin_letter": r["margin_letter"], "match": None})
+
+# --- Phase A: LIS skeleton over exact first-token pairs ---
+pairs, parent, tails = [], {}, []
+for ui, u in enumerate(units):
+    h = u["toks"][0] if u["toks"] else ""
+    cands = sol_pos.get(h, [])
+    if not cands or len(cands) > 40: continue
+    for si in sorted(cands, reverse=True):
+        pid = len(pairs); pairs.append((ui, si))
+        j = bisect.bisect_left([t[0] for t in tails], si)
+        parent[pid] = tails[j - 1][1] if j > 0 else None
+        if j == len(tails): tails.append((si, pid))
+        else: tails[j] = (si, pid)
+skel, pid = [], (tails[-1][1] if tails else None)
+while pid is not None:
+    skel.append(pairs[pid]); pid = parent[pid]
+skel.reverse()
+anchors = []
+for ui, si in skel:
+    if not anchors or (ui > anchors[-1][0] and si > anchors[-1][1]):
+        anchors.append((ui, si))
+for ui, si in anchors: units[ui]["match"] = (si, "anchor")
+
+# --- Phase B: per gap (reverse order so splits don't shift earlier indices):
+# first-token exact/fuzzy, then interior-split ---
+stats = {"gap-exact": 0, "gap-fuzzy": 0, "interior-split": 0}
+bounds = [(-1, -1)] + anchors + [(len(units), len(sol))]
+for (u0, s0), (u1, s1) in reversed(list(zip(bounds, bounds[1:]))):
+    targets = [s for s in range(s0 + 1, s1)]
+    if not targets: continue
+    tj = 0
+    ui = u0 + 1
+    while ui < u1 and tj < len(targets):
+        u = units[ui]
+        if u["match"] is None and u["toks"]:
+            h = u["toks"][0]
+            hit = None
+            for k in range(tj, min(tj + 25, len(targets))):
+                sh = sol_hw[targets[k]]
+                if h == sh: hit = (k, "gap-exact"); break
+                if hit is None and fuzzy(h, sh): hit = (k, "gap-fuzzy")
+            if hit:
+                u["match"] = (targets[hit[0]], hit[1])
+                stats[hit[1]] += 1
+                tj = hit[0] + 1
+                ui += 1
+                continue
+        # interior scan for next unmatched target headword
+        found = None
+        for t in range(1, len(u["toks"])):
+            tok = u["toks"][t]
+            for k in range(tj, min(tj + 8, len(targets))):
+                sh = sol_hw[targets[k]]
+                if tok == sh and len(sh) > 3:
+                    found = (t, k); break
+            if found: break
+        if found:
+            t, k = found
+            right = {"orig_seq": u["orig_seq"], "words": u["words"][t:],
+                     "toks": u["toks"][t:], "scan_page": u["scan_page"],
+                     "printed_page": u["printed_page"], "margin_letter": None,
+                     "match": (targets[k], "interior-split")}
+            u["words"], u["toks"] = u["words"][:t], u["toks"][:t]
+            units.insert(ui + 1, right)
+            stats["interior-split"] += 1
+            tj = k + 1
+            u1 += 1  # region grew by one unit
+            ui += 1  # continue inside the right part
+            continue
+        ui += 1
+
+# --- Phase C: assembly (unmatched units continue previous matched entry) ---
+by_sol, cur = {}, None
+for u in units:
+    if u["match"]:
+        cur = u["match"][0]
+        by_sol.setdefault(cur, {"units": [], "basis": u["match"][1]})
+        by_sol[cur]["units"].append(u)
+    elif cur is not None:
+        by_sol[cur]["units"].append(u)
+
+# --- Phase D: homonym disambiguation. Adler numbers same-headword entries in an
+# order that need not follow Bekker's print order, so order-based matching
+# scrambles homonym groups. Reassign within each group by trigram similarity
+# between the Bekker text and Adler's Greek (carried by SOL). ---
+def tri(s):
+    s = norm(s).replace(" ", "")
+    return {s[i:i + 3] for i in range(len(s) - 2)} if len(s) > 2 else set()
+
+def sim(a, b):
+    A, B = tri(a), tri(b)
+    return len(A & B) / max(1, min(len(A), len(B)))
+
+reassigned = 0
+i = 0
+while i < len(sol_hw):
+    j = i
+    while j < len(sol_hw) and sol_hw[j] == sol_hw[i]: j += 1
+    group = list(range(i, j))
+    i = j
+    if len(group) < 2: continue
+    texts = [(si, by_sol.pop(si)) for si in group if si in by_sol]
+    if not texts: continue
+    scored = []
+    for si in group:
+        ref = sol[si].get("greek_unicode") or sol[si].get("translation") or ""
+        for ti, (osi, m) in enumerate(texts):
+            scored.append((sim(" ".join(w for u in m["units"] for w in u["words"]), ref), si, ti))
+    scored.sort(reverse=True)
+    used_s, used_t = set(), set()
+    for s, si, ti in scored:
+        if si in used_s or ti in used_t: continue
+        used_s.add(si); used_t.add(ti)
+        if texts[ti][0] != si: reassigned += 1
+        by_sol[si] = texts[ti][1]
+    for ti, (osi, m) in enumerate(texts):  # safety: never drop a text
+        if ti not in used_t: by_sol[osi] = m
+
+rows = []
+for si, r in enumerate(sol):
+    m = by_sol.get(si)
+    us = m["units"] if m else []
+    rows.append({
+        "adler_id": r["adler_id"],
+        "sol_headword": r["headword_unicode"],
+        "matched": bool(m),
+        "basis": m["basis"] if m else None,
+        "bekker_lemma": " ".join(us[0]["words"][:3]) if us else None,
+        "scan_pages": sorted({u["scan_page"] for u in us}),
+        "bekker_text": " ".join(" ".join(u["words"]) for u in us) if us else None,
+    })
+rows.sort(key=lambda r: (r["adler_id"].split(",")[0], int(r["adler_id"].split(",")[1])))
+with open(D / "aligned.jsonl", "w") as f:
+    for r in rows: f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+matched = sum(1 for r in rows if r["matched"])
+report = {"sol_entries": len(sol), "sol_matched": matched,
+          "coverage": round(matched / len(sol), 4),
+          "anchors": len(anchors), **stats,
+          "final_units": len(units)}
+open(D / "align-report.json", "w").write(json.dumps(report, indent=2))
+print(json.dumps(report, indent=2))

--- a/scripts/eval/suda-sol/census.mjs
+++ b/scripts/eval/suda-sol/census.mjs
@@ -1,0 +1,105 @@
+// Categorical census over all aligned Suda entries with flash-lite. Issue #3884.
+// Per PAGE (not per entry): one call judges all entries starting on that page —
+// three validated categorical checks only (translation_found, alignment_ok,
+// recitation_signal). Verdicts to census-verdicts/page-<n>.json; resumable.
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+
+const D = (process.env.SOL_DATA_DIR ?? 'scripts/output/sol-harvest') + '/';
+const BOOK = '69a99ce86c7545e2236e12de';
+const MODEL = 'gemini-3.1-flash-lite';
+const KEY = process.env.GEMINI_API_KEY;
+const CONC = 8;
+mkdirSync(D + 'census-verdicts', { recursive: true });
+
+const aligned = readFileSync(D + 'aligned.jsonl', 'utf8').trim().split('\n').map(JSON.parse)
+  .filter((r) => r.matched && r.bekker_text);
+const sol = Object.fromEntries(readFileSync(D + 'sol.jsonl', 'utf8').trim().split('\n')
+  .map(JSON.parse).map((r) => [r.adler_id, r]));
+
+// group entries by starting scan page
+const byPage = new Map();
+for (const r of aligned) {
+  const p = r.scan_pages[0];
+  if (!byPage.has(p)) byPage.set(p, []);
+  byPage.get(p).push(r);
+}
+console.log('entries:', aligned.length, '| pages:', byPage.size);
+
+// page translations (cache once)
+const cachePath = D + 'page-translations.json';
+let tr;
+if (existsSync(cachePath)) tr = JSON.parse(readFileSync(cachePath, 'utf8'));
+else {
+  const c = new MongoClient(process.env.MONGODB_URI);
+  await c.connect();
+  const pages = await c.db('bookstore').collection('pages')
+    .find({ book_id: BOOK, page_number: { $in: [...byPage.keys()] } })
+    .project({ page_number: 1, 'translation.data': 1 }).toArray();
+  await c.close();
+  tr = Object.fromEntries(pages.map((p) => [p.page_number, p.translation?.data ?? null]));
+  writeFileSync(cachePath, JSON.stringify(tr));
+}
+
+const INSTR = `You are checking AI translation records for the Byzantine Suda lexicon. Below: OUR_PAGE_TRANSLATION (AI English translation of one scan page of Bekker's 1854 Greek edition) and a list of ENTRIES, each with: adler_id, bekker_greek (our OCR of that entry from this page), sol_translation (scholar reference translation of the entry the id points to).
+
+For EACH entry answer exactly three categorical questions:
+1. translation_found — does OUR_PAGE_TRANSLATION contain a translation of this bekker_greek entry? (It may start near the end of the page and continue beyond it — a clear start counts.)
+2. alignment_ok — is bekker_greek the SAME Suda entry as sol_translation describes (same headword and subject)? Extra trailing text from the next entry is fine; a DIFFERENT entry is not.
+3. recitation_signal — true ONLY if our English translation of this entry asserts a specific fact (name, number, word) that CONTRADICTS the bekker_greek while matching standard external knowledge. Default false; do not flag style or glosses.
+
+Respond ONLY with a JSON array, one object per entry, same order: [{"adler_id": str, "translation_found": bool, "alignment_ok": bool, "recitation_signal": bool, "note": str|null}] — note only when a flag is raised or answer is uncertain, max 20 words.`;
+
+function prompt(page, entries, trim) {
+  const t = tr[page] ?? '(no translation available)';
+  const list = entries.map((r) => ({
+    adler_id: r.adler_id,
+    bekker_greek: trim ? r.bekker_text.slice(0, 1200) : r.bekker_text,
+    sol_translation: (sol[r.adler_id]?.translation ?? '').slice(0, trim ? 400 : 900),
+  }));
+  return `${INSTR}\n\nOUR_PAGE_TRANSLATION (scan page ${page}):\n${trim ? t.slice(0, 9000) : t}\n\nENTRIES:\n${JSON.stringify(list)}`;
+}
+
+async function callPage(page, entries, trim = false) {
+  const body = {
+    contents: [{ parts: [{ text: prompt(page, entries, trim) }] }],
+    generationConfig: {
+      temperature: 0.1, maxOutputTokens: 8192,
+      thinkingConfig: { thinkingBudget: 512 }, responseMimeType: 'application/json',
+    },
+  };
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${KEY}`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const j = await res.json();
+  const text = j.candidates?.[0]?.content?.parts?.map((x) => x.text).join('') ?? '';
+  if (!text) throw new Error('empty candidate ' + j.candidates?.[0]?.finishReason);
+  const arr = JSON.parse(text);
+  if (!Array.isArray(arr) || arr.length !== entries.length)
+    throw new Error(`shape: got ${Array.isArray(arr) ? arr.length : typeof arr}, want ${entries.length}`);
+  return { arr, usage: j.usageMetadata };
+}
+
+const pages = [...byPage.keys()].sort((a, b) => a - b)
+  .filter((p) => !existsSync(`${D}census-verdicts/page-${p}.json`));
+console.log('pages to do:', pages.length);
+let done = 0, failed = 0, tokens = { in: 0, out: 0 };
+async function worker() {
+  while (pages.length) {
+    const p = pages.shift();
+    const entries = byPage.get(p);
+    try {
+      let r;
+      try { r = await callPage(p, entries); }
+      catch (e) { r = await callPage(p, entries, true); }
+      writeFileSync(`${D}census-verdicts/page-${p}.json`, JSON.stringify(r.arr));
+      tokens.in += r.usage?.promptTokenCount ?? 0;
+      tokens.out += r.usage?.candidatesTokenCount ?? 0;
+      done++;
+      if (done % 50 === 0) console.log(`done ${done}, failed ${failed}, ~$${((tokens.in * 0.1 + tokens.out * 0.4) / 1e6).toFixed(2)}`);
+    } catch (e) { failed++; console.log(`FAIL page ${p}: ${e.message}`); }
+  }
+}
+await Promise.all(Array.from({ length: CONC }, worker));
+console.log(`DONE: ${done} pages, ${failed} failed, tokens ${JSON.stringify(tokens)} ≈ $${((tokens.in * 0.1 + tokens.out * 0.4) / 1e6).toFixed(2)}`);

--- a/scripts/eval/suda-sol/harvest.mjs
+++ b/scripts/eval/suda-sol/harvest.mjs
@@ -1,0 +1,53 @@
+// SOL (Suda On Line) polite harvester — issue #3884
+// Fetches every entry page under cs.uky.edu/~raphael/sol/sol-entries/ to raw/<letter>/<n>.html
+// Sequential, ~4 req/sec max, resumable (skips files that already exist).
+// Run: nohup node harvest.mjs > harvest.log 2>&1 & disown
+import { mkdir, writeFile, access } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE = 'https://www.cs.uky.edu/~raphael/sol/sol-entries/';
+const OUT = path.join(process.env.SOL_DATA_DIR ?? 'scripts/output/sol-harvest', 'raw');
+const UA = 'SourceLibrary-research-harvest/1.0 (sourcelibrary.org; contact derek@playpowerlabs.com; single-thread, throttled)';
+const DELAY_MS = 250;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function get(url, tries = 3) {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (res.ok) return await res.text();
+      if (res.status === 404) return null; // gaps in Adler numbering are normal
+      console.log(`HTTP ${res.status} on ${url} (try ${i + 1})`);
+    } catch (e) {
+      console.log(`ERR ${e.message} on ${url} (try ${i + 1})`);
+    }
+    await sleep(2000 * (i + 1));
+  }
+  return null;
+}
+
+const index = await get(BASE);
+if (!index) { console.error('FATAL: cannot fetch letter index'); process.exit(1); }
+const letters = [...index.matchAll(/href="([a-z]+)\.html"/g)].map((m) => m[1]);
+console.log(`letters: ${letters.length}: ${letters.join(' ')}`);
+
+let fetched = 0, skipped = 0, missing = 0;
+for (const letter of letters) {
+  const letterIdx = await get(`${BASE}${letter}.html`);
+  if (!letterIdx) { console.log(`WARN: no index for ${letter}`); continue; }
+  const nums = [...letterIdx.matchAll(new RegExp(`href="${letter}/([0-9]+)"`, 'g'))].map((m) => m[1]);
+  await mkdir(path.join(OUT, letter), { recursive: true });
+  console.log(`${letter}: ${nums.length} entries`);
+  for (const n of nums) {
+    const file = path.join(OUT, letter, `${n}.html`);
+    if (await access(file).then(() => true, () => false)) { skipped++; continue; }
+    const html = await get(`${BASE}${letter}/${n}`);
+    if (html === null) { missing++; console.log(`MISSING ${letter}/${n}`); continue; }
+    await writeFile(file, html);
+    fetched++;
+    if (fetched % 100 === 0) console.log(`progress: ${fetched} fetched, ${skipped} skipped, ${missing} missing (${letter}/${n})`);
+    await sleep(DELAY_MS);
+  }
+}
+console.log(`DONE: ${fetched} fetched, ${skipped} skipped, ${missing} missing`);

--- a/scripts/eval/suda-sol/judge-instructions.md
+++ b/scripts/eval/suda-sol/judge-instructions.md
@@ -1,0 +1,20 @@
+# Suda translation judge — instructions
+
+You are an expert classicist judging AI translation quality for the Byzantine Suda lexicon. Your task packet (a JSON file, path given in your prompt) contains:
+- bekker_greek_ocr — our OCR of Bekker's 1854 edition, the SOURCE our AI translation worked from
+- our_page_translations — our AI English translation of the full scan page(s); this entry's translation is embedded among other entries; locate it (typically under a transliterated headword)
+- sol_translation — scholar-vetted Suda On Line translation of the same entry
+- adler_greek_via_sol — Adler's critical Greek text of the entry
+- sol_headword, sol_translated_headword, sol_translator
+
+Judge:
+1. alignment_ok — is bekker_greek_ocr the same Suda entry as SOL's (same headword and content)? (The OCR excerpt may drag in the start of the following entry — that is packet windowing, not misalignment.)
+2. Locate OUR entry's translation inside our_page_translations; set our_translation_excerpt to its first ~10 words. If genuinely absent, our_translation_found=false.
+3. fidelity of OUR translation judged ONLY against bekker_greek_ocr (our source): "faithful" | "minor_issues" | "major_errors". List errors as {type: mistranslation|omission|addition|silent_emendation|garble_passthrough|nuance_flattening, severity: minor|major, detail}. A faithful rendering of corrupt OCR counts as faithful; rendering garble as fluent confident English is garble_passthrough.
+4. divergences — substantive differences between OUR translation and sol_translation, each {kind: our_error|sol_error|edition_difference|style_only, detail}, using the two Greek texts as arbiters (edition_difference = Bekker's Greek genuinely differs from Adler's).
+5. recitation_signal — true iff our English asserts something matching external/historical knowledge or SOL AGAINST our own OCR Greek (e.g. silently correcting a proper name); give recitation_detail.
+
+Output — a single JSON object:
+{"adler_id": ..., "alignment_ok": bool, "our_translation_found": bool, "our_translation_excerpt": str|null, "fidelity": str, "errors": [...], "divergences": [...], "recitation_signal": bool, "recitation_detail": str|null, "notes": str|null}
+
+Write this JSON (using the Write tool) to <packet-path>.verdict.json (same path as your packet, with .verdict.json appended). Your final message must be ONLY the JSON, no prose.

--- a/scripts/eval/suda-sol/make-pilot.mjs
+++ b/scripts/eval/suda-sol/make-pilot.mjs
@@ -1,0 +1,65 @@
+// Build 50-entry stratified pilot sample for subagent gold labeling. Issue #3884.
+// Writes pilot/NNN-<adler_id>.json, one self-contained judgment packet per entry.
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const D = (process.env.SOL_DATA_DIR ?? 'scripts/output/sol-harvest') + '/';
+const BOOK = '69a99ce86c7545e2236e12de';
+const aligned = readFileSync(D + 'aligned.jsonl', 'utf8').trim().split('\n').map(JSON.parse);
+const sol = Object.fromEntries(
+  readFileSync(D + 'sol.jsonl', 'utf8').trim().split('\n').map(JSON.parse).map((r) => [r.adler_id, r]));
+
+// deterministic PRNG (no Math.random in workflows; fine here but keep reproducible)
+let seed = 42;
+const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+const shuffle = (a) => { for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(rand() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; } return a; };
+
+const pool = aligned.filter((r) => r.matched && r.bekker_text && r.bekker_text.split(' ').length >= 5);
+const byBasis = { anchor: [], 'gap-fuzzy': [], 'gap-exact': [], 'interior-split': [] };
+for (const r of pool) byBasis[r.basis]?.push(r);
+const wc = (r) => r.bekker_text.split(' ').length;
+const strat = (arr, n) => {
+  const short = shuffle(arr.filter((r) => wc(r) < 40));
+  const med = shuffle(arr.filter((r) => wc(r) >= 40 && wc(r) <= 150));
+  const long = shuffle(arr.filter((r) => wc(r) > 150));
+  const k = Math.ceil(n / 3);
+  return shuffle([...short.slice(0, k), ...med.slice(0, k), ...long.slice(0, n - 2 * k > 0 ? n - 2 * k : k)]).slice(0, n);
+};
+const sample = [
+  ...strat(byBasis.anchor, 35),
+  ...strat(byBasis['gap-fuzzy'], 8),
+  ...strat(byBasis['gap-exact'], 3),
+  ...strat(byBasis['interior-split'], 4),
+];
+console.log('sample:', sample.length, 'entries; pages needed:',
+  new Set(sample.flatMap((r) => r.scan_pages)).size);
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const pageNums = [...new Set(sample.flatMap((r) => r.scan_pages))];
+const pages = await c.db('bookstore').collection('pages')
+  .find({ book_id: BOOK, page_number: { $in: pageNums } })
+  .project({ page_number: 1, 'translation.data': 1 }).toArray();
+await c.close();
+const tr = Object.fromEntries(pages.map((p) => [p.page_number, p.translation?.data ?? null]));
+
+mkdirSync(D + 'pilot', { recursive: true });
+sample.forEach((r, i) => {
+  const s = sol[r.adler_id];
+  const packet = {
+    adler_id: r.adler_id,
+    basis: r.basis,
+    scan_pages: r.scan_pages,
+    bekker_greek_ocr: r.bekker_text,
+    our_page_translations: Object.fromEntries(r.scan_pages.map((p) => [p, tr[p]])),
+    sol_headword: s.headword_unicode,
+    sol_translated_headword: s.translated_headword,
+    sol_translation: s.translation,
+    adler_greek_via_sol: s.greek_unicode,
+    sol_translator: s.translator,
+  };
+  writeFileSync(`${D}pilot/${String(i).padStart(2, '0')}-${r.adler_id.replace(',', '-')}.json`,
+    JSON.stringify(packet, null, 1));
+});
+console.log('wrote', sample.length, 'packets; missing page translations:',
+  sample.filter((r) => r.scan_pages.some((p) => !tr[p])).length);

--- a/scripts/eval/suda-sol/parse-sol.py
+++ b/scripts/eval/suda-sol/parse-sol.py
@@ -1,0 +1,90 @@
+# Parse SOL raw HTML mirror -> sol.jsonl (one line per Adler entry). Issue #3884.
+# Fields: adler_id, headword_betacode, headword_unicode, translated_headword,
+#         vetting_status, translation, greek_betacode, greek_unicode, notes,
+#         keywords, translator, translated_date, n_vetting_events
+import json, re, sys, unicodedata
+from pathlib import Path
+import os
+
+RAW = Path(os.environ.get("SOL_DATA_DIR", "scripts/output/sol-harvest")) / "raw"
+OUT = Path(os.environ.get("SOL_DATA_DIR", "scripts/output/sol-harvest")) / "sol.jsonl"
+
+LET = {"a":"α","b":"β","g":"γ","d":"δ","e":"ε","z":"ζ","h":"η","q":"θ","i":"ι",
+       "k":"κ","l":"λ","m":"μ","n":"ν","c":"ξ","o":"ο","p":"π","r":"ρ","s":"σ",
+       "t":"τ","u":"υ","f":"φ","x":"χ","y":"ψ","w":"ω","v":"ϝ"}
+DIA = {")":"\u0313","(":"\u0314","/":"\u0301","\\":"\u0300","=":"\u0342",
+       "|":"\u0345","+":"\u0308"}
+
+def beta2uni(s):
+    out, i, n = [], 0, len(s)
+    while i < n:
+        ch = s[i]
+        if ch == "*":  # uppercase: * [diacritics] letter [diacritics]
+            i += 1; pre = []
+            while i < n and s[i] in DIA: pre.append(DIA[s[i]]); i += 1
+            if i < n and s[i].lower() in LET:
+                out.append(LET[s[i].lower()].upper()); i += 1
+                out.extend(pre)
+            else: out.extend(pre)
+        elif ch.lower() in LET:
+            out.append(LET[ch.lower()]); i += 1
+        elif ch in DIA:
+            out.append(DIA[ch]); i += 1
+        else:
+            out.append(ch); i += 1
+    txt = unicodedata.normalize("NFC", "".join(out))
+    # final sigma
+    return re.sub(r"σ(?![\u0300-\u0345]*[a-zA-Zα-ωΑ-Ωϝ\u0300-\u0345])", "ς", txt)
+
+TAG = re.compile(r"<[^>]+>")
+def strip(html):
+    t = TAG.sub("", html)
+    t = t.replace("&amp;","&").replace("&lt;","<").replace("&gt;",">").replace("&quot;",'"').replace("&nbsp;"," ").replace("&#39;","'")
+    return re.sub(r"\s+"," ", t).strip()
+
+def block(html, cls):
+    m = re.search(rf'<div class="{cls}">(.*?)</div>', html, re.S)
+    return m.group(1) if m else None
+
+def parse(path, letter, num):
+    html = path.read_text(errors="replace")
+    if "Headword:" not in html: return None
+    hw_zone = html.split("Headword: </strong>",1)[1].split("<br/>",1)[0] if "Headword: </strong>" in html else ""
+    hw_links = re.findall(r'lookup=[^>]*>([^<]+)</a>', hw_zone)
+    hw_beta = " ".join(x.strip() for x in hw_links) or strip(hw_zone)
+    thw = re.search(r"Translated headword: </strong>([^<]*)", html)
+    vet = re.search(r'Vetting Status: (\w+)', html)
+    trans = block(html, "translation")
+    greek = block(html, "greek")
+    notes = block(html, "notes")
+    kws = re.findall(r'field=keyword[^>]*>([^<]+)</a>', html)
+    tb = re.search(r"Translated by</strong>: <a[^>]*>([^<]+)</a> on ([0-9A-Za-z @:]+)", html)
+    editor = block(html, "editor") or ""
+    return {
+        "adler_id": f"{letter},{num}",
+        "headword_betacode": hw_beta,
+        "headword_unicode": beta2uni(hw_beta),
+        "translated_headword": thw.group(1).strip() if thw else None,
+        "vetting_status": vet.group(1) if vet else None,
+        "translation": strip(trans) if trans else None,
+        "greek_betacode": strip(greek) if greek else None,
+        "greek_unicode": beta2uni(strip(greek)) if greek else None,
+        "notes": strip(notes) if notes else None,
+        "keywords": kws,
+        "translator": tb.group(1) if tb else None,
+        "translated_date": tb.group(2).strip() if tb else None,
+        "n_vetting_events": editor.count("<br/>"),
+    }
+
+count, errs = 0, 0
+with OUT.open("w") as f:
+    for ldir in sorted(RAW.iterdir()):
+        if not ldir.is_dir(): continue
+        for p in sorted(ldir.glob("*.html"), key=lambda x: int(x.stem)):
+            try:
+                row = parse(p, ldir.name, p.stem)
+                if row: f.write(json.dumps(row, ensure_ascii=False) + "\n"); count += 1
+                else: errs += 1
+            except Exception as e:
+                errs += 1; print(f"ERR {ldir.name}/{p.stem}: {e}", file=sys.stderr)
+print(f"parsed {count} entries, {errs} skipped/errors -> {OUT}")

--- a/scripts/eval/suda-sol/segment-bekker.mjs
+++ b/scripts/eval/suda-sol/segment-bekker.mjs
@@ -1,0 +1,67 @@
+// Segment Bekker 1854 Suda OCR into entries -> bekker-entries.jsonl. Issue #3884.
+// One row per entry: {seq, lemma, text, scan_page, printed_page, margin_letter, joined_pages}
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+
+const BOOK = '69a99ce86c7545e2236e12de';
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const pages = await c.db('bookstore').collection('pages')
+  .find({ book_id: BOOK, page_number: { $gte: 12, $lte: 1172 } })
+  .project({ page_number: 1, 'ocr.data': 1 })
+  .sort({ page_number: 1 }).toArray();
+await c.close();
+console.log('pages fetched:', pages.length);
+
+const ZWC = /[​‌‍⁠﻿]/g;
+const entries = [];
+let carry = null; // entry continuing from previous page
+
+for (const p of pages) {
+  let t = p.ocr?.data;
+  if (!t) continue;
+  const printed = t.match(/<page-num>(\d+)<\/page-num>/)?.[1];
+  const header = t.match(/<header>([^<]*)<\/header>/)?.[1] ?? '';
+  if (!/[α-ωΑ-Ω]/.test(header)) { carry = null; continue; } // front/back matter
+  t = t.replace(ZWC, '')
+    .replace(/<language>[^<]*<\/language>|<page-type>[^<]*<\/page-type>|<columns>[^<]*<\/columns>|<page-num>[^<]*<\/page-num>|<header>[^<]*<\/header>|<column-break\/>|<sig>[^<]*<\/sig>/g, '')
+    .replace(/<insert>[\s\S]*?<\/insert>/g, '');
+  // paragraphs; <margin>x</margin> may prefix an entry
+  const paras = t.split(/\n+/).map((s) => s.trim()).filter(Boolean);
+  for (let i = 0; i < paras.length; i++) {
+    let para = paras[i];
+    const margin = para.match(/^<margin>([^<]*)<\/margin>\s*/);
+    if (margin) para = para.slice(margin[0].length);
+    para = para.replace(/<margin>[^<]*<\/margin>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!para) continue;
+    const first = para.match(/^[^\s]+/)?.[0] ?? '';
+    // continuation heuristic: first para of a page joins carry if carry ended
+    // hyphenated, or this para starts lowercase-Greek and carry lacks final punct.
+    const startsNewEntry = /^[Α-ΩἈ-ᾯ]/.test(first) ||
+      (/^[α-ωἀ-ῷ]/.test(first) && (!carry || /[.·;]$/.test(carry.text)));
+    if (i === 0 && carry && (!startsNewEntry || /-$/.test(carry.text))) {
+      carry.text = /-$/.test(carry.text)
+        ? carry.text.slice(0, -1) + para
+        : carry.text + ' ' + para;
+      carry.joined_pages.push(p.page_number);
+      continue;
+    }
+    if (carry) entries.push(carry);
+    carry = {
+      seq: entries.length,
+      lemma: para.split(/[\s:·]+/).slice(0, 3).join(' '),
+      text: para,
+      scan_page: p.page_number,
+      printed_page: printed ? Number(printed) : null,
+      margin_letter: margin ? margin[1] : null,
+      joined_pages: [p.page_number],
+    };
+  }
+}
+if (carry) entries.push(carry);
+entries.forEach((e, i) => (e.seq = i));
+writeFileSync((process.env.SOL_DATA_DIR ?? 'scripts/output/sol-harvest') + '/bekker-entries.jsonl',
+  entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+console.log('entries:', entries.length,
+  '| joined-across-pages:', entries.filter((e) => e.joined_pages.length > 1).length,
+  '| with margin letter:', entries.filter((e) => e.margin_letter).length);

--- a/scripts/eval/suda-sol/summarize-pilot.py
+++ b/scripts/eval/suda-sol/summarize-pilot.py
@@ -1,0 +1,43 @@
+# Merge pilot verdicts (gold-labels.jsonl + pilot/*.verdict.json) and summarize. #3884
+import json, glob
+from collections import Counter
+from pathlib import Path
+import os
+
+D = Path(os.environ.get("SOL_DATA_DIR", "scripts/output/sol-harvest"))
+rows = {}
+for l in open(D / "gold-labels.jsonl"):
+    r = json.loads(l); rows[r["adler_id"]] = r
+for f in sorted(glob.glob(str(D / "pilot" / "*.verdict.json"))):
+    try:
+        r = json.loads(open(f).read()); rows[r["adler_id"]] = r
+    except Exception as e:
+        print("BAD VERDICT FILE:", f, e)
+rows = list(rows.values())
+with open(D / "gold-labels-merged.jsonl", "w") as f:
+    for r in rows: f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+n = len(rows)
+fid = Counter(r["fidelity"] for r in rows)
+align = sum(1 for r in rows if r.get("alignment_ok"))
+found = sum(1 for r in rows if r.get("our_translation_found"))
+recit = [r for r in rows if r.get("recitation_signal")]
+err_types = Counter(e["type"] for r in rows for e in r.get("errors", []))
+err_sev = Counter(e["severity"] for r in rows for e in r.get("errors", []))
+div_kinds = Counter(d["kind"] for r in rows for d in r.get("divergences", []))
+major = [r["adler_id"] for r in rows if r["fidelity"] == "major_errors"]
+our_err_entries = [r["adler_id"] for r in rows
+                   if any(d["kind"] == "our_error" for d in r.get("divergences", []))]
+sol_err_entries = [r["adler_id"] for r in rows
+                   if any(d["kind"] == "sol_error" for d in r.get("divergences", []))]
+
+print(f"entries judged: {n}")
+print(f"alignment_ok: {align}/{n}")
+print(f"our_translation_found: {found}/{n}")
+print(f"fidelity: {dict(fid)}")
+print(f"error types: {dict(err_types)}  severities: {dict(err_sev)}")
+print(f"divergence kinds: {dict(div_kinds)}")
+print(f"recitation_signal: {len(recit)}  -> {[r['adler_id'] for r in recit]}")
+print(f"major_errors entries: {major}")
+print(f"entries with our_error divergences: {our_err_entries}")
+print(f"entries with sol_error divergences: {sol_err_entries}")

--- a/scripts/eval/suda-sol/validate-lite.mjs
+++ b/scripts/eval/suda-sol/validate-lite.mjs
@@ -1,0 +1,71 @@
+// Flash-lite judge validation against the 49 gold pilot packets. Issue #3884.
+// Same judgment task as the Claude subagent gold pass; verdicts to lite-verdicts/.
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
+
+const D = (process.env.SOL_DATA_DIR ?? 'scripts/output/sol-harvest') + '/';
+const MODEL = 'gemini-3.1-flash-lite';
+const KEY = process.env.GEMINI_API_KEY;
+if (!KEY) { console.error('no GEMINI_API_KEY'); process.exit(1); }
+mkdirSync(D + 'lite-verdicts', { recursive: true });
+
+const INSTR = `You are an expert classicist judging AI translation quality for the Byzantine Suda lexicon. The packet below contains:
+- bekker_greek_ocr: our OCR of Bekker's 1854 edition, the SOURCE our AI translation worked from
+- our_page_translations: our AI English translation of the full scan page(s); this entry's translation is embedded among other entries; locate it (typically under a transliterated headword)
+- sol_translation: scholar-vetted Suda On Line translation of the same entry
+- adler_greek_via_sol: Adler's critical Greek text of the entry
+
+Judge:
+1. alignment_ok: is bekker_greek_ocr the same Suda entry as SOL's (same headword and content)? (The OCR excerpt may drag in the start of the following entry — that is packet windowing, not misalignment.)
+2. Locate OUR entry's translation inside our_page_translations; our_translation_excerpt = its first ~10 words; our_translation_found=false if genuinely absent.
+3. fidelity of OUR translation judged ONLY against bekker_greek_ocr: "faithful" | "minor_issues" | "major_errors". errors: [{type: mistranslation|omission|addition|silent_emendation|garble_passthrough|nuance_flattening, severity: minor|major, detail}]. A faithful rendering of corrupt OCR counts as faithful; rendering garble as fluent confident English is garble_passthrough.
+4. divergences between OUR translation and sol_translation: [{kind: our_error|sol_error|edition_difference|style_only, detail}], using the two Greek texts as arbiters.
+5. recitation_signal: true iff our English asserts something matching external knowledge or SOL AGAINST our own OCR Greek; recitation_detail.
+
+Respond with ONLY a JSON object:
+{"adler_id": str, "alignment_ok": bool, "our_translation_found": bool, "our_translation_excerpt": str|null, "fidelity": str, "errors": [], "divergences": [], "recitation_signal": bool, "recitation_detail": str|null}`;
+
+async function judge(packet, trim = false) {
+  const p = { ...packet };
+  if (trim) {
+    p.our_page_translations = Object.fromEntries(Object.entries(p.our_page_translations)
+      .map(([k, v]) => [k, v ? v.slice(0, 6000) : v]));
+  }
+  const body = {
+    contents: [{ parts: [{ text: INSTR + '\n\nPACKET:\n' + JSON.stringify(p) }] }],
+    generationConfig: {
+      temperature: 0.1,
+      maxOutputTokens: 4096,
+      thinkingConfig: { thinkingBudget: 512 },
+      responseMimeType: 'application/json',
+    },
+  };
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${KEY}`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = await res.json();
+  const text = j.candidates?.[0]?.content?.parts?.map((x) => x.text).join('') ?? '';
+  if (!text) throw new Error('empty candidate (finishReason: ' + j.candidates?.[0]?.finishReason + ')');
+  return { verdict: JSON.parse(text), usage: j.usageMetadata };
+}
+
+const packets = readdirSync(D + 'pilot').filter((f) => f.endsWith('.json') && !f.includes('verdict')).sort();
+let tokens = { in: 0, out: 0 };
+for (const f of packets) {
+  const out = D + 'lite-verdicts/' + f;
+  if (existsSync(out)) continue;
+  const packet = JSON.parse(readFileSync(D + 'pilot/' + f, 'utf8'));
+  let r;
+  try { r = await judge(packet); }
+  catch (e) {
+    console.log(`retry(trim) ${f}: ${e.message}`);
+    try { r = await judge(packet, true); }
+    catch (e2) { console.log(`FAIL ${f}: ${e2.message}`); continue; }
+  }
+  writeFileSync(out, JSON.stringify(r.verdict, null, 1));
+  tokens.in += r.usage?.promptTokenCount ?? 0;
+  tokens.out += r.usage?.candidatesTokenCount ?? 0;
+  console.log(`${f}: ${r.verdict.fidelity} (${r.verdict.errors?.length ?? 0} errors)`);
+}
+console.log('tokens:', tokens, '≈ $' + ((tokens.in * 0.10 + tokens.out * 0.40) / 1e6).toFixed(4));


### PR DESCRIPTION
Promotes the Suda-SOL benchmark tooling from untracked scratch (`scripts/output/sol-harvest/`) into the repo: harvest → parse → segment → align → gold pilot → judge validation → census, plus a README carrying the pipeline's invariants (Bekker alphabetized vs Adler antistoichic; homonym disambiguation by Greek similarity, never order; both-Greek arbitration; cross-family judging, κ=0.107).

**In scope:** scripts + README only. All scripts read `$SOL_DATA_DIR` (default `scripts/output/sol-harvest`, untracked).
**Out of scope (deliberate):** the data itself — the SOL mirror and derivatives are CC BY-NC-SA and must not enter this AGPL repo. Snapshot backed up to Hetzner `/root/backups/sol-harvest-2026-08-11.tar.gz` (45M). Dataset release files + DOI are tracked on #3884.

Scripts-only change: no Vercel-relevant code, and the Hetzner auto-pull picks it up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)