### PR TITLE
fix(workers): revision guard delegates to the shared lib (#3977)

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -17,48 +17,27 @@
  */
 
 import { MongoClient } from 'mongodb';
-import { randomBytes } from 'crypto';
+
 import { GoogleGenAI } from '@google/genai';
 import { completeBatchUsage, sumBatchResponseUsage } from './lib/supabase-usage-logger.mjs';
 import { syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { hasScope } from './lib/selective-unpause.mjs';
 import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
+import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-revisions.mjs';
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 
 /**
- * Save current page content as a revision before overwriting.
- * Lightweight inline version of src/lib/page-revisions.ts createRevision().
+ * Save current page content as a revision before overwriting — delegates to the
+ * shared helper (scripts/lib/page-revisions.mjs). This worker's inline copy
+ * predated the #3240 refinements (marker-text skip, reason, source_language,
+ * batch_job_id preference) and never received them (#3977).
  */
 async function saveRevisionBeforeOverwrite(db, pageId, field, jobId) {
-  try {
-    const page = await db.collection('pages').findOne(
-      { id: pageId },
-      { projection: { book_id: 1, ocr: 1, translation: 1 } }
-    );
-    if (!page) return;
-    const fieldData = page[field];
-    if (!fieldData?.data) return; // No existing content — first write
-
-    await db.collection('page_revisions').insertOne({
-      id: randomBytes(6).toString('hex'),
-      page_id: pageId,
-      book_id: page.book_id,
-      field,
-      data: fieldData.data,
-      source: fieldData.source || 'ai',
-      model: fieldData.model,
-      language: fieldData.language,
-      prompt_version: fieldData.prompt_version,
-      edited_by: fieldData.edited_by,
-      job_id: jobId,
-      original_date: fieldData.updated_at,
-      created_at: new Date(),
-    });
-  } catch (e) {
-    // Non-fatal — don't block collection on revision failure
-    console.error(`  [revision] Failed for ${pageId}/${field}: ${e.message?.slice(0, 50)}`);
-  }
+  return saveRevisionShared(db, pageId, field, {
+    jobId,
+    reason: field === 'ocr' ? 'reocr_batch' : 'retranslate_batch',
+  });
 }
 
 // ── Config ──

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -24,6 +24,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-revisions.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
@@ -31,7 +32,7 @@ import { getTranslateModelForBook, SKIP_TRANSLATION_PAGE_TYPES } from '../lib/tr
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
-import { createHash, randomBytes } from 'crypto';
+import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
@@ -54,34 +55,14 @@ const SQS_IMAGE_EXTRACTION_QUEUE_URL = process.env.SQS_PAGE_IMAGE_EXTRACTION_QUE
 // Gemini Batch API config (for direct OCR submission, bypassing Vercel)
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 /**
- * Save current page content as a revision before overwriting.
- * Lightweight inline version of src/lib/page-revisions.ts createRevision().
+ * Save current page content as a revision before overwriting — delegates to the
+ * shared helper (scripts/lib/page-revisions.mjs). This worker's inline copy
+ * predated the #3240 refinements (marker-text skip, reason, source_language,
+ * batch_job_id preference) and never received them (#3977). Sole call site is
+ * the preview-model realtime re-OCR path.
  */
 async function saveRevisionBeforeOverwrite(db, pageId, field) {
-  try {
-    const page = await db.collection('pages').findOne(
-      { id: pageId },
-      { projection: { book_id: 1, ocr: 1, translation: 1 } }
-    );
-    if (!page) return;
-    const fieldData = page[field];
-    if (!fieldData?.data) return; // No existing content — first write
-    await db.collection('page_revisions').insertOne({
-      id: randomBytes(6).toString('hex'),
-      page_id: pageId,
-      book_id: page.book_id,
-      field,
-      data: fieldData.data,
-      source: fieldData.source || 'ai',
-      model: fieldData.model,
-      language: fieldData.language,
-      prompt_version: fieldData.prompt_version,
-      original_date: fieldData.updated_at,
-      created_at: new Date(),
-    });
-  } catch (e) {
-    // Non-fatal — don't block pipeline on revision failure
-  }
+  return saveRevisionShared(db, pageId, field, { reason: 'reocr_realtime' });
 }
 
 const OCR_MODEL_FLASH = 'gemini-3-flash-preview';


### PR DESCRIPTION
Closes #3977.

The two remaining pre-#3240 inline copies of `saveRevisionBeforeOverwrite` (batch-collector, pipeline-orchestrator) become one-line shims over `scripts/lib/page-revisions.mjs`, with `reason` tags. `translate-worker` was already migrated (#3725). Call sites unchanged; behavior delta: `[RECITATION_BLOCKED]` markers are no longer archived as revisions, and revisions now carry `reason`/`source_language`/`batch_job_id`.

In scope: the two worker shims + dropping the now-unused `randomBytes` import.
Out of scope: the bulk-variant optimization at the collector call site (Promise.allSettled over per-page calls still works; switching to `saveRevisionsBeforeOverwrite` is a follow-up), and the other consolidations in #3979.

Unit suite green (2621). Scripts-only change — Hetzner picks it up on auto-pull, no Vercel deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)