### PR TITLE
docs: an activity count is not a quality metric (#3894, #3945)

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -129,3 +129,49 @@ what was new is that a *safety control* embodied it.
   in the store production writes to, and cross-check the vendor's own meter (Cloud Monitoring
   hourly buckets — day-aligned queries anchor to the query END time and silently become
   rolling-24h windows). Verified 2026-08-09 for ~$0.05.
+
+## An activity count is not a quality metric, and "carrying" is not "depending"
+
+2026-08-12 (#3894, #3945). An attribution workstream ran for a day reporting
+**"records corrected"** — 28, then 63, then 142. Every number was true and none
+was a measurement: no denominator, no baseline, and **structurally unable to
+come back negative**. When a real metric was finally built
+(`scripts/audit/attribution-health.mjs`, `.claude/docs/attribution-health.md`),
+its first act was to score those same 142 corrections as a **net regression**:
+35 records up a tier, **42 down**. Correcting a byline had cleared `author_id`
+wherever the right person had no thesaurus doc, trading a *wrong but reachable*
+attribution for a *right but unreachable* one. The activity count concealed that
+completely — it could only ever go up.
+
+**If a number cannot fall, it is a report of effort, not of quality.** Before
+quoting progress, ask what would make this number get worse, and if there is no
+answer, build the one that can.
+
+Three numbers from that single workstream were wrong before they were caught,
+each by the same mechanism — a plausible count taken without its denominator:
+
+- **"1,526 books at risk"** if unsafe author-name variants stopped being matched
+  on. The count was books whose `author` *equalled* such a variant. But a book
+  with an explicit `author_id` reaches its author by foreign key and does not
+  care what the variant says; only a book with **no** `author_id` depends on the
+  string. True figure: **zero**. **Carrying a value is not depending on it** —
+  measure the dependency, never the co-occurrence.
+- **"6,025 unusable author strings"** (16% of the visible corpus) from a test
+  asking whether the author string opens some book's title. It flagged every
+  author whose name heads their own book. `author-attribution.mjs` has carried
+  the guard against exactly this since #3434; omitting it reproduced the bug the
+  guard exists to prevent. True figure after that guard **and** after excluding
+  artworks — where the "author" is the artist and titles conventionally open
+  with the artist's name — was **68**.
+- **"142 records corrected"**, above.
+
+**Scope is part of the instrument.** That artwork case is not a detail: 3,606 of
+the 3,674 remaining "defects" were `resource_type`-bearing records with a
+different identity model. A metric over a mixed corpus measures the mixture.
+State the population in the script's own output, as the OCR loop does
+(`ocr-quality-measurement-loop.md`), so the denominator travels with the number.
+
+**Corollary for repairs that clear a field.** Nulling a foreign key to avoid a
+wrong link is the right call — but it is a *cost*, and it will not appear in any
+count of records fixed. Emit it: this run should have reported "22 bylines
+corrected, 22 author pages lost" from the start.

--- a/.claude/handoffs/2026-08-12-attribution-health-loop.md
+++ b/.claude/handoffs/2026-08-12-attribution-health-loop.md
@@ -1,0 +1,69 @@
+# Attribution: from one reader's note to a measurement loop — 2026-08-11/12
+
+Started from a single MCP `submit_feedback` item (a mis-credited 1592 book).
+Ended with a metric that scored the whole day's work as a net regression, which
+is the useful part.
+
+## What shipped
+
+| PR | what |
+|---|---|
+| #3899 | `author-vs-ai-metadata.mjs` — books whose catalogued author is contradicted by enrichment |
+| #3906 | name-form equivalence + contaminated-enrichment flag (residue 220 → 154) |
+| #3907 | `title-page-attribution.mjs` — read the author off the record's own title |
+| #3913 | shared `latin-morphology.mjs`; genitive→nominative by thesaurus lookup |
+| #3921 | `thesaurus-variant-shape.mjs` — `variants[]` is a match surface, 11% unsafe |
+| #3923 | correction: de-matching is safe; I'd measured the wrong denominator |
+| #3945 | `attribution-health.mjs` + `.claude/docs/attribution-health.md` — the metric |
+| #3946 | mint 2 docs, re-link 8 books, second ledger snapshot |
+
+**Data:** 142 book records corrected, 5 author docs merged, 2 minted. Backups in
+session scratch as `_tmp-*-backup-2026-08-11.json` (merge-on-id, reversible).
+
+## The measurement
+
+`node scripts/audit/attribution-health.mjs --snapshot`. Baseline 2026-08-12,
+21,974 visible **text** books: reachable (T3+) **77.87%**, anchored (T4)
+**64.0%**, T1 unusable **68**, contradicted 246 of 4,313. After the mint:
+77.91% / 64.03%. Ledger at `.claude/docs/attribution-health-ledger.jsonl`; the
+script prints its own `SINCE <date>` delta.
+
+## The thing worth remembering
+
+**Every headline number I produced was wrong until something forced a
+denominator into view.** "1,526 books at risk" → 0. "6,025 unusable strings" →
+68. "142 records corrected" → a net −7 on reachability. Written up in
+`invariants/measurement-instruments.md`.
+
+The specific trap: correcting a byline **clears `author_id`** when the right
+person has no thesaurus doc, so a wrong-but-reachable attribution becomes a
+right-but-unreachable one. Only 8 of 41 such records could be recovered, because
+the early passes recorded a verified *name* but no QID (→ #3948).
+
+## Recurring hazard, hit four times
+
+Matching a partial name into a store lands on a **different person**:
+`Annibal Caro` → `hugo-de-sancto-caro`; `Paulus Manutius` → `aldus-manutius`;
+`Iacobi Sannazarii` → *Jacob of Edessa*; `王植` ⟷ `王質` (same romanisation, two
+men). Every instance was caught by **printing which record matched before
+writing**. That habit is the whole defence.
+
+Related: for CJK the characters are the identity — `sameNameForm` strips
+non-Latin script and will happily merge two people who romanise alike.
+
+## Open
+
+- **#3948** recover the ~33 books still stranded at T2
+- **#3949** contamination has a second signature: description-vs-title mismatch
+- **#3950** three audit false positives: Unicode pairs, MARC relators, and
+  `"Various"` as a *legitimate* collective attribution
+- **#3951** human queue: 24 held verdicts, 4 confirmed-distinct CJK pairs, 2
+  wrong QIDs (`lu-ji-2`, `wang-zhi-2`), the `/author/persius` slug question
+
+## Note on scale
+
+142 records is **0.4%** of the visible corpus, and the day drifted into
+infrastructure-about-infrastructure more than once. The reader-facing feedback
+queue that this started in still has untouched items: PDF export layout, BPH
+manuscript records not clickable, gallery "load more", subject-page image links.
+Those are probably the better next move.


### PR DESCRIPTION
Adds the durable lesson from the attribution workstream to `invariants/measurement-instruments.md`, plus the session handoff.

A day of work reported **"records corrected"** — 28, then 63, then 142. Every number was true and none was a measurement: no denominator, no baseline, and **structurally unable to come back negative.** The metric built at the end (#3945) scored those same 142 corrections as a **net regression** — 35 records up a tier, 42 down.

Three numbers from that one workstream were wrong before they were caught, each the same mechanism — a plausible count taken without its denominator:

| claimed | true | why |
|---|---|---|
| 1,526 books at risk | **0** | carrying a value is not depending on it — a book with an `author_id` FK does not care what the variant says |
| 6,025 unusable strings | **68** | dropped a guard `author-attribution.mjs` has carried since #3434, then found the residue was **artworks** |
| 142 records corrected | **−7** | on reachability |

Plus the corollary that run should have emitted from the start: nulling a foreign key to avoid a wrong link is correct **and** a cost, and it appears in no count of records fixed. It should have read *"22 bylines corrected, 22 author pages lost."*

Handoff at `.claude/handoffs/2026-08-12-attribution-health-loop.md` (`git add -f`; technical postmortem, no PII or business content).

**Tier check:** CLAUDE.md unchanged at 224 lines, inside the ~250 budget. This fires when you measure something, so it belongs in the invariant tier, not the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)