### PR TITLE
fix(restore): stop archived-book restores carrying archive-only and retired fields (#3997)

### DIFF
--- a/src/app/api/books/restore/[id]/route.ts
+++ b/src/app/api/books/restore/[id]/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAuth } from '@/lib/auth-helpers';
+import { stripArchiveOnlyFields } from '@/lib/restore-hygiene';
 
 /**
  * Restore a deleted book from the deleted_books archive
@@ -35,10 +36,16 @@ export const POST = withAuth(async (request, session, context) => {
     // Extract pages from the archived document
     const { pages, deleted_at, original_id, ...bookData } = archivedBook;
 
+    // `deleted_books` is not a subset of `books` — spreading an archived doc
+    // back wholesale carries archive bookkeeping and resurrects retired fields
+    // (#3997). Strip them; the audit log below records what was removed.
+    const { clean: restorable, stripped: strippedOnRestore } =
+      stripArchiveOnlyFields(bookData as Record<string, unknown>);
+
     // Restore book (generate new _id to avoid conflicts)
     const newBookId = new ObjectId();
     await db.collection('books').insertOne({
-      ...bookData,
+      ...restorable,
       _id: newBookId,
       restored_at: new Date(),
       restored_from: archivedBook._id
@@ -63,6 +70,9 @@ export const POST = withAuth(async (request, session, context) => {
       book_id: bookData.id,
       book_title: bookData.title,
       pages_affected: pages?.length || 0,
+      ...(Object.keys(strippedOnRestore).length
+        ? { metadata: { stripped_on_restore: strippedOnRestore } }
+        : {}),
     });
 
     return NextResponse.json({

--- a/src/lib/restore-hygiene.ts
+++ b/src/lib/restore-hygiene.ts
@@ -1,0 +1,58 @@
+/**
+ * Field hygiene for restoring an archived book back into `books` (issue #3997).
+ *
+ * `deleted_books` is NOT a subset of `books`. It has drifted into its own
+ * 260-field shape, because the dedup/purge sweeps that archive books write
+ * their own bookkeeping onto the archived copy. Spreading an archived document
+ * back into `books` wholesale therefore carries fields that:
+ *
+ *   1. are meaningless on a live book (archive bookkeeping), and
+ *   2. RESURRECT RETIRED FIELDS — the tenant and hide_reason consolidations
+ *      (#3983, #3986) cleaned `books` but not `deleted_books`, so every
+ *      archived copy still carries them and each restore re-pollutes the
+ *      collection. See `.claude/docs/invariants/field-sprawl.md`.
+ *
+ * It also matters for the `books` $jsonSchema validator (#3969 Track A): under
+ * `validationAction: 'error'` these unblessed fields would make every restore
+ * fail, turning a documented recovery path (CLAUDE.md, Data Protection) into a
+ * 500.
+ *
+ * Nothing is discarded silently — the caller logs what was stripped.
+ */
+
+/** Fields that must never travel from `deleted_books` back into `books`. */
+export const ARCHIVE_ONLY_FIELDS = [
+  // dedup/purge sweep bookkeeping, written onto the archived copy
+  '_original_id',
+  'dedup_batch',
+  'dedup_sim',
+  'delete_reason',
+  'kept_version_id',
+  'needs_reimport',
+  'reason',
+  'materials',
+  // retired — restoring these re-pollutes the collection
+  'hide_reason',
+  'tenant_id',
+] as const;
+
+/**
+ * Split an archived book document into the part that may be written back to
+ * `books` and the archive-only fields that must not be.
+ *
+ * Does not mutate the input.
+ */
+export function stripArchiveOnlyFields(
+  bookData: Record<string, unknown>
+): { clean: Record<string, unknown>; stripped: Record<string, unknown> } {
+  const clean: Record<string, unknown> = {};
+  const stripped: Record<string, unknown> = {};
+  const archiveOnly = new Set<string>(ARCHIVE_ONLY_FIELDS);
+
+  for (const [k, v] of Object.entries(bookData)) {
+    if (archiveOnly.has(k)) stripped[k] = v;
+    else clean[k] = v;
+  }
+
+  return { clean, stripped };
+}

--- a/tests/unit/restore-hygiene.test.ts
+++ b/tests/unit/restore-hygiene.test.ts
@@ -1,0 +1,79 @@
+/**
+ * stripArchiveOnlyFields: field hygiene on the book restore path (#3997).
+ *
+ * What these pin: restoring an archived book must not carry `deleted_books`
+ * bookkeeping back into `books`, and must not resurrect fields retired by the
+ * #3969 consolidations — the tenant/hide_reason cleanup touched `books` but
+ * not `deleted_books`, so every archived copy still carries them and an
+ * unfiltered restore re-pollutes the collection. Real book data must survive
+ * untouched, and what is removed must be returned so the caller can log it.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { stripArchiveOnlyFields, ARCHIVE_ONLY_FIELDS } from '@/lib/restore-hygiene';
+
+describe('stripArchiveOnlyFields', () => {
+  it('keeps real book fields untouched', () => {
+    const input = {
+      id: 'abc123',
+      title: 'Novum lumen chymicum',
+      author: 'Sendivogius',
+      pages_count: 240,
+      visible: false,
+      image_source: { provider: 'internet_archive' },
+    };
+    const { clean, stripped } = stripArchiveOnlyFields(input);
+
+    expect(clean).toEqual(input);
+    expect(stripped).toEqual({});
+  });
+
+  it('removes retired fields so a restore cannot re-pollute the collection', () => {
+    const { clean, stripped } = stripArchiveOnlyFields({
+      id: 'abc123',
+      title: 'Pymander',
+      tenant_id: 'default',
+      hide_reason: 'Duplicate of 69b51e80 (kept: 0ocr/406pg, this: 0ocr/348pg)',
+    });
+
+    expect('tenant_id' in clean).toBe(false);
+    expect('hide_reason' in clean).toBe(false);
+    expect(stripped.tenant_id).toBe('default');
+    expect(stripped.hide_reason).toContain('Duplicate of');
+    expect(clean.title).toBe('Pymander');
+  });
+
+  it('removes dedup/purge bookkeeping that is meaningless on a live book', () => {
+    const { clean, stripped } = stripArchiveOnlyFields({
+      id: 'abc123',
+      dedup_batch: 'bph-2026-07',
+      dedup_sim: 0.98,
+      kept_version_id: '69b51e80',
+      delete_reason: 'duplicate',
+      reason: 'duplicate',
+      needs_reimport: true,
+      materials: ['paper'],
+      _original_id: '69a0278f',
+    });
+
+    expect(Object.keys(clean)).toEqual(['id']);
+    expect(Object.keys(stripped).sort()).toEqual(
+      ['_original_id', 'dedup_batch', 'dedup_sim', 'delete_reason', 'kept_version_id', 'materials', 'needs_reimport', 'reason'].sort()
+    );
+  });
+
+  it('does not mutate its input', () => {
+    const input = { id: 'abc123', tenant_id: 'default' };
+    stripArchiveOnlyFields(input);
+
+    expect(input.tenant_id).toBe('default');
+  });
+
+  it('strips every declared archive-only field', () => {
+    const input = Object.fromEntries(ARCHIVE_ONLY_FIELDS.map((f) => [f, 'x']));
+    const { clean, stripped } = stripArchiveOnlyFields(input);
+
+    expect(clean).toEqual({});
+    expect(Object.keys(stripped).sort()).toEqual([...ARCHIVE_ONLY_FIELDS].sort());
+  });
+});


### PR DESCRIPTION
Closes #3997. Unblocks the `error`-mode flip of the `books` validator (#3969 Track A).

## The problem, measured

`deleted_books` is **not** a subset of `books` — it has drifted into its own **260-field** shape, because the dedup/purge sweeps that archive a book write their own bookkeeping onto the archived copy. `POST /api/books/restore/[id]` spread that document straight back into `books`.

Diffing a full field enumeration of `deleted_books` against the 475 the validator blesses (minus the three the route already destructures out) gives exactly **10 fields**: `_original_id`, `dedup_batch`, `dedup_sim`, `delete_reason`, `kept_version_id`, `needs_reimport`, `reason`, `materials`, `hide_reason`, `tenant_id`.

Two consequences:

1. **Re-pollution, happening today.** The #3983/#3986 consolidations cleaned `books` but **not** `deleted_books`, so every archived copy still carries `tenant_id` and `hide_reason`. Each restore resurrected both — the exact fields just retired, now on the weekly watch's `--forbid` list. A writer nobody counted as a writer: the same shape that opened #3969.
2. **Error mode would 500 every restore** — a recovery path `CLAUDE.md` promises under Data Protection.

## The fix

`src/lib/restore-hygiene.ts` — `stripArchiveOnlyFields()` splits an archived doc into what may be written back and what may not. Extracted rather than inlined so it is unit-testable without mocking Mongo, and reusable if a second restore path ever appears (today there is exactly one — the other two `deleted_books` readers are permanent-delete paths).

**Nothing is discarded silently:** the stripped values go into the `book_restored` audit-log entry, so the dedup verdicts stay recoverable.

`restored_from` — written by this route, carried by no current book, so the full-scan enumeration could not see it — is blessed deliberately in the validator artifact (475 → 476), per the 'adding a legitimate field' path in `.claude/docs/invariants/field-sprawl.md`.

## Verification
- `vitest tests/unit/restore-hygiene.test.ts` — **5/5 pass**. They pin real behaviour: retired fields cannot survive a restore, dedup bookkeeping is removed, genuine book data passes through untouched, the input is not mutated, and every declared field is stripped. A no-op implementation fails them.
- `npx tsc --noEmit` — clean.

## Out of scope
- **Cleaning `tenant_id`/`hide_reason` out of `deleted_books` itself.** This PR defends at the boundary, which is the robust half. Scrubbing the archive is a separate data pass — worth doing, but a restore is safe without it.
- A $jsonSchema validator for `deleted_books` (it deserves one; separate).
- Migrating `deleted_books` to the `books` shape (largest blast radius, option 3 in #3997).

🤖 Generated with [Claude Code](https://claude.com/claude-code)