### PR TITLE
fix(shortlinks): /q/ codes for UUID-keyed books (#3940)

### DIFF
--- a/src/lib/shortlinks.ts
+++ b/src/lib/shortlinks.ts
@@ -1,11 +1,32 @@
 /**
  * Shortlink encoding/decoding for Source Library
  *
- * Encodes a book ID (24 hex chars) + page number into a ~19 char base62 string.
- * Fully reversible, no database lookup needed.
+ * Two stateless schemes, both fully reversible with no database lookup:
+ *
+ *  - ObjectId books: 12 bytes of id + 2 bytes of page -> up to 19 base62 chars.
+ *    This is the original scheme and every already-published shortlink uses it,
+ *    so its output must never change.
+ *  - UUID books: 16 bytes of id + 2 bytes of page -> exactly 25 base62 chars
+ *    (zero-padded), prefixed with `u` (issue #3940). Before this, UUID-keyed
+ *    books got no /q/ link at all and could only be cited by the long
+ *    /book/<uuid>/page/<pageid> form — including some of the most complete
+ *    translations in the corpus.
+ *
+ * The two are told apart by shape, not by guessing: a UUID code is always
+ * exactly 26 chars, and a 14-byte ObjectId code can never reach 26 (2^112 <
+ * 62^19). The zero padding is what makes that width fixed — don't drop it, or a
+ * UUID whose leading bytes are small would encode short and land in the
+ * ObjectId branch on decode.
  */
 
 const BASE62_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/** Marker + fixed body width for the 18-byte (UUID) scheme. */
+const UUID_PREFIX = 'u';
+const UUID_CODE_LENGTH = 25;
+
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Encode bytes to base62 string
@@ -52,54 +73,89 @@ function base62ToBytes(str: string, length: number): Uint8Array {
   return bytes;
 }
 
+/** Pack a hex id (no separators) plus a 2-byte page number into bytes. */
+function packIdAndPage(hex: string, pageNumber: number): Uint8Array {
+  const idLength = hex.length / 2;
+  const combined = new Uint8Array(idLength + 2);
+  for (let i = 0; i < idLength; i++) {
+    combined[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  combined[idLength] = (pageNumber >> 8) & 0xFF;
+  combined[idLength + 1] = pageNumber & 0xFF;
+  return combined;
+}
+
+/** Read the first `length` bytes back out as lowercase hex. */
+function bytesToHex(bytes: Uint8Array, length: number): string {
+  let hex = '';
+  for (let i = 0; i < length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
 /**
  * Encode a book ID and page number into a shortlink code
  *
- * @param bookId - 24 character hex string (MongoDB ObjectId)
+ * @param bookId - 24-char hex ObjectId, or a dashed UUID
  * @param pageNumber - Page number (1-65535)
- * @returns Base62 encoded string (~19 chars)
+ * @returns Base62 encoded string (~19 chars for ObjectIds, `u` + 25 for UUIDs)
  */
 export function encodeShortlink(bookId: string, pageNumber: number): string {
-  if (!/^[a-f0-9]{24}$/i.test(bookId)) {
-    throw new Error('Invalid book ID: must be 24 hex characters');
+  const isObjectId = OBJECT_ID_RE.test(bookId);
+  const isUuid = UUID_RE.test(bookId);
+  if (!isObjectId && !isUuid) {
+    throw new Error('Invalid book ID: must be 24 hex characters or a UUID');
   }
-  if (pageNumber < 1 || pageNumber > 65535) {
+  if (!Number.isInteger(pageNumber) || pageNumber < 1 || pageNumber > 65535) {
     throw new Error('Invalid page number: must be 1-65535');
   }
 
-  // Convert hex book ID to bytes (12 bytes)
-  const bookBytes = new Uint8Array(12);
-  for (let i = 0; i < 12; i++) {
-    bookBytes[i] = parseInt(bookId.slice(i * 2, i * 2 + 2), 16);
+  if (isUuid) {
+    // 16 bytes of UUID + 2 bytes of page = 18 bytes, padded to a fixed width so
+    // the decoder can recognise the scheme by length alone.
+    const combined = packIdAndPage(bookId.replace(/-/g, '').toLowerCase(), pageNumber);
+    const body = bytesToBase62(combined).padStart(UUID_CODE_LENGTH, '0');
+    return `${UUID_PREFIX}${body}`;
   }
 
-  // Convert page number to 2 bytes (big endian)
-  const pageBytes = new Uint8Array(2);
-  pageBytes[0] = (pageNumber >> 8) & 0xFF;
-  pageBytes[1] = pageNumber & 0xFF;
+  // 12 bytes of ObjectId + 2 bytes of page = 14 bytes.
+  return bytesToBase62(packIdAndPage(bookId.toLowerCase(), pageNumber));
+}
 
-  // Combine: 12 bytes book + 2 bytes page = 14 bytes
-  const combined = new Uint8Array(14);
-  combined.set(bookBytes);
-  combined.set(pageBytes, 12);
-
-  return bytesToBase62(combined);
+/** True for codes produced by the 18-byte UUID scheme. */
+function isUuidCode(code: string): boolean {
+  return code.length === UUID_PREFIX.length + UUID_CODE_LENGTH && code.startsWith(UUID_PREFIX);
 }
 
 /**
  * Decode a shortlink code into book ID and page number
  *
  * @param code - Base62 encoded shortlink
- * @returns Object with bookId and pageNumber
+ * @returns Object with bookId (ObjectId hex or dashed UUID) and pageNumber
  */
 export function decodeShortlink(code: string): { bookId: string; pageNumber: number } {
+  if (isUuidCode(code)) {
+    const bytes = base62ToBytes(code.slice(UUID_PREFIX.length), 18);
+    const hex = bytesToHex(bytes, 16);
+    const bookId = [
+      hex.slice(0, 8),
+      hex.slice(8, 12),
+      hex.slice(12, 16),
+      hex.slice(16, 20),
+      hex.slice(20, 32),
+    ].join('-');
+    const pageNumber = (bytes[16] << 8) | bytes[17];
+    if (pageNumber < 1) {
+      throw new Error('Invalid shortlink: page number must be >= 1');
+    }
+    return { bookId, pageNumber };
+  }
+
   const bytes = base62ToBytes(code, 14);
 
   // Extract book ID (first 12 bytes as hex)
-  let bookId = '';
-  for (let i = 0; i < 12; i++) {
-    bookId += bytes[i].toString(16).padStart(2, '0');
-  }
+  const bookId = bytesToHex(bytes, 12);
 
   // Extract page number (last 2 bytes, big endian)
   const pageNumber = (bytes[12] << 8) | bytes[13];
@@ -113,22 +169,27 @@ export function decodeShortlink(code: string): { bookId: string; pageNumber: num
 
 /**
  * Generate the full short URL for a book page
- * Falls back to regular URL if book ID isn't a valid ObjectId
+ * Falls back to the long URL only for ID formats neither scheme can encode
  *
  * @param bookId - Book ID (24-char ObjectId or UUID)
  * @param pageNumber - Page number for shortlink encoding
- * @param pageId - Optional page ID for fallback URL (required for UUID book IDs)
+ * @param pageId - Optional page ID for fallback URL
  * @param baseUrl - Optional base URL (e.g. "https://bph.sourcelibrary.org") used for tenant subdomains.
  *                  Defaults to https://sourcelibrary.org so existing API consumers are unchanged.
  */
 export function getShortUrl(bookId: string, pageNumber: number, pageId?: string, baseUrl?: string): string {
   const base = (baseUrl || 'https://sourcelibrary.org').replace(/\/+$/, '');
-  // Only encode shortlinks for 24-char hex ObjectIds
-  if (/^[a-f0-9]{24}$/i.test(bookId)) {
+  // Both ObjectIds and UUIDs encode statelessly (#3940); the page number still
+  // has to fit the 2 bytes both schemes reserve for it.
+  if (
+    (OBJECT_ID_RE.test(bookId) || UUID_RE.test(bookId)) &&
+    Number.isInteger(pageNumber) && pageNumber >= 1 && pageNumber <= 65535
+  ) {
     const code = encodeShortlink(bookId, pageNumber);
     return `${base}/q/${code}`;
   }
-  // Fallback to regular URL for UUIDs or other ID formats
+  // Fallback to the regular URL for anything else (other ID formats, or a page
+  // number outside the encodable range).
   if (pageId) {
     return `${base}/book/${bookId}/page/${pageId}`;
   }

--- a/tests/unit/shortlink-uuid-codes.test.ts
+++ b/tests/unit/shortlink-uuid-codes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { encodeShortlink, decodeShortlink, getShortUrl } from '@/lib/shortlinks';
+
+// Issue #3940: UUID-keyed books (71 visible ones, including Pico's Opera Omnia
+// and Weyer's De praestigiis daemonum) got no /q/ shortlink at all — the
+// encoder packed exactly 12 bytes of ObjectId, and getShortUrl fell through to
+// the long /book/<uuid>/page/<pageid> form. Shortlinks are what researchers
+// cite, so those books were awkward to cite.
+//
+// The `u` + 25-char scheme must satisfy two things at once: round-trip UUIDs,
+// and never disturb an already-published ObjectId code.
+
+const UUIDS = [
+  'bb7bfc2d-1234-4abc-89de-0123456789ab',
+  'adad5f6d-0000-0000-0000-000000000000',
+  '023f2b73-5a9f-4ada-92c2-258a408d89c2', // real: Barlaam and Josaphat
+  '0b93ce97-9021-4eb7-9613-41b4ce1193b9', // real: Theatrum Chemicum vol. III
+  'ffffffff-ffff-ffff-ffff-ffffffffffff',
+  '00000000-0000-0000-0000-000000000001', // leading zero bytes — the padding case
+];
+
+const OBJECT_ID = '507f1f77bcf86cd799439011';
+
+describe('UUID shortlink codes (#3940)', () => {
+  it('round-trips every UUID / page combination', () => {
+    for (const bookId of UUIDS) {
+      for (const pageNumber of [1, 2, 145, 999, 65535]) {
+        const code = encodeShortlink(bookId, pageNumber);
+        expect(decodeShortlink(code)).toEqual({ bookId, pageNumber });
+      }
+    }
+  });
+
+  it('emits a fixed 26-char `u`-prefixed code, so the decoder can tell the schemes apart by shape', () => {
+    for (const bookId of UUIDS) {
+      const code = encodeShortlink(bookId, 1);
+      expect(code).toHaveLength(26);
+      expect(code.startsWith('u')).toBe(true);
+    }
+    // A leading-zero UUID is the one that would encode short without padding
+    // and get decoded as a 14-byte ObjectId code.
+    expect(encodeShortlink('00000000-0000-0000-0000-000000000001', 1)).toHaveLength(26);
+  });
+
+  it('never produces a code an ObjectId code could collide with', () => {
+    // 14 bytes < 62^19, so ObjectId codes top out at 19 chars.
+    for (const pageNumber of [1, 42, 65535]) {
+      expect(encodeShortlink(OBJECT_ID, pageNumber).length).toBeLessThanOrEqual(19);
+    }
+    expect(encodeShortlink('ffffffffffffffffffffffff', 65535).length).toBeLessThanOrEqual(19);
+  });
+
+  it('leaves published ObjectId codes decoding exactly as before', () => {
+    // Codes hardcoded in /about and the blog posts — these are live citations.
+    expect(decodeShortlink('BhIfljO2ApigrcHcTeD')).toEqual({
+      bookId: '69b21d42ddb4fa7c305b4693',
+      pageNumber: 145,
+    });
+    expect(encodeShortlink('69b21d42ddb4fa7c305b4693', 145)).toBe('BhIfljO2ApigrcHcTeD');
+  });
+
+  it('normalises uppercase input on both id formats', () => {
+    expect(encodeShortlink('BB7BFC2D-1234-4ABC-89DE-0123456789AB', 3)).toBe(
+      encodeShortlink('bb7bfc2d-1234-4abc-89de-0123456789ab', 3)
+    );
+    expect(encodeShortlink(OBJECT_ID.toUpperCase(), 3)).toBe(encodeShortlink(OBJECT_ID, 3));
+  });
+
+  it('rejects ids neither scheme can encode, and unencodable page numbers', () => {
+    expect(() => encodeShortlink('not-an-id', 1)).toThrow();
+    expect(() => encodeShortlink('bb7bfc2d1234-4abc-89de-0123456789ab', 1)).toThrow();
+    expect(() => encodeShortlink(UUIDS[0], 0)).toThrow();
+    expect(() => encodeShortlink(UUIDS[0], 65536)).toThrow();
+    expect(() => encodeShortlink(UUIDS[0], 1.5)).toThrow();
+  });
+});
+
+describe('getShortUrl (#3940)', () => {
+  it('now returns a /q/ shortlink for UUID books instead of the long form', () => {
+    const url = getShortUrl(UUIDS[0], 5, '69d397024e8896250fd674bf');
+    expect(url).toBe(`https://sourcelibrary.org/q/${encodeShortlink(UUIDS[0], 5)}`);
+  });
+
+  it('still shortlinks ObjectId books and honours a tenant base URL', () => {
+    expect(getShortUrl(OBJECT_ID, 5, undefined, 'https://bph.sourcelibrary.org/')).toBe(
+      `https://bph.sourcelibrary.org/q/${encodeShortlink(OBJECT_ID, 5)}`
+    );
+  });
+
+  it('falls back to the long URL only for ids or page numbers no scheme covers', () => {
+    expect(getShortUrl('legacy-slug-id', 5, 'pageid')).toBe(
+      'https://sourcelibrary.org/book/legacy-slug-id/page/pageid'
+    );
+    expect(getShortUrl('legacy-slug-id', 5)).toBe(
+      'https://sourcelibrary.org/book/legacy-slug-id#page-5'
+    );
+    // Out-of-range page: must fall back rather than throw at the call site.
+    expect(getShortUrl(UUIDS[0], 70000, 'pageid')).toBe(
+      `https://sourcelibrary.org/book/${UUIDS[0]}/page/pageid`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3940.

## The problem

`encodeShortlink` packed exactly 12 bytes of ObjectId + 2 bytes of page, and `getShortUrl` explicitly fell back to the long URL for anything that wasn't 24-hex. UUIDs are 16 bytes, so **71 visible UUID-keyed books** got no `/q/` shortlink at all — they could only be cited as `/book/<uuid>/page/<pageid>`. Reported over MCP on Weyer *De praestigiis daemonum*, Pico *Opera Omnia* Basel 1601 (100% translated), an Agrippa 1533, and a Porta 1607. Shortlinks are what researchers cite in papers, so this hit some of the most complete translations in the corpus.

## The fix

The **extended-encoding** option from the issue (stateless, no lookup table, no extra read):

- 16 bytes of UUID + 2 bytes of page = 18 bytes → base62 → **zero-padded to exactly 25 chars**, behind a `u` prefix. So a UUID code is always exactly 26 chars.
- The fixed width is load-bearing: a UUID with small leading bytes would otherwise encode short and be decoded by the 14-byte ObjectId branch. The padding is what makes "recognise the scheme by shape" true rather than probably-true.
- ObjectId codes top out at 19 chars (2^112 < 62^19), so the two widths cannot overlap — including for codes that happen to start with `u`, since base62 contains `u`.
- `getShortUrl` also now falls back instead of throwing when a page number is outside the 2 bytes both schemes reserve for it.

## Scope

In: `src/lib/shortlinks.ts` + a unit test. As the issue predicted, **no call site changes** — the `/q/` route decodes and then looks pages up by `book_id` and resolves the book slug, which works for UUID ids unchanged (`pages.book_id` and `books.id` both hold the dashed UUID; verified against the `bookstore` db).

Out: DB-backed short codes (the other option in the issue) — rejected because it adds a read to every shortlink resolution and the stateless scheme costs only 7 extra chars. Also out: shortening the 26-char code, and any change to the ObjectId scheme.

## Verification

- `npx vitest run` — 2764 tests / 194 files pass; `npx tsc --noEmit` clean.
- New test asserts UUID round-trips (incl. all-zero and all-`f` UUIDs), the fixed 26-char shape, the no-collision width bound, and that a published code from `/about` (`BhIfljO2ApigrcHcTeD`) both decodes and re-encodes byte-identically.
- End-to-end against a dev server on real data:
  - `/q/u060S7hUHNdpHdNCexTcMbWqRN` → 302 → `/book/theatrum-chemicum-vol-iii-1602-zetzner/page/69500496f426a210d10963a3` (UUID book, previously unshortlinkable)
  - `/q/BhIfljO2ApigrcHcTeD` → 302 → the same Plato page as before (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)