### PR TITLE
MCP: honest image guidance in search_images descriptions

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -909,7 +909,7 @@ const TOOLS: Tool[] = [
   {
     name: 'search_images',
     title: 'Search Images',
-    description: 'Search 110,000+ historical illustrations, emblems, engravings, diagrams, AND 23,000+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images you can see and show the user. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.',
+    description: 'Search 110,000+ historical illustrations, emblems, engravings, diagrams, AND 23,000+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images YOU can see — but some chat clients show them only inside the collapsed tool-result view, so never tell the user images are "rendered above"; describe what you see and give each image\'s url link instead. Every image_url is public and stable — an HTML page that references them directly works in any online browser. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.',
     annotations: { title: 'Search Images', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -920,7 +920,7 @@ const TOOLS: Tool[] = [
         year_from: { type: 'number' }, year_to: { type: 'number' },
         book_id: { type: 'string', description: 'Only return images extracted from this book\'s pages. Excludes the museum-artwork collection (artworks do not belong to books).' },
         limit: { type: 'number', description: 'Max results (default 20, max 50)' },
-        include_thumbnail_base64: { type: 'boolean', description: 'Embed each result\'s image as a thumbnail_data_uri (data:image/jpeg;base64,…, ~1000px) directly in the JSON — for building self-contained deliverables (HTML decks, artifacts, PDFs) from a sandboxed environment where CDN URLs cannot be fetched. First 6 results only, and inline image blocks are suppressed in this mode to keep the payload bounded. Typical flow: search WITHOUT this flag first to see candidates, then re-call with it (small limit) for the images you chose.' },
+        include_thumbnail_base64: { type: 'boolean', description: 'Embed each result\'s image as a thumbnail_data_uri (data:image/jpeg;base64,…, ~1000px) directly in the JSON. ONLY useful when your harness consumes tool results programmatically (API/SDK agents that can save the bytes without retyping them) — as a chat assistant you CANNOT copy hundreds of KB of base64 into a file, so do not request this for that purpose. To build a self-contained page from chat instead: fetch the public image_url values with your execution sandbox (if egress is blocked, ask the user to allowlist images.sourcelibrary.org in their network settings), or reference the CDN URLs directly — they are public and stable, so the page works in any online browser. First 6 results only; inline image blocks are suppressed in this mode to keep the payload bounded.' },
       },
     },
   },


### PR DESCRIPTION
Description-only change, from a live claude.ai field test of the image features (#3937):

- The model told the user images were "rendered above" while claude.ai showed them only inside the collapsed tool-result view. The tool description now instructs agents to describe what they see and link the `url`s — never to claim client-side rendering.
- A chat agent invoked `include_thumbnail_base64` and then correctly concluded it cannot retype hundreds of KB of base64 into a file (output-token limits). The param description now states plainly that it serves programmatic harnesses (API/SDK agents that consume tool results in code), and routes chat agents to the working paths: sandbox-fetch the public `image_url` (asking the user to allowlist images.sourcelibrary.org if egress is blocked), or reference the CDN URLs directly — public and stable.

No behavior or schema-shape change; clients pick this up on their next tools/list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)