### PR TITLE
feat(scripts): row-shaped sweep log + whitelisted doc constructors (#3969 prevention)

### DIFF
--- a/scripts/lib/book-docs.mjs
+++ b/scripts/lib/book-docs.mjs
@@ -1,0 +1,145 @@
+/**
+ * Whitelisted document constructors for `books` and `pages` inserts.
+ *
+ * WHY (issue #3969): the ~36 direct-import scripts each hand-roll their insert
+ * literals, which is how one bug (`tenant_id: 'default'`) shipped 62 times and
+ * how `books` accreted ~477 fields, ~140 of them written by a single sweep or
+ * import and then abandoned. This is the CODE-LEVEL schema guard until the
+ * DB-level $jsonSchema validator (issue #3969 Track A, needs a dbAdmin
+ * credential) lands — and the right ergonomics even after it does: unknown
+ * keys THROW at construction time, so the 478th field cannot ship silently.
+ *
+ * The whitelists are the measured union of every field the direct-import
+ * scripts wrote as of 2026-08-13 (AST scan of the insertOne/insertMany
+ * literals in scripts/import/*.mjs, scripts/import-*-artworks.mjs,
+ * scripts/iiif-discovery/import-*.mjs — artwork importers insert into `books`
+ * too, hence the artwork/museum fields). They describe what imports DO write,
+ * not what they SHOULD; known duplicate families (pageCount vs pages_count,
+ * place_of_publication vs place_published) are kept so existing scripts can
+ * adopt this without churn, and get consolidated by #3969 Track B.
+ *
+ * Adding a field here is a deliberate, reviewed act — that is the point.
+ * Retired fields (see RETIRED_FIELDS) are refused with a pointed message and
+ * must never come back.
+ *
+ * Usage:
+ *   import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+ *   const bookDoc = makeBookDoc({ _id: bookId, id: bookIdStr, slug, title, ... });
+ *   await db.collection('books').insertOne(bookDoc);
+ */
+
+/**
+ * Fields retired from the schema — refused even though old dumps still show
+ * them, with the incident that retired each.
+ */
+export const RETIRED_FIELDS = Object.freeze({
+  tenant_id: 'retired by PR #2085 + PR #3983 — canonical tenant membership is tenantId (UUID), set by partner-assignment maintenance, never by imports',
+  tenantId: 'set only by partner-assignment maintenance, never by imports (issue #3969 family 1)',
+  hide_reason: 'orphan sweep column, writer lost to history — use hidden_reason, and record sweep verdicts as rows via scripts/lib/sweep-log.mjs (issue #3969 family 2)',
+});
+
+/** Union of `books` fields written by the direct-import scripts (2026-08-13). */
+export const BOOK_FIELDS = Object.freeze([
+  // identity
+  '_id', 'id', 'slug',
+  // core bibliographic
+  'title', 'display_title', 'author', 'language', 'original_language',
+  'published', 'year', 'original_work_year', 'publisher',
+  'place_published', 'place_of_publication', // known duplicate family — #3969 Track B
+  'categories', 'collections', 'description', 'notes',
+  'normalized_title', 'normalized_author',
+  'is_translation', 'text_role', 'text_source', 'content_type', 'work_id',
+  // provenance / source
+  'ia_identifier', 'source_fingerprint', 'image_source', 'contributing_library',
+  'dublin_core', 'catalog_metadata', 'catalog_ids', 'field_provenance',
+  'metadata', 'metadata_quality', 'shelfmark', 'subject_geographic',
+  'provenance_reference', 'acquisition_campaign',
+  // pipeline / status
+  'status', 'hidden', 'visible', 'pipeline_auto', 'pipeline_status',
+  'processing_priority', 'processing_priority_breakdown',
+  'needs_splitting', 'needs_splitting_reason',
+  'archive_status', 'archive_completed_at', 'archive_metadata',
+  // page accounting
+  'pages_count', 'pageCount', // known duplicate family — #3969 Track B
+  'page_count_source', 'pages_ocr', 'pages_translated', 'pages_archived',
+  // images / artwork (artwork docs live in `books` with resource_type set)
+  'thumbnail', 'resource_type', 'image_display', 'image_source_url',
+  'image_width', 'image_height', 'medium', 'dimensions', 'department',
+  'accession_number', 'micrio_id',
+  'commons_full_url', 'commons_page_title', 'commons_description',
+  'commons_categories', 'commons_width', 'commons_height',
+  'met_object_id', 'met_classification', 'met_department', 'met_dimensions',
+  'met_dynasty', 'met_medium', 'met_period', 'met_reign',
+  'rijksmuseum_id',
+  // ORAEC corpus imports
+  'oraec_id', 'oraec_bibliography', 'oraec_object_type', 'oraec_origplace',
+  'oraec_period', 'oraec_sentence_count',
+  // timestamps
+  'created_at', 'updated_at',
+]);
+
+/** Union of `pages` fields written by the direct-import scripts (2026-08-13). */
+export const PAGE_FIELDS = Object.freeze([
+  // identity
+  '_id', 'id', 'book_id', 'page_number', 'page_label', 'part_title',
+  'source_page', 'source_ref',
+  // images
+  'photo', 'photo_original', 'display_photo', 'archived_photo',
+  'thumbnail', 'image_thumb', 'thumbnail_blob',
+  'image_width', 'image_height', 'width', 'height',
+  // text
+  'ocr', 'translation', 'transliteration',
+  // pipeline
+  'status', 'archive_metadata',
+  // timestamps
+  'created_at', 'updated_at',
+]);
+
+const BOOK_FIELD_SET = new Set(BOOK_FIELDS);
+const PAGE_FIELD_SET = new Set(PAGE_FIELDS);
+
+function makeDoc(fields, allowed, label) {
+  if (fields === null || typeof fields !== 'object' || Array.isArray(fields)) {
+    throw new TypeError(`${label}: expected a plain object of fields, got ${Object.prototype.toString.call(fields)}`);
+  }
+  const keys = Object.keys(fields);
+  const retired = keys.filter((k) => k in RETIRED_FIELDS);
+  if (retired.length > 0) {
+    throw new Error(
+      `${label}: retired field(s) refused: ${retired.map((k) => `${k} (${RETIRED_FIELDS[k]})`).join('; ')}`
+    );
+  }
+  const unknown = keys.filter((k) => !allowed.has(k));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${label}: unknown field(s): ${unknown.join(', ')}. ` +
+        'New fields are a deliberate act (issue #3969) — add them to the whitelist in scripts/lib/book-docs.mjs, ' +
+        'or record per-book sweep actions as rows via scripts/lib/sweep-log.mjs instead.'
+    );
+  }
+  const doc = { ...fields };
+  const now = new Date();
+  if (doc.created_at === undefined) doc.created_at = now;
+  if (doc.updated_at === undefined) doc.updated_at = now;
+  return doc;
+}
+
+/**
+ * Build a `books` insert doc, throwing if any key is not on the whitelist.
+ * Fills created_at/updated_at with the current time when absent.
+ * @param {object} fields
+ * @returns {object} the validated doc (a shallow copy)
+ */
+export function makeBookDoc(fields) {
+  return makeDoc(fields, BOOK_FIELD_SET, 'makeBookDoc');
+}
+
+/**
+ * Build a `pages` insert doc, throwing if any key is not on the whitelist.
+ * Fills created_at/updated_at with the current time when absent.
+ * @param {object} fields
+ * @returns {object} the validated doc (a shallow copy)
+ */
+export function makePageDoc(fields) {
+  return makeDoc(fields, PAGE_FIELD_SET, 'makePageDoc');
+}

--- a/scripts/lib/sweep-log.mjs
+++ b/scripts/lib/sweep-log.mjs
@@ -1,0 +1,84 @@
+/**
+ * Row-shaped sweep logging — the alternative to writing a new COLUMN on `books`.
+ *
+ * WHY (issue #3969): maintenance sweeps historically recorded their verdicts by
+ * stamping a new field on the `books` documents they touched — ~140 distinct
+ * sweep-era fields accreted this way, including orphans like `hide_reason`
+ * (500 production docs whose writer is not even in git history). A sweep that
+ * wants to record "I did X to book Y" should write a ROW here instead:
+ *
+ *   await recordSweepAction(db, {
+ *     sweep: 'dedup-2026-08',
+ *     book_id: '66f0...',
+ *     action: 'hidden-as-duplicate',
+ *     detail: { kept: '66f1...', reason: 'same edition_key' },
+ *   });
+ *
+ * Rows land in the `sweep_log` collection, stamped with timestamp + the
+ * basename of the running script. Query by book_id or by sweep name.
+ *
+ * DELIBERATELY separate from `audit_log` (src/lib/audit-logger.ts): audit_log
+ * feeds the user-facing book history timeline, so writing there would let a
+ * bulk sweep actuate something readers see ("ingest is actuation", #3776).
+ * Nothing user-facing reads `sweep_log`; the timeline can opt in later,
+ * deliberately, per action type.
+ *
+ * Dependency-free by design: the caller passes its already-connected `db`
+ * (a MongoClient.db() handle), so this works from any script without pulling
+ * in a driver or config of its own.
+ */
+
+import { basename } from 'node:path';
+
+const KEBAB_CASE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Insert one sweep-action row into `sweep_log`. Throws on invalid input —
+ * a sweep should fail loudly, not write junk.
+ *
+ * @param {import('mongodb').Db} db - connected Mongo db handle (caller owns the client)
+ * @param {object} entry
+ * @param {string} entry.sweep - kebab-case sweep name, e.g. 'dedup-2026-08' (required)
+ * @param {string} entry.book_id - the book this action touched (required)
+ * @param {string} entry.action - what was done, e.g. 'hidden-as-duplicate' (required)
+ * @param {object|string} [entry.detail] - free-form context: plain object or string
+ * @returns {Promise<object>} the inserted row (driver adds `_id` in place)
+ */
+export async function recordSweepAction(db, { sweep, book_id, action, detail } = {}) {
+  if (!db || typeof db.collection !== 'function') {
+    throw new TypeError('recordSweepAction: first argument must be a connected Mongo db handle');
+  }
+  if (typeof sweep !== 'string' || !KEBAB_CASE.test(sweep)) {
+    throw new TypeError(
+      `recordSweepAction: 'sweep' must be a kebab-case string (e.g. 'dedup-2026-08'), got ${JSON.stringify(sweep)}`
+    );
+  }
+  if (typeof book_id !== 'string' || book_id.length === 0) {
+    throw new TypeError(`recordSweepAction: 'book_id' must be a non-empty string, got ${JSON.stringify(book_id)}`);
+  }
+  if (typeof action !== 'string' || action.length === 0) {
+    throw new TypeError(`recordSweepAction: 'action' must be a non-empty string, got ${JSON.stringify(action)}`);
+  }
+  if (detail !== undefined && typeof detail !== 'string' && !isPlainObject(detail)) {
+    throw new TypeError(
+      `recordSweepAction: 'detail' must be a plain object or string when provided, got ${Object.prototype.toString.call(detail)}`
+    );
+  }
+
+  const row = {
+    timestamp: new Date(),
+    sweep,
+    book_id,
+    action,
+    ...(detail !== undefined ? { detail } : {}),
+    script: basename(process.argv[1] || 'unknown'),
+  };
+  await db.collection('sweep_log').insertOne(row);
+  return row;
+}

--- a/tests/unit/book-docs.test.ts
+++ b/tests/unit/book-docs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * makeBookDoc / makePageDoc: the code-level schema guard for import inserts (#3969).
+ *
+ * What these pin: an unknown key THROWS at construction time (naming the
+ * offending keys), so the 478th `books` field cannot ship silently; retired
+ * fields (tenant_id and friends) are refused with the incident that retired
+ * them; and timestamps are filled only when absent. Pure construction logic —
+ * no DB involved.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  makeBookDoc,
+  makePageDoc,
+  BOOK_FIELDS,
+  PAGE_FIELDS,
+  RETIRED_FIELDS,
+} from '../../scripts/lib/book-docs.mjs';
+
+describe('makeBookDoc', () => {
+  it('passes through a valid import-shaped doc and fills timestamps', () => {
+    const doc = makeBookDoc({
+      id: '66f000000000000000000001',
+      slug: 'de-occulta-philosophia-agrippa',
+      title: 'De occulta philosophia',
+      author: 'Heinrich Cornelius Agrippa',
+      language: 'Latin',
+      published: '1533',
+      categories: ['occult'],
+      pages_count: 362,
+      pages_ocr: 0,
+      pages_translated: 0,
+      status: 'draft',
+      hidden: true,
+      visible: false,
+      image_source: { provider: 'internet_archive' },
+      source_fingerprint: 'ia:deoccultaphiloso00agri',
+    });
+    expect(doc.title).toBe('De occulta philosophia');
+    expect(doc.created_at).toBeInstanceOf(Date);
+    expect(doc.updated_at).toBeInstanceOf(Date);
+  });
+
+  it('preserves caller-supplied timestamps instead of overwriting them', () => {
+    const then = new Date('2020-01-01T00:00:00Z');
+    const doc = makeBookDoc({ title: 'X', created_at: then, updated_at: then });
+    expect(doc.created_at).toBe(then);
+    expect(doc.updated_at).toBe(then);
+  });
+
+  it('returns a copy — the input object is not mutated', () => {
+    const input = { title: 'X' };
+    const doc = makeBookDoc(input);
+    expect(doc).not.toBe(input);
+    expect('created_at' in input).toBe(false);
+  });
+
+  it('throws listing every unknown key', () => {
+    expect(() =>
+      makeBookDoc({ title: 'X', my_new_sweep_field: true, another_stray: 1 })
+    ).toThrow(/unknown field\(s\): my_new_sweep_field, another_stray/);
+  });
+
+  it('refuses retired fields by name, citing the retirement', () => {
+    expect(() => makeBookDoc({ title: 'X', tenant_id: 'default' })).toThrow(/retired.*tenant_id.*#3983/s);
+    expect(() => makeBookDoc({ title: 'X', tenantId: 'default' })).toThrow(/retired.*tenantId/s);
+    expect(() => makeBookDoc({ title: 'X', hide_reason: 'dup' })).toThrow(/retired.*hide_reason/s);
+  });
+
+  it('throws on a non-object input', () => {
+    expect(() => makeBookDoc(null as never)).toThrow(/plain object/);
+    expect(() => makeBookDoc(['title'] as never)).toThrow(/plain object/);
+  });
+});
+
+describe('makePageDoc', () => {
+  it('passes through a valid import-shaped page doc and fills timestamps', () => {
+    const doc = makePageDoc({
+      id: '66f000000000000000000002',
+      book_id: '66f000000000000000000001',
+      page_number: 1,
+      photo: 'https://r2.example/pages/66f000000000000000000001/0001.jpg',
+      photo_original: 'https://r2.example/pages/66f000000000000000000001/0001-full.jpg',
+      thumbnail: 'https://r2.example/pages/66f000000000000000000001/0001-thumb.jpg',
+    });
+    expect(doc.page_number).toBe(1);
+    expect(doc.created_at).toBeInstanceOf(Date);
+    expect(doc.updated_at).toBeInstanceOf(Date);
+  });
+
+  it('throws on unknown keys — book fields are not page fields', () => {
+    expect(() => makePageDoc({ book_id: 'b1', page_number: 1, pages_count: 5 })).toThrow(
+      /unknown field\(s\): pages_count/
+    );
+  });
+
+  it('refuses retired tenant_id on pages too', () => {
+    expect(() => makePageDoc({ book_id: 'b1', page_number: 1, tenant_id: 'default' })).toThrow(/retired/);
+  });
+});
+
+describe('whitelists', () => {
+  it('never contain a retired field', () => {
+    for (const retired of Object.keys(RETIRED_FIELDS)) {
+      expect(BOOK_FIELDS).not.toContain(retired);
+      expect(PAGE_FIELDS).not.toContain(retired);
+    }
+  });
+
+  it('are frozen and duplicate-free', () => {
+    expect(Object.isFrozen(BOOK_FIELDS)).toBe(true);
+    expect(Object.isFrozen(PAGE_FIELDS)).toBe(true);
+    expect(new Set(BOOK_FIELDS).size).toBe(BOOK_FIELDS.length);
+    expect(new Set(PAGE_FIELDS).size).toBe(PAGE_FIELDS.length);
+  });
+});

--- a/tests/unit/sweep-log.test.ts
+++ b/tests/unit/sweep-log.test.ts
@@ -1,0 +1,98 @@
+/**
+ * recordSweepAction: the row-shaped alternative to sweep columns (#3969).
+ *
+ * What these pin: a sweep records its per-book verdicts as ROWS in `sweep_log`,
+ * with a fixed shape (timestamp, sweep, book_id, action, detail?, script) —
+ * and invalid input THROWS instead of writing junk, because a sweep that
+ * half-records is worse than one that stops.
+ *
+ * No live DB: the helper takes any object with a .collection().insertOne(),
+ * so a spy stands in for Mongo and the tests assert the exact row written.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { recordSweepAction } from '../../scripts/lib/sweep-log.mjs';
+
+function fakeDb() {
+  const insertOne = vi.fn(async (doc: Record<string, unknown>) => ({ insertedId: doc._id ?? 'fake-id' }));
+  const collection = vi.fn(() => ({ insertOne }));
+  return { db: { collection }, collection, insertOne };
+}
+
+describe('recordSweepAction', () => {
+  it('writes one row to sweep_log with the documented shape', async () => {
+    const { db, collection, insertOne } = fakeDb();
+    const before = new Date();
+    const row = await recordSweepAction(db, {
+      sweep: 'dedup-2026-08',
+      book_id: '66f000000000000000000001',
+      action: 'hidden-as-duplicate',
+      detail: { kept: '66f000000000000000000002' },
+    });
+
+    expect(collection).toHaveBeenCalledExactlyOnceWith('sweep_log');
+    expect(insertOne).toHaveBeenCalledTimes(1);
+    const written = insertOne.mock.calls[0][0];
+    expect(written).toBe(row); // returns the row it wrote
+    expect(written).toMatchObject({
+      sweep: 'dedup-2026-08',
+      book_id: '66f000000000000000000001',
+      action: 'hidden-as-duplicate',
+      detail: { kept: '66f000000000000000000002' },
+    });
+    expect(written.timestamp).toBeInstanceOf(Date);
+    expect(written.timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    // script is stamped from process.argv[1] — under vitest that's the runner,
+    // but it must always be a non-empty basename (no slashes).
+    expect(typeof written.script).toBe('string');
+    expect(written.script.length).toBeGreaterThan(0);
+    expect(written.script).not.toContain('/');
+  });
+
+  it('accepts a string detail and omits the key entirely when detail is absent', async () => {
+    const { db, insertOne } = fakeDb();
+    await recordSweepAction(db, { sweep: 'a-sweep', book_id: 'b1', action: 'noted', detail: 'kept the longer copy' });
+    expect(insertOne.mock.calls[0][0].detail).toBe('kept the longer copy');
+
+    await recordSweepAction(db, { sweep: 'a-sweep', book_id: 'b2', action: 'noted' });
+    expect('detail' in insertOne.mock.calls[1][0]).toBe(false);
+  });
+
+  it('throws on missing or non-string required fields, without writing', async () => {
+    const { db, insertOne } = fakeDb();
+    const base = { sweep: 'a-sweep', book_id: 'b1', action: 'noted' };
+
+    await expect(recordSweepAction(db, { ...base, sweep: undefined as never })).rejects.toThrow(/'sweep'/);
+    await expect(recordSweepAction(db, { ...base, book_id: '' })).rejects.toThrow(/'book_id'/);
+    await expect(recordSweepAction(db, { ...base, book_id: 123 as never })).rejects.toThrow(/'book_id'/);
+    await expect(recordSweepAction(db, { ...base, action: undefined as never })).rejects.toThrow(/'action'/);
+    // entry object omitted entirely
+    await expect(recordSweepAction(db, undefined as never)).rejects.toThrow(/'sweep'/);
+    expect(insertOne).not.toHaveBeenCalled();
+  });
+
+  it('throws on a non-kebab-case sweep name', async () => {
+    const { db, insertOne } = fakeDb();
+    for (const bad of ['Dedup2026', 'dedup_2026', 'dedup 2026', '-leading', 'trailing-', 'UPPER-CASE']) {
+      await expect(
+        recordSweepAction(db, { sweep: bad, book_id: 'b1', action: 'noted' })
+      ).rejects.toThrow(/kebab-case/);
+    }
+    expect(insertOne).not.toHaveBeenCalled();
+  });
+
+  it('throws on a detail that is neither a plain object nor a string', async () => {
+    const { db, insertOne } = fakeDb();
+    const base = { sweep: 'a-sweep', book_id: 'b1', action: 'noted' };
+    for (const bad of [42, true, ['a'], new Date(), null]) {
+      await expect(recordSweepAction(db, { ...base, detail: bad as never })).rejects.toThrow(/'detail'/);
+    }
+    expect(insertOne).not.toHaveBeenCalled();
+  });
+
+  it('throws when handed something that is not a db handle', async () => {
+    await expect(
+      recordSweepAction(undefined as never, { sweep: 'a-sweep', book_id: 'b1', action: 'noted' })
+    ).rejects.toThrow(/db handle/);
+  });
+});


### PR DESCRIPTION
Implements prevention items 2 and 3 from the #3969 plan ("Prevention — the missing piece is an affordance, not another rule").

## What

**`scripts/lib/sweep-log.mjs`** — `recordSweepAction(db, { sweep, book_id, action, detail })` inserts a row into a new `sweep_log` collection: `{ timestamp, sweep, book_id, action, detail?, script }` (script = basename of `process.argv[1]`). Validates sweep (kebab-case), book_id, action (required strings) and detail (optional plain object or string); throws on invalid input so a sweep fails loudly instead of writing junk. Dependency-free — the caller passes its connected `db`. Deliberately a **separate collection from `audit_log`** (which feeds the user-facing book history timeline via `src/lib/audit-logger.ts`), so sweep rows cannot actuate anything user-facing ("ingest is actuation", #3776).

**`scripts/lib/book-docs.mjs`** — `makeBookDoc(fields)` / `makePageDoc(fields)` validate every key against a whitelist and throw listing the offending keys; fill `created_at`/`updated_at` when absent. Whitelists are the **measured union of fields written by the direct-import scripts as of 2026-08-13** (AST scan of the insertOne/insertMany literals in `scripts/import/*.mjs`, `scripts/import-*-artworks.mjs`, `scripts/iiif-discovery/import-*.mjs`, including conditional-spread keys): 91 book fields, 26 page fields. `tenant_id` / `tenantId` / `hide_reason` are on a `RETIRED_FIELDS` list and refused with a message citing why (PR #3983 / #2085; #3969 family 2). This is the code-level guard until the DB-level $jsonSchema validator (Track A) lands.

**`tests/unit/sweep-log.test.ts` + `tests/unit/book-docs.test.ts`** — 17 tests: valid insert shape (spy db handle, no live Mongo), unknown-key throw, retired-field throw, missing-required throw, kebab-case enforcement, timestamp fill/preserve, whitelist hygiene.

## Out of scope (deliberately)

- **Adopting the helpers in the ~36 existing import scripts** — that churn is a follow-up PR so this one stays reviewable and the whitelist can be sanity-checked first.
- **The DB-level $jsonSchema validator** (#3969 Track A) — blocked on a dbAdmin credential.
- The whitelists mirror what imports *currently* write, so known duplicate families (`pageCount`/`pages_count`, `place_of_publication`/`place_published`) are kept for now; consolidation is #3969 Track B.

## Verification

- `node --check` clean on both modules.
- `npx vitest run tests/unit/sweep-log.test.ts tests/unit/book-docs.test.ts` → 2 files, 17/17 passed.

Refs #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)