### PR TITLE
docs+audit: codify ROW-not-COLUMN; ceiling nested sub-key sprawl (#3969)

### DIFF
--- a/.claude/docs/invariants/field-sprawl.md
+++ b/.claude/docs/invariants/field-sprawl.md
@@ -1,0 +1,59 @@
+# A sweep records a ROW, not a COLUMN
+
+**Read this when:** Writing a maintenance sweep or import that updates `books` or `pages`; adding a field to any Mongo collection; changing `scripts/lib/book-docs.mjs`, `scripts/lib/sweep-log.mjs`, or `scripts/audit/field-sprawl.mjs`; or deciding whether the `books` schema validator should move to `error` mode.
+
+*Written 2026-08-14 after #3969 families 1 and 2. See the issue for the full measurement history.*
+
+---
+
+## The rule
+
+**A sweep records a ROW in a log collection keyed to the book, never a new FIELD on the book.**
+
+Use `recordSweepAction(db, { sweep, book_id, action, detail })` from `scripts/lib/sweep-log.mjs`. It writes to `sweep_log`, stamped with the script name. Deliberately *not* `audit_log` — that one feeds the user-facing book history timeline, so writing there lets a bulk sweep actuate something readers see.
+
+Build import documents with `makeBookDoc()` / `makePageDoc()` from `scripts/lib/book-docs.mjs`. Unknown keys throw; retired keys throw with the incident that retired them.
+
+## Why this is correctness, not tidiness
+
+**A query against a field that exists but is 2%-populated returns a confident, well-formed, WRONG answer.** It does not error and does not return null — it returns a small clean number that reads like a finding.
+
+`books` reached **477 top-level fields with only 17 on ≥99% of documents**, ~140 written by a single sweep and then abandoned. Compare `books_warehouse`, the newest book collection: 129 fields, 25 core. The difference is not complexity; it is accretion.
+
+## The lesson that cost the most: consolidation without enforcement is a treadmill
+
+PR #2085 (2026-05-27) fully consolidated the tenant family — 45K books and 6.4M pages cleaned, writers stripped from `src/`, readers migrated, canonical field declared. It explicitly left the "one-shot historical import scripts" alone as already-run.
+
+**Those scripts are the standard route for 429-prone sources and are reused constantly.** Within three months the field was back on 20,010 books and 4,156,480 pages (#3983 stripped 62 write sites across 36 scripts; the data was re-cleaned 2026-08-13/14).
+
+So: **a cleanup is not done when the data is clean. It is done when something standing prevents the regrowth.** The four layers, strongest first:
+
+1. **The DB refuses it.** `$jsonSchema` + `additionalProperties: false` on `books`. Installing it needs `dbAdmin`; the app credential is `readWriteAnyDatabase` and cannot run `collMod` — that privilege split is what makes it a boundary rather than a convention. Generate with `field-sprawl.mjs --emit-validator` (full scan only — a sampled validator rejects legitimate writes to ~80 rare fields).
+2. **The easy path is the correct path.** The constructors above. One hand-rolled literal per script is why one bug shipped 62 times.
+3. **CI notices drift.** `field-sprawl-watch.yml`, weekly. `--max-fields` ratchets DOWN after each consolidation; `--forbid` lists retired names and fails on reappearance.
+4. **This document.** Weakest layer; the other three exist because it is.
+
+## Adding a legitimate field
+
+Adding a field is meant to be deliberate, not blocked. The path:
+
+1. Add it to `BOOK_FIELDS` / `PAGE_FIELDS` in `scripts/lib/book-docs.mjs` (in its comment-grouped section).
+2. If the validator is installed in `error` mode, re-emit and reinstall it — `field-sprawl.mjs --collection books --emit-validator <file>`, then `scripts/output/install-books-validator.mjs` with a dbAdmin credential. In `warn` mode nothing is required; the write succeeds and is logged.
+3. Ask once whether it should be a field at all. If it records *what a job did*, it is a row (`sweep_log`). If it describes *what the book is*, it is a field.
+
+## Traps that each cost a round
+
+- **Gap ratio does not rank danger.** `deleted_reason` and `deletion_reason` are a perfect duplicate on the same 15 books.
+- **Sampling undercounts fields by ~80 on `books`**, and a 200K-document `$sample` estimated a pages residue at 1.4M when the exact walk found **4.16M**. Anything deciding what to keep or delete must use exact counts.
+- **The validator binds only the top level.** A free-form object field (`metadata`, 60 sub-keys; `translation_verification`, 48) is an unguarded floor below it. The watch carries `--max-nested` for this.
+- **A restore path is a writer.** `POST /api/books/restore/[id]` spreads the drifted 260-field `deleted_books` shape back into `books`, which both re-pollutes retired fields and would 500 under `error` mode (#3997 — blocks the flip).
+- **Hour-scale Mongo jobs belong on Hetzner.** A residential connection drops sustained TLS flows; the 4.16M-row walk died three times locally and completed there.
+
+## Verifying
+
+```
+node --env-file=.env.production.local scripts/audit/field-sprawl.mjs --collection books
+node --env-file=.env.production.local scripts/audit/field-sprawl.mjs --collection books --forbid tenant_id,hide_reason
+```
+
+Exit 1 means a ceiling was exceeded or a retired field came back. **The response is to find the writer and strip it — never to raise the ceiling.**

--- a/.github/workflows/field-sprawl-watch.yml
+++ b/.github/workflows/field-sprawl-watch.yml
@@ -43,6 +43,7 @@ jobs:
           node scripts/audit/field-sprawl.mjs \
             --collection books \
             --max-fields 400 \
+            --max-nested 65 \
             --forbid tenant_id,hide_reason > report.txt 2>&1
           echo "fired=$?" >> "$GITHUB_OUTPUT"
           tail -60 report.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,9 @@ they open with a "Read this when" line so you can bail in two seconds.
 - Quoting a usage number, analytics read/write paths, alarms, health probes, **or using a model as a judge/screen** → `measurement-instruments.md`
 - Writing a test that pins behaviour, or a fixture for one → `tests-that-are-not-guards.md`
 
+**Writing a sweep, an import, or a new field**
+- Adding a field to `books`/`pages`, writing a maintenance sweep, or touching `book-docs.mjs`/`sweep-log.mjs`/`field-sprawl.mjs` → `field-sprawl.md` (**a sweep records a ROW, not a COLUMN**; consolidation without enforcement re-polluted 4.16M rows in 3 months)
+
 ## Domain Context
 
 Detect the work domain from the user's prompt and load the right context automatically:

--- a/scripts/audit/field-sprawl.mjs
+++ b/scripts/audit/field-sprawl.mjs
@@ -84,6 +84,16 @@ const SAMPLE = Number(argVal('--sample') || 3000);
 // ratcheted DOWN deliberately, never drift up unnoticed.
 const MAX_FIELDS = Number(argVal('--max-fields') || 410);
 
+// Ceiling on sub-keys inside a single object-valued field. The validator's
+// additionalProperties:false only binds the top level, so a free-form object
+// is the unguarded floor below it. 0 disables. Baseline 2026-08-14: the worst
+// is books.metadata at 60, so 65 leaves headroom and still catches growth.
+// NOTE: nestedCensus samples 1500 docs, so these counts JITTER a few either
+// way between runs (field_provenance read 37 then 39 minutes apart). Leave
+// several sub-keys of slack when ratcheting or the gate flakes on sampling
+// noise rather than on real drift.
+const MAX_NESTED = Number(argVal('--max-nested') || 0);
+
 // Retired fields: consolidated away and never allowed back. A reappearance
 // means some writer re-grew a field a consolidation removed (this happened to
 // tenant_id within 3 months of PR #2085) — fail loudly. Comma-separated.
@@ -386,6 +396,18 @@ async function main() {
       for (const n of nested) console.log(`   ${n.parent.padEnd(26)} on ${String(n.docs).padStart(7)} docs, ${n.subKeys} sub-keys`);
       const total = census.fields.length + nested.reduce((s, n) => s + n.subKeys, 0);
       console.log(`\n   TOTAL addressable fields (top-level + nested): ${total}`);
+
+      // A $jsonSchema validator with additionalProperties:false constrains only
+      // the TOP level — a free-form object field is an unguarded floor below it,
+      // where the next sweep can put its column instead. Ceiling it too.
+      if (MAX_NESTED) {
+        for (const n of nested) {
+          if (n.subKeys > MAX_NESTED) {
+            console.log(`\n   !! nested '${n.parent}' has ${n.subKeys} sub-keys, over the --max-nested ceiling of ${MAX_NESTED}`);
+            breach = true;
+          }
+        }
+      }
     }
 
     if (WATCHED.includes(name) && census.fields.length > MAX_FIELDS) {


### PR DESCRIPTION
Two gaps the family 1+2 consolidation left open.

## 1. The validator binds only the top level

`additionalProperties: false` constrains the top-level field set and says nothing about what goes *inside* a free-form object field. So `books.metadata` (60 sub-keys), `translation_verification` (49), `field_provenance` (~38) and `enrichment` (24) are an unguarded floor one level below the guard — exactly where the next sweep can put its column instead.

`field-sprawl.mjs` gains `--max-nested N`; the weekly watch runs it at **65** (worst today is `metadata` at 60). **Verified firing** at a deliberately low test threshold of 40:

```
!! nested 'translation_verification' has 49 sub-keys, over the --max-nested ceiling of 40
!! nested 'metadata' has 60 sub-keys, over the --max-nested ceiling of 40
```

One thing worth knowing before anyone ratchets it: sub-key counts come from a 1500-doc `$sample`, so they **jitter** — `field_provenance` read 37 and then 39 minutes apart. The ceiling deliberately carries slack, and the code says why, so a future tightening doesn't produce a gate that flakes on sampling noise instead of failing on real drift.

## 2. The rule had no durable home

'A sweep records a ROW, not a COLUMN' is now proven end-to-end on two families, which is the bar the issue itself set for codifying it. It fires only when you touch a specific subsystem, so per `CLAUDE.md`'s own budget discipline it goes in the **conditional tier**: a new `.claude/docs/invariants/field-sprawl.md` plus one routing line in the index. CLAUDE.md goes 227 → 230 lines, comfortably inside the ~250 budget, so nothing needed demoting.

The doc carries the things that actually cost rounds, not just the rule:
- consolidation without enforcement re-polluted **4.16M rows in under 3 months** (the #2085 → #3983 story) — the four enforcement layers, strongest first
- **how to add a legitimate field** — deliberate, not blocked, with the re-emit/reinstall path
- sampled estimates ran **3× low** (1.4M estimated vs 4.16M actual)
- a restore path is a writer (#3997)
- hour-scale Mongo jobs belong on Hetzner, not a laptop

## Out of scope
- Adopting the constructors in the import scripts (separate PR, in progress).
- Fixing the restore path (#3997) and the error-mode flip it blocks.
- Deleting dead tail fields — needs the reader survey first.

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)