### PR TITLE
feat(audit): field-sprawl watch — weekly ceiling + retired-field ratchet (#3969)

### DIFF
--- a/.github/workflows/field-sprawl-watch.yml
+++ b/.github/workflows/field-sprawl-watch.yml
@@ -1,0 +1,58 @@
+name: Field sprawl watch
+
+# The ratchet half of issue #3969 ("a sweep must record a ROW, not a COLUMN").
+#
+# Two things can only be caught by a standing watch, because the sessions that
+# cause them are gone by the time the damage is visible:
+#   1. The field count on a watched collection drifting UP — some sweep wrote
+#      its verdict as a new column again.
+#   2. A RETIRED field reappearing — a consolidation being silently undone by
+#      a reused writer. This is not hypothetical: tenant_id was cleaned off
+#      45K books + 6.4M pages in PR #2085 and was back on 20K books + 1.4M
+#      pages within 3 months (PR #3983 stripped the writers).
+#
+# Read-only. Findings go to a tracking issue, not a red X on someone's PR
+# (same reasoning as corpus-integrity-watch.yml). Ratchet --max-fields DOWN
+# after each #3969 family consolidation; add each retired field to --forbid.
+
+on:
+  schedule:
+    # Weekly, Tuesdays 07:30 UTC.
+    - cron: '30 7 * * 2'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  field-sprawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci --ignore-scripts
+      - name: Audit field sprawl on watched collections
+        id: run
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          set +e
+          node scripts/audit/field-sprawl.mjs \
+            --collection books \
+            --max-fields 400 \
+            --forbid tenant_id,hide_reason > report.txt 2>&1
+          echo "fired=$?" >> "$GITHUB_OUTPUT"
+          tail -60 report.txt
+      - name: File findings
+        if: steps.run.outputs.fired != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Field sprawl breach on books — $(date -u +'%Y-%m-%d')"
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "Either the field count exceeded the ceiling (a sweep wrote a COLUMN again) or a retired field reappeared (a consolidation is being undone by a reused writer). See issue #3969 for the playbook: find the writer, strip it, re-clean — do not just raise the ceiling." \
+            "$(tail -60 report.txt)")
+          gh issue create --title "$TITLE" --body "$BODY" --label pipeline

--- a/scripts/audit/field-sprawl.mjs
+++ b/scripts/audit/field-sprawl.mjs
@@ -84,6 +84,11 @@ const SAMPLE = Number(argVal('--sample') || 3000);
 // ratcheted DOWN deliberately, never drift up unnoticed.
 const MAX_FIELDS = Number(argVal('--max-fields') || 410);
 
+// Retired fields: consolidated away and never allowed back. A reappearance
+// means some writer re-grew a field a consolidation removed (this happened to
+// tenant_id within 3 months of PR #2085) — fail loudly. Comma-separated.
+const FORBID = (argVal('--forbid') || '').split(',').map((s) => s.trim()).filter(Boolean);
+
 // Collections worth watching by default. Everything else needs --all.
 const WATCHED = ['books', 'deleted_books', 'books_warehouse', 'pages', 'first_translation_attempts', 'entities'];
 
@@ -386,6 +391,18 @@ async function main() {
     if (WATCHED.includes(name) && census.fields.length > MAX_FIELDS) {
       console.log(`\n   !! ${census.fields.length} fields exceeds the --max-fields ceiling of ${MAX_FIELDS}`);
       breach = true;
+    }
+
+    if (FORBID.length) {
+      // Exact countDocuments, not the sample: a retired field re-growing on
+      // 0.1% of docs is precisely the case the sample would miss.
+      for (const f of FORBID) {
+        const n = await db.collection(name).countDocuments({ [f]: { $exists: true } });
+        if (n > 0) {
+          console.log(`\n   !! RETIRED field '${f}' is BACK on ${name}: ${n.toLocaleString()} docs. A writer re-grew it — find and strip the writer, then re-clean.`);
+          breach = true;
+        }
+      }
     }
 
     report.collections.push({ ...census, buckets: Object.fromEntries(Object.entries(buckets).map(([k, v]) => [k, v.length])), spellingPairs: spellings, partialPairs: partials, families: familyReport, nested });


### PR DESCRIPTION
## Why

The two drift modes only a standing watch can catch — the sessions that cause them are gone before the damage is visible:
1. **Field count creeping up** on a watched collection: a sweep wrote a COLUMN again.
2. **A retired field reappearing**: a consolidation silently undone by a reused writer. Not hypothetical — `tenant_id` was cleaned off 45K books + 6.4M pages in PR #2085 and was back on 20K books + 4.16M pages within 3 months (#3983 stripped the writers; cleanup re-applied 2026-08-13/14).

## What

- `field-sprawl.mjs --forbid a,b,c`: exact `countDocuments` per retired field (deliberately not sampled — a field re-growing on 0.1% of docs is precisely what sampling misses), breach exit on any hit. **Validated against production pre-cleanup: fired correctly on `tenant_id` (20,010) and `hide_reason` (500).**
- `.github/workflows/field-sprawl-watch.yml`: weekly (Tue 07:30 UTC), `--max-fields 400 --forbid tenant_id,hide_reason`. Files a tracking issue instead of failing a build — same reasoning as `corpus-integrity-watch.yml` (a red X on a stranger's PR trains people to ignore the signal). Uses the same org-level `MONGODB_URI` secret that workflow already uses.

## Ratchet protocol

After each #3969 family consolidation: lower `--max-fields`, append the retired names to `--forbid`. The playbook on a breach is in the filed issue text: find the writer, strip it, re-clean — never just raise the ceiling.

## Out of scope
- Watching `pages`/other collections (books first; extend after the pattern proves out).
- The DB-level validator (Track A, needs Derek's one-time dbAdmin action).

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)