### PR TITLE
fix(blog): Suda post — control experiment overturns family-blindness claim

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -29,7 +29,7 @@ export const posts: BlogPost[] = [
     slug: 'suda-benchmark',
     title: 'Graded by the Suda',
     subtitle:
-      'One book in our library came with its own answer key: the Suda On Line, 31,000 entries translated by two hundred volunteer scholars over sixteen years. We aligned our AI translation with theirs, let each grade the other with the Greek as arbiter, and learned that a model cannot grade its own family’s homework. Total API cost: $1.15.',
+      'One book in our library came with its own answer key: the Suda On Line, 31,000 entries translated by two hundred volunteer scholars over sixteen years. We aligned our AI translation with theirs, let each grade the other with the Greek as arbiter, and learned that a cheap AI judge fails silently — its incapacity arrives dressed as approval. Total API cost: $1.15.',
     date: '11 August 2026',
     readTime: '9 min read',
     tag: 'Research',

--- a/src/app/blog/suda-benchmark/page.tsx
+++ b/src/app/blog/suda-benchmark/page.tsx
@@ -186,17 +186,35 @@ export default function SudaBenchmarkPage() {
           translation and scholarship that this experiment demonstrates.
         </p>
 
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>Third, and to us most instructive: a judge that cannot do the task does not say
+          so &mdash; it says &ldquo;faithful.&rdquo;</strong> Before scaling the grading, we tested
+          whether a cheap model from the same family as our translator could stand in for the
+          expensive judges. Given the identical entries, the identical rubric, and errors we knew
+          were present because they were already catalogued, it called 47 of 49 entries clean
+          &mdash; missing 90% of the faults, with zero false alarms. Agreement with the gold
+          labels: &kappa; = 0.107, barely above chance. A bigger model of the same family with four
+          times the thinking budget did no better. We initially read this as the obvious morality
+          tale &mdash; a model going easy on its own family&rsquo;s homework &mdash; and an earlier
+          version of this paragraph said exactly that.
+        </p>
+
         <p className="text-secondary leading-relaxed mb-8">
-          <strong>Third, and to us most important: a model cannot grade its own family&rsquo;s
-          homework.</strong> Before scaling the grading, we tested whether a cheap model from the
-          same family as our translator could stand in for the expensive cross-family judges. Given
-          the identical entries, the identical rubric, and errors we knew were present because they
-          were already catalogued, it called 47 of 49 entries clean &mdash; missing 90% of the
-          faults, with zero false alarms. Agreement with the gold labels: &kappa; = 0.107, barely
-          above chance. Escalating to the bigger model of the same family with four times the
-          thinking budget changed nothing. The misses all point one direction: pure leniency toward
-          its own family&rsquo;s output. It is hard to imagine a cleaner argument that AI systems
-          must be evaluated by their rivals, never by their relatives.
+          Then we ran the control an honest reviewer would demand, and the morality tale fell
+          apart. We had fresh translations of the same entries made by the judge&rsquo;s rival
+          family, and had both families grade the identical artifacts: on focused
+          Greek-plus-translation pairs, the cheap judge found errors at the same rate as its
+          expensive rival &mdash; including, decisively, <em>6 of 7 known error-entries in its own
+          family&rsquo;s work</em> once we re-presented them in the focused format. The blindness
+          was never loyalty. It was task collapse: our original test asked the judge to first
+          locate one entry&rsquo;s translation inside a full translated page and then grade it, and
+          the cheap model cannot do that composite task &mdash; so it silently returned
+          &ldquo;faithful,&rdquo; forty-seven times, instead of once saying &ldquo;I
+          can&rsquo;t.&rdquo; The practical rule survives in sharper form: validate a cheap judge
+          on the exact task format you will deploy it on, because its incapacity will arrive
+          dressed as approval. And the methodological rule above it: when a result flatters your
+          suspicion of someone else&rsquo;s model, that is precisely the result to attack with a
+          control.
         </p>
 
         {/* ── The census ── */}


### PR DESCRIPTION
Substantive scientific correction to /blog/suda-benchmark, prompted by running the 2×2 control the post's own critique pass identified as missing (#3884, control table in the issue thread).

**What changed:** the third finding ('a model cannot grade its own family's homework') is replaced by the control-corrected finding: κ=0.107 was task collapse on the embedded locate-then-judge format, not family loyalty — the same cheap judge detects 6/7 known issue-entries in its own family's output when given focused pairs, and matches Claude-judge error rates on identical fresh artifacts. The rewritten passage states openly that an earlier version made the wrong claim. Index subtitle updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)