### PR TITLE
docs(bph): a migration that bulk-writes bph_works pages a human at 04:30

### DIFF
--- a/.claude/docs/bph-catalogue-disaster-recovery.md
+++ b/.claude/docs/bph-catalogue-disaster-recovery.md
@@ -139,6 +139,47 @@ test after changing the grouping.
 A scan that *fails to run* also alerts: a silent detector and an untouched
 catalogue look identical from outside.
 
+### If you are writing a migration that touches `bph_works`, read this first
+
+**A bulk `UPDATE` on `bph_works` pages a human at 04:30 unless it writes
+revisions.** The monitor is doing its job when this happens — the alert cannot
+tell your migration from a stray credential, and that is the entire point — but
+an alert nobody predicted burns someone's morning and, repeated, trains everyone
+to wave the channel away.
+
+Happened 2026-08-14: `add-bph-uuid-keyed-revisions.sql` (PR #3985) backfilled
+`bph_works.uuid` on the 107 rows that had none, so a UNIQUE constraint could be
+added. `uuid` is in the `identifiers` group, the migration wrote no revisions,
+and the scan reported **105 unexplained changes** (105 flagged `changed`; the
+other 2 were records created that afternoon, new to the baseline, so they logged
+as `inserted` and were explained by their own create revisions). Nothing was
+wrong with the data — but nobody knew that until it had been chased.
+
+The contrast in the same night's scan is the lesson, because the same session
+produced both: `scripts/maintenance/translate-ja-state-shelfmark.mjs` changed 31
+rows and wrote a revision per row, and all 31 events came back
+`explanation = revision` with `revision_id` set. Same author, same evening, one
+noisy and one silent — the difference was purely whether history was written.
+
+So, before applying a migration that writes catalogue columns, do one of:
+
+1. **Write a revision row per record** (`editor_email: 'system:<migration>'`),
+   the way `clear-neen-state-shelfmark.mjs` and `translate-ja-state-shelfmark.mjs`
+   do. Best option: the change becomes individually reversible as well as
+   explained.
+2. **Pre-declare it** — tell whoever watches ntfy what is about to move and how
+   many rows, so the morning alert is a confirmation instead of a mystery.
+3. **Mark the events reviewed afterwards** with a note naming the migration
+   (`reviewed_at` / `reviewed_by` / `note`), which is what was done above. This
+   is the fallback, not the plan: it clears the board only after someone has
+   already paid the investigation cost.
+
+Never resolve an unexplained event by pattern-matching on count or timing alone.
+Confirm which columns actually moved — group membership is in
+`add-bph-integrity-monitor.sql` — and sweep only the events you have accounted
+for. In the incident above the review script asserted the bucket contained
+*only* identifiers-only events before touching any of them.
+
 ## Re-drill periodically
 
 The point of a drill is that it decays. Re-run steps 1–3 above (scratch table, then

--- a/scripts/migration/add-bph-uuid-keyed-revisions.sql
+++ b/scripts/migration/add-bph-uuid-keyed-revisions.sql
@@ -46,8 +46,26 @@
 -- The 107 uuid-less rows are backfilled below so the UNIQUE constraint can be
 -- added; they are all UBN-keyed printed books whose links do not change.
 --
--- Run via Supabase SQL editor or psql:
---   psql "$SUPABASE_DB_URL" -f scripts/migration/add-bph-uuid-keyed-revisions.sql
+-- THIS MIGRATION PAGES A HUMAN. Step 1 writes `uuid` on 107 rows without
+-- writing any revision rows, and `uuid` sits in the integrity monitor's
+-- `identifiers` hash group — so the 04:30 scan reports them as UNEXPLAINED and
+-- ntfy alerts. That is the monitor working correctly (it cannot tell this from
+-- a stray credential), but it cost an investigation on 2026-08-14 because
+-- nobody predicted it. If you re-run this on another environment, tell whoever
+-- watches the channel first, and mark the resulting events reviewed with a note
+-- naming this file. See "If you are writing a migration that touches
+-- bph_works" in .claude/docs/bph-catalogue-disaster-recovery.md.
+--
+-- Applied to production 2026-08-13 ~22:55Z. The uuid backfill is one-way: it
+-- only fills nulls, so re-running is a no-op rather than a re-randomisation.
+--
+-- Run via Supabase SQL editor, or through the IPv4 SESSION pooler — the stored
+-- SUPABASE_DB_URL points at db.<ref>.supabase.co, which no longer resolves, and
+-- at port 6543, the TRANSACTION pooler, which refuses DDL. Session pooler is
+-- port 5432, user postgres.<ref>; this project answers on aws-1-eu-west-1. See
+-- scripts/migration/add-index-catalog-author-held.mjs for the region-probing
+-- connection helper. The backfill in step 5 runs ~3 minutes and exceeds the
+-- default statement_timeout — SET statement_timeout first or it rolls back.
 
 BEGIN;
 


### PR DESCRIPTION
The ntfy alert at 00:30 — **"BPH catalogue: 105 unexplained change(s), 105 × identifiers"** — was mine, and this documents the gap so the next person doesn't pay for it twice.

## What happened

`add-bph-uuid-keyed-revisions.sql` (#3985) backfilled `bph_works.uuid` on the 107 rows that had none, so a UNIQUE constraint could be added and revisions could key on uuid for the 2,012 records Memorix issues no UBN for.

`uuid` is in the monitor's `identifiers` hash group, and a migration writes no `bph_works_revisions` rows — so the 04:30 scan could not account for the change and paged a human. **The monitor was right.** It cannot distinguish my migration from a stray credential, and that is the whole point of it.

## Verified before clearing anything

- All 105 events were `changed | ["identifiers"] | UNEXPLAINED`, all from the 04:30 scan, none from any other group.
- Every affected row had **all other identifier columns null** (`ustc_sn`, `ia_identifier`, `ia_url`, `picturae_barcode`, `icn_registration_number`), so `uuid` is the only value that could have moved.
- 107 updated vs 105 flagged is fully accounted for: UBN **33000** and **33001** were created by `jbouman@efm.amsterdam` on 2026-08-13 (14:34 and 14:59), were new to the integrity baseline, and so logged as `inserted` — explained by their own create revisions. 105 + 2 = 107.
- I checked a v4-uuid "signature" first and **discarded it**: 561 rows corpus-wide carry v4 uuids, so it proves nothing. The column-and-timing evidence above is what stands.

The 105 events are marked `reviewed_at` / `reviewed_by` / `note` with the migration named. The review script asserted the bucket held *only* identifiers-only events before touching any of them, so a different finding could not be swept along.

## The lesson, and why it's worth a doc change

The same night's scan contains a controlled comparison, because one session produced both halves:

| change | revisions written? | verdict |
|---|---|---|
| `translate-ja-state-shelfmark.mjs` — 31 rows | yes, one per row | `revision`, `revision_id` set — silent |
| `add-bph-uuid-keyed-revisions.sql` — 107 rows | no | `UNEXPLAINED` — paged a human |

Same author, same evening. The only difference was whether history was written.

So the DR doc now tells a migration author, before they apply anything that writes catalogue columns, to do one of: **write a revision row per record** (best — also makes it individually reversible), **pre-declare the change** to whoever watches ntfy, or **mark the events reviewed afterwards** (the fallback, since it only clears the board after someone has already paid the investigation cost).

It also states the rule that saved this from being sloppy: never resolve an unexplained event on count or timing alone — confirm which columns moved, and sweep only what you have accounted for.

## Also captured

The migration header now records two things that cost a detour on the way in, both of which will cost it again otherwise:

- the stored `SUPABASE_DB_URL` points at `db.<ref>.supabase.co`, which **no longer resolves**, and at port **6543** — the transaction pooler, which refuses DDL. Session pooler is 5432, user `postgres.<ref>`; this project answers on `aws-1-eu-west-1`.
- the step-5 backfill runs ~3 minutes and **exceeds the default `statement_timeout`**, rolling the whole migration back.

## Still owed

`bph-catalogue-disaster-recovery.md` says to re-run the restore drill after any schema change to `bph_works`. #3985 added a column and a UNIQUE constraint, so **that drill is now owed** — about five minutes. Not done here; flagging rather than quietly skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
