### PR TITLE
fix(librarian): list conversations by default, never under a name

### DIFF
--- a/scripts/maintenance/relist-retracted-librarian-threads.mjs
+++ b/scripts/maintenance/relist-retracted-librarian-threads.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Put back the Librarian threads that the 2026-08-01 retraction took down —
+ * this time without anybody's name on them.
+ *
+ * On 2026-08-01, unpublish-default-public-librarian-threads.mjs flipped 539
+ * threads from 'public' to 'private' because the old default had published
+ * them under their authors' real account names (#3505). That was right. It
+ * also left the Recent feed at zero of 1,240 threads, permanently, because
+ * nothing could refill it — every new thread defaulted private and the publish
+ * toggle only worked before the first message.
+ *
+ * The rule now separates the two things that were one switch: a conversation
+ * is listed, and no name travels with it. So the retraction can be undone on
+ * its own terms — these 539 were listed before, and relisting them exposes
+ * strictly less than what their authors actually saw at the time.
+ *
+ * SCOPE — this script touches ONLY threads carrying `visibility_retracted_at`.
+ * That stamp is the exact record of "we took this down", which makes the set
+ * something we can name rather than infer from dates:
+ *
+ *   539  stamped, currently private   → RELIST (515 have >=2 messages)
+ *    20  pre-flip, author chose private, never stamped → LEAVE
+ *   420  pre-flip anonymous 'unlisted', never listed   → LEAVE (relisting
+ *        these would be new publication, not restoration)
+ *   257  created after the flip, under "private by default" → LEAVE
+ *
+ * ORDER MATTERS. Run this only AFTER the anonymisation is live in production.
+ * The Recent feed filters on visibility:'public' and the old code still serves
+ * `creatorName` verbatim, so flipping these before the deploy would re-create
+ * the original leak exactly — 537 signed-in threads back in the feed under
+ * real names. The --apply path refuses to run until it has confirmed the
+ * deployed API anonymises; see assertAnonymisationIsLive().
+ *
+ *   node scripts/maintenance/relist-retracted-librarian-threads.mjs            # dry run
+ *   node scripts/maintenance/relist-retracted-librarian-threads.mjs --apply
+ *   node scripts/maintenance/relist-retracted-librarian-threads.mjs --undo <backup.json>
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import fs from 'fs';
+import path from 'path';
+
+const APPLY = process.argv.includes('--apply');
+const undoIdx = process.argv.indexOf('--undo');
+const UNDO = undoIdx !== -1 ? process.argv[undoIdx + 1] : null;
+const ORIGIN = process.env.RELIST_ORIGIN || 'https://sourcelibrary.org';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI is not set. Run with: node --env-file=.env.production.local scripts/...');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+
+/**
+ * Refuse to publish into code that would leak.
+ *
+ * The check needs a positive control or "no name found" proves nothing: an
+ * empty feed and a correctly anonymised one look identical. So it reads a
+ * thread it knows exists and is anonymously readable, and looks for a field
+ * only the new code emits (`isOwner`). A 200 that lacks it means the old
+ * handler is still deployed.
+ */
+async function assertAnonymisationIsLive(threads) {
+  const probe = await threads.findOne(
+    { visibility: 'unlisted', messageCount: { $gte: 2 } },
+    { projection: { _id: 1 } },
+  );
+  if (!probe) {
+    throw new Error('No unlisted thread to probe with — cannot verify the deploy. Refusing.');
+  }
+
+  const url = `${ORIGIN}/api/embassy/threads/${probe._id.toString()}`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'sourcelibrary-maintenance' } });
+  if (!res.ok) {
+    throw new Error(`Probe ${url} returned ${res.status} — expected 200. Refusing.`);
+  }
+  const data = await res.json();
+
+  // Positive control: we know this thread exists and just read it.
+  if (!Array.isArray(data.messages) || data.messages.length === 0) {
+    throw new Error('Probe returned no messages — probe is not measuring anything. Refusing.');
+  }
+  if (typeof data.thread?.isOwner !== 'boolean') {
+    throw new Error(
+      'Deployed API has no `isOwner` field — the anonymisation is NOT live yet.\n' +
+      'Merge and deploy the thread-visibility change first, or these threads go\n' +
+      'back into the public feed under real names. Refusing.',
+    );
+  }
+  const human = data.messages.find(m => m.authorType === 'human');
+  if (human && human.authorName !== 'A reader') {
+    throw new Error(
+      `Deployed API served authorName="${human.authorName}" to an anonymous caller — ` +
+      'expected "A reader". Refusing.',
+    );
+  }
+  console.log(`Deploy check passed: ${url} anonymises (isOwner present, author "A reader").\n`);
+}
+
+async function main() {
+  await client.connect();
+  const threads = client.db('bookstore').collection('embassy_threads');
+
+  if (UNDO) {
+    const backup = JSON.parse(fs.readFileSync(UNDO, 'utf8'));
+    const ids = backup.ids.map(id => new ObjectId(id));
+    const res = await threads.updateMany(
+      { _id: { $in: ids } },
+      { $set: { visibility: 'private' } },
+    );
+    console.log(`Re-retracted ${res.modifiedCount} of ${ids.length} threads to private.`);
+    return;
+  }
+
+  const filter = { visibility_retracted_at: { $exists: true }, visibility: 'private' };
+  const docs = await threads
+    .find(filter, { projection: { _id: 1, messageCount: 1, creatorId: 1, createdAt: 1 } })
+    .toArray();
+
+  const inFeed = docs.filter(d => (d.messageCount ?? 0) >= 2);
+  const signedIn = docs.filter(d => d.creatorId != null);
+
+  console.log(`retracted threads to relist: ${docs.length}`);
+  console.log(`  will appear in Recent:     ${inFeed.length}`);
+  console.log(`  authored while signed in:  ${signedIn.length} (names stay hidden)`);
+
+  if (!APPLY) {
+    console.log('\nDry run. Re-run with --apply (after the anonymisation is deployed).');
+    return;
+  }
+
+  await assertAnonymisationIsLive(threads);
+
+  const dir = path.join(process.cwd(), 'scripts', 'output');
+  fs.mkdirSync(dir, { recursive: true });
+  const backupPath = path.join(dir, `relist-librarian-threads-${new Date().toISOString().slice(0, 10)}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify({
+    relisted_at: new Date().toISOString(),
+    note: 'Threads moved private -> public (anonymised). Undo with --undo <this file>.',
+    ids: docs.map(d => d._id.toString()),
+  }, null, 2));
+  console.log(`Backup written: ${backupPath}`);
+
+  const res = await threads.updateMany(
+    { _id: { $in: docs.map(d => d._id) } },
+    { $set: { visibility: 'public' } },
+  );
+  console.log(`matched ${res.matchedCount}, modified ${res.modifiedCount}`);
+
+  const remaining = await threads.countDocuments(filter);
+  const nowPublic = await threads.countDocuments({ visibility: 'public', messageCount: { $gte: 2 } });
+  console.log(`still retracted: ${remaining} (expect 0)`);
+  console.log(`now in Recent feed: ${nowPublic}`);
+}
+
+main()
+  .catch(err => { console.error(err.message); process.exitCode = 1; })
+  .finally(() => client.close());

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -7,6 +7,7 @@ import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/li
 import { applyCitationFixes, applyImageRemovals, type CitationFix } from '@/lib/embassy/citation-fixes';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { chatRequestSchema } from '@/lib/embassy/chat-request';
+import { threadVisibility } from '@/lib/embassy/thread-visibility';
 import { toUserId } from '@/lib/user-id';
 
 export const dynamic = 'force-dynamic';
@@ -116,6 +117,18 @@ export async function POST(request: NextRequest) {
     }
     activeThreadId = threadId;
 
+    // Apply the listing toggle to a conversation already under way. It used to
+    // be read only in the create branch below, so a reader who turned listing
+    // off after saying something personal was silently ignored — the one
+    // moment the control most needs to work.
+    const desired = threadVisibility(userId, visibility === 'public');
+    if (thread.visibility !== desired) {
+      await db.collection('embassy_threads').updateOne(
+        { _id: new ObjectId(threadId) },
+        { $set: { visibility: desired } },
+      );
+    }
+
     await db.collection('embassy_messages').insertOne({
       threadId: new ObjectId(threadId),
       authorType: 'human',
@@ -125,16 +138,16 @@ export async function POST(request: NextRequest) {
       createdAt: now,
     });
   } else {
-    // Create new thread. Anonymous threads are 'unlisted' (null creatorId,
-    // so they can't be claimed via the "mine" filter and aren't surfaced in
-    // the public Recent feed) — the conversation still continues in-session
-    // via threadId. Signed-in users keep their public/private choice.
+    // Listed by default for everyone, signed in or not — no name travels with
+    // it (see lib/embassy/thread-visibility). Opting out lands on 'private'
+    // for a signed-in reader and 'unlisted' for an anonymous one, which keeps
+    // the conversation reachable by id so they can get back to it.
     const result = await db.collection('embassy_threads').insertOne({
       type: 'chat',
       title: message.slice(0, 120),
       creatorId: userId,
       creatorName: displayName,
-      visibility: userId ? visibility : 'unlisted',
+      visibility: threadVisibility(userId, visibility === 'public'),
       aiEnabled: true,
       messageCount: 0,
       createdAt: now,

--- a/src/app/api/embassy/threads/[id]/route.ts
+++ b/src/app/api/embassy/threads/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb, getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
 import { ObjectId } from 'mongodb';
+import {
+  attribution,
+  messageAttribution,
+  threadVisibility,
+} from '@/lib/embassy/thread-visibility';
 
 /**
  * GET /api/embassy/threads/[id] — Get a single thread with all messages.
@@ -31,11 +36,13 @@ export async function GET(
   // (anonymous conversations — never surfaced in the Recent feed) stay
   // readable by anyone holding the id: the chat client restores them via
   // /librarian?thread=<id> when an anonymous visitor navigates back.
-  if (thread.visibility === 'private') {
-    const session = await auth();
-    if (!session?.user?.id || thread.creatorId !== session.user.id) {
-      return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
-    }
+  const session = await auth();
+  const isOwner = Boolean(
+    session?.user?.id && thread.creatorId && thread.creatorId === session.user.id,
+  );
+
+  if (thread.visibility === 'private' && !isOwner) {
+    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
   }
 
   const messages = await db.collection('embassy_messages')
@@ -43,13 +50,18 @@ export async function GET(
     .sort({ createdAt: 1 })
     .toArray();
 
+  // A conversation is readable without its author being identifiable. Names
+  // are stripped here, before they reach the response body, for everyone but
+  // the reader who wrote it — including creatorId, which is a stable handle
+  // that links a stranger's threads to each other.
   return NextResponse.json({
     thread: {
       id: thread._id.toString(),
       type: thread.type,
       title: thread.title,
-      creatorName: thread.creatorName,
-      creatorId: thread.creatorId,
+      creatorName: attribution(thread.creatorName, isOwner),
+      creatorId: isOwner ? thread.creatorId : null,
+      isOwner,
       visibility: thread.visibility,
       messageCount: thread.messageCount,
       createdAt: thread.createdAt,
@@ -58,12 +70,70 @@ export async function GET(
     messages: messages.map(m => ({
       id: m._id.toString(),
       authorType: m.authorType,
-      authorName: m.authorName,
+      authorName: messageAttribution(
+        { authorType: m.authorType, authorName: m.authorName },
+        isOwner,
+      ),
       content: m.content,
       sources: m.sources || [],
       createdAt: m.createdAt,
     })),
   });
+}
+
+/**
+ * PATCH /api/embassy/threads/[id] — Change whether a thread is listed.
+ * Body: { listed: boolean }
+ *
+ * The asymmetry here is deliberate. Un-listing is allowed to anyone holding
+ * the thread id; listing requires being the signed-in creator. Holding the id
+ * already grants read access to a non-private thread, so letting the holder
+ * hide it is not an escalation — and it is the only way an anonymous visitor
+ * can retract a conversation they just realised was personal. Publishing, the
+ * direction that can expose someone, stays locked to the account that owns it.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  if (!ObjectId.isValid(id)) {
+    return NextResponse.json({ error: 'Invalid thread ID' }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  if (typeof body?.listed !== 'boolean') {
+    return NextResponse.json({ error: 'listed must be a boolean' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const thread = await db.collection('embassy_threads').findOne({ _id: new ObjectId(id) });
+  if (!thread) {
+    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+
+  const session = await auth();
+  const isOwner = Boolean(
+    session?.user?.id && thread.creatorId && thread.creatorId === session.user.id,
+  );
+
+  // A private thread is invisible to non-owners everywhere else; don't let an
+  // id-holder learn it exists, or flip it, through this route either.
+  if (thread.visibility === 'private' && !isOwner) {
+    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+  if (body.listed && !isOwner) {
+    return NextResponse.json({ error: 'Sign in as the author to list this' }, { status: 403 });
+  }
+
+  const visibility = threadVisibility(thread.creatorId ?? null, body.listed);
+  await db.collection('embassy_threads').updateOne(
+    { _id: new ObjectId(id) },
+    { $set: { visibility } },
+  );
+
+  return NextResponse.json({ ok: true, visibility });
 }
 
 /**

--- a/src/app/api/embassy/threads/route.ts
+++ b/src/app/api/embassy/threads/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
+import { attribution, LISTED_VISIBILITY } from '@/lib/embassy/thread-visibility';
 
 /**
  * GET /api/embassy/threads — List Embassy threads.
@@ -23,7 +24,7 @@ export async function GET(request: NextRequest) {
     }
     filter = { creatorId: session.user.id, messageCount: { $gte: 2 } };
   } else {
-    filter = { visibility: 'public', messageCount: { $gte: 2 } };
+    filter = { visibility: LISTED_VISIBILITY, messageCount: { $gte: 2 } };
   }
 
   const threads = await db.collection('embassy_threads')
@@ -49,7 +50,11 @@ export async function GET(request: NextRequest) {
       return {
         id: thread._id.toString(),
         title: thread.title,
-        creatorName: thread.creatorName,
+        // Only the reader's own list carries a name. The public feed is
+        // anonymised here rather than in the sidebar that renders it — the
+        // 2026-07-30 leak was in this payload, so a component-level fix would
+        // still be one `curl` away.
+        creatorName: attribution(thread.creatorName, mine),
         messageCount: thread.messageCount,
         createdAt: thread.createdAt,
         lastMessageAt: thread.lastMessageAt,

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -389,9 +389,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   useEffect(() => {
     if (status === 'authenticated') setSidebarTab('mine');
   }, [status]);
-  // Private until the reader says otherwise — the toggle beneath the composer
-  // publishes the thread under their account name, so it must be opt-in.
-  const [visibility, setVisibility] = useState<'public' | 'private'>('private');
+  // Listed by default. The toggle beneath the composer controls whether the
+  // conversation appears in Recent — it never controls a name, because the
+  // server strips those from every surface but the reader's own.
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
   // Research notebook accumulated live across the thread (from notebook_update).
   const [notebookFindings, setNotebookFindings] = useState<NotebookFinding[]>([]);
   const [notebookTopic, setNotebookTopic] = useState<string | undefined>();
@@ -458,6 +459,20 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     setListening(true);
     inputRef.current?.focus();
   }, [listening, stopDictation]);
+
+  // Flip the listing toggle. If the conversation already exists it has to be
+  // written through immediately: the old toggle only ever fed the create call,
+  // so a reader who turned listing off mid-conversation changed nothing and
+  // was never told.
+  const setListed = useCallback((listed: boolean) => {
+    setVisibility(listed ? 'public' : 'private');
+    if (!threadId) return;
+    fetch(`/api/embassy/threads/${threadId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ listed }),
+    }).catch(() => { });
+  }, [threadId]);
 
   // Fetch public threads
   useEffect(() => {
@@ -1177,15 +1192,17 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       )}
                     </div>
                     <div className="flex items-center gap-3">
-                      {isSignedIn && (
-                        <button
-                          onClick={() => setVisibility(v => v === 'public' ? 'private' : 'public')}
-                          className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
-                        >
-                          <span>{visibility === 'public' ? 'Public' : 'Private'}</span>
-                          <span className="text-[9px]">{visibility === 'public' ? '(shown in Recent, under your name)' : '(only you)'}</span>
-                        </button>
-                      )}
+                      <button
+                        onClick={() => setListed(visibility !== 'public')}
+                        className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
+                      >
+                        <span>{visibility === 'public' ? 'Listed' : 'Not listed'}</span>
+                        <span className="text-[9px]">
+                          {visibility === 'public'
+                            ? '(shown in Recent, never under your name)'
+                            : isSignedIn ? '(only you)' : '(not shown to anyone else)'}
+                        </span>
+                      </button>
                       <span className="text-[9px] text-[#c0b8b0] font-mono">v5</span>
                     </div>
                   </div>
@@ -1195,7 +1212,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       <Link href="/auth/signin?callbackUrl=/librarian" className="text-[#9e4a3a] hover:underline">
                         Sign in
                       </Link>
-                      {' '}(free) to save your conversations and keep them private.
+                      {' '}(free) to keep your conversations and come back to them later.
                     </p>
                   )}
                 </div>
@@ -1224,6 +1241,12 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     </button>
                   )}
                 </div>
+
+                {sidebarTab === 'recent' && (
+                  <p className="text-[10px] text-[#b0a89c] font-sans mb-3 leading-relaxed">
+                    What other readers are asking, shown without their names.
+                  </p>
+                )}
 
                 {(() => {
                   const allThreads = sidebarTab === 'mine' ? myThreads : threads;

--- a/src/app/librarian/thread/[id]/page.tsx
+++ b/src/app/librarian/thread/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, use } from 'react';
-import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -18,8 +17,12 @@ interface ThreadMessage {
 interface ThreadData {
   id: string;
   title: string;
+  // 'A reader' for everyone but the author — the API anonymises before it
+  // serves, so this is never a real name unless isOwner is true.
   creatorName: string;
-  creatorId?: string;
+  creatorId?: string | null;
+  isOwner?: boolean;
+  visibility?: 'public' | 'private' | 'unlisted';
   messageCount: number;
   createdAt: string;
 }
@@ -740,7 +743,6 @@ function PodcastPlayer({ threadId, isOwner }: { threadId: string; isOwner: boole
 
 export default function ThreadPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { data: session } = useSession();
   const router = useRouter();
   const [thread, setThread] = useState<ThreadData | null>(null);
   const [messages, setMessages] = useState<ThreadMessage[]>([]);
@@ -815,7 +817,29 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
             <p className="text-[12px] text-[#8a8480] font-sans">
               {thread.creatorName} &middot; {formatDate(thread.createdAt)}
             </p>
-            {session?.user?.id && thread.creatorId === session.user.id && (
+            {thread.isOwner && (
+              <button
+                onClick={async () => {
+                  const listed = thread.visibility === 'public';
+                  const res = await fetch(`/api/embassy/threads/${id}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ listed: !listed }),
+                  });
+                  if (res.ok) {
+                    const data = await res.json();
+                    setThread(t => (t ? { ...t, visibility: data.visibility } : t));
+                  }
+                }}
+                className="text-[11px] text-[#b0a89c] hover:text-[#6b6560] font-sans transition-colors"
+                title={thread.visibility === 'public'
+                  ? 'Listed in Recent, without your name. Click to remove it.'
+                  : 'Not listed. Click to add it to Recent, without your name.'}
+              >
+                {thread.visibility === 'public' ? 'Listed' : 'Not listed'}
+              </button>
+            )}
+            {thread.isOwner && (
               <button
                 onClick={async () => {
                   if (!confirm('Delete this conversation? This cannot be undone.')) return;
@@ -866,7 +890,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
         </div>
 
         {/* Podcast section */}
-        <PodcastPlayer threadId={id} isOwner={!!session?.user?.id && session.user.id === thread.creatorId} />
+        <PodcastPlayer threadId={id} isOwner={!!thread.isOwner} />
 
         {/* Illustrations from cited books */}
         <IllustrationGallery threadId={id} />

--- a/src/lib/embassy/chat-request.ts
+++ b/src/lib/embassy/chat-request.ts
@@ -23,13 +23,15 @@ export const chatRequestSchema = z.object({
     .min(1, 'Message cannot be empty')
     .max(5000, 'That message is too long for the Librarian — please keep it under 5,000 characters, or share the text a section at a time.'),
   history: z.array(messageSchema).max(50).optional(),
-  // Default PRIVATE. A Librarian thread is published in the public "Recent"
-  // feed under the reader's real account name, so publishing has to be
-  // something they chose, not something they failed to opt out of. The old
-  // default was 'public', which put 515 conversations and 10 readers' full
-  // names into that feed — a reader wrote in asking why her questions carried
-  // her first and last name.
-  visibility: z.enum(['public', 'private']).default('private'),
+  // The reader's listing choice, not a name-sharing choice — those were the
+  // same switch until now and that is what went wrong twice. Publishing under
+  // real account names put 515 conversations and 10 readers' full names in the
+  // Recent feed, and a reader wrote in asking why her questions carried her
+  // first and last name. Defaulting to private then emptied the feed to zero
+  // for good. Names are now stripped server-side on every surface but the
+  // reader's own (see lib/embassy/thread-visibility), which is what lets the
+  // default go back to listed. 'private' here means "don't list it".
+  visibility: z.enum(['public', 'private']).default('public'),
   stream: z.boolean().optional(),
   // Optional collection slug/topic to weight the search toward. Set by the
   // "Ask the Librarian" entry point on a collection page; the Librarian biases

--- a/src/lib/embassy/thread-visibility.ts
+++ b/src/lib/embassy/thread-visibility.ts
@@ -1,0 +1,73 @@
+/**
+ * Who can see a Librarian conversation, and under whose name.
+ *
+ * The history is the design. Conversations were once listed publicly by
+ * default *and* attributed to the account holder, and a reader wrote in to ask
+ * why her questions were on the site under her full name (feedback
+ * 6a6ab4808b1d5089bd554672, 2026-07-30). Everything was flipped to private.
+ * That closed the leak and also emptied the Recent feed permanently: of 1,240
+ * threads, exactly zero were public, because publishing required flipping a
+ * toggle *before* the first message and no one ever did (feedback
+ * 6a7ca639e9e3ddd465b53523 — "It shows that there are no conversations").
+ *
+ * Both states were wrong because they treated one question as two answers to
+ * the same switch. They are separate:
+ *
+ *     listing the conversation   ≠   naming the person who had it
+ *
+ * So: conversations are listed by default, no name is ever attached for
+ * anyone but the creator, and any reader can take their conversation off the
+ * list entirely.
+ */
+
+export type ThreadVisibility = 'public' | 'private' | 'unlisted';
+
+/** What a reader is called on every surface that is not their own. */
+export const ANONYMOUS_ATTRIBUTION = 'A reader';
+
+/** The visibility values that appear in the Recent feed. */
+export const LISTED_VISIBILITY: ThreadVisibility = 'public';
+
+/**
+ * Visibility for a thread, given who is writing it and whether they want it
+ * listed.
+ *
+ * Opting out means different things for the two kinds of author:
+ *   - signed in → `private`: only the creator can ever open it.
+ *   - anonymous → `unlisted`: off the feed, but still readable by id, because
+ *     that is the only way an anonymous visitor gets back to their own
+ *     conversation (`/librarian?thread=<id>`). `private` would lock them out
+ *     of it — a null creatorId can never match a session id, so the detail
+ *     route would 404 them.
+ */
+export function threadVisibility(userId: string | null, listed: boolean): ThreadVisibility {
+  if (listed) return LISTED_VISIBILITY;
+  return userId ? 'private' : 'unlisted';
+}
+
+/**
+ * The name to serve for a thread creator or a human message author.
+ *
+ * Anonymisation happens here, on the server, before a name reaches a response
+ * body — never in the component that renders it. The original leak was visible
+ * in the API payload, so hiding it in JSX would have left it one `curl` away.
+ */
+export function attribution(
+  storedName: string | null | undefined,
+  isOwner: boolean,
+): string {
+  if (!isOwner) return ANONYMOUS_ATTRIBUTION;
+  return storedName || 'You';
+}
+
+/**
+ * Same, for a message — the Librarian's own byline is not a person's name and
+ * survives anonymisation.
+ */
+export function messageAttribution(
+  message: { authorType?: string; authorName?: string | null },
+  isOwner: boolean,
+): string {
+  if (message.authorType === 'ai') return message.authorName || 'The Librarian';
+  return attribution(message.authorName, isOwner);
+}

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -103,7 +103,7 @@ describe('Embassy API', () => {
       expect(messages[1].authorName).toBe('The Librarian');
     });
 
-    it('allows unauthenticated requests as an anonymous, unlisted thread', async () => {
+    it('lists an anonymous visitor\'s thread, with no creator attached', async () => {
       const { auth } = await import('@/lib/auth');
       (auth as any).mockResolvedValueOnce(null);
 
@@ -117,14 +117,38 @@ describe('Embassy API', () => {
       expect(res.status).toBe(200);
       expect(data.threadId).toBeDefined();
 
-      // Anonymous threads carry a null creatorId and are 'unlisted' — they
-      // never surface in the public Recent feed or anyone's "mine" list, even
-      // when the request asked for 'public'.
+      // Anonymous threads used to be forced 'unlisted' regardless of what was
+      // asked, because listing meant publishing a name. It no longer does —
+      // names are stripped server-side — so a visitor's conversation joins the
+      // Recent feed like anyone else's, still carrying a null creatorId.
       const db = getTestDb();
       const thread = await db.collection('embassy_threads').findOne({
         _id: new ObjectId(data.threadId),
       });
       expect(thread!.creatorId).toBeNull();
+      expect(thread!.visibility).toBe('public');
+    });
+
+    it('honours an anonymous opt-out as unlisted, not private', async () => {
+      const { auth } = await import('@/lib/auth');
+      (auth as any).mockResolvedValueOnce(null);
+
+      const req = makeRequest('/api/embassy/chat', {
+        message: 'Something personal',
+        visibility: 'private',
+      });
+
+      const res = await chatPost(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+
+      // 'private' would lock the visitor out of their own conversation: a null
+      // creatorId can never match a session id, so the detail route would 404
+      // the person who wrote it.
+      const db = getTestDb();
+      const thread = await db.collection('embassy_threads').findOne({
+        _id: new ObjectId(data.threadId),
+      });
       expect(thread!.visibility).toBe('unlisted');
     });
 
@@ -278,7 +302,10 @@ describe('Embassy API', () => {
 
       expect(res.status).toBe(200);
       expect(data.threads).toHaveLength(1);
-      expect(data.threads[0].creatorName).toBe('Scholar');
+      // The feed shows the conversation, never who had it. 'Scholar' is the
+      // stored creatorName; a stranger must not receive it.
+      expect(data.threads[0].creatorName).toBe('A reader');
+      expect(JSON.stringify(data)).not.toContain('Scholar');
       expect(data.threads[0].preview.question).toContain('philosopher');
       expect(data.threads[0].preview.answer).toContain('alchemical');
     });

--- a/tests/unit/librarian-thread-anonymity.test.ts
+++ b/tests/unit/librarian-thread-anonymity.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * A listed Librarian conversation must never carry its author's name.
+ *
+ * This is the same leak twice over. Conversations were public by default AND
+ * attributed to the account holder, so a reader found her questions on the
+ * site under her first and last name (feedback 6a6ab4808b1d5089bd554672).
+ * Flipping everything to private closed it and emptied the Recent feed to zero
+ * of 1,240 threads — the opposite failure (feedback 6a7ca639e9e3ddd465b53523).
+ *
+ * The fix separates listing from naming, and the naming half has to hold in
+ * the RESPONSE BODY, not in the sidebar that renders it: the original leak was
+ * visible in this payload, so a component-level fix would still have been one
+ * `curl` away. Hence the assertions below check the serialised JSON for the
+ * name rather than the field it was expected in.
+ *
+ * These drive the REAL route modules; only `auth()` and Mongo are faked.
+ * Negative control run: dropping `attribution()` from either route turns the
+ * "stranger" cases red.
+ */
+
+const OWNER_ID = 'user-owner-1';
+const OWNER_NAME = 'Rocio Bernardiner';
+const THREAD_ID = '6a7ca639e9e3ddd465b53523';
+
+let currentUserId: string | null = null;
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(async () =>
+    currentUserId ? { user: { id: currentUserId }, expires: 'later' } : null,
+  ),
+}));
+
+type ThreadDoc = {
+  _id: unknown;
+  title: string;
+  creatorId: string | null;
+  creatorName: string;
+  visibility: string;
+  messageCount: number;
+  createdAt: Date;
+  lastMessageAt: Date;
+};
+
+let thread: ThreadDoc;
+const updates: Record<string, unknown>[] = [];
+
+const MESSAGES = [
+  { _id: 'm1', authorType: 'human', authorName: OWNER_NAME, content: 'What is the prisca theologia?', createdAt: new Date() },
+  { _id: 'm2', authorType: 'ai', authorName: 'The Librarian', content: 'It is the doctrine that…', sources: [], createdAt: new Date() },
+];
+
+function fakeDb() {
+  return {
+    collection: (name: string) => {
+      if (name === 'embassy_threads') {
+        return {
+          findOne: async () => thread,
+          updateOne: async (_f: unknown, u: Record<string, unknown>) => {
+            updates.push(u);
+            return { modifiedCount: 1 };
+          },
+          find: () => ({
+            sort: () => ({
+              skip: () => ({ limit: () => ({ toArray: async () => [thread] }) }),
+            }),
+          }),
+        };
+      }
+      return {
+        find: () => ({
+          sort: () => ({
+            toArray: async () => MESSAGES,
+            limit: () => ({ project: () => ({ toArray: async () => MESSAGES }) }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => fakeDb()),
+  getReadDb: vi.fn(async () => fakeDb()),
+}));
+
+const { GET, PATCH } = await import('@/app/api/embassy/threads/[id]/route');
+const { GET: LIST } = await import('@/app/api/embassy/threads/route');
+
+const params = Promise.resolve({ id: THREAD_ID });
+const detailReq = () => new Request(`http://localhost/api/embassy/threads/${THREAD_ID}`) as never;
+const patchReq = (body: unknown) =>
+  new Request(`http://localhost/api/embassy/threads/${THREAD_ID}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  }) as never;
+
+beforeEach(() => {
+  currentUserId = null;
+  updates.length = 0;
+  thread = {
+    _id: { toString: () => THREAD_ID },
+    title: 'What is the prisca theologia?',
+    creatorId: OWNER_ID,
+    creatorName: OWNER_NAME,
+    visibility: 'public',
+    messageCount: 2,
+    createdAt: new Date(),
+    lastMessageAt: new Date(),
+  };
+});
+
+describe('a listed thread served to a stranger', () => {
+  it('carries the author name nowhere in the payload', async () => {
+    const res = await GET(detailReq(), { params });
+    const raw = await res.text();
+
+    expect(raw).not.toContain(OWNER_NAME);
+    expect(raw).not.toContain(OWNER_ID);
+
+    const data = JSON.parse(raw);
+    expect(data.thread.creatorName).toBe('A reader');
+    expect(data.thread.creatorId).toBeNull();
+    expect(data.thread.isOwner).toBe(false);
+    expect(data.messages.find((m: { authorType: string }) => m.authorType === 'human').authorName)
+      .toBe('A reader');
+  });
+
+  it('keeps the Librarian byline, which is not a person', async () => {
+    const res = await GET(detailReq(), { params });
+    const data = await res.json();
+    expect(data.messages.find((m: { authorType: string }) => m.authorType === 'ai').authorName)
+      .toBe('The Librarian');
+  });
+
+  it('still serves the conversation itself — anonymity is not suppression', async () => {
+    const res = await GET(detailReq(), { params });
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0].content).toContain('prisca theologia');
+  });
+
+  it('anonymises the Recent feed too', async () => {
+    const res = await LIST(new Request('http://localhost/api/embassy/threads') as never);
+    const raw = await res.text();
+    expect(raw).not.toContain(OWNER_NAME);
+    expect(JSON.parse(raw).threads[0].creatorName).toBe('A reader');
+  });
+});
+
+describe('the author of the thread', () => {
+  beforeEach(() => { currentUserId = OWNER_ID; });
+
+  it('sees their own name back', async () => {
+    const res = await GET(detailReq(), { params });
+    const data = await res.json();
+    expect(data.thread.creatorName).toBe(OWNER_NAME);
+    expect(data.thread.isOwner).toBe(true);
+  });
+
+  it('gets their real name on their own list', async () => {
+    const res = await LIST(new Request('http://localhost/api/embassy/threads?mine=true') as never);
+    const data = await res.json();
+    expect(data.threads[0].creatorName).toBe(OWNER_NAME);
+  });
+});
+
+describe('an unlisted thread stays reachable by id', () => {
+  it('serves anonymously rather than 404ing', async () => {
+    thread.visibility = 'unlisted';
+    thread.creatorId = null;
+    thread.creatorName = 'A visitor';
+    const res = await GET(detailReq(), { params });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('a private thread', () => {
+  beforeEach(() => { thread.visibility = 'private'; });
+
+  it('404s for a stranger', async () => {
+    const res = await GET(detailReq(), { params });
+    expect(res.status).toBe(404);
+  });
+
+  it('opens for its author', async () => {
+    currentUserId = OWNER_ID;
+    const res = await GET(detailReq(), { params });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('changing whether a thread is listed', () => {
+  it('lets anyone holding the id take it OFF the list', async () => {
+    // Un-listing only ever removes. An anonymous visitor who realises they
+    // said something personal has no account to authenticate with, and the id
+    // already granted them read access, so this is not an escalation.
+    thread.creatorId = null;
+    const res = await PATCH(patchReq({ listed: false }), { params });
+    expect(res.status).toBe(200);
+    expect(updates[0]).toEqual({ $set: { visibility: 'unlisted' } });
+  });
+
+  it('refuses to PUT a thread ON the list for anyone but its author', async () => {
+    thread.visibility = 'unlisted';
+    const res = await PATCH(patchReq({ listed: true }), { params });
+    expect(res.status).toBe(403);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('lets the author list their own thread', async () => {
+    currentUserId = OWNER_ID;
+    thread.visibility = 'private';
+    const res = await PATCH(patchReq({ listed: true }), { params });
+    expect(res.status).toBe(200);
+    expect(updates[0]).toEqual({ $set: { visibility: 'public' } });
+  });
+
+  it('will not confirm a private thread exists to a stranger', async () => {
+    thread.visibility = 'private';
+    const res = await PATCH(patchReq({ listed: false }), { params });
+    expect(res.status).toBe(404);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('rejects a body without a listed boolean', async () => {
+    const res = await PATCH(patchReq({ visibility: 'public' }), { params });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/librarian-thread-visibility-default.test.ts
+++ b/tests/unit/librarian-thread-visibility-default.test.ts
@@ -1,37 +1,55 @@
 import { describe, it, expect } from 'vitest';
 import { chatRequestSchema } from '@/lib/embassy/chat-request';
+import { attribution } from '@/lib/embassy/thread-visibility';
 
 /**
- * A Librarian thread is published in the public "Recent" feed under the
- * reader's real account name (`creatorName`, surfaced by GET /api/embassy/threads).
- * Publishing therefore has to be a choice the reader makes, never a default they
- * failed to opt out of.
+ * The default for a new Librarian thread is LISTED.
  *
- * The old default was 'public'. It put 515 conversations — 10 readers' full
- * first-and-last names — into that feed, and a reader wrote in to ask why her
- * questions carried her name.
+ * This file previously pinned the opposite, and was right to at the time. The
+ * default had been 'public' while the feed also carried `creatorName` — the
+ * reader's real account name — so 515 conversations and 10 readers' full names
+ * went public without anyone choosing it, and a reader wrote in asking why her
+ * questions carried her name (#3505). Flipping the default to private was the
+ * fix, and this test held it there.
  *
- * These exercise the schema rather than grepping the source: flipping the
- * default back to 'public', or dropping `.default()` so the destructure falls
- * through to undefined, fails here.
+ * It also left the Recent feed at zero of 1,240 threads with no way to refill,
+ * which is its own kind of broken. The mistake underneath both states was
+ * treating one switch as the answer to two questions:
+ *
+ *     listing the conversation   is not   naming the person who had it
+ *
+ * Names are now stripped server-side on every surface but the reader's own, so
+ * listing no longer implies exposure and the default can safely go back.
+ *
+ * THE DEFAULT BELOW IS ONLY SAFE WHILE THAT HOLDS. The precondition is
+ * asserted here rather than merely cross-referenced, so that breaking the
+ * anonymisation fails this test too — a listed-by-default schema and a feed
+ * that serves names are individually defensible and catastrophic together.
+ * Full coverage of the anonymisation is in librarian-thread-anonymity.test.ts.
  */
 describe('Librarian chat request — thread visibility', () => {
-  it('defaults to private when the client sends no visibility', () => {
+  it('defaults to listed when the client sends no visibility', () => {
     const parsed = chatRequestSchema.parse({ message: 'what did Ficino say about the sun?' });
-    expect(parsed.visibility).toBe('private');
-  });
-
-  it('defaults to private when visibility is explicitly undefined', () => {
-    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: undefined });
-    expect(parsed.visibility).toBe('private');
-  });
-
-  it('still honours an explicit opt-in to public', () => {
-    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: 'public' });
     expect(parsed.visibility).toBe('public');
   });
 
+  it('defaults to listed when visibility is explicitly undefined', () => {
+    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: undefined });
+    expect(parsed.visibility).toBe('public');
+  });
+
+  it('still honours an explicit opt-out', () => {
+    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: 'private' });
+    expect(parsed.visibility).toBe('private');
+  });
+
   it('rejects any visibility value outside the two-state toggle', () => {
+    // 'unlisted' is a server-side outcome of opting out anonymously, never
+    // something a client may ask for.
     expect(() => chatRequestSchema.parse({ message: 'hello', visibility: 'unlisted' })).toThrow();
+  });
+
+  it('is only safe because a listed thread carries no name', () => {
+    expect(attribution('Rocio Bernardiner', false)).toBe('A reader');
   });
 });

--- a/tests/unit/librarian-thread-visibility.test.ts
+++ b/tests/unit/librarian-thread-visibility.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { threadVisibility, attribution, messageAttribution } from '@/lib/embassy/thread-visibility';
+
+/**
+ * The listing rule, on its own. The asymmetry between a signed-in and an
+ * anonymous opt-out is the part worth pinning: 'private' for an anonymous
+ * thread would lock its own author out, because a null creatorId can never
+ * match a session id, so the detail route would 404 the person who wrote it.
+ */
+describe('threadVisibility', () => {
+  it('lists by default for a signed-in reader', () => {
+    expect(threadVisibility('user-1', true)).toBe('public');
+  });
+
+  it('lists by default for an anonymous visitor', () => {
+    expect(threadVisibility(null, true)).toBe('public');
+  });
+
+  it('makes a signed-in opt-out fully private', () => {
+    expect(threadVisibility('user-1', false)).toBe('private');
+  });
+
+  it('leaves an anonymous opt-out reachable by id, not private', () => {
+    // 'private' would strand the anonymous author outside their own thread.
+    expect(threadVisibility(null, false)).toBe('unlisted');
+  });
+});
+
+describe('attribution', () => {
+  it('gives a stranger no name to work with', () => {
+    expect(attribution('Rocio Bernardiner', false)).toBe('A reader');
+  });
+
+  it('is anonymous even when the stored name is empty', () => {
+    expect(attribution(null, false)).toBe('A reader');
+    expect(attribution('', false)).toBe('A reader');
+  });
+
+  it('gives the author their own name back', () => {
+    expect(attribution('Rocio Bernardiner', true)).toBe('Rocio Bernardiner');
+  });
+
+  it('falls back to "You" for an author with no stored name', () => {
+    expect(attribution(null, true)).toBe('You');
+  });
+});
+
+describe('messageAttribution', () => {
+  it('anonymises a human author for a stranger', () => {
+    expect(messageAttribution({ authorType: 'human', authorName: 'Rocio Bernardiner' }, false))
+      .toBe('A reader');
+  });
+
+  it('leaves the Librarian named — it is not a person', () => {
+    expect(messageAttribution({ authorType: 'ai', authorName: 'The Librarian' }, false))
+      .toBe('The Librarian');
+  });
+});


### PR DESCRIPTION
Closes the feedback item "It shows that there are no conversations in librarian" (feedback `6a7ca639e9e3ddd465b53523`, 2026-08-12).

## What was wrong

The Recent sidebar filters on `visibility: 'public'`. Measured against production: **1,240 threads, 1,196 with ≥2 messages, and exactly 0 public** (662 private, 574 unlisted, 4 with no field). So the panel has been showing *"No conversations yet. Be the first to ask the Librarian something"* on a page that has hosted twelve hundred conversations, several of them today.

That state was the tail of a real privacy fix. Conversations used to be listed by default **and** attributed to the account holder; a reader wrote in asking why her questions were on the site under her first and last name (feedback `6a6ab4808b1d5089bd554672`, 2026-07-30). Everything was flipped private. That closed the leak and left no realistic way to refill the feed:

- anonymous threads hard-coded to `unlisted` (`chat/route.ts`)
- signed-in threads defaulting to `private` (`LibrarianClient.tsx`)
- the Public toggle read **only in the thread-creation branch** — flipping it mid-conversation silently did nothing, and there was no publish affordance afterward

To produce a public thread you had to be signed in and flip a toggle *before typing your first message*. In two and a half weeks nobody did.

## The change

Both states were wrong the same way — they answered one question with one switch:

> listing the conversation **is not** naming the person who had it

Now separated. Conversations are **listed by default**; **no name is ever attached** for anyone but the author; anyone can take their conversation **off the list**.

- `src/lib/embassy/thread-visibility.ts` owns the rule, with the incident history in the header so the next person doesn't re-derive it
- Names — and `creatorId`, a stable handle that links a stranger's threads to each other — are anonymised **in the response body**, not in the sidebar that renders it. The original leak was visible in this payload, so a component-level fix would still be one `curl` away.
- The toggle now works mid-conversation via a new `PATCH /api/embassy/threads/[id]`, which is the moment it most needs to work: someone realising they just said something personal.
- **Un-listing** is open to anyone holding the thread id; **listing** stays locked to the signed-in author. Deliberate asymmetry — un-listing only removes, and holding the id already granted read access, so it is not an escalation. It is also the only retraction an anonymous visitor can make.
- An anonymous opt-out lands on `unlisted`, not `private`: a null `creatorId` can never match a session id, so `private` would 404 the author out of their own conversation.
- Owners get a `Listed` / `Not listed` control on the thread page, for conversations they revisit later.

## Backfill — decided, and it ships in this PR

Derek's call: relist the conversations from **before** the private-default was on; exclude the ones created while it was on.

The 2026-08-01 retraction stamped `visibility_retracted_at` on exactly what it took down, so that set is nameable rather than inferred from dates:

| set | count | action |
|---|---|---|
| stamped `visibility_retracted_at`, now private | **539** (515 with ≥2 messages) | **relist** |
| pre-flip, author chose private, never stamped | 20 | leave |
| pre-flip anonymous `unlisted`, never listed | 420 | leave — relisting is new publication, not restoration |
| created after the flip, under "private by default" | 257 | leave |

`scripts/maintenance/relist-retracted-librarian-threads.mjs` does it. Dry run by default, writes an id backup before any write, `--undo <backup>` re-retracts.

**Run it only after this merges and deploys.** The feed filters on `visibility:'public'` and the *currently deployed* handler still serves `creatorName` verbatim — flipping these first would re-create the original leak exactly: 537 signed-in threads back in the feed under real names. `--apply` refuses until it has confirmed the new handler is live, and that check carries a positive control (an empty feed and a correctly anonymised one look identical, so "no name found" would prove nothing on its own): it reads a thread it knows exists, asserts messages came back, then looks for `isOwner` — a field only the new code emits. Verified read-only against production, where it correctly refuses.

## Out of scope, deliberately

**Podcast attribution is unchanged.** `getPublishedEpisodes` still puts `creatorName` in `<itunes:author>`, but publishing a podcast is an explicit, authenticated, creator-only act — opt-in by definition, a different trust class from a conversation that is merely listed.

**Content-level PII is not addressed and is the residual risk worth naming.** Anonymising the *name* does not anonymise the *words*. Live examples that would land in the feed under the new default: a thread whose title is someone's royalty statement ("Paperback $13.90 USD / Estimated royalties $24.16 / Es real esa cantidad"), and several personal-guidance questions. The mitigations here are the visible default state, the working toggle, and the retraction path — not a filter.

## Verification

- `npx tsc --noEmit` clean
- 24 new tests pass; they drive the **real route modules** with only `auth()` and Mongo faked
- The anonymity assertions check the **serialised payload** for the name rather than the field it was expected in
- **Negative control run**: removing `attribution()` or the listing-permission check turns them red (2 failures), per the "a test that greps source is not a guard" rule in CLAUDE.md
- ESLint: no new errors (the 4 `pendingChoiceRef` errors in `LibrarianClient.tsx` are pre-existing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ePSciYJxshJafD536VQbF
