### PR TITLE
audit(authors): exclude three false-positive classes from the review queue (#3950)

### DIFF
--- a/.claude/docs/attribution-health.md
+++ b/.claude/docs/attribution-health.md
@@ -53,6 +53,25 @@ apparent defect. Artworks need their own instrument.
 - contradicted: 246 of 4,313 books that have a second opinion
 - integrity: 48 `author_id` values pointing at a missing doc, 3 at a tombstone
 
+### The T0/T2 boundary moved on 2026-08-13 (#3950) — do not read it as a regression
+
+`Various` used to be an exact-match placeholder, so `Various poets`,
+`Various Authors` and `Various (Sangam anthology)` fell through to **T2
+UNLINKED** — "a plausible name with no `author_id`", which none of them is.
+Prefix-matching the collective forms moved **59 books from T2 to T0**, and T0
+now reports how many of itself are deliberate collectives (**119 of 1,747**).
+
+**No headline number changed**: reachable and anchored are computed from T3+T4,
+which this does not touch. Ledger rows before and after are comparable on the
+headline and NOT comparable on the T0/T2 split.
+
+A collective stays in T0 on purpose. The ladder measures whether a byline gets a
+reader to an author page, and `Various` does not, however true it is — but the
+audit no longer reports those books as *missing* an attribution, because the
+cataloguer answered the question and the answer is that there is no one author.
+This is the reachability/correctness split the tiers already promise, applied to
+T0.
+
 ## The first thing it measured was a regression
 
 Over the 133 records corrected on 2026-08-11: **35 moved up a tier, 42 moved

--- a/scripts/audit/attribution-health.mjs
+++ b/scripts/audit/attribution-health.mjs
@@ -58,7 +58,21 @@ const LEDGER = '.claude/docs/attribution-health-ledger.jsonl';
 const log = (...a) => { if (!JSON_OUT) console.log(...a); };
 
 /** Placeholders — a value that names nobody. */
-const PLACEHOLDER = /^(unknown|anonymous|anon|various|n\/?a|none|untitled|\[?s\.?\s*n\.?\]?|sine nomine|no author|not stated|unbekannt|onbekend|\[?unknown author\]?)$/i;
+const PLACEHOLDER = /^(unknown|anonymous|anon|n\/?a|none|untitled|\[?s\.?\s*n\.?\]?|sine nomine|no author|not stated|unbekannt|onbekend|\[?unknown author\]?)$/i;
+
+/**
+ * A DELIBERATE COLLECTIVE attribution (#3950). "Various" used to sit in
+ * PLACEHOLDER above, which scored a correctly-catalogued anthology as T0 ABSENT
+ * — "nothing to search for" — when in fact the cataloguer answered the question
+ * and the answer is that there is no single author.
+ *
+ * These STILL COUNT AS T0 for the headline, and that is deliberate: the tier
+ * ladder measures whether a byline gets a reader to an author page, and
+ * "Various" does not, however true it is. What changes is that the audit no
+ * longer reports them as missing attributions. Reachability and correctness are
+ * different questions, and this is a book that is correct and unreachable.
+ */
+const COLLECTIVE = /^(various|multiple authors|diverse|verschiedene|divers auteurs|collective|anthology|mixed authors|several authors)\b/i;
 
 /**
  * Strings that are not names at all. Each pattern is a defect class this
@@ -165,6 +179,7 @@ let contradicted = 0;
 let comparable = 0;
 let danglingLink = 0;
 let tombstoneLink = 0;
+let collective = 0;
 
 const cursor = books.find(scope, {
   projection: { author: 1, author_id: 1, 'ai_metadata.author': 1 },
@@ -173,6 +188,7 @@ for await (const b of cursor) {
   total++;
   const a = typeof b.author === 'string' ? b.author.trim() : '';
 
+  if (COLLECTIVE.test(a)) { tiers.T0_ABSENT++; collective++; continue; }
   if (!a || PLACEHOLDER.test(a)) { tiers.T0_ABSENT++; continue; }
 
   const bad = NOT_A_NAME.find((p) => p.re.test(a)) || (titleish.has(a) ? { tag: 'work-title-as-author' } : null);
@@ -210,6 +226,10 @@ const result = {
     unusable: tiers.T1_UNUSABLE,
   },
   unusable_by: unusableBy,
+  // Of T0, how many are a DELIBERATE collective rather than a missing answer.
+  // Same tier (still unreachable), different meaning — do not read T0 as a
+  // backlog of books nobody has attributed.
+  t0_collective: collective,
   contradictions: { comparable, contradicted },
   integrity: { dangling_author_id: danglingLink, links_to_tombstone: tombstoneLink },
 };
@@ -218,7 +238,12 @@ if (JSON_OUT) console.log(JSON.stringify(result, null, 2));
 else {
   log(`══ attribution health — ${result.scope} books ══\n`);
   log(`  books measured : ${total.toLocaleString()}\n`);
-  for (const [k, v] of Object.entries(tiers)) log(`    ${k.padEnd(14)} ${String(v).padStart(7)}  ${pct(v)}`);
+  for (const [k, v] of Object.entries(tiers)) {
+    log(`    ${k.padEnd(14)} ${String(v).padStart(7)}  ${pct(v)}`);
+    if (k === 'T0_ABSENT' && collective) {
+      log(`      of which ${collective} are a DELIBERATE collective ("Various") — correct, and still unreachable`);
+    }
+  }
   log(`\n  HEADLINE`);
   log(`    reachable (T3+) : ${result.headline.reachable_pct}%   — the byline leads to an author page`);
   log(`    anchored  (T4)  : ${result.headline.anchored_pct}%   — that identity is checkable outside this project`);

--- a/scripts/audit/author-vs-ai-metadata.mjs
+++ b/scripts/audit/author-vs-ai-metadata.mjs
@@ -41,7 +41,7 @@
  *   node scripts/audit/author-vs-ai-metadata.mjs --class=person_vs_person
  */
 import { MongoClient } from 'mongodb';
-import { foldOrtho, sameNameForm } from '../lib/name-equivalence.mjs';
+import { foldOrtho, sameNameForm, stripRelator } from '../lib/name-equivalence.mjs';
 
 const JSON_OUT = process.argv.includes('--json');
 const INCLUDE_HIDDEN = process.argv.includes('--all');
@@ -103,12 +103,30 @@ function overlap(a, b) {
  * That is exactly what the first run of this audit did — 39 non-Latin names
  * reported as anonymous books.
  */
-const PLACEHOLDER = /^(unknown|anonymous|anon|various|n\s*a|none|untitled|s\s*n|sine nomine|no author|not stated|\[?unknown author\]?|unbekannt|onbekend)$/;
+const PLACEHOLDER = /^(unknown|anonymous|anon|n\s*a|none|untitled|s\s*n|sine nomine|no author|not stated|\[?unknown author\]?|unbekannt|onbekend)$/;
 const isPlaceholder = (s) => {
   const raw = String(s ?? '').trim();
   if (!raw) return true;
   return PLACEHOLDER.test(norm(s));
 };
+
+/**
+ * A DELIBERATE COLLECTIVE attribution — not a placeholder (#3950).
+ *
+ * "Various" used to live in PLACEHOLDER above, which asserted that a book so
+ * catalogued has no attribution and that any specific name enrichment offers is
+ * an improvement. For a genuine multi-author anthology the opposite is true:
+ * "Various" is the accurate answer, and a single cherry-picked contributor is a
+ * worse one. Two cases in the #3894 triage turned on this — an alchemical
+ * anthology and "Various Armenian Historians" — where the worker correctly KEPT
+ * the vaguer catalogued value against a specific AI proposal.
+ *
+ * 119 visible books carry a collective byline (48 distinct strings), against
+ * 1,901 genuinely unknown ones. Conflating them made every one of the 119 read
+ * as a filling opportunity.
+ */
+const COLLECTIVE = /^(various|multiple authors|diverse|verschiedene|divers auteurs|collective|anthology|mixed authors|several authors)\b/i;
+const isCollective = (s) => COLLECTIVE.test(String(s ?? '').trim());
 
 /**
  * Whether the Latin-token metric can judge this pair AT ALL.
@@ -129,6 +147,23 @@ const latinShare = (s) => {
   return letters.filter((c) => /[a-zA-Z]/.test(c)).length / letters.length;
 };
 const isUndecidableScript = (cat, ai) => latinShare(cat) < 0.5 || latinShare(ai) < 0.5;
+
+/**
+ * The second way the metric can fail to judge: every token is BELOW the 3-char
+ * floor, so the comparable set is empty (#3950).
+ *
+ * `Yi I`, `Li Bo`, `O Sa-gi` — romanised Korean and Chinese names whose parts are
+ * one or two characters. `tokens()` drops everything under 3 (rightly: "de",
+ * "van" and initials would otherwise manufacture agreement), which leaves NOTHING
+ * to compare, and `overlap()` returns 0 — indistinguishable from real
+ * disagreement. `Yi, I 1536-1584` vs `Yi I` sat in the review queue as two people
+ * on the strength of an empty set.
+ *
+ * This is the same lesson as the non-Latin case above and the ayn/hamza elision
+ * in name-equivalence: TEST WHETHER THE METRIC CAN JUDGE, not whether the strings
+ * differ. An empty comparable set means unjudged; it never means different.
+ */
+const noComparableTokens = (cat, ai) => tokens(cat).size === 0 || tokens(ai).size === 0;
 
 /**
  * An institution, collection or corporate body. These overlap #3483's `is_person`
@@ -241,6 +276,7 @@ log(`  …carrying ai_metadata.author : ${withAi.toLocaleString()} (${(100 * wit
 
 const classes = {
   placeholder_filled: [],
+  collective_vs_specific: [],
   undecidable_script: [],
   institutional: [],
   person_vs_person: [],
@@ -280,8 +316,11 @@ const cursor = books.find(query, {
 
 for await (const b of cursor) {
   compared++;
-  const cat = b.author;
-  const ai = b.ai_metadata.author;
+  // A trailing MARC relator is a ROLE, not part of the name (#3950). Strip it
+  // from both sides before every comparison, or `Grosseteste, Robert 1175?-1253
+  // creator` never matches `Robert Grosseteste`.
+  const cat = stripRelator(b.author);
+  const ai = stripRelator(b.ai_metadata.author);
   if (overlap(cat, ai) > 0) { agree++; continue; }
   // Same person under a different orthography — the corpus's own historiography,
   // not a defect. Checked before any class assignment so it cannot leak into one.
@@ -300,7 +339,8 @@ for await (const b of cursor) {
   };
 
   if (isPlaceholder(cat)) { classes.placeholder_filled.push(row); continue; }
-  if (isUndecidableScript(cat, ai)) { classes.undecidable_script.push(row); continue; }
+  if (isCollective(cat)) { classes.collective_vs_specific.push(row); continue; }
+  if (isUndecidableScript(cat, ai) || noComparableTokens(cat, ai)) { classes.undecidable_script.push(row); continue; }
   if (isInstitutional(cat)) { classes.institutional.push(row); continue; }
 
   // THE RESIDUE. A catalogued person contradicted by a different page-derived
@@ -405,7 +445,8 @@ for (const rows of Object.values(classes)) {
 // ───────────────────────────────────────────────────────────────────────────────
 const DESCRIPTIONS = {
   placeholder_filled: 'catalogued as a placeholder; the AI SUPPLIED a name — an opportunity, not a defect',
-  undecidable_script: 'a non-Latin name on one or both sides — the Latin-token metric cannot judge these',
+  collective_vs_specific: 'catalogued as a COLLECTIVE ("Various"); the AI proposed one name — for a real anthology the vaguer value is the TRUER one, so this is not a filling opportunity',
+  undecidable_script: 'the Latin-token metric CANNOT JUDGE these — a non-Latin name on one side, or every token below the 3-char floor (romanised CJK/Korean). Unjudged, not equivalent',
   institutional: 'corporate/collection heading — belongs with the is_person work (#3483), not a byline fix',
   person_vs_person: 'REVIEW QUEUE: a catalogued person contradicted by a different page-derived person',
 };

--- a/scripts/lib/latin-morphology.mjs
+++ b/scripts/lib/latin-morphology.mjs
@@ -30,10 +30,33 @@
  */
 
 /** Accent-fold, lowercase, punctuation to space. The common floor. */
+/**
+ * Apostrophe-family marks that transliteration uses INSIDE a word: ayn and hamza
+ * (ʻ ʿ ʾ ʼ), the typographic quotes, and the bare ASCII apostrophe.
+ *
+ * These must be ELIDED, not turned into a space (#3950). Every other punctuation
+ * mark here separates two things that really are separate; these sit inside a
+ * single name. Replacing them with a space shatters short transliterations into
+ * sub-floor fragments — `Saʻdī` becomes "sa"+"di", and since every length floor
+ * in this module and its callers is 3 or 4, BOTH fragments are then discarded
+ * and the name reduces to the empty set. An empty set is not "no match", it is
+ * "cannot judge", and it reads downstream as guaranteed disagreement: that is
+ * why `Saʻdī` vs `Saʿdī` — the same name, one codepoint apart — sat in the
+ * person-vs-person queue as though it were two people.
+ *
+ * Elision is not a loosened floor. It changes what counts as ONE token, so the
+ * name arrives at the floors intact ("sadi", 4 chars) instead of pre-shattered.
+ * Names where the mark really does join separable parts (O'Brien → obrien) fold
+ * to the same string either way.
+ */
+const ELIDED_MARKS = /[ʻʼʾʿ‘’ʹʺ`´′']/g;
+
 export function foldAccents(s) {
   if (!s) return '';
   return String(s).normalize('NFKD').replace(/[̀-ͯ]/g, '')
-    .toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+    .toLowerCase()
+    .replace(ELIDED_MARKS, '')
+    .replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
 /**

--- a/scripts/lib/name-equivalence.mjs
+++ b/scripts/lib/name-equivalence.mjs
@@ -36,6 +36,32 @@ export const foldOrtho = foldOrthography;
  */
 export const NAME_STOP = PARTICLES;
 
+/**
+ * MARC relator terms a catalogue appends to a heading to say what the person DID
+ * — `Grosseteste, Robert 1175?-1253 creator`, `Zang Maoxun (臧懋循), compiler`.
+ *
+ * Strip these before comparing two names (#3950): the term is a role, not part
+ * of the name, and leaving it in makes an otherwise identical heading read as a
+ * mismatch. Stripping cannot create a false merge — it only removes a role
+ * token that neither name owns.
+ *
+ * This list is deliberately WIDER than `attribution-health.mjs`'s
+ * `relator-artifact` tag, and the two must not be unified. That audit uses its
+ * pattern to route a string to T1 UNUSABLE — worse than absent — which is right
+ * for a bare `creator` and wrong for `Zang Maoxun (臧懋循), compiler`, a real
+ * person wearing a role annotation. Widening the detector would demote seven
+ * perfectly usable bylines; widening the stripper is free.
+ */
+export const RELATOR_TERMS = /[,;]?\s*\b(creator|contributor|author|editor|compiler|translator|printer|publisher|engraver|illustrator|annotator|commentator|former owner|dedicatee|attributed name)\b\s*\.?\s*$/i;
+
+/** Drop a trailing MARC relator term. Returns the name unchanged if there is none. */
+export function stripRelator(s) {
+  let out = String(s ?? '').trim();
+  // Loop: catalogues stack them ("… editor, translator").
+  for (let i = 0; i < 3 && RELATOR_TERMS.test(out); i++) out = out.replace(RELATOR_TERMS, '').trim();
+  return out.replace(/[,;]\s*$/, '').trim();
+}
+
 /** Strip one Latin case ending so Bodinus/Bodini/Bodino share a stem. */
 export const latinStem = (w) => stripEnding(w, PRECISION_ENDINGS, 4);
 

--- a/tests/unit/name-equivalence.test.ts
+++ b/tests/unit/name-equivalence.test.ts
@@ -22,7 +22,7 @@
  * the queue silently, where a false split only costs a human ten seconds.
  */
 import { describe, it, expect } from 'vitest';
-import { sameNameForm, withinOneEdit, nameStems } from '../../scripts/lib/name-equivalence.mjs';
+import { sameNameForm, withinOneEdit, nameStems, foldOrtho } from '../../scripts/lib/name-equivalence.mjs';
 
 describe('sameNameForm — one person, many name-forms', () => {
   const SAME: Array<[string, string, string]> = [
@@ -103,6 +103,31 @@ describe('withinOneEdit', () => {
   it('accepts equality', () => expect(withinOneEdit('cicero', 'cicero')).toBe(true));
   it('rejects two edits', () => expect(withinOneEdit('aristotel', 'aristotaal')).toBe(false));
   it('rejects a length gap over one', () => expect(withinOneEdit('cicero', 'ciceronis')).toBe(false));
+});
+
+describe('transliteration marks are elided, not treated as separators (#3950)', () => {
+  // ʻ ʿ ʾ and the plain apostrophe all transcribe ayn/hamza INSIDE a word. While
+  // they became a space, "Saʻdī" shattered into "sa"+"di" — both below every
+  // length floor in this module — so the stem set came back EMPTY and two
+  // spellings of one poet read as two people. An empty set is "cannot judge",
+  // and downstream it reads as guaranteed disagreement.
+  it('matches the same name across ayn/hamza codepoints', () => {
+    expect(sameNameForm('Saʻdī', 'Saʿdī')).toBe(true);
+    expect(sameNameForm('Saʻdī', "Sa'dī")).toBe(true);
+    expect(sameNameForm('Saʻdī', 'Saʾdī')).toBe(true);
+  });
+  it('leaves a short transliteration with a usable stem', () => {
+    expect(foldOrtho('Saʻdī')).toBe('sadi');
+    expect(nameStems('Saʻdī').size).toBeGreaterThan(0);
+  });
+  it('folds an elided apostrophe the same way regardless of form', () => {
+    expect(foldOrtho("O'Brien")).toBe(foldOrtho('OBrien'));
+  });
+  // The floors still have to hold: elision must not become a way to merge people.
+  it('still refuses two genuinely different names carrying the mark', () => {
+    expect(sameNameForm('Saʻdī', 'Ḥāfiẓ')).toBe(false);
+    expect(sameNameForm('al-Ashʿarī', 'al-Ghazālī')).toBe(false);
+  });
 });
 
 describe('particles cannot carry a match on their own', () => {


### PR DESCRIPTION
Closes #3950. Residue 109 → 100; `ai_metadata` rows distrusted 27 → 25.

## 1. Transliteration marks — the issue's diagnosis is wrong, and the real one is more useful

#3950 reads this as codepoint survival: *"visually identical, differing by codepoint, surviving `foldOrtho`'s NFD normalisation."* Measured, that isn't what happens — `norm()` and `foldOrtho` **already** collapse `Saʻdī` and `Saʿdī` to the same string.

The defect is *what* they collapse it to. The mark became a **space**, so a short transliteration shattered into `"sa"` + `"di"` — both below every length floor in the stack (`nameStems` ≥ 4, `tokens` > 2). The stem set came back **empty**, and an empty set means *cannot judge*, which reads downstream as guaranteed disagreement.

Fixed at the source in `foldAccents`: ayn, hamza and the apostrophe family are **elided, not separated**, so `sadi` reaches the floors intact. This is not a loosened floor — it changes what counts as one token — and the floors are still tested, including that two genuinely different names carrying the mark stay apart. Fixing it in the shared lib fixes every consumer (read path, backfill, `nominativise`) rather than this audit alone. 36 unit tests pass, 4 new.

## 2. MARC relators

`stripRelator()` drops a trailing role term before comparison, so `Grosseteste, Robert 1175?-1253 creator` matches `Robert Grosseteste`.

The stripper's list is **deliberately wider** than `attribution-health.mjs`'s `relator-artifact` pattern, and I did not unify them despite the issue suggesting it. That pattern routes a string to **T1 UNUSABLE — worse than absent** — which is right for a bare `creator` and wrong for `Zang Maoxun (臧懋循), compiler`, a real person wearing a role annotation. Widening the detector would demote seven perfectly usable bylines; widening the stripper is free.

## 3. "Various" is sometimes correct

Split out of `PLACEHOLDER` into a `collective` class in both audits. **119** visible books carry a collective byline against **1,901** genuinely unknown ones — conflating them asserted that any specific name enrichment offers is an improvement, which is the opposite of true for a real anthology, as the #3894 triage found twice.

In `attribution-health` a collective **stays in T0**, deliberately: the ladder measures whether a byline gets a reader to an author page, and `Various` does not, however true it is. What changes is that T0 now reports how many of itself are deliberate.

⚠️ **One boundary moved.** The old test was exact-match, so `Various poets` / `Various Authors` / `Various (Sangam anthology)` fell through to **T2 UNLINKED** — "a plausible name with no `author_id`", which none of them is. Prefix-matching moves **59 books from T2 to T0**. **No headline number changed** — reachable and anchored are computed from T3+T4. Documented in `attribution-health.md` so the ledger discontinuity is not later read as a regression. I did not append a ledger snapshot for the same reason.

## A fourth class, same shape, unclaimed by the issue

Found while testing (2). Romanised Korean and Chinese names whose parts are one or two characters — `Yi I`, `O Sa-gi` — have **every** token below the 3-char floor, so the comparable set is empty and `overlap()` returns 0, indistinguishable from real disagreement. `Yi, I 1536-1584` vs `Yi I` sat in the review queue as two people on the strength of an empty set. Routed to `undecidable_script`, which is what it always meant. 5 rows.

The through-line in all four is a rule `author-identity.md` already states: **test whether the metric CAN judge, not whether the strings differ.**

Read-only; both audits write nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
