### PR TITLE
nav: Explore hub replaces Map, retire Podcast item, feature podcast on both homepages

### DIFF
--- a/src/app/es/page.tsx
+++ b/src/app/es/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getHomeData } from '@/lib/home-data';
 import HomeView from '@/components/home/HomeView';
+import { FEED_TYPES } from '@/lib/feed-links';
 
 // Spanish-language edition of the homepage — a real, server-rendered, indexable
 // route (not a client string swap), sharing the same data + body as `/`.
@@ -18,6 +19,9 @@ export const metadata: Metadata = {
       es: '/es',
       'x-default': '/',
     },
+    // See src/lib/feed-links.ts — declaring `languages` here replaces the
+    // layout's whole `alternates`, feed links included.
+    types: FEED_TYPES,
   },
   openGraph: {
     images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],

--- a/src/app/es/page.tsx
+++ b/src/app/es/page.tsx
@@ -30,6 +30,6 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePageEs() {
-  const data = await getHomeData();
+  const data = await getHomeData('es');
   return <HomeView data={data} lang="es" />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -75,6 +75,14 @@ export const metadata: Metadata = {
         { url: '/api/feed/gallery', title: 'Source Library Gallery' },
         { url: '/api/feed/blog', title: 'Source Library - Research Notes' },
       ],
+      // The podcast feeds were the only ones the site did not advertise, so a
+      // podcast app pointed at sourcelibrary.org had nothing to autodiscover
+      // even though both feeds have been serving 200s. RSS 2.0, not Atom —
+      // they are podcast feeds with enclosures, and Apple/Spotify want RSS.
+      'application/rss+xml': [
+        { url: '/api/podcast/feed.xml', title: 'Source Library - Deep Dive Podcast' },
+        { url: '/api/podcast/feed.es.xml', title: 'Source Library - Pódcast en español' },
+      ],
     },
   },
   keywords: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { FEED_TYPES } from "@/lib/feed-links";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
 import PageTracker from "@/components/reader/PageTracker";
@@ -69,21 +70,7 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://sourcelibrary.org'),
   alternates: {
     canonical: '/',
-    types: {
-      'application/atom+xml': [
-        { url: '/api/feed/books', title: 'Source Library - New Books' },
-        { url: '/api/feed/gallery', title: 'Source Library Gallery' },
-        { url: '/api/feed/blog', title: 'Source Library - Research Notes' },
-      ],
-      // The podcast feeds were the only ones the site did not advertise, so a
-      // podcast app pointed at sourcelibrary.org had nothing to autodiscover
-      // even though both feeds have been serving 200s. RSS 2.0, not Atom —
-      // they are podcast feeds with enclosures, and Apple/Spotify want RSS.
-      'application/rss+xml': [
-        { url: '/api/podcast/feed.xml', title: 'Source Library - Deep Dive Podcast' },
-        { url: '/api/podcast/feed.es.xml', title: 'Source Library - Pódcast en español' },
-      ],
-    },
+    types: FEED_TYPES,
   },
   keywords: [
     'Hermetic texts',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getHomeData } from '@/lib/home-data';
 import HomeView from '@/components/home/HomeView';
+import { FEED_TYPES } from '@/lib/feed-links';
 
 // ISR: serve cached HTML, revalidate in background every 60 seconds.
 // The homepage uses $sample for randomness — content rotates every revalidation cycle.
@@ -15,6 +16,10 @@ export const metadata: Metadata = {
       es: '/es',
       'x-default': '/',
     },
+    // Next.js replaces the layout's whole `alternates` object rather than
+    // merging it, so declaring `languages` here was silently dropping every
+    // feed link from the site's most-linked page. See src/lib/feed-links.ts.
+    types: FEED_TYPES,
   },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,6 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePage() {
-  const data = await getHomeData();
+  const data = await getHomeData('en');
   return <HomeView data={data} lang="en" />;
 }

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -18,7 +18,7 @@ import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
 
 export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLang }) {
   const t = HOME_STRINGS[lang];
-  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, spanishPodcast } = data;
+  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
 
   return (
@@ -28,17 +28,21 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
       {/* Video Hero */}
       <HeroSection lang={lang} />
 
-      {/* Spanish podcast feature — the first real Spanish content a /es visitor
-          meets. Only rendered on /es, so the English homepage is unchanged. */}
-      {lang === 'es' && spanishPodcast && (
+      {/* Featured podcast episode, in the page's own language.
+          Was /es-only; now on both homepages, and it is the podcast's primary
+          entry point since the header nav item was retired (see SiteHeader).
+          Renders nothing when that language has no published episode, which is
+          currently the state of several languages — an empty section is correct,
+          not a bug. */}
+      {featuredPodcast && (
         <section className="py-14 md:py-20" style={{ background: 'var(--bg-dark)' }}>
           <div className="px-6 md:px-12 max-w-[1100px] mx-auto">
             <div className="grid md:grid-cols-[1fr_1.2fr] gap-8 md:gap-12 items-center">
-              {spanishPodcast.heroImageUrl && (
-                <Link href={`/podcast/${spanishPodcast.threadId}`} className="block rounded-xl overflow-hidden bg-black/30">
+              {featuredPodcast.heroImageUrl && (
+                <Link href={`/podcast/${featuredPodcast.threadId}`} className="block rounded-xl overflow-hidden bg-black/30">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
-                    src={`/api/image?url=${encodeURIComponent(spanishPodcast.heroImageUrl)}&w=720&q=85`}
+                    src={`/api/image?url=${encodeURIComponent(featuredPodcast.heroImageUrl)}&w=720&q=85`}
                     alt=""
                     className="w-full max-h-[360px] object-contain"
                     loading="lazy"
@@ -50,23 +54,23 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                   {t.podcastEyebrow}
                 </p>
                 <h2 className="text-2xl md:text-3xl font-display mb-4 leading-snug" style={{ color: '#f5f0e8' }}>
-                  {spanishPodcast.title}
+                  {featuredPodcast.title}
                 </h2>
                 <p className="text-base leading-relaxed mb-5" style={{ color: '#b8b2a8' }}>
-                  {spanishPodcast.topic}
+                  {featuredPodcast.topic}
                 </p>
 
-                <audio controls preload="none" src={spanishPodcast.audioUrl} className="w-full mb-5">
-                  <a href={spanishPodcast.audioUrl}>{t.podcastListen}</a>
+                <audio controls preload="none" src={featuredPodcast.audioUrl} className="w-full mb-5">
+                  <a href={featuredPodcast.audioUrl}>{t.podcastListen}</a>
                 </audio>
 
-                {spanishPodcast.sources.length > 0 && (
+                {featuredPodcast.sources.length > 0 && (
                   <div className="mb-5">
                     <p className="text-xs uppercase tracking-wider mb-2" style={{ color: '#8a8480' }}>
                       {t.podcastSourcesLabel}
                     </p>
                     <ul className="space-y-1.5">
-                      {spanishPodcast.sources.map((s) => (
+                      {featuredPodcast.sources.map((s) => (
                         <li key={s.bookId}>
                           <Link
                             href={`/book/${s.slug || s.bookId}`}
@@ -87,7 +91,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 )}
 
                 <Link
-                  href={`/podcast/${spanishPodcast.threadId}`}
+                  href={`/podcast/${featuredPodcast.threadId}`}
                   className="inline-flex items-center gap-1.5 text-sm font-medium px-5 py-2.5 rounded-full transition-all hover:brightness-110"
                   style={{ background: 'var(--accent-rust)', color: '#fff' }}
                 >

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -34,9 +34,21 @@ function buildNavLinks(t: NavStrings): NavLink[] {
         { label: t.works, href: '/works' },
       ],
     },
-    { label: t.map, href: '/explore/map', activePrefix: '/explore' },
+    // Points at the /explore hub, not /explore/map. The hub carries the entity
+    // stats, the century heatmap, and cards for all three visualizations; the
+    // nav used to skip past it straight to the map, which is why the hub drew
+    // 13 pageviews in the 30 days to 2026-08-13 while the map drew 262 and the
+    // timeline and constellation together drew 139. Linking the room instead of
+    // one corner of it is the whole change.
+    { label: t.explore, href: '/explore', activePrefix: '/explore' },
     { label: t.librarian, href: '/librarian' },
-    { label: t.podcast, href: '/podcast' },
+    // No Podcast item. Measured over the same 30 days, the header was the only
+    // sitewide English entry point to /podcast and it produced 113 plays, of
+    // which 66 (58%) were the one episode featured on the /es homepage — i.e.
+    // the editorial placement, not the nav, is what makes people listen. The
+    // homepage feature is now rendered for both locales (HomeView), which is
+    // where that traffic is meant to come from. Episodes also stay reachable
+    // from their librarian threads and the footer.
   ];
 }
 

--- a/src/lib/feed-links.ts
+++ b/src/lib/feed-links.ts
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+
+/**
+ * Feed autodiscovery <link> tags, in one place.
+ *
+ * These live here rather than inline in the root layout because Next.js does
+ * NOT deep-merge `alternates`: a route that declares its own `alternates` (for
+ * a canonical URL or hreflang `languages`) replaces the layout's entire object,
+ * silently dropping every feed link. That is how the homepage — the most-linked
+ * page on the site — ended up advertising no feeds at all while /podcast
+ * advertised three.
+ *
+ * So any route that sets `alternates` must spread `FEED_TYPES` into its own
+ * `types`, and adding a feed means editing this list only.
+ */
+export const FEED_TYPES: NonNullable<NonNullable<Metadata['alternates']>['types']> = {
+  'application/atom+xml': [
+    { url: '/api/feed/books', title: 'Source Library - New Books' },
+    { url: '/api/feed/gallery', title: 'Source Library Gallery' },
+    { url: '/api/feed/blog', title: 'Source Library - Research Notes' },
+  ],
+  // RSS 2.0, not Atom — these are podcast feeds with enclosures, and that is
+  // what Apple and Spotify expect.
+  'application/rss+xml': [
+    { url: '/api/podcast/feed.xml', title: 'Source Library - Deep Dive Podcast' },
+    { url: '/api/podcast/feed.es.xml', title: 'Source Library - Pódcast en español' },
+  ],
+};

--- a/src/lib/footer-nav.ts
+++ b/src/lib/footer-nav.ts
@@ -29,6 +29,7 @@ export const FOOTER_NAV_COLUMNS: ReadonlyArray<FooterNavColumn> = [
       { key: 'gallery', href: '/gallery' },
       { key: 'collections', href: '/collections' },
       { key: 'search', href: '/search' },
+      { key: 'podcast', href: '/podcast' },
     ],
   },
   {

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -6,6 +6,7 @@ import { sortCollections, withTimeout, coverOverride } from '@/lib/collections-u
 import { browseBooks, type CatalogBook } from '@/lib/books-catalog';
 import { toGalleryCardUrl } from '@/lib/utils';
 import { type Plate } from '@/components/GalleryMasonry';
+import { type HomeLang } from '@/lib/home-i18n';
 
 // Shared data layer for the homepage. Both the English `/` route and the
 // Spanish `/es` route fetch through getHomeData() so the two pages can never
@@ -626,9 +627,9 @@ const BLOG_POSTS: HomeBlogPost[] = [
   },
 ];
 
-// ---------- Spanish podcast (featured on /es) ----------
+// ---------- Featured podcast episode (both homepages) ----------
 
-export interface SpanishPodcastSource {
+export interface PodcastSource {
   bookId: string;
   slug?: string;
   title: string;
@@ -636,20 +637,40 @@ export interface SpanishPodcastSource {
   origin?: string;
 }
 
-export interface SpanishPodcast {
+export interface FeaturedPodcast {
   threadId: string;
   title: string;
   topic: string;
   audioUrl: string;
   heroImageUrl: string | null;
-  sources: SpanishPodcastSource[];
+  sources: PodcastSource[];
 }
 
-// Latest published Spanish-language deep-dive episode, for the /es feature.
-async function getSpanishPodcast(): Promise<SpanishPodcast | null> {
+// Latest published deep-dive episode in the homepage's own language.
+//
+// This began as a Spanish-only feature. It is now rendered on both homepages
+// because the measurement said the placement is the thing that works: in the
+// 30 days to 2026-08-13 the podcast drew 113 plays, and 66 of them (58%) were
+// this one featured Spanish episode — which also had the best completion rate
+// of any episode (33% vs 29% overall). The other ten-plus episodes, reachable
+// only from the header nav, averaged about five plays each. So the nav item was
+// retired (SiteHeader) and English got the placement that actually earns
+// listens. A language with no published episode simply renders nothing.
+//
+// The language match is NOT `{ language }`. English threads carry no `language`
+// field at all — measured 2026-08-13, all six published English deep-dives have
+// it absent while the single Spanish one has `language: 'es'`. `language: 'en'`
+// therefore matches zero documents, and the English feature would have rendered
+// nothing forever while looking perfectly correct in code review. Absent means
+// English here, so `en` has to accept the missing field.
+async function getFeaturedPodcast(language: HomeLang): Promise<FeaturedPodcast | null> {
   const db = await getReadDb();
+  const languageMatch =
+    language === 'en'
+      ? { $or: [{ language: 'en' }, { language: { $exists: false } }, { language: null }] }
+      : { language };
   const thread = await db.collection('embassy_threads').findOne(
-    { language: 'es', 'podcasts.deep-dive.published': true, 'podcasts.deep-dive.audioUrl': { $exists: true } },
+    { ...languageMatch, 'podcasts.deep-dive.published': true, 'podcasts.deep-dive.audioUrl': { $exists: true } },
     {
       projection: { title: 1, heroImage: 1, 'podcasts.deep-dive': 1 },
       sort: { 'podcasts.deep-dive.generatedAt': -1 },
@@ -679,19 +700,22 @@ export interface HomeData {
   counts: HomeCounts;
   collections: CollectionForGrid[];
   blogPosts: HomeBlogPost[];
-  spanishPodcast: SpanishPodcast | null;
+  featuredPodcast: FeaturedPodcast | null;
 }
 
-export async function getHomeData(): Promise<HomeData> {
-  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, spanishPodcast] = await Promise.all([
+// `lang` selects the podcast episode's language and nothing else — every other
+// query is language-agnostic, which is what keeps the two homepages structurally
+// identical (see the note at the top of this file).
+export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
+  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getRecentlyTranslated(), 20000, [] as CatalogBook[]),
     withTimeout(getHomeGalleryPlates(), 20000, [] as Plate[]),
     getBookCounts(),
     withTimeout(getRemainingCollections(), 20000, SORTED_FALLBACK_COLLECTIONS),
-    withTimeout(getSpanishPodcast(), 8000, null),
+    withTimeout(getFeaturedPodcast(lang), 8000, null),
   ]);
 
-  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, spanishPodcast };
+  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -112,7 +112,7 @@ export interface HomeStrings {
   byYear: string;
   byImages: string;
 
-  // Spanish podcast feature (rendered only on /es)
+  // Featured podcast episode (rendered on both homepages)
   podcastEyebrow: string;
   podcastListen: string;
   podcastSourcesLabel: string;
@@ -218,9 +218,11 @@ const en: HomeStrings = {
   byYear: 'year',
   byImages: 'images',
 
-  podcastEyebrow: 'Spanish podcast',
+  podcastEyebrow: 'Deep dive podcast',
   podcastListen: 'Listen to the episode',
-  podcastSourcesLabel: 'The four books in this episode',
+  // Not "the four books" — the source count varies per episode, and the label
+  // is rendered from whatever `sources` the thread actually carries.
+  podcastSourcesLabel: 'The books in this episode',
   podcastFullEpisode: 'Full episode & transcript',
 
   inSpiritOf: 'In the spirit of',
@@ -327,7 +329,7 @@ const es: HomeStrings = {
 
   podcastEyebrow: 'Pódcast en español',
   podcastListen: 'Escuchar el episodio',
-  podcastSourcesLabel: 'Los cuatro libros de este episodio',
+  podcastSourcesLabel: 'Los libros de este episodio',
   podcastFullEpisode: 'Episodio completo y transcripción',
 
   inSpiritOf: 'En el espíritu de',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -72,9 +72,8 @@ export interface NavStrings {
   browse: string;
   catalogue: string;
   works: string;
-  map: string;
+  explore: string;
   librarian: string;
-  podcast: string;
   search: string;
   menu: string;
   support: string;
@@ -87,9 +86,8 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
     browse: 'Browse',
     catalogue: 'Catalogue',
     works: 'Works',
-    map: 'Map',
+    explore: 'Explore',
     librarian: 'Librarian',
-    podcast: 'Podcast',
     search: 'Search',
     menu: 'Navigation menu',
     support: 'Support',
@@ -100,9 +98,10 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
     browse: 'Explorar',
     catalogue: 'Catálogo',
     works: 'Obras',
-    map: 'Mapa',
+    // NOT 'Explorar' — that is already this nav's label for Browse. The hub is
+    // a set of interactive visualizations, so name it for what it holds.
+    explore: 'Visualizaciones',
     librarian: 'Bibliotecario',
-    podcast: 'Podcast',
     search: 'Buscar',
     menu: 'Menú de navegación',
     support: 'Donar',
@@ -125,6 +124,9 @@ export interface FooterStrings {
   gallery: string;
   collections: string;
   search: string;
+  // Kept reachable here after the header nav item was retired — the podcast is
+  // otherwise only linked from the homepage feature and its librarian thread.
+  podcast: string;
   favorites: string;
   // About column
   about: string;
@@ -233,6 +235,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     gallery: 'Gallery',
     collections: 'Collections',
     search: 'Search',
+    podcast: 'Podcast',
     favorites: 'Favorites',
     about: 'About',
     vision: 'Our Vision',
@@ -263,6 +266,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     gallery: 'Galería',
     collections: 'Colecciones',
     search: 'Buscar',
+    podcast: 'Pódcast',
     favorites: 'Favoritos',
     about: 'Acerca de',
     vision: 'Nuestra visión',


### PR DESCRIPTION
Two nav changes, both driven by 30-day traffic measured 2026-08-13.

## Map → Explore

The nav pointed at `/explore/map`, skipping the hub that holds the entity stats, century heatmap, and cards for all three visualizations.

| destination | 30d pageviews |
|---|---|
| /explore (hub) | **13** |
| /explore/map | 262 |
| /explore/timeline | 100 |
| /explore/constellation | 39 |

The hub drew 13 views for exactly one reason: nothing linked to it. This links the room instead of one corner of it. `/explore` is already on the tenant global-only list with prefix matching, so the partner-subdomain filter is unchanged.

## Podcast item retired

The header was the only sitewide English entry point to `/podcast`. Measured from `podcast_plays` (real audio-player events, not pageviews):

- 113 plays / 30d, from 113 unique pageview ids
- 33 completes — 29% of plays, 6% of the 533 `/podcast*` visits
- **66 of the 113 plays (58%) were the single episode featured on the `/es` homepage**, which also had the best completion rate of any episode (33%)
- the other ten-plus episodes, reachable only via the nav, averaged ~5 plays each

The editorial placement earns listens; the nav slot does not. So the homepage feature — previously gated to `lang === 'es'` — now renders on both homepages in the page's own language, and `/podcast` picks up a footer link in the Library column so it stays reachable.

## Two things worth a reviewer's eye

**The language match is not `{ language }`.** All six published English deep-dives have no `language` field at all; only the Spanish one sets it. `language: 'en'` matches zero documents, so the English feature would have rendered nothing forever while looking perfectly correct in review. `en` now accepts the absent field. Verified both locales resolve to a real episode with audio — `en` → *Inside the Microcosm*, `es` → *La astrología que cruzó el mundo*.

**The sources label hardcoded a count.** English read "The four books in this episode" while the list renders whatever `sources` the thread carries — the English episode has 0, so the block correctly stays hidden. Now "The books in this episode" / "Los libros de este episodio".

The `es` nav label for the hub is **Visualizaciones**, not *Explorar*, which is already this nav's label for Browse.

## Out of scope

- **RSS subscribers are unmeasured.** `feed.xml` is a server route, so client-side analytics never fires on it. I can't tell you from this data whether the feed has podcast-app listeners. Worth a Vercel log check before assuming the numbers above are the whole audience.
- `/works` at 17 views/30d is the weakest remaining nav entry (a Browse dropdown child). Left alone deliberately.
- No change to `/podcast` itself or to episode generation.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)