### PR TITLE
fix(editions): add work_language beside citation.original_language (#3959)

### DIFF
--- a/.claude/docs/editions.md
+++ b/.claude/docs/editions.md
@@ -12,7 +12,7 @@ id, book_id, version (semver), version_label, status (draft|published|superseded
 doi, doi_url, zenodo_id, zenodo_url,
 page_ids[], page_count, content_hash (SHA-256),
 contributors: [{ name, role, type (ai|human), orcid, model }],
-citation: { title, original_title, original_author, original_language, target_language },
+citation: { title, original_title, original_author, original_language, work_language?, target_language },
 license (SPDX: CC-BY-4.0, CC0-1.0, etc.),
 previous_version_id, previous_version_doi, changelog,
 front_matter: { introduction, methodology, acknowledgments, generated_at },
@@ -43,6 +43,41 @@ The route:
 - Gathers AI contributors from page translation models
 - Creates immutable edition record
 - Marks previous published edition as `superseded`
+
+#### The citation block's two languages (#3959)
+
+`citation.original_language` does not mean what its name suggests. It is the
+language of the leaves **we translated from**, which on a translated edition is
+not the language of the work: de Slane's 1863 French *Muqaddimah* yields
+`original_language: "French"` — true about our English translation's source,
+silent about the work being Arabic. Under-specified, not wrong.
+
+`citation.work_language` (added #3959) names the work's language, and appears
+**only when it differs**, so a citation for a translation-of-a-translation can
+state the whole chain. Both are built by `citationLanguageFields()` in
+`src/lib/edition-language.ts`, with a lockstep twin at
+`scripts/lib/edition-citation-language.mjs` for the batch minters — node can't
+import `.ts`. `scripts/audit/edition-citation-language-twins.mjs` asserts the two
+agree (`node --import tsx …`); run it if you touch either.
+
+Two rules, because this block is persisted into `books.editions[]` and travels
+into minted DOI payloads:
+
+- **`original_language` is written verbatim from `books.language`, never
+  normalised.** Normalising would rewrite `"lat"` → `"Latin"` and
+  `"Ancient Greek"` → `"Greek"` on every future edition, silently changing what
+  an already-published citation series claims. Only the new field is normalised.
+- **Historic rows are not backfilled.** A minted citation is a published
+  artifact; editions without `work_language` keep reading exactly as minted, and
+  every consumer treats the absent field as "no distinction to draw". As of
+  2026-08-14 this affects 1 of 167 edition-holding books (a Boethius *De
+  consolatione philosophiae* whose leaves are English over a Latin work).
+
+Zenodo's own language metadata is a **separate** instance of the same
+manifestation-vs-work conflation — `buildDepositionMetadata` reads only
+`citation.title` and re-derives `languages`/`subjects` straight from
+`book.language` (`src/lib/zenodo.ts:379-390`, `:406`). Fixing the citation block
+does not touch DOI payload languages; that is its own issue.
 
 ### 2. Generate Front Matter
 `POST /api/books/{id}/editions/front-matter`

--- a/scripts/audit/edition-citation-language-twins.mjs
+++ b/scripts/audit/edition-citation-language-twins.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Do the two `citationLanguageFields()` implementations agree? (#3959)
+ *
+ * `scripts/lib/edition-citation-language.mjs` and the `citationLanguageFields()`
+ * in `src/lib/edition-language.ts` write the SAME persisted field into
+ * `books.editions[].citation`, from two runtimes that cannot import each other.
+ * Twin files drift silently, and this pair drifts into a minted DOI payload —
+ * so the agreement is worth a runnable check rather than a comment asking for it.
+ *
+ * The TS side is loaded through `tsx`, so this needs no build step:
+ *   node --import tsx scripts/audit/edition-citation-language-twins.mjs
+ *
+ * Exits non-zero on the first disagreement, naming the input.
+ */
+import { citationLanguageFields as fromScripts } from '../lib/edition-citation-language.mjs';
+
+// The package is CommonJS, so tsx transpiles the .ts module to CJS and a static
+// named import from an .mjs file fails ("does not provide an export named").
+// Dynamic import + interop unwrap works under both shapes.
+const srcModule = await import('../../src/lib/edition-language.ts');
+const fromSrc = (srcModule.citationLanguageFields ?? srcModule.default?.citationLanguageFields);
+if (typeof fromSrc !== 'function') {
+  console.error('Could not load citationLanguageFields from src/lib/edition-language.ts');
+  console.error(`exports seen: ${JSON.stringify(Object.keys(srcModule))}`);
+  process.exit(1);
+}
+
+/**
+ * Cases are the shapes that actually occur on `books`, not a fuzz sweep: raw
+ * codes from IIIF/IA, historical registers, placeholders, the de Slane
+ * translation-of-a-translation, and the equal-language case that must stay silent.
+ */
+const CASES = [
+  { label: 'plain original', language: 'Latin' },
+  { label: 'de Slane Muqaddimah', language: 'French', original_language: 'Arabic' },
+  { label: 'raw 3-letter codes', language: 'fre', original_language: 'ara' },
+  { label: 'raw 2-letter codes', language: 'de', original_language: 'la' },
+  { label: 'register prefix on work', language: 'German', original_language: 'Ancient Greek' },
+  { label: 'register prefix both sides', language: 'Medieval Latin', original_language: 'Classical Latin' },
+  { label: 'work equals edition', language: 'Latin', original_language: 'Latin' },
+  { label: 'work equals edition via code', language: 'Latin', original_language: 'lat' },
+  { label: 'placeholder work', language: 'French', original_language: 'unknown' },
+  { label: 'placeholder work (n/a)', language: 'French', original_language: 'n/a' },
+  { label: 'missing edition language', original_language: 'Arabic' },
+  { label: 'empty book', },
+  { label: 'unmapped language', language: 'Occitan', original_language: 'Gascon' },
+  { label: 'translated flag only', language: 'English', is_translation: true },
+  { label: 'text_role only', language: 'English', text_role: 'modern-translation' },
+];
+
+let failures = 0;
+for (const { label, ...book } of CASES) {
+  const a = fromScripts(book);
+  const b = fromSrc(book);
+  const same = JSON.stringify(a) === JSON.stringify(b);
+  if (!same) {
+    failures++;
+    console.error(`✗ ${label}`);
+    console.error(`    scripts: ${JSON.stringify(a)}`);
+    console.error(`    src:     ${JSON.stringify(b)}`);
+  } else {
+    console.log(`✓ ${label} → ${JSON.stringify(a)}`);
+  }
+}
+
+if (failures) {
+  console.error(`\n${failures}/${CASES.length} disagree — the twins have drifted.`);
+  process.exit(1);
+}
+console.log(`\nAll ${CASES.length} cases agree.`);

--- a/scripts/batch/batch-mint-doi.mjs
+++ b/scripts/batch/batch-mint-doi.mjs
@@ -24,6 +24,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { generateScholarlyPdf } from '../lib/scholarly-typst.mjs';
+import { citationLanguageFields } from '../lib/edition-citation-language.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -461,7 +462,9 @@ function createEdition(book, translatedPages) {
       title: `English Translation of ${book.display_title || book.title}`,
       original_title: book.title,
       original_author: book.author,
-      original_language: book.language,
+      // original_language is the language we translated FROM; work_language
+      // appears beside it only when the work itself is in a third language.
+      ...citationLanguageFields(book),
       original_published: book.published,
       target_language: 'en',
     },

--- a/scripts/lib/batch-mint-doi.mjs
+++ b/scripts/lib/batch-mint-doi.mjs
@@ -24,6 +24,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { generateScholarlyPdf } from '../lib/scholarly-typst.mjs';
+import { citationLanguageFields } from '../lib/edition-citation-language.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -456,7 +457,9 @@ function createEdition(book, translatedPages) {
       title: `English Translation of ${book.display_title || book.title}`,
       original_title: book.title,
       original_author: book.author,
-      original_language: book.language,
+      // original_language is the language we translated FROM; work_language
+      // appears beside it only when the work itself is in a third language.
+      ...citationLanguageFields(book),
       original_published: book.published,
       target_language: 'en',
     },

--- a/scripts/lib/edition-citation-language.mjs
+++ b/scripts/lib/edition-citation-language.mjs
@@ -1,0 +1,91 @@
+/**
+ * The language pair for a scholarly edition's `citation` block (#3959).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `editions[].citation.original_language` predates the edition-vs-work
+ * vocabulary and means something narrower than its name suggests: the language
+ * of the leaves WE translated from. On de Slane's French *Muqaddimah* that is
+ * "French" — a true statement about our English translation's source, and one
+ * that says nothing about the work being Arabic. The field is therefore
+ * under-specified, not wrong, and the reader of a DOI citation cannot tell which
+ * sense is meant.
+ *
+ * THE INVARIANT
+ * -------------
+ * This block is persisted into `books.editions[]` and travels into minted DOI
+ * citation payloads, so the fix is strictly ADDITIVE:
+ *
+ *  - `original_language` is passed through VERBATIM from `books.language`, with
+ *    no normalisation. Normalising it would rewrite "lat" to "Latin" and
+ *    "Ancient Greek" to "Greek" on every future edition, silently changing what
+ *    an already-published citation series claims.
+ *  - `work_language` is new, normalised, and omitted when it carries no
+ *    information — so a citation for a translation-of-a-translation can state
+ *    the whole chain while historic rows keep reading exactly as minted.
+ *
+ * Naming follows src/lib/edition-language.ts (#3942): `work_language`, not a
+ * second use of "original", because "original" is the word that caused the
+ * confusion in the first place.
+ *
+ * TWIN FILE: src/lib/edition-language.ts holds `citationLanguageFields()` for
+ * TS/src consumers (node can't import .ts, Next can't import .mjs scripts).
+ * Keep the two in lockstep, like scripts/lib/r2-key.mjs + src/lib/r2-key.ts.
+ *
+ * The comparison — the load-bearing decision, "are these two the same language?"
+ * — is delegated to `canonicalLanguage()` in ./source-language-match.mjs rather
+ * than re-tabulating the code→name mappings here. One alias table, one place to
+ * fix it. A token neither table resolves falls back to the title-cased raw
+ * string, which is what displayLanguage() does on the same input.
+ */
+import { canonicalLanguage } from './source-language-match.mjs';
+
+/**
+ * Tokens that mean "no usable language signal" — mirrors PLACEHOLDER_LANGS in
+ * src/lib/language-utils.ts. A placeholder must never be emitted as a work
+ * language: "the work was written in unknown" is worse than saying nothing.
+ */
+const PLACEHOLDER_LANGS = new Set([
+  'none', 'n/a', 'na', 'unknown', 'und', 'null', '', 'multiple', 'mul',
+  'mixed', 'various', 'zxx', 'undetermined',
+]);
+
+/** Historical-register prefixes displayLanguage() strips before comparing. */
+const REGISTER_PREFIX = /^(modern|ancient|old|classical|medieval|middle|early)\s+/;
+
+function titleCase(value) {
+  return value.replace(/\b[a-z]/g, c => c.toUpperCase());
+}
+
+/**
+ * Normalise a raw language token to a canonical display name, or null when it
+ * carries no signal. Mirrors displayLanguage() in src/lib/language-utils.ts.
+ */
+function displayLanguage(raw) {
+  if (!raw) return null;
+  const cleaned = String(raw).toLowerCase().trim().replace(REGISTER_PREFIX, '');
+  if (!cleaned || PLACEHOLDER_LANGS.has(cleaned)) return null;
+  const canonical = canonicalLanguage(cleaned);
+  return titleCase(canonical || cleaned);
+}
+
+/**
+ * Build the `original_language` / `work_language` pair for a citation block.
+ *
+ * `work_language` is emitted only when the work's language is known AND differs
+ * from the language we translated from. Equal languages carry no information
+ * (the FRBR work and manifestation coincide), and an absent field reads as "this
+ * edition is in the work's own language" — whereas `work_language: null` invites
+ * a citation renderer to print "null".
+ */
+export function citationLanguageFields(book) {
+  const fields = { original_language: book.language ?? '' };
+
+  const edition = displayLanguage(book.language);
+  const work = displayLanguage(book.original_language);
+  if (work && (!edition || work.toLowerCase() !== edition.toLowerCase())) {
+    fields.work_language = work;
+  }
+
+  return fields;
+}

--- a/src/app/api/[tenant]/books/[id]/editions/route.ts
+++ b/src/app/api/[tenant]/books/[id]/editions/route.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAuth } from '@/lib/auth-helpers';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { citationLanguageFields } from '@/lib/edition-language';
 
 // SPDX license options
 export const LICENSES = [
@@ -175,7 +176,9 @@ export const POST = withAuth(async (request, session, context) => {
         title: `English Translation of ${book.display_title || book.title}`,
         original_title: book.title,
         original_author: book.author,
-        original_language: book.language,
+        // original_language is the language we translated FROM; work_language
+        // appears beside it only when the work itself is in a third language.
+        ...citationLanguageFields(book),
         original_published: book.published,
         target_language: 'en',
       },

--- a/src/app/api/books/[id]/editions/route.ts
+++ b/src/app/api/books/[id]/editions/route.ts
@@ -4,6 +4,7 @@ import { TranslationEdition, Contributor, Page, Book } from '@/lib/types';
 import crypto from 'crypto';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAuth } from '@/lib/auth-helpers';
+import { citationLanguageFields } from '@/lib/edition-language';
 
 // SPDX license options
 export const LICENSES = [
@@ -163,7 +164,9 @@ export const POST = withAuth(async (request, session, context) => {
         title: `English Translation of ${book.display_title || book.title}`,
         original_title: book.title,
         original_author: book.author,
-        original_language: book.language,
+        // original_language is the language we translated FROM; work_language
+        // appears beside it only when the work itself is in a third language.
+        ...citationLanguageFields(book),
         original_published: book.published,
         target_language: 'en',
       },

--- a/src/components/editions/EditionsPanel.tsx
+++ b/src/components/editions/EditionsPanel.tsx
@@ -48,6 +48,17 @@ export default function EditionsPanel({ bookId, editions: initialEditions, onDoi
     const year = edition.published_at ? new Date(edition.published_at).getFullYear() : new Date().getFullYear();
     const author = edition.citation.original_author || 'Anonymous';
 
+    // `language` is the language we translated FROM, which on a translated
+    // edition is not the language of the work. BibTeX has no field for the chain,
+    // so when the two differ the note states it — otherwise a citation for our
+    // English←French←Arabic Muqaddimah reads as though the work were French.
+    // Absent on editions minted before #3959; those keep reading as minted.
+    const work = edition.citation.work_language;
+    const source = edition.citation.original_language;
+    const note = work && source
+      ? `AI-assisted translation from ${source}; the work was written in ${work}`
+      : 'AI-assisted translation';
+
     return `@book{sourcelibrary_${year}_${edition.id.slice(0, 8)},
   author       = {${author}},
   title        = {${edition.citation.original_title}},
@@ -55,10 +66,11 @@ export default function EditionsPanel({ bookId, editions: initialEditions, onDoi
   year         = ${year},
   publisher    = {Source Library},
   edition      = {${edition.version}},
-  note         = {AI-assisted translation},${edition.doi ? `
+  note         = {${note}},${edition.doi ? `
   doi          = {${edition.doi}},
   url          = {https://doi.org/${edition.doi}},` : ''}
-  language     = {${edition.citation.original_language || 'unknown'}}
+  language     = {${source || 'unknown'}}${work ? `,
+  origlanguage = {${work}}` : ''}
 }`;
   };
 

--- a/src/lib/edition-language.ts
+++ b/src/lib/edition-language.ts
@@ -92,6 +92,44 @@ export function languageApparatusFields(
 }
 
 /**
+ * The language pair for a scholarly edition's `citation` block (#3959).
+ *
+ * `editions[].citation.original_language` predates this vocabulary and means
+ * something narrower than its name suggests: the language of the leaves WE
+ * translated from. On de Slane's French *Muqaddimah* that is "French", which is
+ * a true statement about our English translation's source and says nothing about
+ * the work being Arabic. So the field is under-specified, not wrong.
+ *
+ * It is also persisted into `books.editions[]` and travels into minted DOI
+ * citation payloads, so the fix is strictly ADDITIVE:
+ *
+ *  - `original_language` is passed through VERBATIM from `books.language`, with
+ *    no normalisation. Running it through `displayLanguage()` would rewrite
+ *    "lat" to "Latin" and "Ancient Greek" to "Greek" on every future edition,
+ *    silently changing what an already-published citation series claims.
+ *  - `work_language` is new, normalised, and omitted when it carries no
+ *    information — so a citation for a translation-of-a-translation can state
+ *    the whole chain while historic rows keep reading exactly as minted.
+ *
+ * TWIN FILE: scripts/lib/edition-citation-language.mjs mirrors this function for
+ * the batch DOI minters (node can't import .ts). Keep the two in lockstep, like
+ * scripts/lib/r2-key.mjs + src/lib/r2-key.ts.
+ */
+export interface CitationLanguageFields {
+  /** Language of the leaves this English translation was made FROM. Verbatim. */
+  original_language: string;
+  /** Language of the WORK, when it differs from the translation source. */
+  work_language?: string;
+}
+
+export function citationLanguageFields(book: LanguageApparatusSource): CitationLanguageFields {
+  const fields: CitationLanguageFields = { original_language: book.language ?? '' };
+  const { work_language } = languageApparatus(book);
+  if (work_language) fields.work_language = work_language;
+  return fields;
+}
+
+/**
  * True when a caller quoting this book's `original` field would be quoting a
  * translator rather than the author — the case the citation apparatus has to
  * disclose.

--- a/src/lib/types/edition.ts
+++ b/src/lib/types/edition.ts
@@ -53,7 +53,20 @@ export interface TranslationEdition {
     title: string;             // "English Translation of [Original Title]"
     original_title: string;
     original_author: string;
+    /**
+     * Language of the leaves THIS translation was made from — not necessarily
+     * the language of the work. Verbatim `books.language`; never normalised,
+     * because this field is persisted and travels into minted DOI payloads.
+     * See `citationLanguageFields()` in src/lib/edition-language.ts (#3959).
+     */
     original_language: string;
+    /**
+     * Language of the WORK, when it differs from `original_language` — i.e. when
+     * this edition is itself a translation and ours is a translation of a
+     * translation. Absent when the two coincide, and absent on every row minted
+     * before #3959 (historic citations are left as minted, not backfilled).
+     */
+    work_language?: string;
     original_published?: string;
     target_language: string;   // "en"
   };

--- a/tests/unit/edition-language.test.ts
+++ b/tests/unit/edition-language.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  citationLanguageFields,
   languageApparatus,
   languageApparatusFields,
   servesTranslatedOriginal,
@@ -90,5 +91,50 @@ describe('languageApparatus', () => {
     expect('edition_language' in f).toBe(false);
     expect(f.work_language).toBe('Arabic');
     expect(f.translation_note).toBeTruthy();
+  });
+});
+
+// #3959 — these values are persisted into books.editions[] and travel into
+// minted DOI citation payloads, so the tests that matter most are the ones
+// pinning what must NOT change.
+describe('citationLanguageFields', () => {
+  it('states the whole chain for a translation of a translation', () => {
+    const f = citationLanguageFields(IBN_KHALDUN);
+    // The language we translated FROM, under the name the schema already used.
+    expect(f.original_language).toBe('French');
+    // The language of the work, which the old block could not express at all.
+    expect(f.work_language).toBe('Arabic');
+  });
+
+  it('passes original_language through VERBATIM, without normalising it', () => {
+    // The load-bearing assertion. Normalising this field would rewrite "lat" to
+    // "Latin" on every future edition, silently changing what an already-minted
+    // citation series claims. Only the NEW field is normalised.
+    expect(citationLanguageFields({ language: 'lat' }).original_language).toBe('lat');
+    expect(citationLanguageFields({ language: 'Ancient Greek' }).original_language).toBe('Ancient Greek');
+    const f = citationLanguageFields({ language: 'fre', original_language: 'ara' });
+    expect(f.original_language).toBe('fre');
+    expect(f.work_language).toBe('Arabic');
+  });
+
+  it('omits work_language when it carries no information', () => {
+    // Absent, not null: an absent field reads as "this edition is in the work's
+    // own language", while work_language: null invites a citation renderer to
+    // print "null" into a published payload.
+    for (const book of [
+      { language: 'Latin' },
+      { language: 'Latin', original_language: 'Latin' },
+      { language: 'Latin', original_language: 'lat' },
+      { language: 'French', original_language: 'unknown' },
+      { language: 'English', text_role: 'modern-translation' },
+    ]) {
+      expect('work_language' in citationLanguageFields(book)).toBe(false);
+    }
+  });
+
+  it('never emits undefined for original_language on a language-less record', () => {
+    // The field is non-optional in TranslationEdition and gets serialised into a
+    // citation; an undefined here would render as "undefined" beside a DOI.
+    expect(citationLanguageFields({}).original_language).toBe('');
   });
 });


### PR DESCRIPTION
Closes #3959.

## The problem

`editions[].citation.original_language` is **under-specified, not wrong**. It names the language of the leaves *we translated from*, which on a translated edition is not the language of the work. De Slane's 1863 French *Muqaddimah* yields `original_language: "French"` — a true statement about our English translation's source, and silent about the work being Arabic. A reader of the DOI citation cannot tell which sense is meant.

## The fix is strictly additive

The block is persisted into `books.editions[]` and travels into minted DOI citation payloads, so nothing existing changes shape or value:

- **`original_language` keeps its name AND its verbatim value.** It is passed through from `books.language` with no normalisation. This is the load-bearing decision and it has a test: normalising would rewrite `"lat"` → `"Latin"` and `"Ancient Greek"` → `"Greek"` on every future edition, silently changing what an already-published citation series claims.
- **`work_language` is new**, normalised, and omitted when it carries no information — so a citation for a translation-of-a-translation can state the whole chain while historic rows read exactly as minted.
- **No backfill.** A minted citation is a published artifact; every consumer treats the absent field as "no distinction to draw".

## Blast radius, measured

Only three files in the repo read `editions[].citation` at all:

| Reader | What it reads | Effect |
|---|---|---|
| `EditionsPanel.tsx` | `original_author`, `original_title`, `original_language`, `title` | BibTeX now emits `origlanguage` and states the chain in `note` **when the two differ**; byte-identical output when they don't |
| `src/lib/zenodo.ts:369` | `citation.title` **only** | none |
| both `batch-mint-doi.mjs` | `citation.title` only | none |

No consumer iterates the citation object (`Object.keys`/`entries`/spread-render), so a new field cannot perturb existing output. `original_published` and `target_language` have zero readers anywhere. Front matter, PDF, EPUB and schema.org never touch the citation block.

**Data impact, measured 2026-08-14 against `bookstore`:** 167 books hold editions; **1** would gain `work_language` on its next mint — a Boethius *De consolatione philosophiae* whose leaves are English over a Latin work, i.e. exactly the case the issue describes. 4,133 books have `original_language` set, so this grows as translations get minted.

## One writer, four sites

`citationLanguageFields()` in `src/lib/edition-language.ts` (reusing the `#3956` vocabulary) replaces four hand-built copies of the block: both API routes and both `batch-mint-doi.mjs` forks. Node can't import `.ts`, so the minters get a lockstep twin at `scripts/lib/edition-citation-language.mjs` — the established `scripts/lib/r2-key.mjs` + `src/lib/r2-key.ts` pattern, and it delegates the comparison to the existing `canonicalLanguage()` alias table rather than re-tabulating code→name mappings.

Twin files drift silently, and **this pair drifts into a minted DOI payload**, so the agreement is a runnable check rather than a comment asking for it: `scripts/audit/edition-citation-language-twins.mjs` compares both implementations across 15 real corpus shapes (raw 3- and 2-letter codes, historical-register prefixes, placeholders, the de Slane case, equal-language, missing language). All 15 agree.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **2782 passed / 195 files**, including 4 new `citationLanguageFields` cases
- `node --import tsx scripts/audit/edition-citation-language-twins.mjs` — 15/15 agree
- `node --check` on all three `.mjs` files
- `eslint` on every changed file — no new warnings (the 7 reported are pre-existing unused-vars)

## Out of scope

**Zenodo's language metadata is a second, independent instance of the same manifestation-vs-work conflation.** `buildDepositionMetadata` reads only `citation.title` and re-derives `languages`/`subjects` straight from `book.language` ([zenodo.ts:379-390](src/lib/zenodo.ts#L379-L390), [:406](src/lib/zenodo.ts#L406)). So fixing the citation block does **not** change any DOI payload language — the issue's framing that this field "travels into Zenodo payloads" is true only of `citation.title`. That needs its own issue; deliberately not bundled here because it changes what published depositions claim.

Also left alone: the two near-duplicate `batch-mint-doi.mjs` forks (they differ only in a prompt's hallucination guardrails, and neither is wired into `package.json`) — deduplicating them is a separate concern from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
