### PR TITLE
refactor(import): build book/page docs via the whitelisted constructors (#3969)

### DIFF
--- a/.claude/docs/import-workflow.md
+++ b/.claude/docs/import-workflow.md
@@ -68,8 +68,17 @@ Applies to all contributors — human and AI.
 - `scripts/import/al-badri-direct.mjs` — original direct-insert pattern (bundled IA item).
 - `scripts/import/daoist-alchemy-ia-batch{,-2}.mjs` — batch-via-API examples.
 - `src/lib/dedup.ts` — fingerprint + normalize + `checkDuplicate` + `scanForDuplicates`.
+- `scripts/lib/book-docs.mjs` — `makeBookDoc`/`makePageDoc`, the whitelisted doc constructors.
 - `.claude/docs/chinese-iiif-sources.md` — per-source IIIF manifest patterns + gotchas.
 - `.claude/docs/daoist-alchemy-acquisition-list.md` — a worked want→dedupe→get example.
+
+## Building the insert docs
+Build every `books`/`pages` insert document with `makeBookDoc()` / `makePageDoc()` from
+`scripts/lib/book-docs.mjs` — never a bare object literal. Unknown keys throw, so a 478th
+field cannot ship silently the way the first 477 did; adding one is then a reviewed edit
+to the whitelist. All 50 direct-import scripts already do this — copy the nearest one.
+The rule, the incident behind it, and where per-book *actions* go instead (rows via
+`scripts/lib/sweep-log.mjs`) are in `.claude/docs/invariants/field-sprawl.md`.
 
 ## Invariants (don't violate)
 - Imports land HIDDEN; flip visible only after QA. Always set `visible`/`hidden` as a pair.

--- a/scripts/iiif-discovery/import-from-cache.mjs
+++ b/scripts/iiif-discovery/import-from-cache.mjs
@@ -39,6 +39,7 @@
 
 import { ObjectId } from 'mongodb';
 import { getScriptClient } from '../lib/mongo.mjs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const args = Object.fromEntries(
   process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
@@ -105,7 +106,7 @@ for (const c of cands) {
   const slug = await uniqueSlug(slugify(title));
   const bookId = new ObjectId();
   const facsimile = isArtwork || FACSIMILE;
-  const doc = {
+  const doc = makeBookDoc({
     _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
@@ -131,7 +132,7 @@ for (const c of cands) {
     ...(c.metadata?.subject_geographic ? { subject_geographic: c.metadata.subject_geographic } : {}),
     source_fingerprint: fp, normalized_title: normTitle(title), normalized_author: normAuthor(author),
     created_at: now, updated_at: now,
-  };
+  });
   if (doc.resource_type === undefined) delete doc.resource_type;
 
   try {
@@ -139,7 +140,7 @@ for (const c of cands) {
     if (!isArtwork) {
       const CHUNK = 500;
       for (let s = 0; s < pages.length; s += CHUNK) {
-        const pdocs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: doc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+        const pdocs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: doc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }); });
         await db.collection('pages').insertMany(pdocs, { ordered: false });
       }
     }

--- a/scripts/iiif-discovery/import-leiden-artworks.mjs
+++ b/scripts/iiif-discovery/import-leiden-artworks.mjs
@@ -36,6 +36,7 @@
 
 import { ObjectId } from 'mongodb';
 import { getScriptClient } from '../lib/mongo.mjs';
+import { makeBookDoc } from '../lib/book-docs.mjs';
 
 const args = Object.fromEntries(
   process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
@@ -111,7 +112,7 @@ for (const c of cands) {
   const bookId = new ObjectId();
   const now = new Date();
   const normTitle = normalizeTitle(title), normAuthor = normalizeAuthor(author);
-  const doc = {
+  const doc = makeBookDoc({
     _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
@@ -143,7 +144,7 @@ for (const c of cands) {
     ...(c.metadata?.reference ? { provenance_reference: c.metadata.reference } : {}),
     source_fingerprint: fp, normalized_title: normTitle, normalized_author: normAuthor,
     created_at: now, updated_at: now,
-  };
+  });
   try {
     await db.collection('books').insertOne(doc);
     await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: doc.id, imported_at: now } });

--- a/scripts/iiif-discovery/import-leiden-books.mjs
+++ b/scripts/iiif-discovery/import-leiden-books.mjs
@@ -37,6 +37,7 @@
 import { ObjectId } from 'mongodb';
 import { chromium } from 'playwright';
 import { getScriptClient } from '../lib/mongo.mjs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const args = Object.fromEntries(
   process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
@@ -124,7 +125,7 @@ for (const c of cands) {
   const slug = await uniqueSlug(slugify(title));
   const bookId = new ObjectId();
   const now = new Date();
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId, id: bookId.toHexString(), slug,
     title, display_title: title, author,
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
@@ -149,12 +150,12 @@ for (const c of cands) {
     ...(c.metadata?.subject_geographic ? { subject_geographic: c.metadata.subject_geographic } : {}),
     source_fingerprint: fp, normalized_title: normalizeTitle(title), normalized_author: normalizeAuthor(author),
     created_at: now, updated_at: now,
-  };
+  });
   try {
     await db.collection('books').insertOne(bookDoc);
     const CHUNK = 500;
     for (let s = 0; s < pages.length; s += CHUNK) {
-      const docs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: bookDoc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: bookDoc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }); });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: bookDoc.id, imported_at: now } });

--- a/scripts/import-aic-artworks.mjs
+++ b/scripts/import-aic-artworks.mjs
@@ -16,6 +16,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const AIC_API = 'https://api.artic.edu/api/v1';
 const AIC_IIIF = 'https://www.artic.edu/iiif/2';
@@ -282,7 +283,7 @@ async function main() {
           }
         }
 
-        const doc = {
+        const doc = makeBookDoc({
           id: generateId(),
           slug,
           title,
@@ -332,7 +333,7 @@ async function main() {
             access_date: new Date().toISOString(),
           },
           harvested_at: new Date(),
-        };
+        });
 
         try {
           await books.insertOne(doc);

--- a/scripts/import-cleveland-artworks.mjs
+++ b/scripts/import-cleveland-artworks.mjs
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const CMA_API = 'https://openaccess-api.clevelandart.org/api/artworks';
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
@@ -191,7 +192,7 @@ function buildDoc(obj, slug, resourceType, displayUrl, thumbUrl, width, height) 
     ? String(obj.creation_date_earliest)
     : yearMatch?.[0] || '';
 
-  return {
+  return makeBookDoc({
     id: generateId(),
     slug,
     title,
@@ -238,7 +239,7 @@ function buildDoc(obj, slug, resourceType, displayUrl, thumbUrl, width, height) 
       access_date: new Date().toISOString(),
     },
     harvested_at: new Date(),
-  };
+  });
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────

--- a/scripts/import-commons-artworks.mjs
+++ b/scripts/import-commons-artworks.mjs
@@ -27,6 +27,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
@@ -556,7 +557,7 @@ async function main() {
       }
 
       // Build the book document
-      const doc = {
+      const doc = makeBookDoc({
         id: generateId(),
         slug: `art-${slug}`,
         title: info.title || info.commonsTitle.replace('File:', '').replace(/\.[^.]+$/, ''),
@@ -625,7 +626,7 @@ async function main() {
           attribution: info.credit || info.artist || '',
           access_date: new Date(),
         },
-      };
+      });
 
       if (dryRun) {
         console.log(`  [DRY] ${doc.slug} — ${doc.title} (${info.width}x${info.height})`);

--- a/scripts/import-getty-artworks.mjs
+++ b/scripts/import-getty-artworks.mjs
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const GETTY_API = 'https://data.getty.edu/museum/collection';
 const GETTY_IIIF = 'https://media.getty.edu/iiif/image';
@@ -297,7 +298,7 @@ async function main() {
             }
           }
 
-          const doc = {
+          const doc = makeBookDoc({
             id: generateId(),
             slug,
             title,
@@ -337,7 +338,7 @@ async function main() {
               access_date: new Date().toISOString(),
             },
             harvested_at: new Date(),
-          };
+          });
 
           try {
             await books.insertOne(doc);

--- a/scripts/import-met-artworks.mjs
+++ b/scripts/import-met-artworks.mjs
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
@@ -302,7 +303,7 @@ async function main() {
       }
     }
 
-    const doc = {
+    const doc = makeBookDoc({
       id: generateId(),
       slug,
       title,
@@ -348,7 +349,7 @@ async function main() {
         access_date: new Date().toISOString(),
       },
       harvested_at: new Date(),
-    };
+    });
 
     try {
       await books.insertOne(doc);

--- a/scripts/import-naj-sancai.mjs
+++ b/scripts/import-naj-sancai.mjs
@@ -13,6 +13,7 @@ import sharp from 'sharp';
 import * as fs from 'fs';
 import * as path from 'path';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { makeBookDoc, makePageDoc } from './lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
@@ -87,7 +88,7 @@ async function main() {
     }
 
     const now = new Date();
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId,
       id: bookIdStr,
       slug,
@@ -130,7 +131,7 @@ async function main() {
       description: 'Physical volume 52 of the Sancai Tuhui (三才圖會), a Ming Dynasty illustrated encyclopedia compiled by Wang Qi and Wang Siyi (1609). Contains juan 91-92 covering beasts (獸類), including both real animals and mythical creatures from the Shanhaijing. This scan is from the National Archives of Japan (内閣文庫), CC0 public domain, with minimal watermarking.',
       created_at: now,
       updated_at: now,
-    };
+    });
 
     await db.collection('books').insertOne(bookDoc);
     console.log(`Book created: ${slug} (${bookIdStr})\n`);
@@ -183,7 +184,7 @@ async function main() {
 
           // Create page record
           const pageOid = new ObjectId();
-          const pageDoc = {
+          const pageDoc = makePageDoc({
             _id: pageOid,
             id: pageOid.toHexString(),
             book_id: bookIdStr,
@@ -201,7 +202,7 @@ async function main() {
             },
             created_at: now,
             updated_at: now,
-          };
+          });
 
           await db.collection('pages').insertOne(pageDoc);
           uploaded++;

--- a/scripts/import-nga-artworks.mjs
+++ b/scripts/import-nga-artworks.mjs
@@ -28,6 +28,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
 import { createReadStream } from 'fs';
 import { createInterface } from 'readline';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
 const R2_PREFIX = 'artwork';
@@ -280,7 +281,7 @@ async function main() {
         }
       }
 
-      const doc = {
+      const doc = makeBookDoc({
         id: generateId(),
         slug,
         title,
@@ -327,7 +328,7 @@ async function main() {
         // Wikidata cross-reference if available
         ...(obj.wikidataid && { wikidata_id: obj.wikidataid }),
         harvested_at: new Date(),
-      };
+      });
 
       try {
         await books.insertOne(doc);

--- a/scripts/import-rijks-artworks.mjs
+++ b/scripts/import-rijks-artworks.mjs
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from './lib/book-docs.mjs';
 
 const SEARCH_BASE = 'https://data.rijksmuseum.nl/search/collection';
 const RESOLVER = 'https://id.rijksmuseum.nl';
@@ -443,7 +444,7 @@ async function main() {
         }
       }
 
-      const doc = {
+      const doc = makeBookDoc({
         id: generateId(),
         slug,
         title: obj.title,
@@ -501,7 +502,7 @@ async function main() {
           access_date: new Date().toISOString(),
         },
         harvested_at: new Date(),
-      };
+      });
 
       await books.insertOne(doc);
       const icLabel = iiif.iconclassCodes?.length > 0 ? ` [IC: ${iiif.iconclassCodes.join(', ')}]` : '';

--- a/scripts/import/al-badri-direct.mjs
+++ b/scripts/import/al-badri-direct.mjs
@@ -15,6 +15,7 @@
  */
 
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -102,7 +103,7 @@ async function main() {
   const bookId = new ObjectId();
   const bookIdStr = bookId.toHexString();
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId,
     id: bookIdStr,
     slug,
@@ -141,7 +142,7 @@ async function main() {
     normalized_author: 'muhammad ibn ahmad al badri al dimashqi',
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 
   await db.collection('books').insertOne(bookDoc);
   console.log(`Inserted book ${bookIdStr} slug=${slug}`);
@@ -151,7 +152,7 @@ async function main() {
     const pageDocs = [];
     for (let p = start; p < Math.min(start + CHUNK, PAGE_COUNT); p++) {
       const pageId = new ObjectId();
-      pageDocs.push({
+      pageDocs.push(makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -161,7 +162,7 @@ async function main() {
         photo_original: getPageUrl(p),
         created_at: new Date(),
         updated_at: new Date(),
-      });
+      }));
     }
     await db.collection('pages').insertMany(pageDocs, { ordered: false });
     console.log(`Inserted pages ${start + 1}-${start + pageDocs.length}`);

--- a/scripts/import/batch-import-istc-bsb.mjs
+++ b/scripts/import/batch-import-istc-bsb.mjs
@@ -14,6 +14,7 @@
  */
 
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -203,7 +204,7 @@ async function main() {
     const bookIdStr = bookId.toHexString();
     const slug = await ensureUniqueSlug(db, generateSlug(title, author));
 
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId,
       id: bookIdStr,
       slug,
@@ -237,14 +238,14 @@ async function main() {
       visible: false,
       created_at: new Date(),
       updated_at: new Date(),
-    };
+    });
 
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages
     const pageDocs = pages.map((p, i) => {
       const pageId = new ObjectId();
-      return {
+      return makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -254,7 +255,7 @@ async function main() {
         photo_original: p.photo,
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
     });
 
     // Insert pages in batches of 500

--- a/scripts/import/bncf-aldine-direct.mjs
+++ b/scripts/import/bncf-aldine-direct.mjs
@@ -32,6 +32,7 @@ import { pipeline } from 'stream/promises';
 import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
@@ -432,7 +433,7 @@ async function main() {
         ? (rasterizedPages?.[0]?.thumbUrl || rasterizedPages?.[0]?.displayUrl || '')
         : getThumbUrl(0);
 
-      const bookDoc = {
+      const bookDoc = makeBookDoc({
         _id: bookId,
         id: bookIdStr,
         slug,
@@ -486,7 +487,7 @@ async function main() {
         normalized_author: normalizeAuthor(entry.author),
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
 
       await db.collection('books').insertOne(bookDoc);
 
@@ -497,7 +498,7 @@ async function main() {
         for (let start = 0; start < rasterizedPages.length; start += CHUNK) {
           const pageDocs = rasterizedPages.slice(start, start + CHUNK).map(rp => {
             const pageId = new ObjectId();
-            return {
+            return makePageDoc({
               _id: pageId,
               id: pageId.toHexString(),
               book_id: bookIdStr,
@@ -513,7 +514,7 @@ async function main() {
               archive_metadata: { archived_at: new Date(), source: 'pdf_rasterized' },
               created_at: new Date(),
               updated_at: new Date(),
-            };
+            });
           });
           await db.collection('pages').insertMany(pageDocs, { ordered: false });
         }
@@ -522,7 +523,7 @@ async function main() {
           const pageDocs = [];
           for (let p = start; p < Math.min(start + CHUNK, pageCount); p++) {
             const pageId = new ObjectId();
-            pageDocs.push({
+            pageDocs.push(makePageDoc({
               _id: pageId,
               id: pageId.toHexString(),
               book_id: bookIdStr,
@@ -532,7 +533,7 @@ async function main() {
               photo_original: getPageUrl(p),
               created_at: new Date(),
               updated_at: new Date(),
-            });
+            }));
           }
           await db.collection('pages').insertMany(pageDocs, { ordered: false });
         }

--- a/scripts/import/bsb-from-file.mjs
+++ b/scripts/import/bsb-from-file.mjs
@@ -20,6 +20,7 @@
 
 import { MongoClient, ObjectId } from 'mongodb';
 import fs from 'fs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -242,7 +243,7 @@ async function main() {
       const bookIdStr = bookId.toHexString();
       const slug = await ensureUniqueSlug(db, generateSlug(title, author));
 
-      const bookDoc = {
+      const bookDoc = makeBookDoc({
         _id: bookId,
         id: bookIdStr,
         slug,
@@ -278,7 +279,7 @@ async function main() {
         visible: false,
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
 
       await db.collection('books').insertOne(bookDoc);
 
@@ -286,7 +287,7 @@ async function main() {
       for (let start = 0; start < pages.length; start += 500) {
         const chunk = pages.slice(start, start + 500).map((p, j) => {
           const pageId = new ObjectId();
-          return {
+          return makePageDoc({
             _id: pageId,
             id: pageId.toHexString(),
             book_id: bookIdStr,
@@ -296,7 +297,7 @@ async function main() {
             photo_original: p.photo,
             created_at: new Date(),
             updated_at: new Date(),
-          };
+          });
         });
         await db.collection('pages').insertMany(chunk, { ordered: false });
       }

--- a/scripts/import/ccag-vii-pdf-direct.mjs
+++ b/scripts/import/ccag-vii-pdf-direct.mjs
@@ -32,6 +32,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { execFileSync } from 'child_process';
 import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
@@ -216,7 +217,7 @@ async function main() {
   // Build + insert book
   const now = new Date();
   const pdfStat = statSync(PDF_PATH);
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId,
     id: bookIdStr,
     slug,
@@ -279,7 +280,7 @@ async function main() {
     normalized_author: normalizeAuthor(BOOK_META.author),
     created_at: now,
     updated_at: now,
-  };
+  });
 
   await db.collection('books').insertOne(bookDoc);
   console.log(`Inserted book ${bookIdStr} (${slug})`);
@@ -290,7 +291,7 @@ async function main() {
     const docs = [];
     for (let p = start; p < Math.min(start + CHUNK, pageCount); p++) {
       const pageId = new ObjectId();
-      docs.push({
+      docs.push(makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -308,7 +309,7 @@ async function main() {
         },
         created_at: now,
         updated_at: now,
-      });
+      }));
     }
     await db.collection('pages').insertMany(docs, { ordered: false });
     console.log(`  pages ${start + 1}–${start + docs.length} inserted`);

--- a/scripts/import/early-america-direct.mjs
+++ b/scripts/import/early-america-direct.mjs
@@ -10,6 +10,7 @@
  *   node scripts/import/early-america-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const BOOKS = [
@@ -86,14 +87,14 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title.slice(0,50)}" (${pageCount}pp,${pageCountSource})`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → ${bookIdStr} "${b.title.slice(0,46)}" (${pageCount}pp)`);imported++;
   }
   await client.close();

--- a/scripts/import/fetch-wikisource-javanese.mjs
+++ b/scripts/import/fetch-wikisource-javanese.mjs
@@ -20,6 +20,7 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { parseArgs } from 'util';
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const { values: args } = parseArgs({ options: {
   work: { type: 'string' }, search: { type: 'string' }, max: { type: 'string', default: '20' },
@@ -82,7 +83,7 @@ async function createTextBook(doc) {
   const bookId = new ObjectId(); const now = new Date();
   let slug = slugify(doc.work), n = 1;
   while (await db.collection('books').findOne({ slug })) { slug = `${slugify(doc.work)}-${++n}`; }
-  const pageDocs = doc.parts.map((p, i) => ({
+  const pageDocs = doc.parts.map((p, i) => makePageDoc({
     _id: new ObjectId(), id: new ObjectId().toHexString(), book_id: bookId.toHexString(),
     page_number: i + 1,
     part_title: p.title === doc.work ? null : p.title.replace(doc.work + '/', ''),
@@ -90,7 +91,7 @@ async function createTextBook(doc) {
     ocr: { data: p.text, language: 'jv', source: 'wikisource', updated_at: now },
     created_at: now, updated_at: now,
   }));
-  await db.collection('books').insertOne({
+  await db.collection('books').insertOne(makeBookDoc({
     _id: bookId, id: bookId.toHexString(), slug,
     title: doc.work, display_title: doc.work, author: 'Anonymous',
     language: 'Javanese', published: null,
@@ -103,7 +104,7 @@ async function createTextBook(doc) {
     status: args.publish ? 'published' : 'imported', hidden: !args.publish, visible: !!args.publish,
     pipeline_auto: { status: 'complete', ocr_deferred: true, ocr_deferred_reason: 'text-only work (romanized Javanese); English translation is a separate text-translate pass', source: 'wikisource-text-import', last_updated: now },
     created_at: now, updated_at: now,
-  });
+  }));
   await db.collection('pages').insertMany(pageDocs);
   console.log(`    ✓ imported text book: /book/${slug} (${pageDocs.length} parts)${args.publish ? ' [PUBLISHED]' : ' [hidden]'}`);
 }

--- a/scripts/import/founders-collected-direct.mjs
+++ b/scripts/import/founders-collected-direct.mjs
@@ -12,6 +12,7 @@
  *   node scripts/import/founders-collected-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -72,14 +73,14 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
   }
   await client.close();

--- a/scripts/import/founding-chase.mjs
+++ b/scripts/import/founding-chase.mjs
@@ -11,6 +11,7 @@
  *   node scripts/import/founding-chase.mjs --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 const BOOKS = [
   { ia: 'bim_early-english-books-1641-1700_a-letter-concerning-tole_locke-john_1689', title: 'A Letter Concerning Toleration', author: 'John Locke', language: 'English', published: '1689' },
@@ -44,13 +45,13 @@ async function main(){
     const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null;
     const bookId=new ObjectId(),bookIdStr=bookId.toHexString();const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`,thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY  ${b.ia} "${b.title}" (${pageCount}pp)`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK   ${b.ia} "${b.title}" (${pageCount}pp)`);imported++;
   }
   await client.close();console.log(`\n=== ${COMMIT?'COMMITTED':'DRY'} — imported:${imported} skipped:${skipped} failed:${failed} ===`);

--- a/scripts/import/founding-docs-direct.mjs
+++ b/scripts/import/founding-docs-direct.mjs
@@ -20,6 +20,7 @@
  *   node scripts/import/founding-docs-direct.mjs --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 
@@ -141,7 +142,7 @@ async function main() {
     const photo = i => `https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb = i => `https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
 
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId, id: bookIdStr, slug,
       title: b.title, display_title: null, author: b.author,
       language: b.language, published: b.published,
@@ -176,7 +177,7 @@ async function main() {
       source_fingerprint: fp,
       normalized_title: normalizeTitle(b.title), normalized_author: normalizeAuthor(b.author),
       created_at: now, updated_at: now,
-    };
+    });
 
     if (!COMMIT) { console.log(`DRY   ${b.ia} — would insert "${b.title}" (${pageCount}pp, ${pageCountSource}) slug=${slug}`); imported++; continue; }
 
@@ -186,8 +187,8 @@ async function main() {
       const docs = [];
       for (let k = 0; k < CHUNK && s + k < pageCount; k++) {
         const i = s + k; const pid = new ObjectId();
-        docs.push({ _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: i + 1,
-          photo: photo(i), thumbnail: thumb(i), photo_original: photo(i), created_at: now, updated_at: now });
+        docs.push(makePageDoc({ _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: i + 1,
+          photo: photo(i), thumbnail: thumb(i), photo_original: photo(i), created_at: now, updated_at: now }));
       }
       await db.collection('pages').insertMany(docs, { ordered: false });
     }

--- a/scripts/import/founding-enrich-direct.mjs
+++ b/scripts/import/founding-enrich-direct.mjs
@@ -19,6 +19,7 @@
  *   node scripts/import/founding-enrich-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 const COLLECTION_TAG = 'american-founding';
 
@@ -145,16 +146,16 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:b.role,
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:b.role,
       ...(b.isTranslation?{is_translation:true,original_language:b.originalLanguage}:{}),
       collections:[COLLECTION_TAG],
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp, ${pageCountSource}, role:${b.role}${b.isTranslation?'→'+b.originalLanguage:''})`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp, role:${b.role})`);imported++;
   }
   await client.close();

--- a/scripts/import/founding-influences2-direct.mjs
+++ b/scripts/import/founding-influences2-direct.mjs
@@ -14,6 +14,7 @@
  *   node scripts/import/founding-influences2-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -96,14 +97,14 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
   }
   await client.close();

--- a/scripts/import/founding-tail-direct.mjs
+++ b/scripts/import/founding-tail-direct.mjs
@@ -11,6 +11,7 @@
  *   node scripts/import/founding-tail-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -81,14 +82,14 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
   }
   await client.close();

--- a/scripts/import/fragmenta-direct.mjs
+++ b/scripts/import/fragmenta-direct.mjs
@@ -22,6 +22,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 const HANDLES = process.argv.slice(2).filter(a => /^\d+$/.test(a));
@@ -120,7 +121,7 @@ async function importItem(db, m) {
   const bookIdStr = bookId.toHexString();
   const slug = await uniqueSlug(db, slugify(`${m.text}-fragmenta-${m.signum}`));
   const now = new Date();
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId, id: bookIdStr, slug,
     title: m.title, display_title: m.text, author: m.author,
     language: 'Latin', original_language: 'Latin',
@@ -148,9 +149,9 @@ async function importItem(db, m) {
     normalized_title: slugify(m.text).replace(/-/g, ' '),
     normalized_author: slugify(m.author).replace(/-/g, ' '),
     created_at: now, updated_at: now,
-  };
+  });
   await db.collection('books').insertOne(bookDoc);
-  const docs = pages.map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo_original, created_at: now, updated_at: now }; });
+  const docs = pages.map((p, k) => { const pid = new ObjectId(); return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo_original, created_at: now, updated_at: now }); });
   await db.collection('pages').insertMany(docs, { ordered: false });
   console.log(`  ✓ inserted ${slug} (${bookIdStr}) — ${pages.length} pages, hidden`);
   console.log(`    https://sourcelibrary.org/book/${slug}`);

--- a/scripts/import/harvard-iiif-direct-batch.mjs
+++ b/scripts/import/harvard-iiif-direct-batch.mjs
@@ -15,6 +15,7 @@
  *   node scripts/import/harvard-iiif-direct-batch.mjs --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 
@@ -69,7 +70,7 @@ async function main(){
     if (!COMMIT){ console.log(`· ${b.fhcl} ${pages.length}p | ${b.title.slice(0,50)} | ${label.slice(0,40)}`); results.push({fhcl:b.fhcl,pages:pages.length}); await new Promise(x=>setTimeout(x,1500)); continue; }
     const bookId=new ObjectId(), id=bookId.toHexString(), now=new Date();
     const slug=await uniqueSlug(db, slugify(b.title.split('—')[1]||b.title));
-    await db.collection('books').insertOne({
+    await db.collection('books').insertOne(makeBookDoc({
       _id:bookId, id, slug, title:b.title, display_title:label||b.title.split('—')[0].trim(),
       author:b.author, language:'Chinese', original_language:'Chinese', published:b.published,
       categories:[], collections:b.colls, thumbnail:pages[0]?.thumbnail||'',
@@ -83,9 +84,9 @@ async function main(){
       status:'draft', hidden:true, visible:false, source_fingerprint:fp,
       normalized_title:slugify(b.title.split('—')[0]).replace(/-/g,' '), normalized_author:slugify(b.author).replace(/-/g,' '),
       created_at:now, updated_at:now,
-    });
+    }));
     for (let s=0;s<pages.length;s+=500){ const docs=pages.slice(s,s+500).map((p,k)=>{ const pid=new ObjectId();
-      return { _id:pid, id:pid.toHexString(), book_id:id, page_number:s+k+1, photo:p.photo, thumbnail:p.thumbnail, photo_original:p.photo, created_at:now, updated_at:now }; });
+      return makePageDoc({ _id:pid, id:pid.toHexString(), book_id:id, page_number:s+k+1, photo:p.photo, thumbnail:p.thumbnail, photo_original:p.photo, created_at:now, updated_at:now }); });
       await db.collection('pages').insertMany(docs,{ordered:false}); }
     console.log(`✓ ${b.fhcl} → ${slug} (${pages.length}p)`); results.push({fhcl:b.fhcl,ok:true,pages:pages.length,slug});
     await new Promise(x=>setTimeout(x,2000));

--- a/scripts/import/harvard-philosophy-direct.mjs
+++ b/scripts/import/harvard-philosophy-direct.mjs
@@ -21,6 +21,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 const ROWS = JSON.parse(readFileSync('scripts/output/harvard-phil-rows.json', 'utf8'));
@@ -90,7 +91,7 @@ async function main() {
     if (!COMMIT) { console.log(`· ${it.fhcl} ${String(pages.length).padStart(4)}p | ${title.slice(0, 50)}${it.vol ? ` [vol ${it.vol}]` : ''}`); results.push({ fhcl: it.fhcl, pages: pages.length }); await new Promise(x => setTimeout(x, 800)); continue; }
     const bookId = new ObjectId(), id = bookId.toHexString(), now = new Date();
     const slug = await uniqueSlug(db, slugify(it.en) || ('harvard-' + it.fhcl));
-    await db.collection('books').insertOne({
+    await db.collection('books').insertOne(makeBookDoc({
       _id: bookId, id, slug, title, display_title: it.cjk || label,
       author, language: 'Chinese', original_language: 'Chinese', published: '',
       categories: [], collections: ['east-asia', 'chinese-classics'], thumbnail: pages[0]?.thumbnail || '',
@@ -107,9 +108,9 @@ async function main() {
       status: 'draft', hidden: true, visible: false, source_fingerprint: fp,
       normalized_title: slugify(it.cjk).replace(/-/g, ' '), normalized_author: slugify(author).replace(/-/g, ' '),
       created_at: now, updated_at: now,
-    });
+    }));
     for (let s = 0; s < pages.length; s += 500) {
-      const docs = pages.slice(s, s + 500).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: id, page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + 500).map((p, k) => { const pid = new ObjectId(); return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: id, page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo, created_at: now, updated_at: now }); });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     console.log(`✓ ${it.fhcl} → ${slug} (${pages.length}p)`); results.push({ fhcl: it.fhcl, ok: true, pages: pages.length, slug });

--- a/scripts/import/harvard-wuzhen-direct.mjs
+++ b/scripts/import/harvard-wuzhen-direct.mjs
@@ -22,6 +22,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { readFileSync } from 'node:fs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 const MANIFEST_PATH = '/tmp/wuzhen-manifest.json';
@@ -82,7 +83,7 @@ async function main() {
   const slug = await uniqueSlug(db, slugify('daoyan-neiwai-mijue-quanshu-wuzhen-pian'));
   const now = new Date();
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId, id: bookIdStr, slug,
     title, display_title, author,
     language: 'Chinese', original_language: 'Chinese',
@@ -108,7 +109,7 @@ async function main() {
     normalized_title: slugify(display_title).replace(/-/g, ' '),
     normalized_author: 'boduan zhang',
     created_at: now, updated_at: now,
-  };
+  });
   await db.collection('books').insertOne(bookDoc);
   console.log(`Inserted book ${bookIdStr} slug=${slug}`);
 
@@ -116,9 +117,9 @@ async function main() {
   for (let s = 0; s < pages.length; s += CHUNK) {
     const docs = pages.slice(s, s + CHUNK).map((p, k) => {
       const pid = new ObjectId();
-      return { _id: pid, id: pid.toHexString(), book_id: bookIdStr,
+      return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo,
-        created_at: now, updated_at: now };
+        created_at: now, updated_at: now });
     });
     await db.collection('pages').insertMany(docs, { ordered: false });
     console.log(`  inserted pages ${s + 1}-${s + docs.length}`);

--- a/scripts/import/ia-bundle-import.mjs
+++ b/scripts/import/ia-bundle-import.mjs
@@ -38,6 +38,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import fs from 'fs';
 import crypto from 'crypto';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
@@ -155,7 +156,7 @@ async function main() {
       const bookId = new ObjectId();
       const bookIdStr = bookId.toHexString();
 
-      const bookDoc = {
+      const bookDoc = makeBookDoc({
         _id: bookId,
         id: bookIdStr,
         slug,
@@ -194,7 +195,7 @@ async function main() {
         normalized_author: normalizeAuthor(entry.author),
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
 
       await db.collection('books').insertOne(bookDoc);
 
@@ -203,7 +204,7 @@ async function main() {
         const pageDocs = [];
         for (let p = start; p < Math.min(start + CHUNK, pageCount); p++) {
           const pageId = new ObjectId();
-          pageDocs.push({
+          pageDocs.push(makePageDoc({
             _id: pageId,
             id: pageId.toHexString(),
             book_id: bookIdStr,
@@ -213,7 +214,7 @@ async function main() {
             photo_original: getPageUrl(p),
             created_at: new Date(),
             updated_at: new Date(),
-          });
+          }));
         }
         await db.collection('pages').insertMany(pageDocs, { ordered: false });
       }

--- a/scripts/import/iiif-direct-import.mjs
+++ b/scripts/import/iiif-direct-import.mjs
@@ -28,6 +28,7 @@
 
 import { MongoClient, ObjectId } from 'mongodb';
 import fs from 'fs';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -131,7 +132,7 @@ async function processEntry(db, entry, idx) {
     const bookId = new ObjectId();
     const bookIdStr = bookId.toHexString();
     const slug = await ensureUniqueSlug(db, generateSlug(entry.title, entry.author));
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId, id: bookIdStr, slug,
       title: entry.title || 'Unknown', author: entry.author || 'Unknown',
       language: entry.language || 'Unknown', published: entry.year ? String(entry.year) : 'Unknown',
@@ -150,14 +151,14 @@ async function processEntry(db, entry, idx) {
       },
       status: 'draft', hidden: true, visible: false,
       created_at: new Date(), updated_at: new Date(),
-    };
+    });
     await db.collection('books').insertOne(bookDoc);
     for (let start = 0; start < pages.length; start += 500) {
       const chunk = pages.slice(start, start + 500).map((p, j) => {
         const pageId = new ObjectId();
-        return { _id: pageId, id: pageId.toHexString(), book_id: bookIdStr,
+        return makePageDoc({ _id: pageId, id: pageId.toHexString(), book_id: bookIdStr,
           page_number: start + j + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo,
-          created_at: new Date(), updated_at: new Date() };
+          created_at: new Date(), updated_at: new Date() });
       });
       await db.collection('pages').insertMany(chunk, { ordered: false });
     }

--- a/scripts/import/import-artwork.mjs
+++ b/scripts/import/import-artwork.mjs
@@ -22,6 +22,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import fs from 'fs';
+import { makeBookDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -386,7 +387,7 @@ async function createArtworkDoc(db, artwork, entry) {
     if (yearMatch) year = parseInt(yearMatch[1], 10);
   }
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId,
     id: bookIdStr,
     slug,
@@ -445,7 +446,7 @@ async function createArtworkDoc(db, artwork, entry) {
     normalized_author: normAuthor,
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 
   await db.collection('books').insertOne(bookDoc);
   return { status: 'ok', id: bookIdStr, title: artwork.title };

--- a/scripts/import/import-hashika-e-posters.mjs
+++ b/scripts/import/import-hashika-e-posters.mjs
@@ -21,6 +21,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc } from '../lib/book-docs.mjs';
 
 const HOST = 'https://cdm16022.contentdm.oclc.org';
 const ALIAS = 'p16022coll127';
@@ -134,7 +135,7 @@ async function main() {
       let b = slugify(title) || `hashika-e-${ptr}`; let slug = `art-${b}`; let n = 1;
       while (await books.findOne({ slug })) { slug = `art-${b}-${++n}`; }
 
-      await books.insertOne({
+      await books.insertOne(makeBookDoc({
         _id: bookId, id: bookId.toHexString(), slug,
         title, display_title: title, author: 'Anonymous',
         language: 'Japanese', original_language: 'Japanese',
@@ -166,7 +167,7 @@ async function main() {
         },
         source_fingerprint: fingerprint,
         created_at: new Date(), updated_at: new Date(),
-      });
+      }));
       imported++;
       console.log(`  ✓ ${slug} — "${title}" (${date}) ${meta0.width}x${meta0.height}`);
     } catch (e) { failed++; console.log(`  ✗ ${ptr}: ${e.message}`); }

--- a/scripts/import/import-idp-batch.mjs
+++ b/scripts/import/import-idp-batch.mjs
@@ -16,6 +16,7 @@
 
 import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -180,7 +181,7 @@ for (let i = 0; i < candidates.length; i++) {
     const bookId = new ObjectId();
     const slug = slugify(`${pressmark}-idp-dunhuang`);
 
-    const book = {
+    const book = makeBookDoc({
       _id: bookId,
       id: bookId.toHexString(),
       title: pressmark,
@@ -229,7 +230,7 @@ for (let i = 0; i < candidates.length; i++) {
       pipeline_status: 'archive_complete',
       created_at: new Date(),
       updated_at: new Date(),
-    };
+    });
 
     // 3. Download images and upload to R2
     const pages = [];
@@ -246,7 +247,7 @@ for (let i = 0; i < candidates.length; i++) {
 
         if (img.index === 0) thumbnailUrl = photoUrl;
 
-        pages.push({
+        pages.push(makePageDoc({
           _id: new ObjectId(),
           id: new ObjectId().toHexString(),
           book_id: bookId.toHexString(),
@@ -263,7 +264,7 @@ for (let i = 0; i < candidates.length; i++) {
           },
           created_at: new Date(),
           updated_at: new Date(),
-        });
+        }));
       } catch (imgErr) {
         console.log(`    Image ${img.index} failed: ${imgErr.message}`);
       }

--- a/scripts/import/import-kloss-collection.mjs
+++ b/scripts/import/import-kloss-collection.mjs
@@ -30,6 +30,7 @@ import { execSync, execFileSync } from 'child_process';
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────
 
@@ -240,7 +241,7 @@ async function importRecord(db, record, index, total) {
     // Catalog URL for this specific record
     const catalogUrl = `https://ais.vrijmetselarij.nl/axiellwebapi/wwwopac.ashx?command=search&database=fullCatalogue&search=priref=${priref}&xmltype=grouped&output=xml`;
 
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId,
       id: bookIdStr,
       slug,
@@ -295,7 +296,7 @@ async function importRecord(db, record, index, total) {
       hidden: true,
       created_at: now,
       updated_at: now,
-    };
+    });
 
     await db.collection('books').insertOne(bookDoc);
 
@@ -304,7 +305,7 @@ async function importRecord(db, record, index, total) {
     for (let i = 0; i < pageCount; i++) {
       const pageId = new ObjectId();
       const photoUrl = blobUrls[i]?.photo || '';
-      pageDocs.push({
+      pageDocs.push(makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -324,7 +325,7 @@ async function importRecord(db, record, index, total) {
         // Do NOT initialize ocr/translation — causes false completion bug
         created_at: now,
         updated_at: now,
-      });
+      }));
     }
 
     await db.collection('pages').insertMany(pageDocs);

--- a/scripts/import/import-met-egyptian.mjs
+++ b/scripts/import/import-met-egyptian.mjs
@@ -12,6 +12,7 @@
  *   --dry-run              Print what would be imported without writing
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -244,7 +245,7 @@ async function main() {
       const bookIdStr = bookId.toHexString();
       const slug = await generateSlug(db, title);
 
-      const bookDoc = {
+      const bookDoc = makeBookDoc({
         _id: bookId,
         id: bookIdStr,
         slug,
@@ -307,14 +308,14 @@ async function main() {
         met_department: obj.department || null,
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
 
       await db.collection('books').insertOne(bookDoc);
 
       // Create page documents
       const pageDocs = images.map((imgUrl, idx) => {
         const pageId = new ObjectId();
-        return {
+        return makePageDoc({
           _id: pageId,
           id: pageId.toHexString(),
           book_id: bookIdStr,
@@ -324,7 +325,7 @@ async function main() {
           photo_original: imgUrl,
           created_at: new Date(),
           updated_at: new Date(),
-        };
+        });
       });
 
       await db.collection('pages').insertMany(pageDocs, { ordered: false });

--- a/scripts/import/import-oraec.mjs
+++ b/scripts/import/import-oraec.mjs
@@ -26,6 +26,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -309,7 +310,7 @@ async function main() {
     try {
       const slug = await generateSlug(db, title);
 
-      const pageDoc = {
+      const pageDoc = makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -325,10 +326,10 @@ async function main() {
         },
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
       await db.collection('pages').insertOne(pageDoc);
 
-      const bookDoc = {
+      const bookDoc = makeBookDoc({
         _id: bookId,
         id: bookIdStr,
         slug,
@@ -382,7 +383,7 @@ async function main() {
         normalized_author: normalizeAuthor(author),
         created_at: new Date(),
         updated_at: new Date(),
-      };
+      });
 
       try {
         await db.collection('books').insertOne(bookDoc);

--- a/scripts/import/import-pdf-books.mjs
+++ b/scripts/import/import-pdf-books.mjs
@@ -37,6 +37,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { parseArgs } from 'util';
 import sharp from 'sharp';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const { values: args } = parseArgs({ options: {
   manifest:    { type: 'string' },
@@ -277,21 +278,21 @@ async function importBook(db, entry) {
         uploadToR2(`${base}-thumb.jpg`, thumbBuf),
       ]);
       if (pageNum % 25 === 0) console.log(`    uploaded ${pageNum}/${rendered.length}`);
-      return {
+      return makePageDoc({
         _id: new ObjectId(), id: new ObjectId().toHexString(), book_id: bookIdStr,
         page_number: pageNum,
         photo: displayUrl, display_photo: displayUrl, archived_photo: fullUrl,
         thumbnail: thumbUrl, image_thumb: thumbUrl,
         image_width: meta.width, image_height: meta.height, width: meta.width, height: meta.height,
         ocr: null, status: 'archived', created_at: now, updated_at: now,
-      };
+      });
     }, PARALLEL_PAGES);
 
     const validPages = pageDocs.filter(Boolean);
 
     // 5. Build the book record — full provenance
     const provEntry = { source: 'import-pdf-books', provider: entry.provider, method: extractMethod, confidence: 1.0, date: now.toISOString() };
-    const book = {
+    const book = makeBookDoc({
       _id: bookId, id: bookIdStr, slug,
       title: entry.title,
       display_title: entry.display_title || entry.title,
@@ -366,7 +367,7 @@ async function importBook(db, entry) {
       } } : {}),
       thumbnail: (validPages.find(p => p.page_number === 1) || validPages[0])?.photo,
       created_at: now, updated_at: now,
-    };
+    });
 
     await db.collection('books').insertOne(book);
     await db.collection('pages').insertMany(validPages);

--- a/scripts/import/import-rijksmuseum-artworks.mjs
+++ b/scripts/import/import-rijksmuseum-artworks.mjs
@@ -27,6 +27,7 @@ import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { parseArgs } from 'util';
 import sharp from 'sharp';
+import { makeBookDoc } from '../lib/book-docs.mjs';
 
 const { values: args } = parseArgs({ options: {
   'dry-run': { type: 'boolean', default: false },
@@ -148,7 +149,7 @@ async function main() {
           let base2 = slugify(title) || `rijks-${objNum}`; slug = `art-${base2}`; let n = 1;
           while (await booksCol.findOne({ slug })) { slug = `art-${base2}-${++n}`; }
           const licenseId = (img.license || '').includes('zero') ? 'CC0-1.0' : (img.license || '').includes('publicdomain') ? 'CC0-1.0' : (img.license || 'unknown');
-          await booksCol.insertOne({
+          await booksCol.insertOne(makeBookDoc({
             _id: bookId, id: bookId.toHexString(), slug,
             title, display_title: title, author: 'Anonymous', language: 'Visual',
             published: date, resource_type: 'object', content_type: 'artwork',
@@ -168,7 +169,7 @@ async function main() {
             },
             source_fingerprint: fingerprint,
             created_at: new Date(), updated_at: new Date(),
-          });
+          }));
           imported++;
           console.log(`  ✓ ${slug} — ${title} (${place || '?'}, ${date || '?'}) ${meta.width}x${meta.height}`);
         } catch (e) { failed++; console.log(`  ✗ ${objNum}: ${e.message}`); }

--- a/scripts/import/import-sefaria.mjs
+++ b/scripts/import/import-sefaria.mjs
@@ -29,6 +29,7 @@
  */
 
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const ARGS = process.argv.slice(2);
 const PROBE = ARGS.includes('--probe');
@@ -194,7 +195,7 @@ async function importWork(db, w) {
   const slug = await generateUniqueSlug(db, slugify(`${w.display_title}-${w.author}`));
   const now = new Date();
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId, id: bookIdStr, slug,
     title: w.title, display_title: w.display_title, author: w.author,
     language: w.language, original_language: w.language,
@@ -226,18 +227,18 @@ async function importWork(db, w) {
     normalized_title: slugify(w.title).replace(/-/g, ' '),
     normalized_author: slugify(w.author).replace(/-/g, ' '),
     created_at: now, updated_at: now,
-  };
+  });
 
   await db.collection('books').insertOne(bookDoc);
 
   const pageDocs = pages.map((p, idx) => {
     const pid = new ObjectId();
-    const doc = {
+    const doc = makePageDoc({
       _id: pid, id: pid.toHexString(),
       book_id: bookIdStr, page_number: idx + 1,
       source_ref: p.source_ref,
       created_at: now, updated_at: now,
-    };
+    });
     // Omit empty ocr/translation entirely (empty strings trigger false completion).
     if (p.heData) doc.ocr = { data: p.heData, language: w.language, model: null, source: 'manual', updated_at: now };
     if (p.enData) doc.translation = { data: p.enData, language: 'English', model: null, source: 'manual', updated_at: now };

--- a/scripts/import/import-thirukkural.ts
+++ b/scripts/import/import-thirukkural.ts
@@ -9,6 +9,7 @@
 
 import { MongoClient, ObjectId } from 'mongodb';
 import { config } from 'dotenv';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 config({ path: '.env.local' });
 
@@ -138,7 +139,7 @@ async function importBook(client: MongoClient, book: BookImport) {
   const getThumbnailUrl = (n: number) =>
     `https://archive.org/download/${book.ia_identifier}/page/n${n}/full/pct:15/0/default.jpg`;
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId,
     id: bookIdStr,
     title: book.title,
@@ -169,7 +170,7 @@ async function importBook(client: MongoClient, book: BookImport) {
     curator_notes: book.notes,
     created_at: now,
     updated_at: now
-  };
+  });
 
   await booksCol.insertOne(bookDoc);
 
@@ -177,7 +178,7 @@ async function importBook(client: MongoClient, book: BookImport) {
   const pageDocs = [];
   for (let i = 0; i < pageCount; i++) {
     const pageId = new ObjectId();
-    pageDocs.push({
+    pageDocs.push(makePageDoc({
       _id: pageId,
       id: pageId.toHexString(),
       book_id: bookIdStr,
@@ -189,7 +190,7 @@ async function importBook(client: MongoClient, book: BookImport) {
       translation: { language: 'English', model: null, data: '' },
       created_at: now,
       updated_at: now
-    });
+    }));
   }
 
   // Insert in batches of 500 to avoid memory issues

--- a/scripts/import/import-umn-health-texts.mjs
+++ b/scripts/import/import-umn-health-texts.mjs
@@ -26,6 +26,7 @@
  *   node scripts/import/import-umn-health-texts.mjs [--limit N]      # import hidden
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const HOST = 'https://cdm16022.contentdm.oclc.org';
 const ALIAS = 'p16022coll362';
@@ -120,7 +121,7 @@ async function main() {
       let b = slugify(title) || `umn-health-${it.pointer}`; let slug = b; let n = 1;
       while (await books.findOne({ slug })) { slug = `${b}-${++n}`; }
 
-      await books.insertOne({
+      await books.insertOne(makeBookDoc({
         _id: bookId, id: idStr, slug,
         title, display_title: title, author: md(meta, 'Creator') || 'Unknown',
         language, original_language: language,
@@ -149,12 +150,12 @@ async function main() {
         pipeline_auto: { status: 'parked', reason: 'awaiting kuzushiji OCR benchmark', last_updated: new Date() },
         source_fingerprint: fp,
         created_at: new Date(), updated_at: new Date(),
-      });
+      }));
 
       const CHUNK = 200;
       for (let s = 0; s < pages.length; s += CHUNK) {
         // pages collection has a UNIQUE index on `id` — must set a distinct id per doc.
-        const docs = pages.slice(s, s + CHUNK).map(p => ({ _id: new ObjectId(), id: new ObjectId().toHexString(), book_id: idStr, ...p }));
+        const docs = pages.slice(s, s + CHUNK).map(p => makePageDoc({ _id: new ObjectId(), id: new ObjectId().toHexString(), book_id: idStr, ...p }));
         await pagesCol.insertMany(docs, { ordered: false });
       }
       imported++; totalPages += pages.length;

--- a/scripts/import/jefferson-canon-direct.mjs
+++ b/scripts/import/jefferson-canon-direct.mjs
@@ -16,6 +16,7 @@
  *   node scripts/import/jefferson-canon-direct.mjs --dry-run | --commit
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 // ===== TASK 1: Skipwith 1771 list — on-mission gaps =====
@@ -145,14 +146,14 @@ async function main(){
     const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
     const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
     const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
-    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+    const bookDoc=makeBookDoc({_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
       dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
       catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
       image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
-      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now});
     if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
     await db.collection('books').insertOne(bookDoc);
-    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push(makePageDoc({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now}));}await db.collection('pages').insertMany(docs,{ordered:false});}
     console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
   }
   await client.close();

--- a/scripts/import/marcianus-299-direct.mjs
+++ b/scripts/import/marcianus-299-direct.mjs
@@ -25,6 +25,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 
@@ -175,7 +176,7 @@ async function main() {
   const slug = await uniqueSlug(db, slugify('marcianus-graecus-299-greek-alchemists'));
   const now = new Date();
 
-  const bookDoc = {
+  const bookDoc = makeBookDoc({
     _id: bookId, id: bookIdStr, slug,
     title, display_title, author,
     language: 'Greek', original_language: 'Greek',
@@ -206,7 +207,7 @@ async function main() {
     normalized_title: 'marcianus graecus 299',
     normalized_author: 'zosimos of panopolis',
     created_at: now, updated_at: now,
-  };
+  });
   await db.collection('books').insertOne(bookDoc);
   console.log(`\nInserted book ${bookIdStr} slug=${slug}`);
 
@@ -216,7 +217,7 @@ async function main() {
       const gi = s + k;
       const pid = new ObjectId();
       const r2url = uploaded[gi];
-      return {
+      return makePageDoc({
         _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: gi + 1,
         page_label: p.name || null,
@@ -226,7 +227,7 @@ async function main() {
         thumbnail: r2url,
         image_width: p.w || null, image_height: p.h || null,
         created_at: now, updated_at: now,
-      };
+      });
     });
     await db.collection('pages').insertMany(docs, { ordered: false });
     console.log(`  inserted pages ${s + 1}-${s + docs.length}`);

--- a/scripts/import/met-shunga-albums-direct.mjs
+++ b/scripts/import/met-shunga-albums-direct.mjs
@@ -28,6 +28,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org) bot';
@@ -124,7 +125,7 @@ async function main() {
       await new Promise(r => setTimeout(r, 500));
     }
 
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId, id: bookIdStr, slug: album.bookSlug,
       title: album.title, display_title: album.title,
       author: f0.author,
@@ -150,20 +151,20 @@ async function main() {
       status: 'draft', hidden: true, visible: false,
       source_fingerprint: fp,
       created_at: now, updated_at: now,
-    };
+    });
     await books.insertOne(bookDoc);
     console.log(`  inserted book ${bookIdStr} slug=${album.bookSlug}`);
 
     const pageDocs = fragments.map((f, i) => {
       const pid = new ObjectId();
-      return {
+      return makePageDoc({
         _id: pid, id: pid.toHexString(), book_id: bookIdStr,
         page_number: i + 1,
         photo: archived[i].photo, thumbnail: archived[i].thumbnail,
         photo_original: f.commons_full_url,
         source_page: { artwork_slug: f.slug, met_page: pageNums[i] },
         created_at: now, updated_at: now,
-      };
+      });
     });
     await db.collection('pages').insertMany(pageDocs, { ordered: false });
     console.log(`  inserted ${pageDocs.length} pages`);

--- a/scripts/import/ndl-daoist-import.mjs
+++ b/scripts/import/ndl-daoist-import.mjs
@@ -15,6 +15,7 @@
  */
 
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -266,7 +267,7 @@ async function main() {
 
     const now = new Date();
 
-    const bookDoc = {
+    const bookDoc = makeBookDoc({
       _id: bookId,
       id: bookIdStr,
       slug,
@@ -327,7 +328,7 @@ async function main() {
       status: 'draft',
       created_at: now,
       updated_at: now,
-    };
+    });
 
     // 5. Insert book
     await booksCol.insertOne(bookDoc);
@@ -336,7 +337,7 @@ async function main() {
     // 6. Create pages
     const pageDocs = pageImages.map((img, i) => {
       const pageId = new ObjectId();
-      return {
+      return makePageDoc({
         _id: pageId,
         id: pageId.toHexString(),
         book_id: bookIdStr,
@@ -346,7 +347,7 @@ async function main() {
         photo_original: img.photo,
         created_at: now,
         updated_at: now,
-      };
+      });
     });
 
     await pagesCol.insertMany(pageDocs);

--- a/scripts/import/oraec-paginate-translate.mjs
+++ b/scripts/import/oraec-paginate-translate.mjs
@@ -18,6 +18,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { makePageDoc } from '../lib/book-docs.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
@@ -140,7 +141,7 @@ async function processBook(db, bookId) {
     }
 
     const pageId = new ObjectId();
-    const pageDoc = {
+    const pageDoc = makePageDoc({
       _id: pageId,
       id: pageId.toHexString(),
       book_id: bid,
@@ -162,7 +163,7 @@ async function processBook(db, bookId) {
       },
       created_at: new Date(),
       updated_at: new Date(),
-    };
+    });
 
     await db.collection('pages').insertOne(pageDoc);
     process.stdout.write(`  [${pageNum}/${numPages}] sentences ${start + 1}-${end} ✓\n`);

--- a/scripts/import/shwep-curator-pass-import.mjs
+++ b/scripts/import/shwep-curator-pass-import.mjs
@@ -17,6 +17,7 @@
  */
 
 import { MongoClient, ObjectId } from 'mongodb';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -160,7 +161,7 @@ function buildBookDoc({ entry, pageCount, pageCountSource, thumbnail, slug, iaMe
     bookId,
     bookIdStr,
     fingerprint,
-    bookDoc: {
+    bookDoc: makeBookDoc({
       _id: bookId,
       id: bookIdStr,
       slug,
@@ -200,7 +201,7 @@ function buildBookDoc({ entry, pageCount, pageCountSource, thumbnail, slug, iaMe
       normalized_author: normalizeAuthor(entry.author),
       created_at: new Date(),
       updated_at: new Date(),
-    },
+    }),
   };
 }
 
@@ -308,7 +309,7 @@ async function main() {
         const pageDocs = [];
         for (let p = start; p < Math.min(start + CHUNK, pageCount); p++) {
           const pageId = new ObjectId();
-          pageDocs.push({
+          pageDocs.push(makePageDoc({
             _id: pageId,
             id: pageId.toHexString(),
             book_id: bookIdStr,
@@ -318,7 +319,7 @@ async function main() {
             photo_original: getPageUrl(p),
             created_at: new Date(),
             updated_at: new Date(),
-          });
+          }));
         }
         await db.collection('pages').insertMany(pageDocs, { ordered: false });
       }

--- a/scripts/import/tartu-dspace-pdf-direct.mjs
+++ b/scripts/import/tartu-dspace-pdf-direct.mjs
@@ -23,6 +23,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 // Optional: --items <path.json> supplies the import list (array of item objects with the
@@ -100,7 +101,7 @@ async function importItem(db, it) {
 
     const bookId = new ObjectId(); const idStr = bookId.toHexString();
     const slug = await uniqueSlug(db, it.slug_base); const now = new Date();
-    await db.collection('books').insertOne({
+    await db.collection('books').insertOne(makeBookDoc({
       _id: bookId, id: idStr, slug,
       title: it.title, display_title: it.display_title, author: it.author,
       language: it.language, original_language: it.language, published: it.published, year: it.year,
@@ -118,10 +119,10 @@ async function importItem(db, it) {
       status: 'draft', hidden: true, visible: false, source_fingerprint: fp,
       normalized_title: slugify(it.display_title).replace(/-/g, ' '), normalized_author: slugify(it.author).replace(/-/g, ' '),
       created_at: now, updated_at: now,
-    });
+    }));
     const CHUNK = 500;
     for (let s = 0; s < pages.length; s += CHUNK) {
-      const docs = pages.slice(s, s + CHUNK).map((photo, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), book_id: idStr, page_number: s + k + 1, photo, thumbnail: photo, photo_original: photo, created_at: now, updated_at: now }; });
+      const docs = pages.slice(s, s + CHUNK).map((photo, k) => { const pid = new ObjectId(); return makePageDoc({ _id: pid, id: pid.toHexString(), book_id: idStr, page_number: s + k + 1, photo, thumbnail: photo, photo_original: photo, created_at: now, updated_at: now }); });
       await db.collection('pages').insertMany(docs, { ordered: false });
     }
     console.log(`  ✓ inserted ${slug} (${idStr}) — ${pages.length} pages, hidden`);

--- a/scripts/lib/book-docs.mjs
+++ b/scripts/lib/book-docs.mjs
@@ -13,10 +13,14 @@
  * scripts wrote as of 2026-08-13 (AST scan of the insertOne/insertMany
  * literals in scripts/import/*.mjs, scripts/import-*-artworks.mjs,
  * scripts/iiif-discovery/import-*.mjs — artwork importers insert into `books`
- * too, hence the artwork/museum fields). They describe what imports DO write,
- * not what they SHOULD; known duplicate families (pageCount vs pages_count,
- * place_of_publication vs place_published) are kept so existing scripts can
- * adopt this without churn, and get consolidated by #3969 Track B.
+ * too, hence the artwork/museum fields), widened on 2026-08-14 by the 50
+ * scripts that actually adopted the constructors: the first scan read only
+ * top-level literal keys, so keys reached through a helper's `return {…}`, a
+ * conditional spread, or a `.ts` importer were invisible until the call threw.
+ * They describe what imports DO write, not what they SHOULD; known duplicate
+ * families (pageCount vs pages_count, place_of_publication vs place_published,
+ * image_full vs commons_full_url) are kept so existing scripts can adopt this
+ * without churn, and get consolidated by #3969 Track B.
  *
  * Adding a field here is a deliberate, reviewed act — that is the point.
  * Retired fields (see RETIRED_FIELDS) are refused with a pointed message and
@@ -43,15 +47,22 @@ export const BOOK_FIELDS = Object.freeze([
   // identity
   '_id', 'id', 'slug',
   // core bibliographic
-  'title', 'display_title', 'author', 'language', 'original_language',
-  'published', 'year', 'original_work_year', 'publisher',
+  'title', 'display_title', 'display_author', 'original_title',
+  'author', 'language', 'original_language',
+  'published', 'year', 'original_work_year', 'date_earliest', 'date_latest',
+  'publisher',
   'place_published', 'place_of_publication', // known duplicate family — #3969 Track B
-  'categories', 'collections', 'description', 'notes',
+  'categories', 'collections', 'curator_notes', 'description', 'faceted_tags',
+  'notes', 'scholarly_notes',
   'normalized_title', 'normalized_author',
-  'is_translation', 'text_role', 'text_source', 'content_type', 'work_id',
+  'is_translation', 'text_role', 'text_source', 'translation_status',
+  'content_type', 'work_id',
   // provenance / source
   'ia_identifier', 'source_fingerprint', 'image_source', 'contributing_library',
+  'provider', 'held_by', 'current_location', 'attribution_note',
   'dublin_core', 'catalog_metadata', 'catalog_ids', 'field_provenance',
+  'enrichment', 'linked_art', 'wikidata_id',
+  'harvested_at', 'harvest_source', 'harvest_category',
   'metadata', 'metadata_quality', 'shelfmark', 'subject_geographic',
   'provenance_reference', 'acquisition_campaign',
   // pipeline / status
@@ -63,11 +74,17 @@ export const BOOK_FIELDS = Object.freeze([
   'pages_count', 'pageCount', // known duplicate family — #3969 Track B
   'page_count_source', 'pages_ocr', 'pages_translated', 'pages_archived',
   // images / artwork (artwork docs live in `books` with resource_type set)
-  'thumbnail', 'resource_type', 'image_display', 'image_source_url',
-  'image_width', 'image_height', 'medium', 'dimensions', 'department',
+  'thumbnail', 'thumbnail_blob', 'resource_type', 'image_display',
+  'image_full', 'image_source_url', 'image_thumb', 'archived_full_url',
+  'image_width', 'image_height', 'full_width', 'full_height',
+  'medium', 'dimensions', 'dimensions_display', 'department',
   'accession_number', 'micrio_id',
-  'commons_full_url', 'commons_page_title', 'commons_description',
-  'commons_categories', 'commons_width', 'commons_height',
+  'commons_assessment', 'commons_attribution_required', 'commons_categories',
+  'commons_copyrighted', 'commons_credit', 'commons_description',
+  'commons_full_url', 'commons_height', 'commons_license', 'commons_license_id',
+  'commons_license_url', 'commons_mediatype', 'commons_page_title',
+  'commons_restrictions', 'commons_sha1', 'commons_title', 'commons_upload_date',
+  'commons_uploader', 'commons_url', 'commons_usage_terms', 'commons_width',
   'met_object_id', 'met_classification', 'met_department', 'met_dimensions',
   'met_dynasty', 'met_medium', 'met_period', 'met_reign',
   'rijksmuseum_id',
@@ -88,7 +105,7 @@ export const PAGE_FIELDS = Object.freeze([
   'thumbnail', 'image_thumb', 'thumbnail_blob',
   'image_width', 'image_height', 'width', 'height',
   // text
-  'ocr', 'translation', 'transliteration',
+  'ocr', 'summary', 'translation', 'transliteration',
   // pipeline
   'status', 'archive_metadata',
   // timestamps

--- a/scripts/migration/bph-s3-to-r2.mjs
+++ b/scripts/migration/bph-s3-to-r2.mjs
@@ -22,6 +22,7 @@ import { execSync } from 'child_process';
 import { parseArgs } from 'util';
 import sharp from 'sharp';
 import { join } from 'path';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 // --- Config ---
 const CONCURRENCY = 20; // pages in parallel per book
@@ -131,7 +132,7 @@ function pagePaths(bookId, pageNumber) {
 // --- Make page record ---
 function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
   const id = new ObjectId().toHexString();
-  return {
+  return makePageDoc({
     _id: new ObjectId(id),
     id,
     book_id: bookId,
@@ -143,7 +144,7 @@ function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
     summary: null,
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 }
 
 // --- Provenance helper ---
@@ -172,7 +173,7 @@ function makeBookRecord(meta) {
     date: now.toISOString(),
   };
 
-  return {
+  return makeBookDoc({
     _id: new ObjectId(id),
     id,
     title: meta.title || 'Untitled',
@@ -219,7 +220,7 @@ function makeBookRecord(meta) {
     },
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 }
 
 // --- Concurrency limiter ---

--- a/scripts/migration/bulk-import-to-r2.mjs
+++ b/scripts/migration/bulk-import-to-r2.mjs
@@ -28,6 +28,7 @@ import { createReadStream, readdirSync, readFileSync, statSync, existsSync } fro
 import { basename, join, extname } from 'path';
 import { parseArgs } from 'util';
 import sharp from 'sharp';
+import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
 
 // --- Config ---
 const CONCURRENCY = parseInt(process.env.CONCURRENCY || '20');
@@ -109,7 +110,7 @@ function pagePaths(bookId, pageNumber) {
 // --- Create page record ---
 function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
   const id = new ObjectId().toHexString();
-  return {
+  return makePageDoc({
     _id: new ObjectId(id),
     id,
     book_id: bookId,
@@ -121,13 +122,13 @@ function makePageRecord(bookId, pageNumber, photoUrl, thumbnailUrl) {
     summary: null,
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 }
 
 // --- Create book record ---
 function makeBookRecord(meta) {
   const id = new ObjectId().toHexString();
-  return {
+  return makeBookDoc({
     _id: new ObjectId(id),
     id,
     title: meta.title || 'Untitled',
@@ -151,7 +152,7 @@ function makeBookRecord(meta) {
     pipeline_auto: true,
     created_at: new Date(),
     updated_at: new Date(),
-  };
+  });
 }
 
 // --- Concurrency limiter ---


### PR DESCRIPTION
## Why

PR #3984 added `makeBookDoc` / `makePageDoc` in `scripts/lib/book-docs.mjs` — whitelisted
constructors that throw on unknown or retired keys — and then nothing used them. An
affordance with no adoption prevents nothing. This makes them load-bearing: every
direct-to-Mongo import script now builds its `books`/`pages` insert docs through them, so
field #478 cannot ship silently (issue #3969).

## Scripts converted (50)

- `scripts/import/*.mjs` (36): al-badri-direct, batch-import-istc-bsb, bncf-aldine-direct,
  bsb-from-file, ccag-vii-pdf-direct, early-america-direct, fetch-wikisource-javanese,
  founders-collected-direct, founding-chase, founding-docs-direct, founding-enrich-direct,
  founding-influences2-direct, founding-tail-direct, fragmenta-direct,
  harvard-iiif-direct-batch, harvard-philosophy-direct, harvard-wuzhen-direct,
  ia-bundle-import, iiif-direct-import, import-artwork, import-hashika-e-posters,
  import-idp-batch, import-kloss-collection, import-met-egyptian, import-oraec,
  import-pdf-books, import-rijksmuseum-artworks, import-sefaria, import-umn-health-texts,
  jefferson-canon-direct, marcianus-299-direct, met-shunga-albums-direct, ndl-daoist-import,
  oraec-paginate-translate, shwep-curator-pass-import, tartu-dspace-pdf-direct
- `scripts/import/import-thirukkural.ts` (1) — TS adopted cleanly; `scripts/` is excluded
  from `tsconfig.json`, and `tsx` resolves the `.mjs` import, so there is no interop cost.
- `scripts/import-*.mjs` (8): aic, cleveland, commons, getty, met, nga, rijks artworks +
  import-naj-sancai
- `scripts/iiif-discovery/import-*.mjs` (3): import-from-cache, import-leiden-artworks,
  import-leiden-books
- `scripts/migration/` (2): bph-s3-to-r2, bulk-import-to-r2

## Fields added to the whitelist

The 2026-08-13 scan behind the original lists read only **top-level literal keys in
`scripts/import/*.mjs`-shaped call sites**. Adoption surfaced the rest: keys reached through
a helper's `return {…}`, through a conditional spread, or written by a `.ts` importer or a
`scripts/`-root artwork harvester. Each of these was already being written to `books` /
`pages` in production; none is new behaviour, and nothing was removed.

**`BOOK_FIELDS` +40**

| Field(s) | Written by | Why it was missing |
|---|---|---|
| `curator_notes` | import-thirukkural.ts, direct-import-cosmogony.ts | `.ts` importers were outside the scan |
| `display_author` | import-naj-sancai | `scripts/`-root script, partial scan |
| `original_title`, `date_earliest`, `date_latest`, `translation_status`, `scholarly_notes` | ndl-daoist-import | catalog-coverage vocabulary; `scholarly_notes` has no reader in `src/` — Track B candidate |
| `provider`, `held_by` | import-umn-health-texts, import-hashika-e-posters | top-level duplicate of `image_source.provider` — Track B candidate |
| `current_location`, `dimensions_display`, `faceted_tags` | rijksmuseum, met-shunga, hashika artwork docs | read by `ArtworkInfo.tsx` / artwork search |
| `image_full`, `image_thumb`, `thumbnail_blob`, `archived_full_url`, `full_width`, `full_height` | artwork importers | artwork image family; `image_thumb`/`thumbnail_blob` existed on `PAGE_FIELDS` only, and artwork docs live in `books` |
| `attribution_note`, `enrichment`, `linked_art`, `wikidata_id` | commons, rijks, nga | reached only via conditional spreads, so the literal scan never saw them |
| `harvested_at`, `harvest_source`, `harvest_category` | all seven artwork harvesters | harvester provenance |
| `commons_title`, `commons_url`, `commons_license`, `commons_license_id`, `commons_license_url`, `commons_usage_terms`, `commons_copyrighted`, `commons_attribution_required`, `commons_restrictions`, `commons_credit`, `commons_assessment`, `commons_sha1`, `commons_mediatype`, `commons_upload_date`, `commons_uploader` | import-commons-artworks (+ the `commons_title`/`commons_url`/`commons_license` trio in all six museum harvesters) | the licence/attribution block the original scan missed entirely |

**`PAGE_FIELDS` +1**: `summary` (`migration/bph-s3-to-r2`, `migration/bulk-import-to-r2` write
it as a `null` placeholder; read by the book-index and chat routes).

**Retired fields:** none of the 50 scripts writes `tenant_id`, `tenantId`, or `hide_reason`.
Nothing had to be removed. (`scripts/import/etl-kloss-catalog-to-supabase.mjs` writes
`tenant_id`, but to a **Supabase** table where it is the correct key — that script is not
converted and is out of scope.)

## Verification

- `node --check` on all 49 modified `.mjs` files — exit 0, no diagnostics.
- **Behaviour-preservation proof**: an AST pass parses each converted file, splices every
  `makeBookDoc(...)` / `makePageDoc(...)` call back down to its object-literal argument,
  drops the added import line, and diffs the result against `HEAD`. **50/50 byte-identical.**
  The only two apparent mismatches are the arrow-implicit-return shape
  (`=> ({…})` → `=> makePageDoc({…})`), where unwrapping legitimately cannot restore the parens.
- **Runtime smoke**: the same pass extracts every static key set actually passed at each of
  the ~90 call sites and calls the real constructor with it. Zero throws after the whitelist
  additions — i.e. these scripts will construct, not explode, when next run.
- `npx vitest run tests/unit/book-docs.test.ts tests/unit/sweep-log.test.ts` — 17/17 pass.
- `npx tsc --noEmit` — exit 0.
- No script was executed and no database was contacted.

## Hunks worth a close look

1. **`scripts/iiif-discovery/import-from-cache.mjs:136`** — `if (doc.resource_type === undefined) delete doc.resource_type;` now runs on the constructor's shallow copy. Behaviour is identical (the key is whitelisted, passes through as `undefined`, then gets deleted), but the doc is mutated after construction.
2. **`scripts/import/import-idp-batch.mjs:280-281`** — `book.thumbnail` / `book.pages_count` are assigned after `makeBookDoc` returns and before the insert; both keys are whitelisted, but the constructor never sees those two writes.
3. **`scripts/import/import-sefaria.mjs:243-244`** — same shape: `doc.ocr` / `doc.translation` set after `makePageDoc`.
4. **`scripts/import/import-umn-health-texts.mjs:158`** — the only genuinely dynamic spread: `makePageDoc({ _id, id, book_id, ...p })`, where `p` comes from the IIIF canvas mapper at :108-113 (`page_number`, `photo`, `thumbnail`, `photo_original` — all whitelisted today, but a change to that mapper would reach the doc unseen). **This is also the one place with a real behaviour delta**: those page docs set no `created_at`/`updated_at`, so the constructor now stamps both. Every other converted literal sets them explicitly.
5. **Nested builders** — `import-cleveland-artworks.mjs` (`buildDoc()`'s `return`), `shwep-curator-pass-import.mjs` (`bookDoc:` inside the object `buildBookDoc()` returns), and both migration scripts (`makeBookRecord()` / `makePageRecord()` returns) are wrapped at the `return`, which is where the whole doc is built.
6. **Conditional spreads** are validated only on the runs where the condition holds — `import-artwork.mjs` has 14, `import-commons-artworks.mjs`/`import-nga-artworks.mjs`/`import-rijks-artworks.mjs` one apiece for `attribution_note`/`wikidata_id`/`enrichment`. All their keys are now whitelisted, so the intermittent-throw hazard is closed, but the constructor's guarantee here is per-run, not static.

## Out of scope

- `scripts/import/pdf-direct.ts` and `scripts/import/direct-import-cosmogony.ts` — the two
  remaining `.ts` importers that insert into `books`/`pages`. Only `import-thirukkural.ts`
  was in the brief; converting the other two is a small follow-up.
- `scripts/maintenance/bph-nas-ingest.mjs`, `scripts/workers/erara-import-queue.mjs`,
  `scripts/split-book.mjs`, `scripts/repair-foreign-folder-pair.mjs`,
  `scripts/tmp-import-berlin-papyri.mjs` and other non-import writers — same treatment is owed,
  separate PR.
- Duplicate-family consolidation (`pageCount`/`pages_count`, `place_published`/`place_of_publication`,
  `image_full`/`commons_full_url`, top-level `provider` vs `image_source.provider`) stays with
  #3969 Track B. This PR deliberately records the sprawl rather than fixing it.
- No import script's actual behaviour was changed, and no "bug I noticed" was fixed.

## Docs

`.claude/docs/import-workflow.md` gains a short **Building the insert docs** section: new
import scripts build docs through the constructors, because unknown keys throw and field
#478 therefore cannot ship silently. It points at `.claude/docs/invariants/field-sprawl.md`
(merged in #3998) for the rule itself and for where per-book *actions* go instead
(rows via `scripts/lib/sweep-log.mjs`), rather than restating either.

Rebased onto `f2817c12` — no conflict with #3998, which does not touch `book-docs.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
