### PR TITLE
fix(tenants): stop the tenant_id re-pollution (field sprawl #3969, family 1)

### DIFF
--- a/scripts/iiif-discovery/import-from-cache.mjs
+++ b/scripts/iiif-discovery/import-from-cache.mjs
@@ -106,7 +106,7 @@ for (const c of cands) {
   const bookId = new ObjectId();
   const facsimile = isArtwork || FACSIMILE;
   const doc = {
-    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
     published: c.date_text || 'Unknown', ...(year ? { year } : {}),
@@ -139,7 +139,7 @@ for (const c of cands) {
     if (!isArtwork) {
       const CHUNK = 500;
       for (let s = 0; s < pages.length; s += CHUNK) {
-        const pdocs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: doc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+        const pdocs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: doc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
         await db.collection('pages').insertMany(pdocs, { ordered: false });
       }
     }

--- a/scripts/iiif-discovery/import-leiden-artworks.mjs
+++ b/scripts/iiif-discovery/import-leiden-artworks.mjs
@@ -112,7 +112,7 @@ for (const c of cands) {
   const now = new Date();
   const normTitle = normalizeTitle(title), normAuthor = normalizeAuthor(author);
   const doc = {
-    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
     published: c.date_text || 'Unknown', ...(year ? { year } : {}),

--- a/scripts/iiif-discovery/import-leiden-books.mjs
+++ b/scripts/iiif-discovery/import-leiden-books.mjs
@@ -125,7 +125,7 @@ for (const c of cands) {
   const bookId = new ObjectId();
   const now = new Date();
   const bookDoc = {
-    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
     published: c.date_text || 'Unknown', ...(year ? { year } : {}),
@@ -154,7 +154,7 @@ for (const c of cands) {
     await db.collection('books').insertOne(bookDoc);
     const CHUNK = 500;
     for (let s = 0; s < pages.length; s += CHUNK) {
-      const docs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookDoc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: bookDoc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: bookDoc.id, imported_at: now } });

--- a/scripts/import-aic-artworks.mjs
+++ b/scripts/import-aic-artworks.mjs
@@ -285,7 +285,6 @@ async function main() {
         const doc = {
           id: generateId(),
           slug,
-          tenant_id: 'default',
           title,
           display_title: title,
           author: artist,

--- a/scripts/import-cleveland-artworks.mjs
+++ b/scripts/import-cleveland-artworks.mjs
@@ -194,7 +194,6 @@ function buildDoc(obj, slug, resourceType, displayUrl, thumbUrl, width, height) 
   return {
     id: generateId(),
     slug,
-    tenant_id: 'default',
     title,
     display_title: title,
     author: artist,

--- a/scripts/import-commons-artworks.mjs
+++ b/scripts/import-commons-artworks.mjs
@@ -559,7 +559,6 @@ async function main() {
       const doc = {
         id: generateId(),
         slug: `art-${slug}`,
-        tenant_id: 'default',
         title: info.title || info.commonsTitle.replace('File:', '').replace(/\.[^.]+$/, ''),
         display_title: info.title || undefined,
         author: cat.artist,

--- a/scripts/import-getty-artworks.mjs
+++ b/scripts/import-getty-artworks.mjs
@@ -300,7 +300,6 @@ async function main() {
           const doc = {
             id: generateId(),
             slug,
-            tenant_id: 'default',
             title,
             display_title: title,
             author: artist,

--- a/scripts/import-met-artworks.mjs
+++ b/scripts/import-met-artworks.mjs
@@ -305,7 +305,6 @@ async function main() {
     const doc = {
       id: generateId(),
       slug,
-      tenant_id: 'default',
       title,
       display_title: title,
       author: artist,

--- a/scripts/import-naj-sancai.mjs
+++ b/scripts/import-naj-sancai.mjs
@@ -91,7 +91,6 @@ async function main() {
       _id: bookId,
       id: bookIdStr,
       slug,
-      tenant_id: 'default',
       title: '三才圖會 鳥獸三卷-四卷',
       display_title: 'Sancai Tuhui — Birds & Beasts, Juan 91-92 (National Archives of Japan)',
       author: '王圻、王思義',

--- a/scripts/import-nga-artworks.mjs
+++ b/scripts/import-nga-artworks.mjs
@@ -283,7 +283,6 @@ async function main() {
       const doc = {
         id: generateId(),
         slug,
-        tenant_id: 'default',
         title,
         display_title: title,
         author: artist,

--- a/scripts/import-rijks-artworks.mjs
+++ b/scripts/import-rijks-artworks.mjs
@@ -446,7 +446,6 @@ async function main() {
       const doc = {
         id: generateId(),
         slug,
-        tenant_id: 'default',
         title: obj.title,
         display_title: obj.title,
         author: target.artistName,

--- a/scripts/import/al-badri-direct.mjs
+++ b/scripts/import/al-badri-direct.mjs
@@ -106,7 +106,6 @@ async function main() {
     _id: bookId,
     id: bookIdStr,
     slug,
-    tenant_id: 'default',
     title: entry.title,
     display_title: entry.display_title,
     author: entry.author,
@@ -155,7 +154,6 @@ async function main() {
       pageDocs.push({
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: p + 1,
         photo: getPageUrl(p),

--- a/scripts/import/batch-import-istc-bsb.mjs
+++ b/scripts/import/batch-import-istc-bsb.mjs
@@ -207,7 +207,6 @@ async function main() {
       _id: bookId,
       id: bookIdStr,
       slug,
-      tenant_id: 'default',
       title,
       author,
       language,
@@ -248,7 +247,6 @@ async function main() {
       return {
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: i + 1,
         photo: p.photo,

--- a/scripts/import/bncf-aldine-direct.mjs
+++ b/scripts/import/bncf-aldine-direct.mjs
@@ -436,7 +436,6 @@ async function main() {
         _id: bookId,
         id: bookIdStr,
         slug,
-        tenant_id: 'default',
         title: entry.title,
         display_title: null,
         author: entry.author,
@@ -501,7 +500,6 @@ async function main() {
             return {
               _id: pageId,
               id: pageId.toHexString(),
-              tenant_id: 'default',
               book_id: bookIdStr,
               page_number: rp.pageNumber,
               photo: rp.displayUrl,
@@ -527,7 +525,6 @@ async function main() {
             pageDocs.push({
               _id: pageId,
               id: pageId.toHexString(),
-              tenant_id: 'default',
               book_id: bookIdStr,
               page_number: p + 1,
               photo: getPageUrl(p),

--- a/scripts/import/bsb-from-file.mjs
+++ b/scripts/import/bsb-from-file.mjs
@@ -246,7 +246,6 @@ async function main() {
         _id: bookId,
         id: bookIdStr,
         slug,
-        tenant_id: 'default',
         title,
         author,
         language,
@@ -290,7 +289,6 @@ async function main() {
           return {
             _id: pageId,
             id: pageId.toHexString(),
-            tenant_id: 'default',
             book_id: bookIdStr,
             page_number: start + j + 1,
             photo: p.photo,

--- a/scripts/import/ccag-vii-pdf-direct.mjs
+++ b/scripts/import/ccag-vii-pdf-direct.mjs
@@ -220,7 +220,6 @@ async function main() {
     _id: bookId,
     id: bookIdStr,
     slug,
-    tenant_id: 'default',
     title: BOOK_META.title,
     display_title: BOOK_META.display_title,
     author: BOOK_META.author,
@@ -294,7 +293,6 @@ async function main() {
       docs.push({
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: p + 1,
         photo: pageUrls[p].url,

--- a/scripts/import/fragmenta-direct.mjs
+++ b/scripts/import/fragmenta-direct.mjs
@@ -121,7 +121,7 @@ async function importItem(db, m) {
   const slug = await uniqueSlug(db, slugify(`${m.text}-fragmenta-${m.signum}`));
   const now = new Date();
   const bookDoc = {
-    _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+    _id: bookId, id: bookIdStr, slug,
     title: m.title, display_title: m.text, author: m.author,
     language: 'Latin', original_language: 'Latin',
     published: m.dateLabel, year: m.year,
@@ -150,7 +150,7 @@ async function importItem(db, m) {
     created_at: now, updated_at: now,
   };
   await db.collection('books').insertOne(bookDoc);
-  const docs = pages.map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookIdStr, page_number: k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo_original, created_at: now, updated_at: now }; });
+  const docs = pages.map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo_original, created_at: now, updated_at: now }; });
   await db.collection('pages').insertMany(docs, { ordered: false });
   console.log(`  ✓ inserted ${slug} (${bookIdStr}) — ${pages.length} pages, hidden`);
   console.log(`    https://sourcelibrary.org/book/${slug}`);

--- a/scripts/import/harvard-iiif-direct-batch.mjs
+++ b/scripts/import/harvard-iiif-direct-batch.mjs
@@ -70,7 +70,7 @@ async function main(){
     const bookId=new ObjectId(), id=bookId.toHexString(), now=new Date();
     const slug=await uniqueSlug(db, slugify(b.title.split('—')[1]||b.title));
     await db.collection('books').insertOne({
-      _id:bookId, id, slug, tenant_id:'default', title:b.title, display_title:label||b.title.split('—')[0].trim(),
+      _id:bookId, id, slug, title:b.title, display_title:label||b.title.split('—')[0].trim(),
       author:b.author, language:'Chinese', original_language:'Chinese', published:b.published,
       categories:[], collections:b.colls, thumbnail:pages[0]?.thumbnail||'',
       pages_count:pages.length, pages_ocr:0, pages_translated:0, pages_archived:0, content_type:'book',
@@ -85,7 +85,7 @@ async function main(){
       created_at:now, updated_at:now,
     });
     for (let s=0;s<pages.length;s+=500){ const docs=pages.slice(s,s+500).map((p,k)=>{ const pid=new ObjectId();
-      return { _id:pid, id:pid.toHexString(), tenant_id:'default', book_id:id, page_number:s+k+1, photo:p.photo, thumbnail:p.thumbnail, photo_original:p.photo, created_at:now, updated_at:now }; });
+      return { _id:pid, id:pid.toHexString(), book_id:id, page_number:s+k+1, photo:p.photo, thumbnail:p.thumbnail, photo_original:p.photo, created_at:now, updated_at:now }; });
       await db.collection('pages').insertMany(docs,{ordered:false}); }
     console.log(`✓ ${b.fhcl} → ${slug} (${pages.length}p)`); results.push({fhcl:b.fhcl,ok:true,pages:pages.length,slug});
     await new Promise(x=>setTimeout(x,2000));

--- a/scripts/import/harvard-philosophy-direct.mjs
+++ b/scripts/import/harvard-philosophy-direct.mjs
@@ -91,7 +91,7 @@ async function main() {
     const bookId = new ObjectId(), id = bookId.toHexString(), now = new Date();
     const slug = await uniqueSlug(db, slugify(it.en) || ('harvard-' + it.fhcl));
     await db.collection('books').insertOne({
-      _id: bookId, id, slug, tenant_id: 'default', title, display_title: it.cjk || label,
+      _id: bookId, id, slug, title, display_title: it.cjk || label,
       author, language: 'Chinese', original_language: 'Chinese', published: '',
       categories: [], collections: ['east-asia', 'chinese-classics'], thumbnail: pages[0]?.thumbnail || '',
       pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0, content_type: 'book',
@@ -109,7 +109,7 @@ async function main() {
       created_at: now, updated_at: now,
     });
     for (let s = 0; s < pages.length; s += 500) {
-      const docs = pages.slice(s, s + 500).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: id, page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + 500).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: id, page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo, created_at: now, updated_at: now }; });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     console.log(`✓ ${it.fhcl} → ${slug} (${pages.length}p)`); results.push({ fhcl: it.fhcl, ok: true, pages: pages.length, slug });

--- a/scripts/import/harvard-wuzhen-direct.mjs
+++ b/scripts/import/harvard-wuzhen-direct.mjs
@@ -83,7 +83,7 @@ async function main() {
   const now = new Date();
 
   const bookDoc = {
-    _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+    _id: bookId, id: bookIdStr, slug,
     title, display_title, author,
     language: 'Chinese', original_language: 'Chinese',
     published: '明萬曆 Ming Wanli (1573–1620)',
@@ -116,7 +116,7 @@ async function main() {
   for (let s = 0; s < pages.length; s += CHUNK) {
     const docs = pages.slice(s, s + CHUNK).map((p, k) => {
       const pid = new ObjectId();
-      return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookIdStr,
+      return { _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo,
         created_at: now, updated_at: now };
     });

--- a/scripts/import/ia-bundle-import.mjs
+++ b/scripts/import/ia-bundle-import.mjs
@@ -159,7 +159,6 @@ async function main() {
         _id: bookId,
         id: bookIdStr,
         slug,
-        tenant_id: 'default',
         title: entry.title,
         display_title: entry.display_title || null,
         author: entry.author,
@@ -207,7 +206,6 @@ async function main() {
           pageDocs.push({
             _id: pageId,
             id: pageId.toHexString(),
-            tenant_id: 'default',
             book_id: bookIdStr,
             page_number: p + 1,
             photo: getPageUrl(p),

--- a/scripts/import/iiif-direct-import.mjs
+++ b/scripts/import/iiif-direct-import.mjs
@@ -132,7 +132,7 @@ async function processEntry(db, entry, idx) {
     const bookIdStr = bookId.toHexString();
     const slug = await ensureUniqueSlug(db, generateSlug(entry.title, entry.author));
     const bookDoc = {
-      _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+      _id: bookId, id: bookIdStr, slug,
       title: entry.title || 'Unknown', author: entry.author || 'Unknown',
       language: entry.language || 'Unknown', published: entry.year ? String(entry.year) : 'Unknown',
       categories: [], collections: entry.collections || [],
@@ -155,7 +155,7 @@ async function processEntry(db, entry, idx) {
     for (let start = 0; start < pages.length; start += 500) {
       const chunk = pages.slice(start, start + 500).map((p, j) => {
         const pageId = new ObjectId();
-        return { _id: pageId, id: pageId.toHexString(), tenant_id: 'default', book_id: bookIdStr,
+        return { _id: pageId, id: pageId.toHexString(), book_id: bookIdStr,
           page_number: start + j + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo,
           created_at: new Date(), updated_at: new Date() };
       });

--- a/scripts/import/import-artwork.mjs
+++ b/scripts/import/import-artwork.mjs
@@ -390,7 +390,6 @@ async function createArtworkDoc(db, artwork, entry) {
     _id: bookId,
     id: bookIdStr,
     slug,
-    tenant_id: 'default',
     title: artwork.title,
     display_title: artwork.title,
     author: artwork.author || 'Unknown artist',

--- a/scripts/import/import-kloss-collection.mjs
+++ b/scripts/import/import-kloss-collection.mjs
@@ -244,7 +244,6 @@ async function importRecord(db, record, index, total) {
       _id: bookId,
       id: bookIdStr,
       slug,
-      tenant_id: 'default',
       title,
       display_title: null,
       author,
@@ -308,7 +307,6 @@ async function importRecord(db, record, index, total) {
       pageDocs.push({
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: i + 1,
         photo: photoUrl,

--- a/scripts/import/import-met-egyptian.mjs
+++ b/scripts/import/import-met-egyptian.mjs
@@ -248,7 +248,6 @@ async function main() {
         _id: bookId,
         id: bookIdStr,
         slug,
-        tenant_id: 'default',
         title,
         author,
         language,
@@ -318,7 +317,6 @@ async function main() {
         return {
           _id: pageId,
           id: pageId.toHexString(),
-          tenant_id: 'default',
           book_id: bookIdStr,
           page_number: idx + 1,
           photo: imgUrl,

--- a/scripts/import/import-oraec.mjs
+++ b/scripts/import/import-oraec.mjs
@@ -312,7 +312,6 @@ async function main() {
       const pageDoc = {
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: 1,
         photo: null,
@@ -333,7 +332,6 @@ async function main() {
         _id: bookId,
         id: bookIdStr,
         slug,
-        tenant_id: 'default',
         title,
         author: origPlace ? `${origPlace} (${objectType})` : objectType,
         language: 'Egyptian hieroglyphs',

--- a/scripts/import/import-sefaria.mjs
+++ b/scripts/import/import-sefaria.mjs
@@ -195,7 +195,7 @@ async function importWork(db, w) {
   const now = new Date();
 
   const bookDoc = {
-    _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+    _id: bookId, id: bookIdStr, slug,
     title: w.title, display_title: w.display_title, author: w.author,
     language: w.language, original_language: w.language,
     published: w.published, categories: [], collections: w.collections || [],
@@ -233,7 +233,7 @@ async function importWork(db, w) {
   const pageDocs = pages.map((p, idx) => {
     const pid = new ObjectId();
     const doc = {
-      _id: pid, id: pid.toHexString(), tenant_id: 'default',
+      _id: pid, id: pid.toHexString(),
       book_id: bookIdStr, page_number: idx + 1,
       source_ref: p.source_ref,
       created_at: now, updated_at: now,

--- a/scripts/import/import-thirukkural.ts
+++ b/scripts/import/import-thirukkural.ts
@@ -141,7 +141,6 @@ async function importBook(client: MongoClient, book: BookImport) {
   const bookDoc = {
     _id: bookId,
     id: bookIdStr,
-    tenant_id: 'default',
     title: book.title,
     display_title: null,
     author: book.author,
@@ -181,7 +180,6 @@ async function importBook(client: MongoClient, book: BookImport) {
     pageDocs.push({
       _id: pageId,
       id: pageId.toHexString(),
-      tenant_id: 'default',
       book_id: bookIdStr,
       page_number: i + 1,
       photo: getPageImageUrl(i),

--- a/scripts/import/marcianus-299-direct.mjs
+++ b/scripts/import/marcianus-299-direct.mjs
@@ -176,7 +176,7 @@ async function main() {
   const now = new Date();
 
   const bookDoc = {
-    _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+    _id: bookId, id: bookIdStr, slug,
     title, display_title, author,
     language: 'Greek', original_language: 'Greek',
     text_role: 'original',
@@ -217,7 +217,7 @@ async function main() {
       const pid = new ObjectId();
       const r2url = uploaded[gi];
       return {
-        _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookIdStr,
+        _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: gi + 1,
         page_label: p.name || null,
         photo: IC_BASE + p.src,          // provenance: original Internet Culturale source

--- a/scripts/import/met-shunga-albums-direct.mjs
+++ b/scripts/import/met-shunga-albums-direct.mjs
@@ -125,7 +125,7 @@ async function main() {
     }
 
     const bookDoc = {
-      _id: bookId, id: bookIdStr, slug: album.bookSlug, tenant_id: 'default',
+      _id: bookId, id: bookIdStr, slug: album.bookSlug,
       title: album.title, display_title: album.title,
       author: f0.author,
       language: 'Japanese', original_language: 'Japanese',
@@ -157,7 +157,7 @@ async function main() {
     const pageDocs = fragments.map((f, i) => {
       const pid = new ObjectId();
       return {
-        _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookIdStr,
+        _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: i + 1,
         photo: archived[i].photo, thumbnail: archived[i].thumbnail,
         photo_original: f.commons_full_url,

--- a/scripts/import/ndl-daoist-import.mjs
+++ b/scripts/import/ndl-daoist-import.mjs
@@ -270,7 +270,6 @@ async function main() {
       _id: bookId,
       id: bookIdStr,
       slug,
-      tenant_id: 'default',
       title: item.title,
       display_title: item.display_title,
       original_title: item.original_title,
@@ -340,7 +339,6 @@ async function main() {
       return {
         _id: pageId,
         id: pageId.toHexString(),
-        tenant_id: 'default',
         book_id: bookIdStr,
         page_number: i + 1,
         photo: img.photo,

--- a/scripts/import/oraec-paginate-translate.mjs
+++ b/scripts/import/oraec-paginate-translate.mjs
@@ -143,7 +143,6 @@ async function processBook(db, bookId) {
     const pageDoc = {
       _id: pageId,
       id: pageId.toHexString(),
-      tenant_id: 'default',
       book_id: bid,
       page_number: pageNum,
       // First page gets the archived image, rest get null

--- a/scripts/import/shwep-curator-pass-import.mjs
+++ b/scripts/import/shwep-curator-pass-import.mjs
@@ -164,7 +164,6 @@ function buildBookDoc({ entry, pageCount, pageCountSource, thumbnail, slug, iaMe
       _id: bookId,
       id: bookIdStr,
       slug,
-      tenant_id: 'default',
       title: entry.title,
       display_title: entry.display_title || null,
       author: entry.author,
@@ -312,7 +311,6 @@ async function main() {
           pageDocs.push({
             _id: pageId,
             id: pageId.toHexString(),
-            tenant_id: 'default',
             book_id: bookIdStr,
             page_number: p + 1,
             photo: getPageUrl(p),

--- a/scripts/import/tartu-dspace-pdf-direct.mjs
+++ b/scripts/import/tartu-dspace-pdf-direct.mjs
@@ -101,7 +101,7 @@ async function importItem(db, it) {
     const bookId = new ObjectId(); const idStr = bookId.toHexString();
     const slug = await uniqueSlug(db, it.slug_base); const now = new Date();
     await db.collection('books').insertOne({
-      _id: bookId, id: idStr, slug, tenant_id: 'default',
+      _id: bookId, id: idStr, slug,
       title: it.title, display_title: it.display_title, author: it.author,
       language: it.language, original_language: it.language, published: it.published, year: it.year,
       categories: [], collections: [], thumbnail: pages[0] || '',
@@ -121,7 +121,7 @@ async function importItem(db, it) {
     });
     const CHUNK = 500;
     for (let s = 0; s < pages.length; s += CHUNK) {
-      const docs = pages.slice(s, s + CHUNK).map((photo, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: idStr, page_number: s + k + 1, photo, thumbnail: photo, photo_original: photo, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + CHUNK).map((photo, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: idStr, page_number: s + k + 1, photo, thumbnail: photo, photo_original: photo, created_at: now, updated_at: now }; });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     console.log(`  ✓ inserted ${slug} (${idStr}) — ${pages.length} pages, hidden`);

--- a/scripts/maintenance/cleanup-tenant-id-pollution.mjs
+++ b/scripts/maintenance/cleanup-tenant-id-pollution.mjs
@@ -113,6 +113,8 @@ async function cascadeUnsetSnakeTenantId({ db, bookIds, apply, label }) {
   let revisionsUnset = 0;
   let galleryMatched = 0;
   let galleryUnset = 0;
+  let literalMatched = 0;
+  let literalUnset = 0;
 
   for (const ids of chunk(bookIds, BOOK_CHUNK_SIZE)) {
     const pq = { book_id: { $in: ids }, tenant_id: { $exists: true } };
@@ -120,6 +122,16 @@ async function cascadeUnsetSnakeTenantId({ db, bookIds, apply, label }) {
     if (apply) {
       const r = await pages.updateMany(pq, { $unset: { tenant_id: '' } });
       pagesUnset += r.modifiedCount;
+    }
+
+    // camelCase tenantId holding the literal string 'default' — a small bug
+    // cohort (the UUID field fed a slug). Part 1 can't reach these: it
+    // cascades from books with a bad tenantId, and books are clean.
+    const dq = { book_id: { $in: ids }, tenantId: 'default' };
+    literalMatched += await pages.countDocuments(dq);
+    if (apply) {
+      const r = await pages.updateMany(dq, { $unset: { tenantId: '' } });
+      literalUnset += r.modifiedCount;
     }
 
     const rq = { book_id: { $in: ids }, tenant_id: { $exists: true } };
@@ -138,6 +150,7 @@ async function cascadeUnsetSnakeTenantId({ db, bookIds, apply, label }) {
   }
 
   console.log(`  [${label}] pages matched=${pagesMatched}${apply ? ` unset=${pagesUnset}` : ''}`);
+  console.log(`  [${label}] pages tenantId='default' matched=${literalMatched}${apply ? ` unset=${literalUnset}` : ''}`);
   console.log(`  [${label}] page_revisions matched=${revisionsMatched}${apply ? ` unset=${revisionsUnset}` : ''}`);
   console.log(`  [${label}] gallery_images matched=${galleryMatched}${apply ? ` unset=${galleryUnset}` : ''}`);
 }

--- a/scripts/migration/bph-s3-to-r2.mjs
+++ b/scripts/migration/bph-s3-to-r2.mjs
@@ -134,7 +134,6 @@ function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
   return {
     _id: new ObjectId(id),
     id,
-    tenant_id: 'default',
     book_id: bookId,
     page_number: pageNumber,
     photo: photoUrl,
@@ -176,7 +175,6 @@ function makeBookRecord(meta) {
   return {
     _id: new ObjectId(id),
     id,
-    tenant_id: 'default',
     title: meta.title || 'Untitled',
     display_title: meta.display_title || meta.title,
     author: meta.author || 'Unknown',

--- a/scripts/migration/bulk-import-to-r2.mjs
+++ b/scripts/migration/bulk-import-to-r2.mjs
@@ -112,7 +112,6 @@ function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
   return {
     _id: new ObjectId(id),
     id,
-    tenant_id: 'default',
     book_id: bookId,
     page_number: pageNumber,
     photo: photoUrl,
@@ -131,7 +130,6 @@ function makeBookRecord(meta) {
   return {
     _id: new ObjectId(id),
     id,
-    tenant_id: 'default',
     title: meta.title || 'Untitled',
     display_title: meta.display_title || meta.title,
     author: meta.author || 'Unknown',


### PR DESCRIPTION
## Why

#3969 family 1 (`tenantId`/`tenant_id`/`tenant`). Investigating the consolidation ladder turned up that **this consolidation was already done once**: PR #2085 (2026-05-27) unset snake `tenant_id` on 45,283 books + 6.4M pages, stripped the `src/` writers, and left the import scripts untouched as 'one-shot, already ran'.

That assumption failed. The direct-import scripts are actively reused (they're the standard route for 429-prone sources per `.claude/docs/import-workflow.md`), so the field **re-polluted**: measured 2026-08-13, **20,010 books and ~1.4M pages** carry `tenant_id: 'default'` again.

Verified before touching anything:
- `books.tenantId` is clean — exactly the 3 real subdomain UUIDs (bph 2,466 / bhutan 1,631 / kloss 1,517).
- `books.tenant_id` is **100% the literal `'default'`** — zero real tenant slugs, so unsetting loses nothing.
- No active leak: the only isolation reader (`book/[id]/page.tsx` dual match) treats a stray slug as *more* restrictive, never less. The risk is future sweeps reading the wrong field.

## In scope

- Remove `tenant_id: 'default'` from every insert doc in `scripts/` — 36 files, 62 sites (all doc literals, no query filters; each verified). All `.mjs` pass `node --check`.
- `cleanup-tenant-id-pollution.mjs`: part 2's walk now also unsets the literal `tenantId: 'default'` on pages (UUID field fed a slug — small cohort; part 1's book cascade can't reach it because books are clean).

## Out of scope

- Running the cleanup against production — happens after merge, dry-run numbers reviewed first.
- `books.tenant` (148 docs, `{name:'ritman', external_id}`) — that's catalogue provenance misnamed, not tenant membership; it has a live reader (`/api/catalog` uses it as 'location'). Separate concern, needs a rename not an unset.
- The prevention half (#3969 Track A): the `$jsonSchema` validator with `tenant_id` on the retired list — blocked on a one-time dbAdmin action. **This PR is exhibit A for why Track A matters: consolidation without enforcement re-polluted in under 3 months.**

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)