### PR TITLE
fix(blog): Suda post — SOL-error count 6→5 after notes-aware re-adjudication

### DIFF
--- a/src/app/blog/suda-benchmark/page.tsx
+++ b/src/app/blog/suda-benchmark/page.tsx
@@ -175,12 +175,15 @@ export default function SudaBenchmarkPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <strong>Second: the reference makes mistakes too.</strong> In 6 of 49 entries the judges
-          found the scholarly translation erring against its own Greek &mdash; small things, an
-          imported word, a stretched construal, the ordinary residue of any twenty-five-year
-          project. We say this with gratitude, not glee: the Suda On Line is the only reason this
-          measurement exists, and we will report what we found upstream, with the evidence, the way
-          their own contributors would. When a machine translation and a human translation can each
+          <strong>Second: the reference makes mistakes too.</strong> In 5 of 49 entries the judges
+          found the scholarly translation erring against its own Greek &mdash; small things, a word
+          construed against its attested sense, a misparsed genitive, the ordinary residue of any
+          twenty-five-year project. (We first counted six. On re-examination with SOL&rsquo;s own
+          annotations in view, one claim dissolved &mdash; the error in that entry was ours, and we
+          have corrected this paragraph accordingly. Every surviving claim was re-adjudicated the
+          same way, with instructions to extend SOL maximal charity.) We say this with gratitude,
+          not glee: the Suda On Line is the only reason this measurement exists, and we will report
+          what we found upstream, with the evidence, the way their own contributors would. When a machine translation and a human translation can each
           be checked against the Greek, each becomes an error-detector for the other. That
           reciprocity &mdash; not replacement &mdash; is the actual relationship between AI
           translation and scholarship that this experiment demonstrates.


### PR DESCRIPTION
Factual correction to the live post /blog/suda-benchmark: the notes-aware re-adjudication (#3884) dissolved one of six claimed SOL errors (phi,125 — our judge normalized the transmitted προφαίνειν; the fault was ours). The paragraph now reads 5 of 49, states the correction openly, and documents the charity-first re-adjudication. One-paragraph diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)