### PR TITLE
MCP App: in-chat image gallery for search_images (MCP Apps extension)

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -9,6 +9,7 @@ import { classifyApiError } from '@/lib/mcp-errors';
 import { MAX_FEEDBACK_MESSAGE, MIN_FEEDBACK_MESSAGE } from '@/lib/feedback-limits';
 import { stripProvenanceMarks } from '@/lib/provenance';
 import { languageApparatusFields, type LanguageApparatusSource } from '@/lib/edition-language';
+import { GALLERY_VIEWER_HTML, GALLERY_VIEWER_RESOURCE_URI, MCP_APP_MIME_TYPE } from '@/lib/mcp-gallery-app';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -909,8 +910,11 @@ const TOOLS: Tool[] = [
   {
     name: 'search_images',
     title: 'Search Images',
-    description: 'Search 110,000+ historical illustrations, emblems, engravings, diagrams, AND 23,000+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images YOU can see — but some chat clients show them only inside the collapsed tool-result view, so never tell the user images are "rendered above"; describe what you see and give each image\'s url link instead. Every image_url is public and stable — an HTML page that references them directly works in any online browser. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.',
+    description: 'Search 110,000+ historical illustrations, emblems, engravings, diagrams, AND 23,000+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images YOU can see. Hosts that support MCP Apps render an in-chat image gallery for this tool automatically; on other clients images may sit inside the collapsed tool-result view, so never tell the user images are "rendered above" unless the gallery appeared — describe what you see and give each image\'s url link instead. Every image_url is public and stable — an HTML page that references them directly works in any online browser. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.',
     annotations: { title: 'Search Images', ...READ_ONLY },
+    // MCP Apps (2026-01-26): hosts that support in-chat UI fetch this ui://
+    // resource and render the gallery grid in the conversation (#3978).
+    _meta: { ui: { resourceUri: GALLERY_VIEWER_RESOURCE_URI } },
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -1201,7 +1205,19 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
     { name: 'source-library', version: SERVER_VERSION },
-    { capabilities: { tools: {}, resources: {} } },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        // MCP Apps extension (2026-01-26 spec): tells hosts we serve
+        // `text/html;profile=mcp-app` UI resources, so clients that support
+        // in-chat apps (claude.ai web + desktop) render the gallery viewer
+        // instead of hiding images in the tool-result accordion (#3978).
+        extensions: {
+          'io.modelcontextprotocol/ui': { mimeTypes: [MCP_APP_MIME_TYPE] },
+        },
+      },
+    },
   );
 
   /**
@@ -1223,6 +1239,13 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
       description: 'What the corpus holds, which search tool to reach for, how citation and provenance work, and the failure modes worth knowing before you spend calls. Read this first if you are doing sustained research rather than a single lookup.',
       mimeType: 'text/plain',
     },
+    {
+      uri: GALLERY_VIEWER_RESOURCE_URI,
+      name: 'Gallery viewer (MCP App)',
+      title: 'In-chat image gallery for search_images',
+      description: 'UI resource rendered by MCP Apps-capable hosts as an in-chat image grid for search_images results. Not meant to be read as a document.',
+      mimeType: MCP_APP_MIME_TYPE,
+    },
   ] as const;
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
@@ -1233,6 +1256,24 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
     const uri = request.params.uri;
     const known = RESOURCES.find((r) => r.uri === uri);
     if (!known) throw new Error(`Unknown resource: ${uri}`);
+    // The MCP App is served inline — a ui:// URI is not fetchable. Its CSP
+    // meta is load-bearing: resourceDomains maps to the iframe's img-src, so
+    // dropping images.sourcelibrary.org here silently blanks every thumbnail.
+    if (uri === GALLERY_VIEWER_RESOURCE_URI) {
+      return {
+        contents: [{
+          uri,
+          mimeType: MCP_APP_MIME_TYPE,
+          text: GALLERY_VIEWER_HTML,
+          _meta: {
+            ui: {
+              csp: { resourceDomains: ['https://images.sourcelibrary.org'] },
+              prefersBorder: true,
+            },
+          },
+        }],
+      };
+    }
     const resp = await fetch(uri, { signal: AbortSignal.timeout(8000) });
     if (!resp.ok) throw new Error(`Could not read ${uri}: HTTP ${resp.status}`);
     return { contents: [{ uri, mimeType: known.mimeType, text: await resp.text() }] };

--- a/src/lib/mcp-gallery-app.ts
+++ b/src/lib/mcp-gallery-app.ts
@@ -1,0 +1,170 @@
+/**
+ * MCP App: in-chat gallery viewer for search_images (#3978).
+ *
+ * Served as the `ui://source-library/gallery-viewer` resource
+ * (mimeType `text/html;profile=mcp-app`). Hosts that support the MCP Apps
+ * extension (claude.ai web + Claude desktop) render this in a sandboxed
+ * iframe INSIDE the chat window and feed it the tool result over
+ * postMessage JSON-RPC — which is the only way to put actual pictures in
+ * front of the user there: plain MCP image blocks are collapsed into the
+ * tool-result accordion (anthropics/claude-ai-mcp#238).
+ *
+ * The protocol is hand-rolled rather than bundling @modelcontextprotocol/ext-apps:
+ * we need exactly three messages (ui/initialize out; its result and
+ * ui/notifications/tool-result in), and a self-contained string keeps the
+ * resource dependency-free. Wire shapes follow the 2026-01-26 apps spec.
+ *
+ * CSP note: the iframe's img-src is opt-in via the resource's
+ * `_meta.ui.csp.resourceDomains` (declared where this resource is served in
+ * src/app/api/mcp/route.ts) — images.sourcelibrary.org must stay listed
+ * there or every thumbnail silently breaks.
+ */
+export const GALLERY_VIEWER_RESOURCE_URI = 'ui://source-library/gallery-viewer';
+export const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
+
+export const GALLERY_VIEWER_HTML = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --bg: #faf8f4; --fg: #1f1d1a; --muted: #6b6559; --card: #ffffff;
+    --border: rgba(0,0,0,.12); --shadow: rgba(0,0,0,.08);
+  }
+  [data-theme="dark"] {
+    --bg: #1a1917; --fg: #ece8e1; --muted: #a39c8e; --card: #242220;
+    --border: rgba(255,255,255,.12); --shadow: rgba(0,0,0,.35);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 14px/1.45 Georgia, 'Times New Roman', serif;
+    padding: 12px;
+  }
+  .head { display: flex; align-items: baseline; gap: 8px; margin: 2px 2px 10px; }
+  .head b { font-size: 15px; }
+  .head span { color: var(--muted); font-size: 12px; }
+  .grid {
+    display: grid; gap: 10px;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+  .card {
+    background: var(--card); border: 1px solid var(--border);
+    box-shadow: 0 1px 3px var(--shadow);
+    display: flex; flex-direction: column; overflow: hidden;
+  }
+  .card a.imgwrap { display: block; background: #111; text-align: center; }
+  .card img { width: 100%; height: 170px; object-fit: contain; display: block; }
+  .meta { padding: 7px 9px 9px; }
+  .cap {
+    font-size: 12.5px; line-height: 1.35;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  .sub { color: var(--muted); font-size: 11px; margin-top: 3px; }
+  .sub a { color: var(--muted); }
+  .empty { color: var(--muted); padding: 18px 6px; font-style: italic; }
+  a { color: inherit; text-decoration: none; }
+  a:hover .cap, .sub a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<div class="head"><b>Source Library</b><span id="count"></span></div>
+<div id="root" class="empty">Loading images…</div>
+<script>
+(function () {
+  var INIT_ID = 1;
+
+  function post(msg) { window.parent.postMessage(msg, '*'); }
+
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  function applyTheme(theme) {
+    if (theme === 'dark' || theme === 'light') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  }
+
+  function render(result) {
+    var root = document.getElementById('root');
+    var countEl = document.getElementById('count');
+    var data = null;
+    // Prefer structuredContent; fall back to parsing the first text block,
+    // which carries the search_images JSON.
+    if (result && result.structuredContent && result.structuredContent.images) {
+      data = result.structuredContent;
+    } else if (result && result.content) {
+      for (var i = 0; i < result.content.length; i++) {
+        var block = result.content[i];
+        if (block.type === 'text') {
+          try {
+            var parsed = JSON.parse(block.text);
+            if (parsed && parsed.images) { data = parsed; break; }
+          } catch (e) { /* caption blocks aren't JSON — keep scanning */ }
+        }
+      }
+    }
+    if (!data || !data.images || !data.images.length) {
+      root.className = 'empty';
+      root.textContent = (data && data.note) ? data.note : 'No images in this result.';
+      return;
+    }
+    countEl.textContent = data.total > data.images.length
+      ? 'showing ' + data.images.length + ' of ' + data.total + ' images'
+      : data.images.length + (data.images.length === 1 ? ' image' : ' images');
+    root.className = 'grid';
+    root.innerHTML = data.images.map(function (img) {
+      if (!img.image_url) return '';
+      var title = esc(img.description || (img.book && img.book.title) || 'Untitled');
+      var bits = [];
+      if (img.book && img.book.author) bits.push(esc(img.book.author));
+      else if (img.artist) bits.push(esc(img.artist));
+      if (img.book && img.book.year) bits.push(esc(img.book.year));
+      else if (img.year) bits.push(esc(img.year));
+      if (img.page) bits.push('p. ' + esc(img.page));
+      var href = esc(img.url || img.book_url || '#');
+      return '<div class="card">'
+        + '<a class="imgwrap" href="' + href + '" target="_blank" rel="noopener">'
+        + '<img src="' + esc(img.image_url) + '" alt="' + title + '" loading="lazy"></a>'
+        + '<div class="meta"><a href="' + href + '" target="_blank" rel="noopener">'
+        + '<div class="cap">' + title + '</div></a>'
+        + '<div class="sub">' + bits.join(' · ') + '</div></div>'
+        + '</div>';
+    }).join('');
+  }
+
+  window.addEventListener('message', function (ev) {
+    var msg = ev.data;
+    if (!msg || msg.jsonrpc !== '2.0') return;
+    if (msg.id === INIT_ID && msg.result) {
+      var ctx = msg.result.hostContext || {};
+      applyTheme(ctx.theme);
+      return;
+    }
+    if (msg.method === 'ui/notifications/tool-result') {
+      render(msg.params || {});
+      return;
+    }
+    if (msg.method === 'ui/notifications/host-context-changed' && msg.params) {
+      applyTheme(msg.params.theme || (msg.params.hostContext && msg.params.hostContext.theme));
+    }
+  });
+
+  post({
+    jsonrpc: '2.0',
+    id: INIT_ID,
+    method: 'ui/initialize',
+    params: {
+      protocolVersion: '2026-01-26',
+      capabilities: {},
+      clientInfo: { name: 'Source Library gallery viewer', version: '1.0.0' },
+      appCapabilities: { availableDisplayModes: ['inline'] },
+    },
+  });
+})();
+</script>
+</body>
+</html>`;


### PR DESCRIPTION
Implements #3978 — real pictures in the chat window on claude.ai web and Claude desktop, where plain MCP image blocks are collapsed into the tool-result accordion (anthropics/claude-ai-mcp#238).

## What

- `search_images` declares `_meta.ui.resourceUri: ui://source-library/gallery-viewer` (MCP Apps, 2026-01-26 spec).
- The server serves that resource as `text/html;profile=mcp-app`: a self-contained, theme-aware image grid (`src/lib/mcp-gallery-app.ts`). Apps-capable hosts render it in a sandboxed iframe inside the conversation; each card links to its sourcelibrary.org page.
- `capabilities.extensions['io.modelcontextprotocol/ui']` advertised in the handshake.
- Resource `_meta.ui.csp.resourceDomains: ['https://images.sourcelibrary.org']` — maps to the iframe's `img-src`; load-bearing.
- Protocol hand-rolled (3 messages: `ui/initialize` out; its result + `ui/notifications/tool-result` in) — no SDK bundle needed, resource stays dependency-free.
- Inline image blocks unchanged as fallback for non-Apps clients (Claude Code renders those fine).

## Safety vs the directory validator

- No tool renamed or removed; additions only.
- `npm run audit:mcp:self-test`: 14/14.
- Live contract audit against the Vercel preview to be posted below before merge (the #3978 caution — the May de-listing taught us validator-visible surface changes get checked on a preview first).

## Verification plan post-merge

- JSON-RPC: initialize shows the extensions capability; resources/read returns the HTML with CSP meta; tools/list shows `_meta.ui` on search_images.
- Derek tests in a fresh claude.ai conversation: "show me images of the ouroboros" → gallery grid appears in-chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)