### PR TITLE
BPH catalogue: manuscripts, the records that had no editable address, and search export

### DIFF
--- a/scripts/lib/bph-state-shelfmark.mjs
+++ b/scripts/lib/bph-state-shelfmark.mjs
@@ -11,11 +11,17 @@
 /** Values that mean "no", not a shelf mark. Compared case-insensitively. */
 const NOT_A_SHELFMARK = new Set(['neen', 'nee']);
 
+/** `ja` carries real information (the copy IS on loan from the state
+    collection) so it is translated, not dropped — José Bouman, 2026-08-12.
+    See the TS twin for the full note. */
+const TRANSLATE = new Map([['ja', 'yes']]);
+
 export function normalizeStateShelfMark(raw) {
   if (raw == null) return null;
   const kept = String(raw)
     .split('|')
     .map((part) => part.trim())
-    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()));
+    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()))
+    .map((part) => TRANSLATE.get(part.toLowerCase()) ?? part);
   return kept.length > 0 ? kept.join('|') : null;
 }

--- a/scripts/maintenance/translate-ja-state-shelfmark.mjs
+++ b/scripts/maintenance/translate-ja-state-shelfmark.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Translate the "ja" answers in bph_works.state_shelf_mark to "yes".
+ *
+ * WHY
+ * ---
+ * Sibling of clear-neen-state-shelfmark.mjs, which emptied the Dutch "no"
+ * answers on 30 July and deliberately left "ja" ("yes") alone because deleting
+ * it would have discarded the only record that those copies ARE on loan from
+ * the state collection. That was left as a librarian's decision, and surfaced
+ * as a bucket in the catalogue worklist so it would actually get asked.
+ *
+ * It got asked, and answered — José Bouman (BPH), 2026-08-12:
+ *
+ *   "State Collection shelf mark still reads 'ja' — These items will also have
+ *    in the remark-field the note 'In: [+ author-title]'. […] This set of 31 is
+ *    owned by the State, therefore the 'Ja'. Better change it to 'yes'."
+ *
+ * So the value is kept and translated, not emptied. The write boundary is
+ * updated in the same change (src/lib/bph-state-shelfmark.ts and its scripts
+ * twin now map ja→yes), so a Memorix re-import cannot put the Dutch back —
+ * without that half, this sweep would silently undo itself on the next import.
+ *
+ * AUDIT TRAIL
+ * -----------
+ * bph_works is the BPH's catalogue of record: every mutation is traceable via
+ * bph_works_revisions (see src/lib/bph-catalog.ts). This writes a revision row
+ * per affected UBN — with the real `from` value, so each change is individually
+ * reversible — BEFORE touching the live rows, matching the ordering
+ * applyWorkRevision uses: if the run dies midway the failure direction is an
+ * orphaned revision, never an unrecorded edit. It is a bulk writer rather than
+ * a caller of applyWorkRevision only because that helper is TypeScript; the
+ * invariant it protects is preserved.
+ *
+ * A backup of every affected row is written to scripts/output/ before any write.
+ *
+ * Idempotent: re-running finds nothing to do.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/translate-ja-state-shelfmark.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/translate-ja-state-shelfmark.mjs --apply
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync, mkdirSync } from 'fs';
+import { parseArgs } from 'util';
+import { randomUUID } from 'crypto';
+import { normalizeStateShelfMark } from '../lib/bph-state-shelfmark.mjs';
+
+const { values: args } = parseArgs({ options: { apply: { type: 'boolean', default: false } } });
+const APPLY = args.apply;
+const EDITOR = 'system:translate-ja-state-shelfmark';
+const NOTE =
+  'Bulk cleanup: "ja" (Dutch "yes") was imported from Memorix bruikleen_icn into ' +
+  'the State Collection shelf mark field. Kept and translated to "yes" rather ' +
+  'than emptied — it records that the copy IS on loan from the state ' +
+  'collection. Decision by José Bouman, 2026-08-12.';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/**
+ * Page through every row that could be affected. Filter is `%ja%` — looser than
+ * the normaliser on purpose, so nothing is left behind that the read path would
+ * then render differently from what is stored. Rows that merely CONTAIN the
+ * letters ("Jakarta") are excluded by comparing the normalised value, never by
+ * substring.
+ */
+async function fetchCandidates() {
+  const rows = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await sb
+      .from('bph_works')
+      .select('ubn, uuid, state_shelf_mark, field_provenance')
+      .ilike('state_shelf_mark', '%ja%')
+      .range(from, from + 999);
+    if (error) throw new Error(`fetch failed at offset ${from}: ${error.message}`);
+    rows.push(...data);
+    if (data.length < 1000) break;
+  }
+  return rows;
+}
+
+function pendingChanges(rows) {
+  return rows
+    .map((r) => ({ ...r, next: normalizeStateShelfMark(r.state_shelf_mark) }))
+    .filter((r) => r.next !== r.state_shelf_mark);
+}
+
+async function main() {
+  console.log(APPLY ? 'MODE: APPLY (writing)' : 'MODE: DRY RUN (use --apply to write)');
+
+  const candidates = await fetchCandidates();
+  console.log(`Rows whose state_shelf_mark mentions "ja":  ${candidates.length}`);
+
+  const affected = pendingChanges(candidates);
+  console.log(`Rows the normaliser changes:               ${affected.length}`);
+  const untouched = candidates.length - affected.length;
+  if (untouched > 0) {
+    // Compare by key, not object identity — pendingChanges() returns spread
+    // copies, so `affected.includes(candidate)` is always false and would
+    // report every candidate as "kept". A wrong diagnostic here is worse than
+    // none: it reads as evidence that the filter is over-broad.
+    const changedKeys = new Set(affected.map((r) => r.ubn ?? r.uuid));
+    console.log(`Rows left alone (real values containing "ja"): ${untouched}`);
+    for (const r of candidates.filter((c) => !changedKeys.has(c.ubn ?? c.uuid)).slice(0, 10)) {
+      console.log(`    kept: ${JSON.stringify(r.state_shelf_mark)}  (ubn ${r.ubn})`);
+    }
+  }
+
+  const transitions = new Map();
+  for (const r of affected) {
+    const key = `${JSON.stringify(r.state_shelf_mark)} -> ${JSON.stringify(r.next)}`;
+    transitions.set(key, (transitions.get(key) || 0) + 1);
+  }
+  console.log('\nTransitions:');
+  for (const [k, n] of [...transitions.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(6)}  ${k}`);
+  }
+
+  if (affected.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = `scripts/output/ja-state-shelfmark-backup-${stamp}.json`;
+  if (!APPLY) {
+    console.log(`\nDRY RUN — would write ${affected.length} revision rows, update ${affected.length} rows,`);
+    console.log(`and back up the prior values to ${backupPath}.`);
+    return;
+  }
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(
+    backupPath,
+    JSON.stringify(
+      {
+        generated: new Date().toISOString(),
+        reason: NOTE,
+        rows: affected.map((r) => ({
+          ubn: r.ubn,
+          uuid: r.uuid,
+          state_shelf_mark: r.state_shelf_mark,
+          field_provenance: r.field_provenance,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`\nBacked up ${affected.length} prior values → ${backupPath}`);
+
+  // 1. History first — see AUDIT TRAIL above.
+  const appliedAt = new Date().toISOString();
+  const { error: revErr } = await sb.from('bph_works_revisions').insert(
+    affected.map((r) => ({
+      id: randomUUID(),
+      ubn: r.ubn,
+      change_type: 'edit',
+      field_changes: {
+        state_shelf_mark: { from: r.state_shelf_mark, to: r.next, source: 'bulk cleanup' },
+      },
+      editor_email: EDITOR,
+      proposed_by: null,
+      source_pending_id: null,
+      applied_at: appliedAt,
+      note: NOTE,
+    })),
+  );
+  if (revErr) throw new Error(`revision insert failed: ${revErr.message}`);
+  console.log(`Revisions written: ${affected.length}`);
+
+  // 2. Then the live rows, one at a time — 31 rows, and each needs its own
+  //    field_provenance merged rather than overwritten (Supabase cannot
+  //    deep-merge JSONB from the client, and other writers' entries must live).
+  const provenanceEntry = { source: 'bulk cleanup', edited_by: EDITOR, edited_at: appliedAt };
+  let updated = 0;
+  for (const r of affected) {
+    const existing = r.field_provenance && typeof r.field_provenance === 'object' ? r.field_provenance : {};
+    const { error } = await sb
+      .from('bph_works')
+      .update({
+        state_shelf_mark: r.next,
+        field_provenance: { ...existing, state_shelf_mark: provenanceEntry },
+      })
+      .eq('ubn', r.ubn);
+    if (error) throw new Error(`update failed for ubn=${r.ubn}: ${error.message}`);
+    updated++;
+  }
+  console.log(`Rows updated:      ${updated}`);
+
+  // 3. Verify by re-reading, not by trusting our own counters.
+  const remaining = pendingChanges(await fetchCandidates());
+  console.log(`Rows still needing the change: ${remaining.length} (expect 0)`);
+  if (remaining.length !== 0) {
+    console.error('VERIFICATION FAILED — sample:', remaining.slice(0, 5).map((r) => r.ubn).join(', '));
+    process.exit(1);
+  }
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('\nFAILED:', err.message);
+  process.exit(1);
+});

--- a/scripts/migration/add-bph-uuid-keyed-revisions.sql
+++ b/scripts/migration/add-bph-uuid-keyed-revisions.sql
@@ -1,0 +1,107 @@
+-- Make the BPH catalogue editor work for records that have no UBN.
+--
+-- WHY THIS EXISTS
+--
+-- Memorix issues no UBN for manuscripts or photographs. 2,012 of 29,881 rows
+-- (812 manuscripts + 959 photocopies + a few printed stubs) have `ubn IS NULL`,
+-- and that is correct data, not missing data — José Bouman, 2026-08-12:
+--
+--   "Manuscripts never have a UBN, instead they have a manuscript number
+--    (M+ number, or just a number, like 216, 217, 218)."
+--
+-- But the whole edit path is hard-keyed on a non-null UBN:
+--
+--   * bph_works_revisions.ubn is `TEXT NOT NULL REFERENCES bph_works(ubn)`
+--   * applyWorkRevision() fetches with .eq('ubn', ubn) and inserts a revision
+--     row carrying that ubn
+--   * the edit page fetches with .eq('ubn', ubn) and notFound()s otherwise
+--
+-- So every one of those 2,012 records 404s on /catalog/{key}/edit, and no new
+-- manuscript can be created at all without inventing a UBN for it. #3654 made
+-- these records *viewable* by accepting a uuid in the URL; it did not make them
+-- editable, which is the other half of what was reported:
+--
+--   José Bouman, 2026-07-31 — "It is not possible to click on titles with a
+--   shelf mark M (+number), nor on those with shelfmark Fot (+ number) TO EDIT
+--   THEM or see more information"
+--   José Bouman, 2026-08-13 — "the blank form should show other fields than the
+--   one for printed books. No UBN required."
+--
+-- Inventing a UBN is not an option: the BPH writes the UBN into the physical
+-- book by hand, so a synthetic one would end up in ink inside a manuscript that
+-- is not supposed to have one. The identifier has to stay absent.
+--
+-- WHAT THIS DOES
+--
+-- Adds `uuid` as an alternative revision key, so a revision can target a work
+-- by UBN (as all 30k existing revisions do) or by uuid (manuscripts, photos).
+-- Every existing row keeps its ubn; nothing is rewritten.
+--
+-- MEASURED BEFORE WRITING (production, 2026-08-13, all 29,881 rows paged):
+--   uuid NULL/empty ............ 107   (all record_type='printed', all have a ubn)
+--   duplicate uuid values ...... 0
+--   rows with neither key ...... 0     <- nothing becomes unaddressable
+--   ubn values of uuid shape ... 0     <- the shape-based routing stays unambiguous
+--
+-- The 107 uuid-less rows are backfilled below so the UNIQUE constraint can be
+-- added; they are all UBN-keyed printed books whose links do not change.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$SUPABASE_DB_URL" -f scripts/migration/add-bph-uuid-keyed-revisions.sql
+
+BEGIN;
+
+-- 1. Every work needs a durable uuid before uuid can be a key. `uuid` is TEXT
+--    (not the uuid type) — it holds Memorix's own identifiers, so keep the
+--    column type and just generate text-shaped uuids for the stragglers.
+UPDATE bph_works
+   SET uuid = gen_random_uuid()::text
+ WHERE uuid IS NULL OR TRIM(uuid) = '';
+
+-- 2. A foreign key needs a unique target. Verified 0 duplicates above; this
+--    will fail loudly rather than silently if that ever stops being true.
+ALTER TABLE bph_works
+  ADD CONSTRAINT bph_works_uuid_key UNIQUE (uuid);
+
+-- 3. A revision may now be keyed by either identifier.
+ALTER TABLE bph_works_revisions
+  ALTER COLUMN ubn DROP NOT NULL;
+
+ALTER TABLE bph_works_revisions
+  ADD COLUMN IF NOT EXISTS work_uuid TEXT REFERENCES bph_works(uuid);
+
+-- 4. ...but never by neither. This is the invariant the NOT NULL used to carry:
+--    a revision that points at no work is history with no subject.
+ALTER TABLE bph_works_revisions
+  ADD CONSTRAINT bph_revision_targets_a_work
+  CHECK (ubn IS NOT NULL OR work_uuid IS NOT NULL);
+
+-- 5. Backfill work_uuid on existing revisions so history reads uniformly and a
+--    future migration can drop the ubn key without losing the join.
+UPDATE bph_works_revisions r
+   SET work_uuid = w.uuid
+  FROM bph_works w
+ WHERE r.ubn = w.ubn
+   AND r.work_uuid IS NULL;
+
+CREATE INDEX IF NOT EXISTS bph_works_revisions_work_uuid_idx
+  ON bph_works_revisions (work_uuid);
+
+-- 6. The contributor queue has the same FK on ubn. Its ubn is already nullable
+--    (a contributor may propose a new work without knowing the UBN), but a
+--    proposal against an EXISTING manuscript still has nothing to point at, so
+--    it needs the same uuid key. No CHECK here: unlike a revision, a pending
+--    row legitimately targets no work yet.
+ALTER TABLE bph_works_pending_changes
+  ADD COLUMN IF NOT EXISTS work_uuid TEXT REFERENCES bph_works(uuid);
+
+UPDATE bph_works_pending_changes p
+   SET work_uuid = w.uuid
+  FROM bph_works w
+ WHERE p.ubn = w.ubn
+   AND p.work_uuid IS NULL;
+
+CREATE INDEX IF NOT EXISTS bph_works_pending_changes_work_uuid_idx
+  ON bph_works_pending_changes (work_uuid);
+
+COMMIT;

--- a/scripts/migration/add-bph-worklist-rpc.sql
+++ b/scripts/migration/add-bph-worklist-rpc.sql
@@ -22,6 +22,17 @@
 -- So each category below is scoped to something a librarian would genuinely
 -- act on, and every one carries samples so the number is never just a number.
 --
+-- EVERY SAMPLE CARRIES `uuid`, AND THAT IS THE ONLY KEY THE SITE CAN RESOLVE.
+-- `bph_works.id` and `bph_works.uuid` are two DIFFERENT uuids on every row, and
+-- /catalog/{key} routes a uuid-shaped key to the `uuid` column (see
+-- src/lib/bph-catalog-key.ts). Three of the categories below select exactly the
+-- rows where `ubn IS NULL`, so their links can only fall back to a uuid — and
+-- while these samples emitted `id`, all 2,012 of them 404'd. José Bouman,
+-- 2026-08-12: "I cannot access these by clicking on them, so I can't see what
+-- is the case" — reported against this worklist, one week after the catalogue
+-- browser's own null-ubn links were fixed in #3654. Same symptom, second path.
+-- `id` is kept in the payload for debugging; never build a link from it.
+--
 -- Run via Supabase SQL editor or psql:
 --   psql "$DATABASE_URL" -f scripts/migration/add-bph-worklist-rpc.sql
 
@@ -48,7 +59,7 @@ LANGUAGE sql STABLE AS $$
          'Manuscripts on the shelf with no title and no UBN',
          'Real objects we hold and can locate, but which the catalogue barely describes. Each needs a title and a number.',
          count(*),
-         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', present_location)
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', present_location)
                   ORDER BY shelf_mark) FILTER (WHERE rn <= 25), '[]'::jsonb)
   FROM (
     SELECT w.*, row_number() OVER (ORDER BY w.shelf_mark) rn
@@ -68,7 +79,7 @@ LANGUAGE sql STABLE AS $$
          'Printed records with no title, shelf mark or UBN',
          'Probably residue from an old import rather than real holdings. Needs a decision: complete them, or remove them.',
          count(*),
-         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', author)
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', author)
                   ORDER BY id) FILTER (WHERE rn <= 25), '[]'::jsonb)
   FROM (
     SELECT w.*, row_number() OVER (ORDER BY w.id) rn
@@ -87,7 +98,7 @@ LANGUAGE sql STABLE AS $$
          'Records with no UBN',
          'These cannot be found by catalogue number, only by title. Mostly photocopies and manuscripts.',
          count(*),
-         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
                   ORDER BY id) FILTER (WHERE rn <= 25), '[]'::jsonb)
   FROM (
     SELECT w.*, public.bph_any_title(w) AS any_title, row_number() OVER (ORDER BY w.id) rn
@@ -102,7 +113,7 @@ LANGUAGE sql STABLE AS $$
          'State Collection shelf mark still reads "ja"',
          'Same import fault as the "neen" values that were cleared on 30 July. Emptying these would lose the only record that the copy IS on loan from the State Collection, so it needs your decision.',
          count(*),
-         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
                   ORDER BY ubn) FILTER (WHERE rn <= 25), '[]'::jsonb)
   FROM (
     SELECT w.*, public.bph_any_title(w) AS any_title, row_number() OVER (ORDER BY w.ubn) rn

--- a/scripts/migration/add-bph-worklist-rpc.sql
+++ b/scripts/migration/add-bph-worklist-rpc.sql
@@ -55,9 +55,14 @@ RETURNS TABLE (category text, label text, detail text, n bigint, samples jsonb)
 LANGUAGE sql STABLE AS $$
   -- Real physical objects, on a shelf, with no name and no catalogue number.
   -- The most interesting rows in the catalogue and currently invisible.
+  -- José Bouman answered this one on 2026-08-12: "These are indeed incomplete
+  -- descriptions and they will be enhanced (sooner or later). Leave them as
+  -- they are." So it stays visible as a known backlog, but it no longer asks
+  -- for a number — manuscripts never get one — and it no longer reads as a
+  -- question awaiting a decision that has already been made.
   SELECT 'undescribed_manuscripts',
-         'Manuscripts on the shelf with no title and no UBN',
-         'Real objects we hold and can locate, but which the catalogue barely describes. Each needs a title and a number.',
+         'Manuscripts on the shelf with no title yet',
+         'Known incomplete descriptions, to be enhanced when there is time (José, 12 Aug). Listed so they are not forgotten; nothing to decide.',
          count(*),
          COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', present_location)
                   ORDER BY shelf_mark) FILTER (WHERE rn <= 25), '[]'::jsonb)
@@ -92,26 +97,50 @@ LANGUAGE sql STABLE AS $$
 
   UNION ALL
 
-  -- No catalogue number at all. Findable by title, never by number — which is
-  -- how the BPH actually works day to day.
-  SELECT 'missing_ubn',
-         'Records with no UBN',
-         'These cannot be found by catalogue number, only by title. Mostly photocopies and manuscripts.',
+  -- Records with NO WAY TO FIND THE OBJECT: no catalogue number and no shelf
+  -- mark either.
+  --
+  -- This category used to be "Records with no UBN", all 2,012 of them, and it
+  -- was wrong in the way this file exists to prevent — it counted correct data
+  -- as a defect. José Bouman, 2026-08-12, answering it:
+  --
+  --   "Manuscripts never have a UBN, instead they have a manuscript number
+  --    (M+ number, or just a number, like 216, 217, 218). […] M-numbers
+  --    (manuscripts) and FOT-items don't have a UBN"
+  --
+  -- 1,771 of the 2,012 are exactly those manuscripts (812) and photocopies
+  -- (959), correctly catalogued, and no amount of librarian attention would
+  -- ever change them. Asking about them forever is how a worklist teaches
+  -- someone to stop opening it. What is genuinely actionable is a record with
+  -- neither identifier — nothing to search by and nothing to find on a shelf.
+  -- Measured 2026-08-13: 253 rows, of which 228 have no title either (they are
+  -- the empty_printed_stubs above) and 25 have a title but no location at all.
+  SELECT 'unfindable_records',
+         'Records with no UBN and no shelf mark',
+         'Nothing to look them up by and nothing to find them on a shelf with. Each needs an identifier, or removing.',
          count(*),
          COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
                   ORDER BY id) FILTER (WHERE rn <= 25), '[]'::jsonb)
   FROM (
     SELECT w.*, public.bph_any_title(w) AS any_title, row_number() OVER (ORDER BY w.id) rn
-    FROM bph_works w WHERE w.ubn IS NULL
+    FROM bph_works w
+    WHERE w.ubn IS NULL
+      AND (w.shelf_mark IS NULL OR TRIM(w.shelf_mark) = '')
   ) t
 
   UNION ALL
 
   -- The other half of the "neen" cleanup, deliberately left for a librarian:
   -- emptying "ja" would destroy the only trace that these copies ARE on loan.
+  -- Answered and swept on 2026-08-13: José chose "yes" over emptying, because
+  -- the value records that the copy IS on loan. The 31 rows were translated by
+  -- scripts/maintenance/translate-ja-state-shelfmark.mjs and the normaliser now
+  -- maps ja→yes at the write boundary, so this returns 0 and drops out of the
+  -- page. It is KEPT as a standing detector: a non-zero count here means a
+  -- Memorix re-import has reintroduced the Dutch.
   SELECT 'state_shelfmark_ja',
-         'State Collection shelf mark still reads "ja"',
-         'Same import fault as the "neen" values that were cleared on 30 July. Emptying these would lose the only record that the copy IS on loan from the State Collection, so it needs your decision.',
+         'State Collection shelf mark reads "ja" again',
+         'Cleared on 13 Aug (translated to "yes"). If this is non-zero, an import has put the Dutch back — the normaliser should have prevented it.',
          count(*),
          COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'uuid', uuid, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
                   ORDER BY ubn) FILTER (WHERE rn <= 25), '[]'::jsonb)

--- a/src/app/api/[tenant]/catalog/[ubn]/edit/route.ts
+++ b/src/app/api/[tenant]/catalog/[ubn]/edit/route.ts
@@ -9,6 +9,7 @@ import {
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { supabaseAdmin } from '@/lib/supabase';
+import { catalogKeyColumn } from '@/lib/bph-catalog-key';
 
 /**
  * POST /api/[tenant]/catalog/[ubn]/edit
@@ -171,10 +172,15 @@ export const POST = withAuth(
         { status: 500 },
       );
     }
+    // Key the proposal the same way a revision is keyed: by UBN when the record
+    // has one, by uuid for the 2,012 that don't. Both columns carry a FK to
+    // bph_works, so putting a uuid in `ubn` would be rejected outright.
+    const pendingKey =
+      catalogKeyColumn(ubn) === 'uuid' ? { ubn: null, work_uuid: ubn } : { ubn, work_uuid: null };
     const { data: inserted, error: insertErr } = await supabaseAdmin
       .from('bph_works_pending_changes')
       .insert({
-        ubn,
+        ...pendingKey,
         change_type: 'edit',
         proposer_email: userEmail,
         proposer_user_id: userId,

--- a/src/app/api/[tenant]/catalog/[ubn]/edit/route.ts
+++ b/src/app/api/[tenant]/catalog/[ubn]/edit/route.ts
@@ -175,8 +175,10 @@ export const POST = withAuth(
     // Key the proposal the same way a revision is keyed: by UBN when the record
     // has one, by uuid for the 2,012 that don't. Both columns carry a FK to
     // bph_works, so putting a uuid in `ubn` would be rejected outright.
-    const pendingKey =
-      catalogKeyColumn(ubn) === 'uuid' ? { ubn: null, work_uuid: ubn } : { ubn, work_uuid: null };
+    // work_uuid is only sent when it is actually needed, so a ubn-keyed
+    // proposal still inserts cleanly on an environment where
+    // add-bph-uuid-keyed-revisions.sql hasn't been applied yet.
+    const pendingKey = catalogKeyColumn(ubn) === 'uuid' ? { ubn: null, work_uuid: ubn } : { ubn };
     const { data: inserted, error: insertErr } = await supabaseAdmin
       .from('bph_works_pending_changes')
       .insert({

--- a/src/app/api/[tenant]/catalog/create/route.ts
+++ b/src/app/api/[tenant]/catalog/create/route.ts
@@ -33,6 +33,9 @@ import { getDb } from '@/lib/mongodb';
 
 const EDITABLE_SET = new Set<string>(EDITABLE_BPH_FIELDS);
 
+/** Record types Memorix issues no UBN for. Mirrors TYPES_WITHOUT_UBN in the form. */
+const UBN_OPTIONAL_TYPES = new Set(['manuscript', 'photocopy']);
+
 interface CreatePayload {
   ubn?: string;
   fieldChanges?: Record<string, { to: unknown; source?: string; evidence?: string }>;
@@ -112,16 +115,37 @@ export const POST = withAuth(
       return NextResponse.json({ error: 'Body is not valid JSON' }, { status: 400 });
     }
 
+    // Manuscripts and photographs have NO UBN — Memorix issues none, and the
+    // BPH writes UBNs into the physical book by hand, so inventing one would
+    // put a number in ink inside an object that is not supposed to carry one
+    // (José Bouman, 2026-08-13). Those records are keyed by a minted uuid and
+    // found by their manuscript number / shelf mark instead.
     const ubn = typeof payload.ubn === 'string' ? payload.ubn.trim() : '';
-    if (!ubn) {
-      return NextResponse.json({ error: 'A UBN (catalogue id) is required' }, { status: 400 });
-    }
-    if (!isValidUbn(ubn)) {
+    if (ubn && !isValidUbn(ubn)) {
       return NextResponse.json(
         { error: 'UBN may only contain letters, numbers, dot, dash and underscore (no spaces or slashes)' },
         { status: 400 },
       );
     }
+    const recordType = (payload.fieldChanges?.record_type?.to ?? null) as string | null;
+    if (!ubn && !UBN_OPTIONAL_TYPES.has(recordType ?? '')) {
+      return NextResponse.json(
+        {
+          error:
+            'A UBN (catalogue id) is required for printed books. Set the record type to Manuscript or Photograph if this object has no UBN.',
+        },
+        { status: 400 },
+      );
+    }
+    if (!ubn && !String(payload.fieldChanges?.shelf_mark?.to ?? '').trim()) {
+      return NextResponse.json(
+        { error: 'A record with no UBN needs a shelf mark (its manuscript number) — it is the only way to find the object.' },
+        { status: 400 },
+      );
+    }
+    // The key the revision hangs off. A uuid here makes applyWorkRevision write
+    // the row with ubn = NULL; see src/lib/bph-catalog.ts.
+    const key = ubn || crypto.randomUUID();
 
     const rawChanges = payload?.fieldChanges;
     if (!rawChanges || typeof rawChanges !== 'object' || Object.keys(rawChanges).length === 0) {
@@ -167,13 +191,15 @@ export const POST = withAuth(
 
     try {
       const result = await applyWorkRevision({
-        ubn,
+        ubn: key,
         changeType: 'create',
         fieldChanges,
         editorEmail: userEmail,
         note: typeof payload.note === 'string' ? payload.note : null,
       });
-      return NextResponse.json({ ok: true, mode: 'created', ubn, ...result });
+      // `key` is what the record is addressable by; `ubn` stays for callers
+      // that expect it and is empty for the no-UBN types.
+      return NextResponse.json({ ok: true, mode: 'created', ubn, key, ...result });
     } catch (err) {
       if (err instanceof BphCatalogError) {
         const msg = err.message;

--- a/src/app/api/[tenant]/catalog/pending/[id]/approve/route.ts
+++ b/src/app/api/[tenant]/catalog/pending/[id]/approve/route.ts
@@ -45,7 +45,7 @@ export const POST = withAuth(
     // 1. Fetch the pending row and lock-check that it's still pending.
     const { data: pendingRow, error: fetchErr } = await supabaseAdmin
       .from('bph_works_pending_changes')
-      .select('id, ubn, work_uuid, change_type, proposer_email, field_changes, note, status')
+      .select('id, ubn, change_type, proposer_email, field_changes, note, status')
       .eq('id', id)
       .maybeSingle();
     if (fetchErr) {
@@ -57,7 +57,6 @@ export const POST = withAuth(
     const row = pendingRow as {
       id: string;
       ubn: string | null;
-      work_uuid: string | null;
       change_type: string;
       proposer_email: string;
       field_changes: Record<string, { to: unknown; source?: string; evidence?: string; from?: unknown }>;
@@ -80,8 +79,19 @@ export const POST = withAuth(
     }
     // A proposal is keyed by UBN, or by uuid for the 2,012 records that have
     // no UBN (manuscripts, photographs). Requiring a UBN here rejected every
-    // contributor correction to a manuscript.
-    const workKey = row.ubn || row.work_uuid;
+    // contributor correction to a manuscript. work_uuid is read separately so
+    // an environment without add-bph-uuid-keyed-revisions.sql still approves
+    // ubn-keyed proposals normally.
+    let workUuidFromRow: string | null = null;
+    if (!row.ubn) {
+      const { data: extra } = await supabaseAdmin
+        .from('bph_works_pending_changes')
+        .select('work_uuid')
+        .eq('id', id)
+        .maybeSingle();
+      workUuidFromRow = (extra as { work_uuid?: string | null } | null)?.work_uuid ?? null;
+    }
+    const workKey = row.ubn || workUuidFromRow;
     if (!workKey) {
       return NextResponse.json({ error: 'Pending edit targets no work (neither UBN nor uuid)' }, { status: 400 });
     }

--- a/src/app/api/[tenant]/catalog/pending/[id]/approve/route.ts
+++ b/src/app/api/[tenant]/catalog/pending/[id]/approve/route.ts
@@ -45,7 +45,7 @@ export const POST = withAuth(
     // 1. Fetch the pending row and lock-check that it's still pending.
     const { data: pendingRow, error: fetchErr } = await supabaseAdmin
       .from('bph_works_pending_changes')
-      .select('id, ubn, change_type, proposer_email, field_changes, note, status')
+      .select('id, ubn, work_uuid, change_type, proposer_email, field_changes, note, status')
       .eq('id', id)
       .maybeSingle();
     if (fetchErr) {
@@ -57,6 +57,7 @@ export const POST = withAuth(
     const row = pendingRow as {
       id: string;
       ubn: string | null;
+      work_uuid: string | null;
       change_type: string;
       proposer_email: string;
       field_changes: Record<string, { to: unknown; source?: string; evidence?: string; from?: unknown }>;
@@ -77,8 +78,12 @@ export const POST = withAuth(
         { status: 400 },
       );
     }
-    if (!row.ubn) {
-      return NextResponse.json({ error: 'Pending edit has no UBN' }, { status: 400 });
+    // A proposal is keyed by UBN, or by uuid for the 2,012 records that have
+    // no UBN (manuscripts, photographs). Requiring a UBN here rejected every
+    // contributor correction to a manuscript.
+    const workKey = row.ubn || row.work_uuid;
+    if (!workKey) {
+      return NextResponse.json({ error: 'Pending edit targets no work (neither UBN nor uuid)' }, { status: 400 });
     }
 
     // 2. Re-validate field names against the current whitelist.
@@ -103,7 +108,7 @@ export const POST = withAuth(
     let revisionId: string;
     try {
       const result = await applyWorkRevision({
-        ubn: row.ubn,
+        ubn: workKey,
         changeType: 'edit',
         fieldChanges,
         editorEmail,

--- a/src/app/api/catalog/bph/export/route.ts
+++ b/src/app/api/catalog/bph/export/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { applyBphFilters, readBphFilters } from '@/lib/bph-catalog-filters';
+
+/**
+ * GET /api/catalog/bph/export — the current catalogue search, as a spreadsheet.
+ *
+ * Asked for by José Bouman (BPH), 2026-08-12:
+ *
+ *   "Is it possible to export a search selection? I would like to have all
+ *    books which have JRR in one of the fields.... This is an important
+ *    feature, that we often! use!"
+ *
+ * Takes exactly the query string the browsing API takes, and runs it through
+ * the SAME filter module (src/lib/bph-catalog-filters.ts) — so "export" always
+ * means "the rows I am looking at", never a near-miss. Only `offset`/`limit`
+ * are ignored: an export is the whole selection, not the visible page.
+ *
+ * Public, like the catalogue itself. The staff-only columns (internal_remarks,
+ * exhibition_history) are deliberately NOT in the export — they are not public
+ * on the detail page either, and an export is the easiest way to leak a field
+ * by accident. An editor-scoped export can be added later if the librarians
+ * want their working notes included.
+ */
+
+export const dynamic = 'force-dynamic';
+
+// Hard ceiling. The whole catalogue is ~29,900 rows, so this exports everything
+// even unfiltered; it exists to bound memory, not to trim results. If a future
+// catalogue outgrows it the response says so in a trailing note rather than
+// silently truncating — a short export that looks complete is the failure mode
+// worth engineering against.
+const MAX_ROWS = 50_000;
+const PAGE = 1000; // supabase-js silently caps a select at 1000 rows
+
+// Column order follows the catalogue card: what a librarian reads first comes
+// first. `full_title` sits beside `title` because manuscripts use one and
+// printed books the other.
+const EXPORT_COLUMNS: Array<{ key: string; header: string }> = [
+  { key: 'ubn', header: 'UBN' },
+  { key: 'record_type', header: 'Record type' },
+  { key: 'shelf_mark', header: 'Shelf mark' },
+  { key: 'state_shelf_mark', header: 'State Collection shelf mark' },
+  { key: 'present_location', header: 'Present location' },
+  { key: 'title', header: 'Short title' },
+  { key: 'full_title', header: 'Full title' },
+  { key: 'parallel_title', header: 'Full title (transcription)' },
+  { key: 'uniform_title', header: 'Variant title' },
+  { key: 'series_title', header: 'Series' },
+  { key: 'volume_title', header: 'Volume' },
+  { key: 'author', header: 'Author' },
+  { key: 'variant_author', header: 'Author (as on title page)' },
+  { key: 'pseudonym', header: 'Pseudonym' },
+  { key: 'editor', header: 'Editor / translator' },
+  { key: 'variant_editor', header: 'Editor (as on title page)' },
+  { key: 'year', header: 'Year' },
+  { key: 'place', header: 'Place' },
+  { key: 'printer', header: 'Printer' },
+  { key: 'publisher', header: 'Publisher' },
+  { key: 'impressum_original', header: 'Original impressum' },
+  { key: 'language', header: 'Language' },
+  { key: 'keywords', header: 'Keywords' },
+  { key: 'object_size_cm', header: 'Object size (cm)' },
+  { key: 'bibliographic_format', header: 'Format' },
+  { key: 'number_of_copies', header: 'Copies held' },
+  { key: 'binding', header: 'Binding' },
+  { key: 'bound_with', header: 'Bound with' },
+  { key: 'provenance', header: 'Provenance' },
+  { key: 'collection', header: 'Collection' },
+  { key: 'bibliography', header: 'Bibliography' },
+  { key: 'remarks', header: 'Remarks' },
+  { key: 'ustc_sn', header: 'USTC' },
+  { key: 'ia_identifier', header: 'Internet Archive id' },
+  { key: 'uuid', header: 'Record id' },
+];
+
+/**
+ * RFC 4180 quoting, plus a leading apostrophe on anything a spreadsheet would
+ * execute. A catalogue field can legitimately begin with "=" or "-" (a shelf
+ * mark, a transcribed title), and Excel treats those as formulas — CSV
+ * injection, and a real hazard for a file a librarian opens by double-clicking.
+ */
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  let s = String(value);
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  if (/[",\n\r]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export async function GET(req: NextRequest) {
+  const filters = readBphFilters(req.nextUrl.searchParams);
+
+  const rows: Array<Record<string, unknown>> = [];
+  let truncated = false;
+
+  for (let offset = 0; offset < MAX_ROWS; offset += PAGE) {
+    let query = supabase.from('bph_works').select(EXPORT_COLUMNS.map((c) => c.key).join(', '));
+    query = applyBphFilters(query, filters, {
+      mode: 'new',
+      hasNormalizedColumns: true,
+      hasFirstTranslationColumn: true,
+    });
+    const { data, error } = await query.range(offset, offset + PAGE - 1);
+    if (error) {
+      console.error('[catalog/bph/export] query failed:', error);
+      return NextResponse.json({ error: 'Export failed — please try again' }, { status: 500 });
+    }
+    const page = (data ?? []) as unknown as Array<Record<string, unknown>>;
+    rows.push(...page);
+    if (page.length < PAGE) break;
+    if (rows.length >= MAX_ROWS) {
+      truncated = true;
+      break;
+    }
+  }
+
+  const lines = [EXPORT_COLUMNS.map((c) => csvEscape(c.header)).join(',')];
+  for (const row of rows) {
+    lines.push(EXPORT_COLUMNS.map((c) => csvEscape(row[c.key])).join(','));
+  }
+  // Never let a cap pass for a complete answer.
+  if (truncated) {
+    lines.push('');
+    lines.push(csvEscape(`NOTE: export capped at ${MAX_ROWS} rows — narrow the search and export again.`));
+  }
+
+  // A named, dated file: a librarian ends up with several of these in Downloads
+  // and needs to tell them apart. The search term goes in the name when there
+  // is one, reduced to characters a filesystem is happy with.
+  const stamp = new Date().toISOString().slice(0, 10);
+  const termRaw = filters.q || filters.author || filters.title || filters.shelfMark || '';
+  const term = termRaw.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+  const filename = `bph-catalogue${term ? `-${term}` : ''}-${stamp}.csv`;
+
+  // The BOM makes Excel read it as UTF-8; without it, every "Böhme" in the
+  // export opens as "BÃ¶hme" on a default Windows install.
+  return new NextResponse(`﻿${lines.join('\r\n')}\r\n`, {
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': `attachment; filename="${filename}"`,
+      'cache-control': 'no-store',
+    },
+  });
+}

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase, sanitizeFilterValue } from '@/lib/supabase';
-import { normalizeBphSearchText } from '@/lib/text-normalize';
+import { supabase } from '@/lib/supabase';
+import { applyBphFilters, readBphFilters, isUnfiltered } from '@/lib/bph-catalog-filters';
 import { getReadDb } from '@/lib/mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { logSearchEvent } from '@/lib/search-event-log';
@@ -86,45 +86,21 @@ function isMissingColumnError(err: { message?: string; code?: string }): boolean
 export async function GET(req: NextRequest) {
   const sp = req.nextUrl.searchParams;
 
-  // Simple search.
-  const q = sp.get('q')?.trim() || '';
+  // Filters + sort are parsed and applied by the shared module the CSV export
+  // also uses, so the two surfaces can never diverge.
+  const filters = readBphFilters(sp);
+  const {
+    q, firstTranslation, sort, language, yearFrom, yearTo, digitized,
+    author, title, place, printer, publisher, editor, keyword, shelfMark, provenance,
+  } = filters;
 
-  // Per-field advanced search.
-  const author = sp.get('author')?.trim() || '';
-  const title = sp.get('title')?.trim() || '';
-  const place = sp.get('place')?.trim() || '';
-  const printer = sp.get('printer')?.trim() || '';
-  const publisher = sp.get('publisher')?.trim() || '';
-  const editor = sp.get('editor')?.trim() || '';
-  const keyword = sp.get('keyword')?.trim() || '';
-  const language = sp.get('language')?.trim() || '';
-  const shelfMark = sp.get('shelf_mark')?.trim() || '';
-  const provenance = sp.get('provenance')?.trim() || '';
-
-  const yearFrom = sp.get('yearFrom') ? parseInt(sp.get('yearFrom')!, 10) : null;
-  const yearTo = sp.get('yearTo') ? parseInt(sp.get('yearTo')!, 10) : null;
-
-  const digitized = sp.get('digitized'); // 'true' | 'false' | 'sl' | null
-
-  // First-translation filter: denormalised onto `bph_works.is_first_translation`
-  // by the sync-bph-sl-book-ids cron (and one-shot backfill at
-  // scripts/migration/backfill-bph-first-translation.mjs). Implicitly digitised-on-SL —
-  // only rows with a non-null sl_book_id can carry the flag.
-  const firstTranslation = sp.get('first_translation') === '1';
-
-  const sort = sp.get('sort') || 'title';
   const offset = Math.max(0, parseInt(sp.get('offset') || '0', 10) || 0);
   const limit = Math.min(200, Math.max(1, parseInt(sp.get('limit') || String(PER_PAGE), 10) || PER_PAGE));
 
   // Default unfiltered "digitised on Source Library" view: skip the COUNT(*)
   // and return the pinned 2,222. Any filter / search / advanced field falls
   // through to the normal exact-count path.
-  const isPinnedDigitizedView =
-    digitized === 'sl' &&
-    !q && !author && !title && !place && !printer && !publisher && !editor &&
-    !keyword && !language && !shelfMark && !provenance &&
-    yearFrom === null && yearTo === null &&
-    !firstTranslation;
+  const isPinnedDigitizedView = filters.digitized === 'sl' && isUnfiltered(filters);
 
   // Run the query in the requested mode. Returns the supabase result object.
   async function runQuery(mode: 'new' | 'legacy') {
@@ -141,174 +117,15 @@ export async function GET(req: NextRequest) {
       .from('bph_works')
       .select(fields, isPinnedDigitizedView ? { count: 'planned', head: false } : { count: 'exact' });
 
-    // Simple search. When the diacritic-normalised `search_norm` column
-    // exists (after applying add-bph-diacritic-normalization.sql), query
-    // against it with the normalised user input so "Boehme" finds "Böhme".
-    // Falls back to the original tsvector / per-field ilike on first miss.
-    if (q.length >= 2) {
-      // A bare 3–4 digit query is almost always a publication year, so also
-      // match the numeric `year` column — the text columns / tsvector don't
-      // include the year, so "1545" otherwise returned nothing. Digits-only,
-      // so it's safe to inline in an .or() string.
-      const yearQ = /^\d{3,4}$/.test(q) ? q : null;
-      // UBN gets its own lane rather than living in `search_norm`. That column
-      // is matched with ILIKE '%q%' and UBNs are 1–5 digit numbers, so folding
-      // them in would make every year search also match the UBNs containing
-      // those digits (1545 would drag in 15450–15459, 11545, 21545, 31545…).
-      // Exact match for an all-digit query is what "search by UBN" means;
-      // non-numeric UBNs ("BPH 131", "PH144", "PH 2") still need a substring
-      // match. Reported by José Bouman (BPH) — searching a UBN returned nothing.
-      const digitsOnly = /^\d+$/.test(q);
-      const ubnLane = digitsOnly
-        ? `ubn.eq.${q}`
-        : `ubn.ilike.%${sanitizeFilterValue(q)}%`;
-      if (mode === 'new' && hasNormalizedColumns !== false) {
-        if (yearQ) {
-          query = query.or(`search_norm.ilike.%${yearQ}%,year.eq.${yearQ},${ubnLane}`);
-        } else {
-          const normQ = sanitizeFilterValue(normalizeBphSearchText(q));
-          if (normQ.length > 0) {
-            query = query.or(`search_norm.ilike.%${normQ}%,${ubnLane}`);
-          } else {
-            query = query.or(ubnLane);
-          }
-        }
-      } else if (mode === 'new') {
-        if (yearQ) {
-          // A tsvector match can't be OR'd with a column filter in a single
-          // .or(); for a pure year, match the year column directly.
-          query = query.eq('year', Number(yearQ));
-        } else {
-          const safe = sanitizeFilterValue(q);
-          query = query.textSearch('search_tsv', safe, { type: 'websearch', config: 'simple' });
-        }
-      } else {
-        const safe = sanitizeFilterValue(q);
-        if (yearQ) {
-          query = query.or(`title.ilike.%${yearQ}%,author.ilike.%${yearQ}%,shelf_mark.ilike.%${yearQ}%,year.eq.${yearQ}`);
-        } else {
-          query = query.or(`title.ilike.%${safe}%,author.ilike.%${safe}%,shelf_mark.ilike.%${safe}%`);
-        }
-      }
-    }
-
-    const ilikeFilter = (col: string, val: string) => {
-      if (!val) return;
-      const safe = sanitizeFilterValue(val);
-      const normVal = sanitizeFilterValue(normalizeBphSearchText(val));
-      const useNorm = mode === 'new' && hasNormalizedColumns !== false && normVal.length > 0;
-
-      if (mode === 'new') {
-        // Per-field `*_norm` columns roll up the standard field with its
-        // variants (e.g. author_norm covers author + variant_author +
-        // pseudonym), so one ilike replaces the previous .or() chain.
-        if (useNorm) {
-          const normCol = col === 'shelf_mark' ? 'shelf_mark_norm' : `${col}_norm`;
-          query = query.ilike(normCol, `%${normVal}%`);
-          return;
-        }
-        if (col === 'author') {
-          query = query.or(`author.ilike.%${safe}%,variant_author.ilike.%${safe}%,pseudonym.ilike.%${safe}%`);
-        } else if (col === 'title') {
-          query = query.or(`title.ilike.%${safe}%,parallel_title.ilike.%${safe}%,uniform_title.ilike.%${safe}%`);
-        } else if (col === 'editor') {
-          query = query.or(`editor.ilike.%${safe}%,variant_editor.ilike.%${safe}%`);
-        } else if (col === 'printer') {
-          query = query.or(`printer.ilike.%${safe}%,variant_printer.ilike.%${safe}%`);
-        } else if (col === 'publisher') {
-          query = query.or(`publisher.ilike.%${safe}%,variant_publisher.ilike.%${safe}%`);
-        } else if (col === 'shelf_mark') {
-          query = query.or(`shelf_mark.ilike.%${safe}%,state_shelf_mark.ilike.%${safe}%`);
-        } else {
-          query = query.ilike(col, `%${safe}%`);
-        }
-      } else {
-        // Legacy schema only has author, title, place, printer, publisher, shelf_mark.
-        if (['author', 'title', 'place', 'printer', 'publisher', 'shelf_mark'].includes(col)) {
-          query = query.ilike(col, `%${safe}%`);
-        }
-        // editor / language / provenance not available in legacy; silently dropped.
-      }
-    };
-    ilikeFilter('author', author);
-    ilikeFilter('title', title);
-    ilikeFilter('editor', editor);
-    ilikeFilter('place', place);
-    ilikeFilter('printer', printer);
-    ilikeFilter('publisher', publisher);
-    ilikeFilter('shelf_mark', shelfMark);
-
-    if (keyword) query = query.eq('keywords', keyword);
-    if (mode === 'new') {
-      if (language) query = query.eq('language', language);
-      if (provenance) query = query.eq('provenance', provenance);
-    }
-
-    if (yearFrom !== null && !Number.isNaN(yearFrom)) query = query.gte('year', yearFrom);
-    if (yearTo !== null && !Number.isNaN(yearTo)) query = query.lte('year', yearTo);
-
-    if (digitized === 'true') {
-      if (mode === 'new') {
-        query = query.or('sl_book_id.not.is.null,ia_identifier.not.is.null');
-      } else {
-        query = query.not('ia_identifier', 'is', null);
-      }
-    } else if (digitized === 'sl' && mode === 'new') {
-      query = query.not('sl_book_id', 'is', null);
-    } else if (digitized === 'held' && mode === 'new') {
-      // Catalogue entries with a non-null `present_location` are books
-      // physically in the building (Leeszaal, Depot, …). Catalog-only
-      // references and works held elsewhere have null present_location.
-      // Requested by Paul Dijstelberge (BPH) — visitors wanted a way to see
-      // just the volumes they could ask to consult on site.
-      query = query.not('present_location', 'is', null);
-    } else if (digitized === 'false') {
-      if (mode === 'new') {
-        query = query.is('sl_book_id', null).is('ia_identifier', null);
-      } else {
-        query = query.is('ia_identifier', null);
-      }
-    }
-
-    // First-translation filter — denormalised column on bph_works. Falls back
-    // to "return nothing" on the legacy schema or runtimes that booted before
-    // the migration ran (auto-detected via the retry path below).
-    if (firstTranslation) {
-      if (mode === 'new' && hasFirstTranslationColumn !== false) {
-        query = query.eq('is_first_translation', true);
-      } else {
-        // No column → return nothing. PostgREST doesn't have a clean
-        // "always false" predicate; use a sentinel that can't appear
-        // in sl_book_id.
-        query = query.eq('sl_book_id', '__no_first_translations__');
-      }
-    }
-
-    switch (sort) {
-      case 'year_asc':
-        query = query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
-        break;
-      case 'year_desc':
-        query = query.order('year', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
-        break;
-      case 'author':
-        query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
-        break;
-      case 'author_desc':
-        query = query.order('author', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
-        break;
-      case 'title_desc':
-        // nullsFirst:false matches every other sort — Supabase otherwise puts
-        // null titles ahead of real ones for descending sorts, which renders
-        // five "None" rows at the top of an unfiltered desc listing.
-        query = query.order('title', { ascending: false, nullsFirst: false });
-        break;
-      case 'shelfmark':
-        query = query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
-        break;
-      default:
-        query = query.order('title', { ascending: true });
-    }
+    // Every user-facing filter and the sort live in src/lib/bph-catalog-filters.ts,
+    // shared with the CSV export route so the two can never match different
+    // sets. Schema-mode fallbacks stay here — they are about what the database
+    // can answer, not about what the user asked for.
+    query = applyBphFilters(query, filters, {
+      mode,
+      hasNormalizedColumns: hasNormalizedColumns !== false,
+      hasFirstTranslationColumn: hasFirstTranslationColumn !== false,
+    });
 
     return await query.range(offset, offset + limit - 1);
   }

--- a/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
@@ -7,6 +7,7 @@ import { ROLE_LEVEL } from '@/lib/auth';
 import { effectiveCatalogRole, normalizeCatalogRole } from '@/lib/catalog-role';
 import { getDb } from '@/lib/mongodb';
 import { EDITABLE_BPH_FIELDS } from '@/lib/bph-catalog';
+import { catalogKeyColumn } from '@/lib/bph-catalog-key';
 import BphWorkEditForm from '@/components/catalog/BphWorkEditForm';
 
 /**
@@ -72,18 +73,26 @@ export default async function EditCatalogEntryPage({ params }: Props) {
   // from 20260624000000), retry without them. The form silently shows those
   // fields empty, and a save would fail at write time with the same error —
   // the right behaviour (don't pretend to save what we can't write).
-  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original', 'contributors', 'exhibition_history'];
-  const cols = ['ubn', ...EDITABLE_BPH_FIELDS, 'field_provenance', 'sl_book_id'].join(', ');
-  const fallbackCols = ['ubn', ...EDITABLE_BPH_FIELDS.filter((c) => !maybeMissingCols.includes(c)), 'field_provenance', 'sl_book_id'].join(', ');
+  // `record_type` and `full_title` are newer whitelist entries; drop them too
+  // if their migration hasn't run on this environment.
+  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original', 'contributors', 'exhibition_history', 'record_type', 'full_title'];
+  const cols = ['ubn', 'uuid', ...EDITABLE_BPH_FIELDS, 'field_provenance', 'sl_book_id'].join(', ');
+  const fallbackCols = ['ubn', 'uuid', ...EDITABLE_BPH_FIELDS.filter((c) => !maybeMissingCols.includes(c)), 'field_provenance', 'sl_book_id'].join(', ');
+  // Address by UBN or, for the 2,012 records that have none, by uuid — the same
+  // shape rule the detail route uses. This page queried `ubn` unconditionally
+  // until 2026-08-13, so every manuscript and photograph 404'd here even after
+  // #3654 made them viewable: "It is not possible to click on titles with a
+  // shelf mark M (+number) […] to edit them" (José Bouman, 2026-07-31).
+  const keyCol = catalogKeyColumn(ubn);
   let { data, error } = await supabase
     .from('bph_works')
     .select(cols)
-    .eq('ubn', ubn)
+    .eq(keyCol, ubn)
     .maybeSingle();
   if (error) {
     const msg = (error.message || '').toLowerCase();
     if (msg.includes('does not exist') || msg.includes('could not find')) {
-      const retry = await supabase.from('bph_works').select(fallbackCols).eq('ubn', ubn).maybeSingle();
+      const retry = await supabase.from('bph_works').select(fallbackCols).eq(keyCol, ubn).maybeSingle();
       data = retry.data;
       error = retry.error;
     }
@@ -91,7 +100,11 @@ export default async function EditCatalogEntryPage({ params }: Props) {
 
   if (error || !data) notFound();
 
-  const work = data as unknown as Record<string, unknown> & { ubn: string };
+  const work = data as unknown as Record<string, unknown> & { ubn: string | null; uuid: string | null; shelf_mark?: string | null };
+  // The key the form saves back through: UBN when the record has one, else the
+  // uuid. Never null — a row with neither key is unaddressable, and production
+  // has zero of those (verified across all 29,881 rows, 2026-08-13).
+  const workKey = work.ubn || work.uuid || ubn;
 
   return (
     <div className="bg-cream min-h-screen">
@@ -106,11 +119,14 @@ export default async function EditCatalogEntryPage({ params }: Props) {
           Edit catalogue entry
         </h1>
         <p className="text-sm text-muted mb-6">
-          UBN {work.ubn} · Signed in as {session.user.email}
+          {/* Manuscripts and photographs have no UBN — naming one would be a
+              lie, and the shelf mark is what a librarian actually uses to find
+              the object on the shelf. */}
+          {work.ubn ? `UBN ${work.ubn}` : `Shelf mark ${work.shelf_mark || '—'} · no UBN`} · Signed in as {session.user.email}
         </p>
 
         <BphWorkEditForm
-          ubn={work.ubn}
+          ubn={workKey}
           tenant={tenant}
           initial={work}
           editorEmail={session.user.email || ''}

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -159,8 +159,19 @@ interface SlBook {
 }
 
 async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
-  // Either a UBN or, for the 2,012 records Memorix issues no UBN for, a uuid.
-  const col = catalogKeyColumn(ubn);
+  const row = await fetchWorkBy(catalogKeyColumn(ubn), ubn);
+  if (row) return row;
+  // Second chance on the primary key. `bph_works.id` is a DIFFERENT uuid from
+  // `bph_works.uuid`, and until 2026-08-13 the workspace worklist built its
+  // sample links from `id` — so every link a librarian copied or bookmarked out
+  // of "Needs your attention" addresses a key `catalogKeyColumn` sends to the
+  // `uuid` column, where it matches nothing (José Bouman, 2026-08-12). The RPC
+  // now emits `uuid`, but those older links are already out in the world.
+  if (catalogKeyColumn(ubn) === 'uuid') return fetchWorkBy('id', ubn);
+  return null;
+}
+
+async function fetchWorkBy(col: 'ubn' | 'uuid' | 'id', ubn: string): Promise<BphWorkRow | null> {
   // Try with the external-link columns first; if the column doesn't exist yet
   // (migration not applied on this environment), retry without them so the
   // page still renders.

--- a/src/app/embed/[tenant]/catalog/workspace/page.tsx
+++ b/src/app/embed/[tenant]/catalog/workspace/page.tsx
@@ -41,7 +41,11 @@ interface WorklistRow {
   label: string;
   detail: string;
   n: number;
-  samples: Array<{ ubn: string | null; id: string; shelf_mark: string | null; hint: string | null }>;
+  // `uuid` is the linkable key when `ubn` is null; `id` is a different uuid and
+  // is carried for debugging only. Optional because the pending_contributions
+  // category comes from bph_works_pending_changes, which has no uuid column —
+  // its rows always carry a ubn, so they never need the fallback.
+  samples: Array<{ ubn: string | null; uuid?: string | null; id: string; shelf_mark: string | null; hint: string | null }>;
 }
 
 interface RevisionRow {
@@ -234,11 +238,16 @@ export default async function CatalogueWorkspacePage({ params }: Props) {
                   {w.samples.slice(0, 12).map((s, i) => (
                     <a
                       key={`${w.category}-${s.id}-${i}`}
-                      href={`/catalog/${encodeURIComponent(s.ubn || s.id)}`}
+                      // ubn → uuid, never `id`. Three of these categories select
+                      // exactly the rows where ubn IS NULL, so the fallback is
+                      // the link for all 2,012 of them; `bph_works.id` is a
+                      // DIFFERENT uuid from `bph_works.uuid` and resolves to
+                      // nothing (José Bouman, 2026-08-12). See the RPC header.
+                      href={`/catalog/${encodeURIComponent(s.ubn || s.uuid || s.id)}`}
                       className="text-accent-rust hover:underline"
                       title={s.hint || undefined}
                     >
-                      {s.ubn || s.shelf_mark || s.id.slice(0, 8)}
+                      {s.ubn || s.shelf_mark || (s.uuid || s.id).slice(0, 8)}
                     </a>
                   ))}
                   {Number(w.n) > 12 && <span className="text-muted">+{n(Number(w.n) - 12)} more</span>}

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -51,6 +51,10 @@ const SECTIONS: Array<{
     title: 'Title',
     fields: [
       { name: 'title', label: 'Short title' },
+      // Manuscripts are titled here, not in `title`: 663 of the 812 manuscripts
+      // carry full_title and NONE carry title. It was missing from this form
+      // entirely, which made a manuscript's title uneditable anywhere in the UI.
+      { name: 'full_title', label: 'Full title', type: 'textarea' },
       { name: 'parallel_title', label: 'Full title (transcription)', type: 'textarea' },
       { name: 'uniform_title', label: 'Variant title' },
       { name: 'series_title', label: 'Series' },
@@ -138,6 +142,54 @@ const SECTIONS: Array<{
   },
 ];
 
+/**
+ * What kind of object a record describes. Constrained enum `bph_record_type`;
+ * production holds exactly these three (28,110 · 959 · 812, measured
+ * 2026-08-13). Order is most-common-first so the default sits at the top.
+ */
+const RECORD_TYPES = [
+  { value: 'printed', label: 'Printed book', hint: 'Has a UBN. The default for the collection.' },
+  { value: 'manuscript', label: 'Manuscript', hint: 'Identified by its manuscript number (M 341, or bare 216). No UBN.' },
+  { value: 'photocopy', label: 'Photograph / photocopy', hint: 'The Fot series. No UBN.' },
+] as const;
+
+type RecordType = (typeof RECORD_TYPES)[number]['value'];
+
+/**
+ * The fields a manuscript record actually uses, measured across all 812
+ * manuscripts in production (2026-08-13). Everything else is 0.0% populated —
+ * no manuscript has a title, ubn, place, year, printer, publisher, keywords or
+ * number_of_copies, because those describe an edition coming off a press and a
+ * manuscript is a unique object.
+ *
+ *   shelf_mark 100%  ·  full_title 82%  ·  uniform_title 70%  ·  author 64%
+ *   language 48%  ·  object_size_cm 47%  ·  remarks 41%  ·  binding 29%
+ *   provenance 22%  ·  bibliography 15%
+ *
+ * This is what "the same format as those already catalogued" means concretely
+ * (José Bouman, 2026-08-13). present_location and the two staff-only note
+ * fields are included as well — they apply to any physical object we hold.
+ */
+const MANUSCRIPT_FIELDS = new Set<string>([
+  'full_title', 'uniform_title',
+  'author', 'variant_author', 'pseudonym',
+  'author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'author_viaf_id',
+  'language',
+  'object_size_cm', 'binding', 'bound_with',
+  'present_location', 'shelf_mark', 'provenance', 'collection',
+  'bibliography', 'remarks', 'internal_remarks', 'exhibition_history',
+]);
+
+/** Photographs use the same reduced shape as manuscripts. */
+const FIELDS_BY_TYPE: Record<RecordType, Set<string> | null> = {
+  printed: null, // null = show everything
+  manuscript: MANUSCRIPT_FIELDS,
+  photocopy: MANUSCRIPT_FIELDS,
+};
+
+/** Records of these types carry no UBN, so the create form must not demand one. */
+const TYPES_WITHOUT_UBN = new Set<RecordType>(['manuscript', 'photocopy']);
+
 /** Normalise the stored `contributors` JSONB into editable rows. */
 function parseContributors(v: unknown): BphContributor[] {
   if (!Array.isArray(v)) return [];
@@ -215,6 +267,28 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
     () => JSON.stringify(cleanContributors(contributors)) !== JSON.stringify(cleanContributors(initialContributors)),
     [contributors, initialContributors],
   );
+  // What kind of object this record describes. Drives which fields the form
+  // shows and whether a UBN is required at all. Editable on existing records
+  // too: 252 rows with an "M …" shelf mark are typed `printed`, and a librarian
+  // needs to be able to correct that.
+  const initialRecordType = ((): RecordType => {
+    const v = initial.record_type;
+    return RECORD_TYPES.some((t) => t.value === v) ? (v as RecordType) : 'printed';
+  })();
+  const [recordType, setRecordType] = useState<RecordType>(initialRecordType);
+  const needsUbn = !TYPES_WITHOUT_UBN.has(recordType);
+
+  // Sections/fields filtered to the chosen record type. Hidden fields stay in
+  // the list (they carry the author-authority quad) — the filter is about which
+  // *kinds of description* apply to this object, not about the render.
+  const visibleSections = useMemo(() => {
+    const allowed = FIELDS_BY_TYPE[recordType];
+    if (!allowed) return SECTIONS;
+    return SECTIONS.map((s) => ({ ...s, fields: s.fields.filter((f) => allowed.has(f.name)) })).filter(
+      (s) => s.fields.length > 0,
+    );
+  }, [recordType]);
+
   const [createUbn, setCreateUbn] = useState(suggestedUbn || '');
   const [source, setSource] = useState('');
   const [evidence, setEvidence] = useState('');
@@ -236,13 +310,26 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
     return changed;
   }, [values, initial]);
 
+  const recordTypeChanged = recordType !== initialRecordType;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (isCreate && !createUbn.trim()) {
+    // Only printed books have a UBN. Demanding one for a manuscript is what
+    // blocked José Bouman from cataloguing them at all (2026-08-13); the record
+    // is addressed by its uuid instead, and found by its manuscript number.
+    if (isCreate && needsUbn && !createUbn.trim()) {
       setError('Give the new record a UBN (catalogue id).');
       return;
     }
-    if (changedFields.length === 0 && !contributorsChanged) {
+    if (isCreate && !needsUbn && !values['shelf_mark']?.trim()) {
+      setError(
+        recordType === 'manuscript'
+          ? 'Give the manuscript its number (e.g. “M 341” or “216”) in the Shelf mark field — it is how the object is found.'
+          : 'Give the record its shelf mark (e.g. “Fot 118”) — it is how the object is found.',
+      );
+      return;
+    }
+    if (changedFields.length === 0 && !contributorsChanged && !recordTypeChanged) {
       setError(isCreate ? 'Add at least a title before saving.' : 'No fields have changed — nothing to save.');
       return;
     }
@@ -274,6 +361,17 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
     }
     // Repeatable contributors are a single JSONB field, edited outside the flat
     // value map — include the cleaned array when it changed.
+    // record_type lives outside the flat value map (it's a radio group, and it
+    // decides what the rest of the form shows). Always sent on create so a new
+    // record is typed rather than left null — an untyped record can never
+    // appear in the worklist buckets that filter on record_type.
+    if (recordTypeChanged || isCreate) {
+      fieldChanges.record_type = {
+        to: recordType,
+        source: source.trim(),
+        ...(evidence.trim() ? { evidence: evidence.trim() } : {}),
+      };
+    }
     if (contributorsChanged) {
       fieldChanges.contributors = {
         to: cleanContributors(contributors),
@@ -290,7 +388,9 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          ...(isCreate ? { ubn: createUbn.trim() } : {}),
+          // A UBN-less record sends no ubn at all; the API mints a uuid to key
+          // it by. Sending '' would read as "a UBN I forgot to fill in".
+          ...(isCreate && needsUbn ? { ubn: createUbn.trim() } : {}),
           fieldChanges,
           ...(note.trim() ? { note: note.trim() } : {}),
         }),
@@ -301,12 +401,19 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         setSubmitting(false);
         return;
       }
-      const body = (await res.json()) as { mode?: 'applied' | 'queued' | 'created'; pendingId?: string; ubn?: string };
+      const body = (await res.json()) as {
+        mode?: 'applied' | 'queued' | 'created';
+        pendingId?: string;
+        ubn?: string;
+        key?: string;
+      };
       if (body.mode === 'created') {
         // New record is live. Land the cataloguer on it so they can see the
-        // entry they just made (and its first history row).
-        const newUbn = body.ubn || createUbn.trim();
-        router.push(`/catalog/${encodeURIComponent(newUbn)}`);
+        // entry they just made (and its first history row). `key` is the
+        // addressable id — the UBN for printed books, the minted uuid for
+        // manuscripts and photographs, which have no UBN to navigate by.
+        const newKey = body.key || body.ubn || createUbn.trim();
+        router.push(`/catalog/${encodeURIComponent(newKey)}`);
         router.refresh();
         return;
       }
@@ -370,33 +477,79 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         </div>
       )}
 
-      {/* Create mode — new-record intro + the catalogue id. The UBN is
-          pre-filled with a safe Source-Library id (SL-…) but editors can
-          replace it with a real BPH UBN if the record already has one. */}
-      {isCreate && (
+      {/* What is being catalogued. First question on the form, because it
+          decides which fields the rest of it shows and whether a UBN applies
+          at all — "the blank form should show other fields than the one for
+          printed books. No UBN required." (José Bouman, 2026-08-13) */}
+      <div className="p-4 bg-white border border-border-light rounded-lg">
+        <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">
+          {isCreate ? 'What are you cataloguing?' : 'Kind of record'}
+        </h2>
+        <div className="space-y-2">
+          {RECORD_TYPES.map((t) => (
+            <label key={t.value} className="flex items-start gap-2.5 cursor-pointer">
+              <input
+                type="radio"
+                name="record_type"
+                value={t.value}
+                checked={recordType === t.value}
+                onChange={() => setRecordType(t.value)}
+                className="mt-1 accent-accent-rust"
+              />
+              <span className="text-sm">
+                <span className="text-primary font-medium">{t.label}</span>
+                {recordTypeChanged && recordType === t.value && (
+                  <span className="ml-2 text-[10px] uppercase text-accent-rust font-medium">changed</span>
+                )}
+                <span className="block text-xs text-muted">{t.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Create mode — the catalogue id, for the record types that have one.
+          Pre-filled from the 33,000+ allocation range (José Bouman, 2026-07-15:
+          the UBN gets written into the physical book by hand, so it must be a
+          plain number in the BPH's own sequence). */}
+      {isCreate && needsUbn && (
         <div className="p-4 bg-white border border-border-light rounded-lg">
           <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">New catalogue record</h2>
           <FormField
             label="UBN (catalogue id) *"
-            hint="Pre-filled with a Source-Library id. Replace it with the BPH UBN if this record already has one. Letters, numbers, dot, dash, underscore only."
+            hint="Pre-filled with the next free number in the BPH range. Replace it if this record already has a UBN. Letters, numbers, dot, dash, underscore only."
           >
             <input
               type="text"
               value={createUbn}
               onChange={(e) => setCreateUbn(e.target.value)}
               className="w-full text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary font-mono focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
-              placeholder="SL-000001"
+              placeholder={suggestedUbn || '33000'}
             />
           </FormField>
         </div>
       )}
 
-      {/* Edit mode — surface the UBN (catalogue id) read-only so the cataloguer
-          always sees which record they're editing (Paul D., 2026-06-24). The
-          UBN is the primary key and isn't changed through this form. */}
+      {/* Create mode, no-UBN types — say plainly that this is correct, not a
+          field we forgot. The shelf mark below carries the identity. */}
+      {isCreate && !needsUbn && (
+        <div className="p-4 bg-white border border-border-light rounded-lg">
+          <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-1">No UBN</h2>
+          <p className="text-sm text-secondary">
+            {recordType === 'manuscript'
+              ? 'Manuscripts have no UBN. Give this one its manuscript number in the Shelf mark field below — “M 341”, or a bare number like “216”.'
+              : 'Photographs have no UBN. Give this one its shelf mark in the field below — e.g. “Fot 118”.'}
+          </p>
+        </div>
+      )}
+
+      {/* Edit mode — surface the identifier read-only so the cataloguer always
+          sees which record they're editing (Paul D., 2026-06-24). */}
       {!isCreate && (
         <div className="p-4 bg-white border border-border-light rounded-lg">
-          <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-1">UBN (catalogue id)</h2>
+          <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-1">
+            {needsUbn ? 'UBN (catalogue id)' : 'Record id (no UBN)'}
+          </h2>
           <p className="font-mono text-sm text-primary">{ubn}</p>
         </div>
       )}
@@ -437,7 +590,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         </div>
       </div>
 
-      {SECTIONS.map((section) => (
+      {visibleSections.map((section) => (
         <section key={section.title}>
           <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-2">{section.title}</h2>
           <div className="space-y-3 p-4 bg-white border border-border-light rounded-lg">

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { useDebouncedCallback } from 'use-debounce';
-import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal } from 'lucide-react';
+import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal, Download } from 'lucide-react';
 import { useEmbed } from '@/lib/EmbedContext';
 import PlaceholderCover from '@/components/book/PlaceholderCover';
 // Book URL helper moved inline to use basePath
@@ -382,6 +382,21 @@ export default function BphCatalogBrowser({
     return params;
   }, []);
 
+  /**
+   * The current selection as a spreadsheet. Same query string the results came
+   * from, minus paging — the export is the whole selection, not the page on
+   * screen. Asked for by José Bouman (BPH), 2026-08-12: "Is it possible to
+   * export a search selection? […] This is an important feature, that we
+   * often! use!"
+   */
+  const exportHref = useMemo(() => {
+    const params = buildParams(searchQuery, sort, keyword, 0, adv);
+    params.delete('limit');
+    params.delete('offset');
+    const qs = params.toString();
+    return `/api/catalog/bph/export${qs ? `?${qs}` : ''}`;
+  }, [buildParams, searchQuery, sort, keyword, adv]);
+
   const fetchWorks = useCallback(async (q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
     // Cancel any in-flight request so fast typing doesn't show stale results
     // when an earlier query resolves after a later one.
@@ -664,6 +679,16 @@ export default function BphCatalogBrowser({
             <span className="font-medium text-primary">{total.toLocaleString('en-US')}</span>
             {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString('en-US')} works` : ' works'}
           </span>
+          {total > 0 && (
+            <a
+              href={exportHref}
+              className="inline-flex items-center gap-1.5 text-sm text-secondary hover:text-primary transition-colors"
+              title={`Download all ${total.toLocaleString('en-US')} results as a spreadsheet`}
+            >
+              <Download className="w-3.5 h-3.5" />
+              Export
+            </a>
+          )}
           <div className="flex items-center gap-3 ml-auto">
             {/* Sort control — sits to the LEFT of the list/grid toggle. Drives
                 the same `sort` state as the list-view column headers, so it

--- a/src/lib/bph-catalog-filters.ts
+++ b/src/lib/bph-catalog-filters.ts
@@ -1,0 +1,244 @@
+/**
+ * The BPH catalogue search predicate, in one place.
+ *
+ * Two surfaces run the same search: the browsing API (`/api/catalog/bph`) and
+ * the CSV export (`/api/catalog/bph/export`). They MUST agree — an export that
+ * quietly matches a different set than the screen it was launched from is worse
+ * than no export at all, because the librarian has no way to see the drift.
+ * José Bouman, 2026-08-12, asking for the feature:
+ *
+ *   "Is it possible to export a search selection? I would like to have all
+ *    books which have JRR in one of the fields.... This is an important
+ *    feature, that we often! use!"
+ *
+ * So the filters live here and both routes call them. Add a filter here, never
+ * in a route.
+ *
+ * Schema-mode fallbacks (legacy 11-column schema, missing *_norm columns, …)
+ * stay in the browsing route: they are about what the database can answer, not
+ * about what the user asked for.
+ */
+
+import { sanitizeFilterValue } from '@/lib/supabase';
+import { normalizeBphSearchText } from '@/lib/text-normalize';
+
+/** A PostgREST filter builder. Structurally typed so both routes' query objects fit. */
+export interface FilterableQuery<T> {
+  or(filters: string): T;
+  eq(column: string, value: unknown): T;
+  is(column: string, value: unknown): T;
+  not(column: string, op: string, value: unknown): T;
+  gte(column: string, value: unknown): T;
+  lte(column: string, value: unknown): T;
+  ilike(column: string, pattern: string): T;
+  textSearch(column: string, query: string, options?: { type?: 'websearch' | 'plain' | 'phrase'; config?: string }): T;
+  order(column: string, options?: { ascending?: boolean; nullsFirst?: boolean }): T;
+}
+
+export interface BphFilters {
+  q: string;
+  author: string;
+  title: string;
+  place: string;
+  printer: string;
+  publisher: string;
+  editor: string;
+  keyword: string;
+  language: string;
+  shelfMark: string;
+  provenance: string;
+  yearFrom: number | null;
+  yearTo: number | null;
+  digitized: string | null;
+  firstTranslation: boolean;
+  sort: string;
+}
+
+/** Read the filter set out of a URL. Identical parsing for both routes. */
+export function readBphFilters(sp: URLSearchParams): BphFilters {
+  const yearFromRaw = sp.get('yearFrom');
+  const yearToRaw = sp.get('yearTo');
+  return {
+    q: sp.get('q')?.trim() || '',
+    author: sp.get('author')?.trim() || '',
+    title: sp.get('title')?.trim() || '',
+    place: sp.get('place')?.trim() || '',
+    printer: sp.get('printer')?.trim() || '',
+    publisher: sp.get('publisher')?.trim() || '',
+    editor: sp.get('editor')?.trim() || '',
+    keyword: sp.get('keyword')?.trim() || '',
+    language: sp.get('language')?.trim() || '',
+    shelfMark: sp.get('shelf_mark')?.trim() || '',
+    provenance: sp.get('provenance')?.trim() || '',
+    yearFrom: yearFromRaw ? parseInt(yearFromRaw, 10) : null,
+    yearTo: yearToRaw ? parseInt(yearToRaw, 10) : null,
+    digitized: sp.get('digitized'),
+    firstTranslation: sp.get('first_translation') === '1',
+    sort: sp.get('sort') || 'title',
+  };
+}
+
+/** True when no filter is set — the unfiltered catalogue view. */
+export function isUnfiltered(f: BphFilters): boolean {
+  return (
+    !f.q && !f.author && !f.title && !f.place && !f.printer && !f.publisher && !f.editor &&
+    !f.keyword && !f.language && !f.shelfMark && !f.provenance &&
+    f.yearFrom === null && f.yearTo === null &&
+    !f.firstTranslation
+  );
+}
+
+/** What the current schema can answer. Detected and cached by the browsing route. */
+export interface SchemaCaps {
+  mode: 'new' | 'legacy';
+  hasNormalizedColumns: boolean;
+  hasFirstTranslationColumn: boolean;
+}
+
+/**
+ * Apply every user-facing filter. Returns the narrowed query.
+ *
+ * Ordering is applied too, so a paged export walks the same sequence the screen
+ * shows — otherwise "export the first 500" and "look at the first 500" differ.
+ */
+export function applyBphFilters<T extends FilterableQuery<T>>(query: T, f: BphFilters, caps: SchemaCaps): T {
+  const { mode } = caps;
+  const useNormCols = mode === 'new' && caps.hasNormalizedColumns;
+
+  // Simple search across the whole record.
+  if (f.q.length >= 2) {
+    // A bare 3–4 digit query is almost always a publication year; the text
+    // columns and the tsvector don't carry it, so "1545" otherwise found
+    // nothing. Digits-only, so it is safe to inline into an .or() string.
+    const yearQ = /^\d{3,4}$/.test(f.q) ? f.q : null;
+    // UBN gets its own lane rather than living in `search_norm`, which is
+    // matched with ILIKE '%q%'. UBNs are 1–5 digit numbers, so folding them in
+    // would make every year search also match the UBNs containing those digits
+    // (1545 would drag in 15450–15459, 11545, 21545, 31545…). Exact match for
+    // an all-digit query is what "search by UBN" means; non-numeric UBNs
+    // ("BPH 131", "PH144", "PH 2") still need a substring match. Reported by
+    // José Bouman — searching a UBN returned nothing.
+    const ubnLane = /^\d+$/.test(f.q) ? `ubn.eq.${f.q}` : `ubn.ilike.%${sanitizeFilterValue(f.q)}%`;
+    if (useNormCols) {
+      if (yearQ) {
+        query = query.or(`search_norm.ilike.%${yearQ}%,year.eq.${yearQ},${ubnLane}`);
+      } else {
+        const normQ = sanitizeFilterValue(normalizeBphSearchText(f.q));
+        query = normQ.length > 0 ? query.or(`search_norm.ilike.%${normQ}%,${ubnLane}`) : query.or(ubnLane);
+      }
+    } else if (mode === 'new') {
+      if (yearQ) {
+        // A tsvector match can't be OR'd with a column filter in one .or();
+        // for a pure year, match the year column directly.
+        query = query.eq('year', Number(yearQ));
+      } else {
+        query = query.textSearch('search_tsv', sanitizeFilterValue(f.q), { type: 'websearch', config: 'simple' });
+      }
+    } else {
+      const safe = sanitizeFilterValue(f.q);
+      query = yearQ
+        ? query.or(`title.ilike.%${yearQ}%,author.ilike.%${yearQ}%,shelf_mark.ilike.%${yearQ}%,year.eq.${yearQ}`)
+        : query.or(`title.ilike.%${safe}%,author.ilike.%${safe}%,shelf_mark.ilike.%${safe}%`);
+    }
+  }
+
+  // Per-field advanced search. The `*_norm` columns roll a standard field up
+  // with its variants (author_norm covers author + variant_author + pseudonym),
+  // so one ilike replaces the .or() chain when they exist.
+  const ilikeFilter = (col: string, val: string) => {
+    if (!val) return;
+    const safe = sanitizeFilterValue(val);
+    const normVal = sanitizeFilterValue(normalizeBphSearchText(val));
+    if (mode === 'new') {
+      if (useNormCols && normVal.length > 0) {
+        query = query.ilike(col === 'shelf_mark' ? 'shelf_mark_norm' : `${col}_norm`, `%${normVal}%`);
+        return;
+      }
+      if (col === 'author') {
+        query = query.or(`author.ilike.%${safe}%,variant_author.ilike.%${safe}%,pseudonym.ilike.%${safe}%`);
+      } else if (col === 'title') {
+        query = query.or(`title.ilike.%${safe}%,parallel_title.ilike.%${safe}%,uniform_title.ilike.%${safe}%`);
+      } else if (col === 'editor') {
+        query = query.or(`editor.ilike.%${safe}%,variant_editor.ilike.%${safe}%`);
+      } else if (col === 'printer') {
+        query = query.or(`printer.ilike.%${safe}%,variant_printer.ilike.%${safe}%`);
+      } else if (col === 'publisher') {
+        query = query.or(`publisher.ilike.%${safe}%,variant_publisher.ilike.%${safe}%`);
+      } else if (col === 'shelf_mark') {
+        query = query.or(`shelf_mark.ilike.%${safe}%,state_shelf_mark.ilike.%${safe}%`);
+      } else {
+        query = query.ilike(col, `%${safe}%`);
+      }
+    } else if (['author', 'title', 'place', 'printer', 'publisher', 'shelf_mark'].includes(col)) {
+      // Legacy schema has only these; editor / language / provenance are
+      // silently dropped rather than erroring.
+      query = query.ilike(col, `%${safe}%`);
+    }
+  };
+  ilikeFilter('author', f.author);
+  ilikeFilter('title', f.title);
+  ilikeFilter('editor', f.editor);
+  ilikeFilter('place', f.place);
+  ilikeFilter('printer', f.printer);
+  ilikeFilter('publisher', f.publisher);
+  ilikeFilter('shelf_mark', f.shelfMark);
+
+  if (f.keyword) query = query.eq('keywords', f.keyword);
+  if (mode === 'new') {
+    if (f.language) query = query.eq('language', f.language);
+    if (f.provenance) query = query.eq('provenance', f.provenance);
+  }
+
+  if (f.yearFrom !== null && !Number.isNaN(f.yearFrom)) query = query.gte('year', f.yearFrom);
+  if (f.yearTo !== null && !Number.isNaN(f.yearTo)) query = query.lte('year', f.yearTo);
+
+  if (f.digitized === 'true') {
+    query = mode === 'new'
+      ? query.or('sl_book_id.not.is.null,ia_identifier.not.is.null')
+      : query.not('ia_identifier', 'is', null);
+  } else if (f.digitized === 'sl' && mode === 'new') {
+    query = query.not('sl_book_id', 'is', null);
+  } else if (f.digitized === 'held' && mode === 'new') {
+    // Catalogue entries with a non-null `present_location` are books physically
+    // in the building (Leeszaal, Depot, …). Catalogue-only references and works
+    // held elsewhere have null present_location. Requested by Paul Dijstelberge
+    // — visitors wanted a way to see just the volumes they could ask to consult.
+    query = query.not('present_location', 'is', null);
+  } else if (f.digitized === 'false') {
+    query = mode === 'new'
+      ? query.is('sl_book_id', null).is('ia_identifier', null)
+      : query.is('ia_identifier', null);
+  }
+
+  if (f.firstTranslation) {
+    if (mode === 'new' && caps.hasFirstTranslationColumn) {
+      query = query.eq('is_first_translation', true);
+    } else {
+      // No column → return nothing. PostgREST has no clean "always false"
+      // predicate; use a sentinel that cannot appear in sl_book_id.
+      query = query.eq('sl_book_id', '__no_first_translations__');
+    }
+  }
+
+  return applyBphSort(query, f.sort);
+}
+
+/** Result ordering. nullsFirst:false everywhere so null titles never lead. */
+export function applyBphSort<T extends FilterableQuery<T>>(query: T, sort: string): T {
+  switch (sort) {
+    case 'year_asc':
+      return query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+    case 'year_desc':
+      return query.order('year', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+    case 'author':
+      return query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+    case 'author_desc':
+      return query.order('author', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+    case 'title_desc':
+      return query.order('title', { ascending: false, nullsFirst: false });
+    case 'shelfmark':
+      return query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+    default:
+      return query.order('title', { ascending: true });
+  }
+}

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -25,6 +25,7 @@
 
 import { supabaseAdmin } from '@/lib/supabase';
 import { getDb } from '@/lib/mongodb';
+import { catalogKeyColumn } from '@/lib/bph-catalog-key';
 
 /**
  * Fields a contributor or editor can change through this helper. Adding a
@@ -36,8 +37,17 @@ import { getDb } from '@/lib/mongodb';
  * (link enrichers, the generated tsvector trigger, this helper itself).
  */
 export const EDITABLE_BPH_FIELDS = [
-  // Title family
+  // What kind of object this record describes. Decides which fields the editor
+  // form even shows, and gates two of the worklist buckets. Constrained enum
+  // `bph_record_type`; measured production values are exactly:
+  // printed (28,110) · photocopy (959) · manuscript (812).
+  'record_type',
+  // Title family. `full_title` is where MANUSCRIPTS keep their title — 82% of
+  // the 812 manuscripts have one and ZERO have `title` — so leaving it out of
+  // this whitelist made a manuscript's title uneditable anywhere in the UI
+  // (José Bouman, 2026-08-13: "the same format as those already catalogued").
   'title',
+  'full_title',
   'parallel_title',
   'uniform_title',
   // Authorship
@@ -140,6 +150,19 @@ export interface FieldChange {
 export type FieldChangeMap = Partial<Record<EditableBphField, FieldChange>>;
 
 export interface ApplyWorkRevisionInput {
+  /**
+   * How to address the work: a UBN, or — for the 2,012 records Memorix issues
+   * no UBN for (manuscripts, photographs) — that row's `uuid`. Which column is
+   * queried is decided by shape via catalogKeyColumn(), the same rule the
+   * /catalog/{key} route uses; no UBN in production is uuid-shaped, so the two
+   * cannot collide.
+   *
+   * On create this is the identifier the new row gets. Pass a uuid here to
+   * create a record with NO ubn, which is what a manuscript requires — the BPH
+   * writes UBNs into the physical book by hand, so a synthetic one would end up
+   * in ink inside a manuscript that is not supposed to have one (José Bouman,
+   * 2026-08-13).
+   */
   ubn: string;
   changeType?: ChangeType;
   fieldChanges: FieldChangeMap;
@@ -204,6 +227,11 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
   }
   assertEditableFields(fieldChanges);
 
+  // Which column this key addresses. Shape-based, identical to the public
+  // route's rule — see src/lib/bph-catalog-key.ts for why it cannot collide.
+  const keyCol = catalogKeyColumn(ubn);
+  const isUuidKeyed = keyCol === 'uuid';
+
   // 1. Fetch the current row so we can: (a) merge field_provenance without
   //    clobbering existing entries (USTC matcher, metadata enrichment, etc.)
   //    write their own provenance keys and we must preserve them, and
@@ -211,23 +239,32 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
   // Supabase typed select() with a dynamic column list returns an over-broad
   // union; the runtime shape is { ubn, field_provenance, sl_book_id, ...editable fields }
   // so we cast through unknown and narrow on the application side.
-  const selectCols = ['ubn', 'field_provenance', 'sl_book_id', ...Object.keys(fieldChanges)].join(', ');
+  const selectCols = ['ubn', 'uuid', 'field_provenance', 'sl_book_id', ...Object.keys(fieldChanges)].join(', ');
   const { data: rawCurrent, error: fetchErr } = await supabaseAdmin
     .from('bph_works')
     .select(selectCols)
-    .eq('ubn', ubn)
+    .eq(keyCol, ubn)
     .maybeSingle();
 
   if (fetchErr) throw new BphCatalogError('fetch bph_works failed', fetchErr);
   const current = rawCurrent as unknown as
-    | (Record<string, unknown> & { field_provenance: unknown; sl_book_id: string | null })
+    | (Record<string, unknown> & { uuid: string | null; field_provenance: unknown; sl_book_id: string | null })
     | null;
   if (!current && changeType !== 'create') {
-    throw new BphCatalogError(`bph_works row not found for ubn=${ubn}`);
+    throw new BphCatalogError(`bph_works row not found for ${keyCol}=${ubn}`);
   }
   if (current && changeType === 'create') {
-    throw new BphCatalogError(`A catalogue entry with UBN "${ubn}" already exists — edit it instead`);
+    throw new BphCatalogError(
+      isUuidKeyed
+        ? `A catalogue entry with uuid "${ubn}" already exists — edit it instead`
+        : `A catalogue entry with UBN "${ubn}" already exists — edit it instead`,
+    );
   }
+
+  // The uuid this revision hangs off. For a ubn-keyed edit it comes from the
+  // live row; for a uuid-keyed create the caller's key IS the uuid; for a
+  // ubn-keyed create we mint one so every new row is addressable both ways.
+  const workUuid = isUuidKeyed ? ubn : current?.uuid || crypto.randomUUID();
 
   const appliedAt = new Date().toISOString();
   const revisionId = crypto.randomUUID();
@@ -270,7 +307,12 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
       .from('bph_works_revisions')
       .insert({
         id: revisionId,
-        ubn,
+        // A revision targets a work by UBN or by uuid — never neither (there is
+        // a CHECK constraint saying so). Manuscripts and photographs have no
+        // UBN at all, so `ubn` is null for those and `work_uuid` carries the
+        // link. See scripts/migration/add-bph-uuid-keyed-revisions.sql.
+        ubn: isUuidKeyed ? (current?.ubn as string | null) ?? null : ubn,
+        work_uuid: workUuid,
         change_type: changeType,
         field_changes: liveFieldChanges,
         editor_email: editorEmail,
@@ -287,13 +329,21 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     //     leave a created record with no provenance trail. Only `ubn` is
     //     required by the schema (everything else nullable). The row is marked
     //     Source-Library-originated (via acquisition_source) so it's
-    //     distinguishable from Memorix-synced rows. `record_type` is a
-    //     constrained enum (bph_record_type) we deliberately leave unset
-    //     rather than guess between printed/manuscript/journal.
+    //     distinguishable from Memorix-synced rows.
+    //
+    //     `record_type` is supplied by the cataloguer through the form (it
+    //     decides which fields the form even shows), so it arrives in
+    //     `updates` like any other field. It used to be left unset here
+    //     rather than guessed between printed/manuscript/photocopy — but a
+    //     record with no type can never appear in the worklist buckets that
+    //     filter on it, so guessing was replaced by asking.
+    //
+    //     A uuid-keyed create writes NO ubn: that is the manuscript case.
     const { error: insErr } = await supabaseAdmin
       .from('bph_works')
       .insert({
-        ubn,
+        ubn: isUuidKeyed ? null : ubn,
+        uuid: workUuid,
         ...updates,
         field_provenance: mergedProvenance,
         created_at: appliedAt,
@@ -305,8 +355,9 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     const { error: revErr } = await insertRevision();
     if (revErr) {
       // Roll back the just-created row — a record without history would
-      // violate the audit invariant.
-      await supabaseAdmin.from('bph_works').delete().eq('ubn', ubn);
+      // violate the audit invariant. Delete by uuid: it is set on every row we
+      // insert, including the manuscripts that have no ubn to delete by.
+      await supabaseAdmin.from('bph_works').delete().eq('uuid', workUuid);
       throw new BphCatalogError('insert bph_works_revisions failed (create rolled back)', revErr);
     }
   } else {
@@ -324,7 +375,7 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
         ...updates,
         field_provenance: mergedProvenance,
       })
-      .eq('ubn', ubn);
+      .eq(keyCol, ubn);
 
     if (updErr) {
       // Revision row is already in. Surface the error so the caller knows

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -302,25 +302,59 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     ...provenancePatch,
   };
 
-  const insertRevision = () =>
-    supabaseAdmin!
-      .from('bph_works_revisions')
-      .insert({
-        id: revisionId,
-        // A revision targets a work by UBN or by uuid — never neither (there is
-        // a CHECK constraint saying so). Manuscripts and photographs have no
-        // UBN at all, so `ubn` is null for those and `work_uuid` carries the
-        // link. See scripts/migration/add-bph-uuid-keyed-revisions.sql.
-        ubn: isUuidKeyed ? (current?.ubn as string | null) ?? null : ubn,
-        work_uuid: workUuid,
-        change_type: changeType,
-        field_changes: liveFieldChanges,
-        editor_email: editorEmail,
-        proposed_by: proposedBy,
-        source_pending_id: sourcePendingId,
-        applied_at: appliedAt,
-        note,
-      });
+  // A revision targets a work by UBN or by uuid — never neither (there is a
+  // CHECK constraint saying so). Manuscripts and photographs have no UBN at
+  // all, so `ubn` is null for those and `work_uuid` carries the link. See
+  // scripts/migration/add-bph-uuid-keyed-revisions.sql.
+  const revisionRow = {
+    id: revisionId,
+    ubn: isUuidKeyed ? (current?.ubn as string | null) ?? null : ubn,
+    work_uuid: workUuid,
+    change_type: changeType,
+    field_changes: liveFieldChanges,
+    editor_email: editorEmail,
+    proposed_by: proposedBy,
+    source_pending_id: sourcePendingId,
+    applied_at: appliedAt,
+    note,
+  };
+
+  /**
+   * Insert the revision, degrading if the work_uuid migration hasn't run on
+   * this environment yet.
+   *
+   * Without this, deploying the code before applying the migration would break
+   * EVERY catalogue edit, not just the manuscript ones — an unknown column
+   * fails the insert, and the insert is the gate the whole mutation path sits
+   * behind. A ubn-keyed edit works perfectly well on the old schema, so it
+   * should keep working; only the uuid-keyed rows genuinely need the column,
+   * and they are unreachable on the old schema anyway (the FK would reject
+   * them). Mirrors the same graceful-degradation pattern used by the catalogue
+   * read routes for un-run migrations.
+   */
+  const insertRevision = async () => {
+    const first = await supabaseAdmin!.from('bph_works_revisions').insert(revisionRow);
+    if (!first.error) return first;
+    const msg = (first.error.message || '').toLowerCase();
+    const missingColumn =
+      msg.includes('work_uuid') && (msg.includes('does not exist') || msg.includes('could not find'));
+    if (!missingColumn) return first;
+    if (isUuidKeyed) {
+      // No ubn to fall back on: this row is only reachable through the new
+      // schema. Report the real cause rather than a confusing FK error.
+      return {
+        ...first,
+        error: {
+          ...first.error,
+          message:
+            'This record has no UBN, which needs scripts/migration/add-bph-uuid-keyed-revisions.sql to be applied first. ' +
+            first.error.message,
+        },
+      };
+    }
+    const { work_uuid: _dropped, ...legacyRow } = revisionRow;
+    return supabaseAdmin!.from('bph_works_revisions').insert(legacyRow);
+  };
 
   if (changeType === 'create') {
     // 2a. The revisions table has a FK on ubn → bph_works(ubn), so the row

--- a/src/lib/bph-state-shelfmark.ts
+++ b/src/lib/bph-state-shelfmark.ts
@@ -20,22 +20,31 @@
  * sides together.
  */
 
-/**
- * Values that mean "no", not a shelf mark. Compared case-insensitively.
- *
- * Deliberately limited to the negative answers: `ja` ("yes") also appears in
- * the column (31 rows as of 2026-07-30) and is equally not a shelf mark, but
- * emptying it would discard the only record that those copies ARE on loan from
- * the state collection. That needs a librarian's decision and a column that can
- * express it, so it is left alone here rather than swept.
- */
+/** Values that mean "no", not a shelf mark. Compared case-insensitively. */
 const NOT_A_SHELFMARK = new Set(['neen', 'nee']);
+
+/**
+ * `ja` ("yes") is the other Memorix boolean in this column — 31 rows. It is not
+ * a shelf mark either, but unlike `neen` it is not noise: it is the only record
+ * that those copies ARE on loan from the state collection, so it is translated
+ * rather than dropped. José Bouman (BPH) made the call on 2026-08-12, having
+ * been asked for exactly this decision by the catalogue worklist:
+ *
+ *   "This set of 31 is owned by the State, therefore the 'Ja'. Better change
+ *    it to 'yes'."
+ *
+ * Normalised at the write boundary as well as swept in the data, so a Memorix
+ * re-import cannot put the Dutch back — the same belt-and-braces the `neen`
+ * cleanup used.
+ */
+const TRANSLATE = new Map([['ja', 'yes']]);
 
 export function normalizeStateShelfMark(raw: string | null | undefined): string | null {
   if (raw == null) return null;
   const kept = String(raw)
     .split('|')
     .map((part) => part.trim())
-    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()));
+    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()))
+    .map((part) => TRANSLATE.get(part.toLowerCase()) ?? part);
   return kept.length > 0 ? kept.join('|') : null;
 }

--- a/tests/unit/bph-catalog-filters.test.ts
+++ b/tests/unit/bph-catalog-filters.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The BPH catalogue search predicate is shared by two surfaces — the browsing
+ * API and the CSV export — because an export that matches a different set than
+ * the screen it was launched from is worse than no export: nothing reveals the
+ * drift. These tests pin the parsing and the predicate SHAPE, so a change to
+ * one surface cannot quietly become a change to only one surface.
+ *
+ * Behaviour equivalence with the pre-refactor route was established by running
+ * 23 queries against production and localhost and comparing total + ordered
+ * results (23/23 identical, 2026-08-13). These tests guard it going forward.
+ *
+ * Requested by José Bouman (BPH), 2026-08-12: "Is it possible to export a
+ * search selection? I would like to have all books which have JRR in one of
+ * the fields.... This is an important feature, that we often! use!"
+ */
+import { describe, it, expect } from 'vitest';
+import { readBphFilters, isUnfiltered, applyBphFilters, type SchemaCaps } from '../../src/lib/bph-catalog-filters';
+
+/** Records every builder call so the predicate can be asserted on. */
+function recorder() {
+  const calls: string[] = [];
+  const q: Record<string, (...a: unknown[]) => unknown> = {};
+  for (const m of ['or', 'eq', 'is', 'not', 'gte', 'lte', 'ilike', 'textSearch', 'order']) {
+    q[m] = (...args: unknown[]) => {
+      calls.push(`${m}(${args.map((a) => JSON.stringify(a)).join(',')})`);
+      return q;
+    };
+  }
+  return { q, calls };
+}
+
+const NEW_SCHEMA: SchemaCaps = { mode: 'new', hasNormalizedColumns: true, hasFirstTranslationColumn: true };
+
+const parse = (qs: string) => readBphFilters(new URLSearchParams(qs));
+
+describe('readBphFilters', () => {
+  it('reads every filter the browsing UI can set', () => {
+    const f = parse('q=JRR&author=Fludd&title=alchimia&place=Amsterdam&printer=Blaeu&publisher=Elzevier'
+      + '&editor=Casaubon&keyword=alchemy&language=Latin&shelf_mark=M+3&provenance=Ritman'
+      + '&yearFrom=1600&yearTo=1650&digitized=sl&first_translation=1&sort=year_asc');
+    expect(f).toEqual({
+      q: 'JRR', author: 'Fludd', title: 'alchimia', place: 'Amsterdam', printer: 'Blaeu',
+      publisher: 'Elzevier', editor: 'Casaubon', keyword: 'alchemy', language: 'Latin',
+      shelfMark: 'M 3', provenance: 'Ritman', yearFrom: 1600, yearTo: 1650,
+      digitized: 'sl', firstTranslation: true, sort: 'year_asc',
+    });
+  });
+
+  it('trims, and defaults sort to title', () => {
+    const f = parse('q=%20%20Bohme%20%20');
+    expect(f.q).toBe('Bohme');
+    expect(f.sort).toBe('title');
+  });
+
+  it('leaves absent years null rather than NaN', () => {
+    expect(parse('').yearFrom).toBeNull();
+    expect(parse('').yearTo).toBeNull();
+  });
+});
+
+describe('isUnfiltered', () => {
+  it('is true only when nothing narrows the set', () => {
+    expect(isUnfiltered(parse(''))).toBe(true);
+    // The digitised lane is a view, not a filter — it drives the pinned count.
+    expect(isUnfiltered(parse('digitized=sl'))).toBe(true);
+    expect(isUnfiltered(parse('sort=year_asc'))).toBe(true);
+  });
+
+  it('is false as soon as any real filter is set', () => {
+    for (const qs of ['q=JRR', 'author=Fludd', 'yearFrom=1600', 'first_translation=1', 'keyword=alchemy']) {
+      expect(isUnfiltered(parse(qs)), qs).toBe(false);
+    }
+  });
+});
+
+describe('applyBphFilters — the lanes that were reported as broken', () => {
+  it('matches a UBN exactly for an all-digit query, never as a substring', () => {
+    // José Bouman: searching a UBN returned nothing. A substring lane would
+    // make "1545" also drag in 15450–15459, 11545, 21545…
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('q=1545'), NEW_SCHEMA);
+    const orCall = calls.find((c) => c.startsWith('or('))!;
+    expect(orCall).toContain('ubn.eq.1545');
+    expect(orCall).not.toContain('ubn.ilike');
+  });
+
+  it('also matches the year column for a bare 3–4 digit query', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('q=1545'), NEW_SCHEMA);
+    expect(calls.find((c) => c.startsWith('or('))).toContain('year.eq.1545');
+  });
+
+  it('falls back to a substring lane for a non-numeric UBN like "BPH 131"', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('q=BPH+131'), NEW_SCHEMA);
+    expect(calls.find((c) => c.startsWith('or('))).toContain('ubn.ilike');
+  });
+
+  it('searches the diacritic-normalised column so "Bohme" finds "Böhme"', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('q=Bohme'), NEW_SCHEMA);
+    expect(calls.find((c) => c.startsWith('or('))).toContain('search_norm.ilike');
+  });
+
+  it('ignores a one-character query rather than scanning the corpus', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('q=B'), NEW_SCHEMA);
+    expect(calls.filter((c) => c.startsWith('or(') || c.startsWith('textSearch('))).toHaveLength(0);
+  });
+
+  it('rolls an author search up with its variants via the _norm column', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('author=Fludd'), NEW_SCHEMA);
+    expect(calls).toContain('ilike("author_norm","%fludd%")');
+  });
+
+  it('uses shelf_mark_norm, not shelf_mark_norm-by-convention', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('shelf_mark=M+3'), NEW_SCHEMA);
+    expect(calls.some((c) => c.startsWith('ilike("shelf_mark_norm"'))).toBe(true);
+  });
+
+  it('returns nothing for a first-translation filter the schema cannot answer', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('first_translation=1'), { ...NEW_SCHEMA, hasFirstTranslationColumn: false });
+    expect(calls).toContain('eq("sl_book_id","__no_first_translations__")');
+  });
+
+  it('always orders, so a paged export walks the same sequence as the screen', () => {
+    for (const sort of ['title', 'title_desc', 'year_asc', 'year_desc', 'author', 'author_desc', 'shelfmark']) {
+      const { q, calls } = recorder();
+      applyBphFilters(q as never, parse(`sort=${sort}`), NEW_SCHEMA);
+      expect(calls.some((c) => c.startsWith('order(')), sort).toBe(true);
+    }
+  });
+
+  it('never orders nulls first — null titles must not lead any listing', () => {
+    for (const sort of ['title_desc', 'year_asc', 'year_desc', 'author', 'author_desc', 'shelfmark']) {
+      const { q, calls } = recorder();
+      applyBphFilters(q as never, parse(`sort=${sort}`), NEW_SCHEMA);
+      for (const c of calls.filter((c) => c.startsWith('order('))) {
+        expect(c.includes('"nullsFirst":true'), `${sort}: ${c}`).toBe(false);
+      }
+    }
+  });
+
+  it('drops language and provenance on the legacy schema instead of erroring', () => {
+    const { q, calls } = recorder();
+    applyBphFilters(q as never, parse('language=Latin&provenance=Ritman'), {
+      mode: 'legacy', hasNormalizedColumns: false, hasFirstTranslationColumn: false,
+    });
+    expect(calls.some((c) => c.includes('language'))).toBe(false);
+    expect(calls.some((c) => c.includes('provenance'))).toBe(false);
+  });
+});

--- a/tests/unit/bph-state-shelfmark.test.ts
+++ b/tests/unit/bph-state-shelfmark.test.ts
@@ -26,6 +26,11 @@ const FIXTURES = [
   '|',
   '||',
   'ja',
+  'Ja',
+  '  JA  ',
+  'ja|PH3018',
+  'PHja22',
+  'Jakarta',
   'PH3018',
   'PH1883-B',
   'PH3154-C',
@@ -74,7 +79,20 @@ describe('normalizeStateShelfMark behavior', () => {
     expect(ts('zie PH3301')).toBe('zie PH3301');
   });
 
-  it('leaves "ja" alone — emptying it would discard a real (if crude) signal', () => {
-    expect(ts('ja')).toBe('ja');
+  it('translates "ja" to "yes" rather than emptying it', () => {
+    // "ja" is not a shelf mark, but it is the only record that these 31 copies
+    // ARE on loan from the state collection — so it is translated, not dropped.
+    // José Bouman, 2026-08-12: "This set of 31 is owned by the State, therefore
+    // the 'Ja'. Better change it to 'yes'."
+    expect(ts('ja')).toBe('yes');
+    expect(ts('Ja')).toBe('yes');
+    expect(ts('  JA  ')).toBe('yes');
+  });
+
+  it('translates "ja" per segment, and never inside a real shelf mark', () => {
+    expect(ts('ja|PH3018')).toBe('yes|PH3018');
+    // Substring safety: a real mark that merely contains the letters is intact.
+    expect(ts('PHja22')).toBe('PHja22');
+    expect(ts('Jakarta')).toBe('Jakarta');
   });
 });


### PR DESCRIPTION
Four things José Bouman (BPH) reported — two through the footer feedback widget, two by email — and one root cause under three of them.

## What was reported

| when | where | what |
|---|---|---|
| 2026-07-31 | feedback, `/catalog/11312/edit` | "not possible to click on titles with a shelf mark M (+number), nor on those with shelfmark Fot (+ number) **to edit them** or see more information" |
| 2026-08-12 | feedback, `/catalog/31084/edit` | "Is it possible to export a search selection? […] This is an important feature, that we often! use!" |
| 2026-08-12 | email, "Needs your attention" | answers to all four worklist questions, incl. "change it to 'yes'" and "I cannot access these by clicking on them" |
| 2026-08-13 | email, "Cataloguing manuscripts" | "the blank form should show other fields than the one for printed books. No UBN required." |

## The root cause

Memorix issues no UBN for manuscripts or photographs. **2,012 of 29,881 rows have `ubn IS NULL`** — 812 manuscripts, 959 photocopies — and that is correct data, not missing data.

#3654 taught `/catalog/{key}` to accept a uuid, which made those records **viewable**. Everything else still keyed on a non-null UBN:

- `bph_works_revisions.ubn` is `TEXT NOT NULL REFERENCES bph_works(ubn)`
- `applyWorkRevision()` fetched and wrote with `.eq('ubn', …)`
- the edit page fetched with `.eq('ubn', …)` and `notFound()`d otherwise

So all 2,012 still 404'd on `/catalog/{key}/edit`, and no manuscript could be created at all. That is the unfixed half of the July report, and the whole of the August 13 one.

Separately, the workspace worklist built its sample links from `bph_works.id` — **a different uuid from `bph_works.uuid`** — so every link in the three UBN-less buckets resolved to nothing. That is the August 12 "I cannot access these by clicking on them", reported a week after the browser's own links were fixed. Same symptom, second path.

Inventing a UBN was not an option: the BPH writes UBNs into the physical book by hand, so a synthetic one ends up in ink inside an object not supposed to carry one.

## What this does

**Manuscripts are a first-class record type.** `record_type` is now chosen on the form (printed / manuscript / photocopy) instead of left null, and it picks the field set. Measured across all 812 manuscripts, exactly ten fields are ever used — `shelf_mark` 100%, `full_title` 82%, `uniform_title` 70%, `author` 64%, `language` 48%, `object_size_cm` 47%, `remarks` 41%, `binding` 29%, `provenance` 22%, `bibliography` 15% — and `title`, `ubn`, `place`, `year`, `printer`, `publisher`, `keywords`, `number_of_copies` are **0.0%** populated, because those describe an edition off a press and a manuscript is a unique object. That is what "the same format as those already catalogued" means concretely.

**`full_title` becomes editable.** 663 manuscripts keep their title there and none use `title`, so a manuscript's title was uneditable anywhere in the UI.

**Search export.** New `/api/catalog/bph/export` plus an Export control on the results header. The filters moved into `src/lib/bph-catalog-filters.ts`, shared with the browsing API, so the two can never match different sets — an export that quietly differs from the screen it was launched from is worse than no export, because nothing reveals the drift.

**The worklist stops asking questions José answered.** "Records with no UBN" (2,012) was counting correct data as a defect; narrowed to records with no UBN *and* no shelf mark — 253 that genuinely cannot be found by any means. The 86 undescribed manuscripts became a known backlog ("Leave them as they are"). The "ja" bucket is now a re-import detector.

**"ja" → "yes", already applied** (31 rows, production). Per-row revisions carrying the real from-value plus a JSON backup, so each is individually reversible. The normaliser maps `ja`→`yes` at the **write** boundary too — without that half, a Memorix re-import would silently undo the sweep.

## Verification

- **Filter refactor is behaviour-preserving**: 23 queries run against production (old code) and localhost (new module), comparing total **and** ordered results — **23/23 identical**. Covers the diacritic lane (Bohme→Böhme, 741), bare-year (1545, 33), both UBN lanes (131→126, "BPH 131"→1), every sort, every digitised mode.
- **Export matches its search exactly**: `q=JRR` → 41 rows and 41 results (José's actual query); `shelf_mark=M` → 11,595 and 11,595, i.e. 12 pages, so the supabase-js 1,000-row cap is handled.
- **The 404 is fixed without any migration**: the old worklist link `000f89e8-…` now returns 200 "Mein Manuscript"; the canonical uuid works; a printed book by UBN is unaffected; a nonsense key still 404s.
- **Edit-page lookup**: old behaviour 404s the manuscript, new behaviour finds it, printed books unchanged. (Tested at query level — the auth gate precedes the lookup, so a signed-out HTTP probe cannot reach it.)
- 2,738 unit tests pass, including 16 new ones pinning the shared predicate. `tsc --noEmit` clean, eslint 0 errors.

## Migrations — NOT yet applied

Both are additive and the code **degrades gracefully without them**, so this is safe to merge and deploy first.

1. `scripts/migration/add-bph-uuid-keyed-revisions.sql` — lets a revision target a work by uuid. Required before a manuscript can be **created or edited**. Backfills 107 uuid-less rows (all printed, all with a UBN), adds a UNIQUE on `bph_works.uuid` (verified 0 duplicates, 0 rows with neither key), makes `revisions.ubn` nullable with a CHECK that one key is always present.
2. `scripts/migration/add-bph-worklist-rpc.sql` — re-run for the new bucket and for `uuid` in the sample links.

Until (1) runs, `applyWorkRevision` drops `work_uuid` and ubn-keyed edits work exactly as before; a uuid-keyed edit returns a message naming the migration rather than a confusing FK error.

## Out of scope

- **"please change catalog to catalogue"** — the visible labels already say "catalogue" everywhere; what José sees is the URL. The proxy already accepts `/catalogue/…`, so switching the canonical links is a safe follow-up, but it touches every internal href and belongs in its own PR.
- José's guess that the UBN-less printed records carry an `In: [author-title]` note **does not hold** — 0 of 241 do; 228 are empty stubs with no title, shelf mark, or UBN. They said they were guessing *because they could not click through to look*, which is the bug this fixes. For the 31 "ja" rows the note holds for 14 of 31. Worth telling them when we reply.
- A 32nd row reads `"ja, maar heeft geen eigen ICN nr"` — a real free-text note, correctly left alone by the sweep, but the exact-match bucket never surfaced it. One for José.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
