### PR TITLE
maint(books): delete 50 orphan fields (applied), ratchet the watch, add the card prior-suggester

### DIFF
--- a/.github/workflows/field-sprawl-watch.yml
+++ b/.github/workflows/field-sprawl-watch.yml
@@ -42,9 +42,9 @@ jobs:
           set +e
           node scripts/audit/field-sprawl.mjs \
             --collection books \
-            --max-fields 400 \
+            --max-fields 385 \
             --max-nested 65 \
-            --forbid tenant_id,hide_reason > report.txt 2>&1
+            --forbid tenant_id,hide_reason,ft_prediction,ft_candidate,translation_audit_2026_06,existing_translation,translated_from,superseded_by,translation_requested_by_reader,work_authority,wikidata_work_ids,language_relabeled_from,language_relabeled_at,language_correction,language_corrected_at,language_corrected_by,author_corrected_2026_06_30,title_corrected_2026_06_30,bibliographic_correction,acquisition_wave,acquisition_priority,priority_translation,forshaw_relevance,pipeline_hold,pipeline_priority_at,pipeline_priority_reason,current_job_id,enrichment_phase,warehouse_reason,ia_identifier_previous,ia_repoint_reason,ica_records,dedup_note,deletion_batch,published_location,published_place,related_artwork,morgan_accession,morgan_bibid,resourced_from,rights_note,rights_status,author_original,thumbnail_page_id,former_resource_type,modern_typeset,split_warnings,unhidden_note,part_number,source_notes,summary_updated_at,cover_page_id > report.txt 2>&1
           echo "fired=$?" >> "$GITHUB_OUTPUT"
           tail -60 report.txt
       - name: File findings

--- a/scripts/eval/card-prior-candidates.mjs
+++ b/scripts/eval/card-prior-candidates.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * Propose candidate English translations for EMPTY translation cards, from the
+ * LoC/ESTC catalogue in `reference_translations`.
+ *
+ * WHY
+ * An empty card is a live absence claim readers see — "No earlier English
+ * translation is known to us". 604 of 919 cards are empty. Meanwhile
+ * `reference_translations` holds 105,317 English items whose original was not
+ * English, 126,558 of them carrying an LCCN. If any of those is a translation
+ * of an empty card's work, the card is WRONG in the direction that matters.
+ *
+ * WHAT THIS IS NOT
+ * It never writes to a card. The method's rule (.claude/docs/translation-card-
+ * method.md) is: "Anyone — instrument or human — proposes an entry WITH A
+ * CITATION. A reviewer merges it. Nothing lands unreviewed on a card that
+ * changes what readers see." This is a suggester. Output is a review file.
+ *
+ * WHY MATCHING IS THE HARD PART
+ * `reference_translations` rows carry NO work_id, book_id, translator or URL —
+ * they are raw MARC-derived catalogue records. Linking them to a work is
+ * exactly the card method's `wrong_work_identity` error class. A naive surname
+ * substring match was measured at ~100% false positives on a 56-card probe:
+ * "Ruel" matched *Bar*ruel, "Kircher" matched Rudolf Kircher and Unterkircher
+ * but never Athanasius, "Estienne" matched *L*estienne. So this uses:
+ *
+ *   1. ANCHORED author match (`^Surname,`) — not substring.
+ *   2. MARC `uniform_title` (populated on 67.6%) — the library world's own
+ *      work identifier, e.g. "Meditations." for Marcus Aurelius. This is the
+ *      signal that actually carries work identity.
+ *   3. Original-language agreement where the card knows it.
+ *   4. A token-overlap score against the card's work title.
+ *
+ * Each candidate is scored and the evidence is printed with it, so a reviewer
+ * judges the match rather than trusting it.
+ *
+ * USAGE
+ *   node --env-file=.env.production.local scripts/eval/card-prior-candidates.mjs \
+ *     [--limit N] [--min-score 0.34] [--out <file.md>]
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+
+const argVal = (f, d) => { const i = process.argv.indexOf(f); return i > -1 ? process.argv[i + 1] : d; };
+const LIMIT = Number(argVal('--limit', 0)) || 0;
+const MIN_SCORE = Number(argVal('--min-score', 0.34));
+const OUT = argVal('--out', `scripts/eval/results/card-prior-candidates.md`);
+
+const escRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Pull the surname out of a card author.
+ *
+ * Cards write natural order ("Athanasius Kircher"); MARC writes inverted order
+ * ("Kircher, Athanasius"). Taking the FIRST token anchors on the given name and
+ * matches nothing — that bug produced a flat zero across 115 cards before a
+ * positive control located it. Take the LAST token, unless the string is
+ * already inverted (contains a comma), in which case the surname is first.
+ */
+function surnameOf(rawAuthor) {
+  const a = String(rawAuthor || '').split('|')[0].replace(/[;.,\s]+$/, '').trim();
+  if (!a) return '';
+  if (a.includes(',')) return a.split(',')[0].trim();
+  const parts = a.split(/\s+/).filter(Boolean);
+  return parts[parts.length - 1] || '';
+}
+
+/** Normalise a title for comparison: fold case, diacritics and punctuation. */
+function norm(s) {
+  return String(s || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const STOP = new Set(['the', 'a', 'an', 'of', 'de', 'des', 'du', 'la', 'le', 'les', 'el', 'il', 'and', 'et', 'und', 'or', 'on', 'in', 'ad', 'ex', 'vol', 'liber', 'libri', 'book', 'books']);
+const tokens = (s) => norm(s).split(' ').filter((t) => t.length > 2 && !STOP.has(t));
+
+/** Jaccard-ish overlap, weighted toward covering the card's title. */
+function titleScore(cardTitle, rowUniform, rowTitle) {
+  const a = new Set(tokens(cardTitle));
+  if (!a.size) return 0;
+  const best = [rowUniform, rowTitle].map((t) => {
+    const b = new Set(tokens(t));
+    if (!b.size) return 0;
+    let hit = 0;
+    for (const t2 of a) if (b.has(t2)) hit++;
+    return hit / a.size;
+  });
+  return Math.max(...best);
+}
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('Missing MONGODB_URI'); process.exit(2); }
+
+const client = new MongoClient(uri, { serverSelectionTimeoutMS: 20000 });
+await client.connect();
+const db = client.db('bookstore');
+const rt = db.collection('reference_translations');
+
+const empties = await db.collection('work_translation_history')
+  .find({ $or: [{ entries: { $size: 0 } }, { entries: { $exists: false } }] },
+        { projection: { _id: 1, author: 1, work_title: 1, status: 1, search: 1 } })
+  .toArray();
+
+const cards = LIMIT ? empties.slice(0, LIMIT) : empties;
+console.log(`empty cards to probe: ${cards.length} (of ${empties.length})`);
+
+const results = [];
+let probed = 0;
+
+for (const card of cards) {
+  const author = String(card.author || '').split('|')[0].trim();
+  const surname = surnameOf(card.author);
+  if (surname.length < 4) continue;
+  probed++;
+
+  // Anchored on the surname at the START of the MARC author string — the form
+  // MARC uses ("Kircher, Athanasius"). Substring matching is what produced the
+  // false positives.
+  let rows = [];
+  try {
+    rows = await rt.find(
+      {
+        author: { $regex: `^${escRe(surname)}\\b`, $options: 'i' },
+        item_language: 'eng',
+        original_languages: { $exists: true, $ne: [] },
+      },
+      { projection: { _id: 0, lccn: 1, author: 1, title: 1, uniform_title: 1, year: 1, publisher: 1, original_languages: 1, source: 1, added_entries: 1 },
+        limit: 40, maxTimeMS: 20000 },
+    ).toArray();
+  } catch (err) {
+    console.error(`  ! ${card._id}: ${err.message}`);
+    continue;
+  }
+
+  const scored = rows
+    .map((r) => ({ r, score: titleScore(card.work_title, r.uniform_title, r.title) }))
+    .filter((x) => x.score >= MIN_SCORE)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4);
+
+  if (scored.length) results.push({ card, scored });
+  if (probed % 100 === 0) console.log(`  …${probed} probed, ${results.length} cards with candidates`);
+}
+
+console.log(`\nprobed ${probed} cards; ${results.length} have >=1 candidate at score >= ${MIN_SCORE}`);
+
+const lines = [];
+lines.push(`# Candidate priors for EMPTY translation cards`);
+lines.push('');
+lines.push(`Generated by \`scripts/eval/card-prior-candidates.mjs\` (min-score ${MIN_SCORE}).`);
+lines.push('');
+lines.push(`**These are PROPOSALS, not entries.** An empty card is a live absence claim`);
+lines.push(`("No earlier English translation is known to us"). Each row below is a`);
+lines.push(`catalogue record that *might* refute one. Matching is on anchored author +`);
+lines.push(`MARC uniform_title + title-token overlap, which is the card method's`);
+lines.push(`\`wrong_work_identity\` failure class — so **a reviewer must open the citation`);
+lines.push(`and confirm the work identity before anything lands on a card.**`);
+lines.push('');
+lines.push(`Probed ${probed} empty cards · ${results.length} with candidates.`);
+lines.push('');
+for (const { card, scored } of results) {
+  lines.push(`## ${card.work_title || '(untitled)'}`);
+  lines.push(`card: \`${card._id}\` · author: ${card.author} · status: ${card.status}`);
+  lines.push('');
+  for (const { r, score } of scored) {
+    lines.push(`- **${r.year}** — ${r.title}`);
+    lines.push(`  - uniform_title: \`${r.uniform_title || '(none)'}\` · score ${score.toFixed(2)}`);
+    lines.push(`  - author: ${r.author} · publisher: ${r.publisher || '—'} · orig: ${JSON.stringify(r.original_languages)}`);
+    lines.push(`  - **LCCN ${r.lccn}** (${r.source})${r.added_entries?.length ? ` · added entries: ${r.added_entries.join('; ')}` : ''}`);
+  }
+  lines.push('');
+}
+writeFileSync(OUT, lines.join('\n'));
+console.log(`wrote ${OUT}`);
+
+await client.close();

--- a/scripts/maintenance/delete-orphan-book-fields.mjs
+++ b/scripts/maintenance/delete-orphan-book-fields.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+/**
+ * Delete orphan fields from `books` — the fields nothing reads and nothing
+ * writes (issue #3969, the shrink half of Track B).
+ *
+ * The validator freezes the field count; only this reduces it.
+ *
+ * NOTHING IS LOST. Every book touched gets ONE row in `sweep_log` recording
+ * every removed field and its value, so a deletion is recoverable from the
+ * ledger. That is the ROW-not-COLUMN rule applied to its own cleanup.
+ *
+ * HOW THE LIST WAS BUILT (and why it is not the list the audits produced)
+ * Two reader surveys classified these as orphan. Both used
+ * `git grep -E "\bfield\b"` — which in this repo matches NOTHING and exits 1,
+ * because BSD ERE has no `\b`. Verified: `git grep -E '\bpages_count\b' --
+ * src/lib/types/book.ts` finds nothing while `-P` finds it. A silent false
+ * negative is indistinguishable from "no references", which is the worst
+ * possible failure for a deletion decision, so every candidate was re-checked
+ * with `git grep -P` across src/, scripts/ and mcp-server/, excluding only:
+ *   - scripts/audit/field-sprawl.mjs  (census grouping lists, not a reader)
+ *   - scripts/lib/book-docs.mjs       (write-side whitelist, not a reader)
+ *   - _archived/ paths                (dead code)
+ * That re-check removed SIX fields the first survey had called orphan
+ * (free_tier, material, last_updated, cover, translator, archived_reason).
+ *
+ * Deliberately NOT here: anything read only by a cron/worker. `photo` is the
+ * case in point — read solely by sync-books-catalog.mjs, feeding the public
+ * listing thumbnails via Supabase. Invisible to any src/-only grep.
+ *
+ * Dry-run by default; pass --apply to write.
+ */
+
+import { MongoClient } from 'mongodb';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const SWEEP = 'orphan-field-deletion-2026-08';
+
+/** Verified clean: zero references under `git grep -P` outside census/whitelist files. */
+export const ORPHAN_FIELDS = [
+  // abandoned first-translation sweeps
+  'ft_prediction', 'ft_candidate', 'translation_audit_2026_06', 'existing_translation',
+  'translated_from', 'superseded_by', 'translation_requested_by_reader',
+  'work_authority', 'wikidata_work_ids',
+  // language-relabel sweeps
+  'language_relabeled_from', 'language_relabeled_at', 'language_correction',
+  'language_corrected_at', 'language_corrected_by',
+  // dated one-shot metadata sweeps
+  'author_corrected_2026_06_30', 'title_corrected_2026_06_30', 'bibliographic_correction',
+  // acquisition / curation experiments
+  'acquisition_wave', 'acquisition_priority', 'priority_translation', 'forshaw_relevance',
+  // pipeline-priority / hold experiment
+  'pipeline_hold', 'pipeline_priority_at', 'pipeline_priority_reason',
+  'current_job_id', 'enrichment_phase',
+  // warehouse-as-a-flag (superseded by the books_warehouse collection)
+  'warehouse_reason',
+  // IA re-point / dedup forensics
+  'ia_identifier_previous', 'ia_repoint_reason', 'ica_records', 'dedup_note',
+  'deletion_batch',
+  // place triplication (canonical: place_published / place_of_publication)
+  'published_location', 'published_place',
+  // artwork / museum one-way street
+  'related_artwork', 'morgan_accession', 'morgan_bibid', 'resourced_from',
+  // rights
+  'rights_note', 'rights_status',
+  // misc orphans
+  'author_original', 'thumbnail_page_id', 'former_resource_type', 'modern_typeset',
+  'split_warnings', 'unhidden_note', 'part_number', 'source_notes',
+  'summary_updated_at', 'cover_page_id',
+];
+
+const APPLY = process.argv.includes('--apply');
+// --limit N: canary mode. Delete from at most N books, so the sweep_log
+// round-trip can be proved on a small set before the full run.
+const LIMIT = (() => { const i = process.argv.indexOf('--limit'); return i > -1 ? Number(process.argv[i + 1]) : 0; })();
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('Missing MONGODB_URI'); process.exit(2); }
+
+const client = new MongoClient(uri, { serverSelectionTimeoutMS: 20000, socketTimeoutMS: 600000 });
+await client.connect();
+const db = client.db(process.env.DB_NAME || 'bookstore');
+const books = db.collection('books');
+
+console.log(`Orphan field deletion — ${ORPHAN_FIELDS.length} fields`);
+console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+// Exact per-field counts. Sampling is not admissible for a deletion decision:
+// on this collection a 3,000-doc sample missed ~95 fields entirely.
+const counts = [];
+for (const f of ORPHAN_FIELDS) {
+  const n = await books.countDocuments({ [f]: { $exists: true } }, { maxTimeMS: 60000 });
+  counts.push([f, n]);
+}
+counts.sort((a, b) => b[1] - a[1]);
+for (const [f, n] of counts) console.log(`  ${f.padEnd(34)} ${n}`);
+
+const live = counts.filter(([, n]) => n > 0);
+const totalFieldInstances = counts.reduce((s, [, n]) => s + n, 0);
+const affected = await books.countDocuments(
+  { $or: ORPHAN_FIELDS.map((f) => ({ [f]: { $exists: true } })) },
+  { maxTimeMS: 120000 },
+);
+console.log(`\nfields with >0 docs : ${live.length} of ${ORPHAN_FIELDS.length}`);
+console.log(`field instances     : ${totalFieldInstances}`);
+console.log(`distinct books      : ${affected}`);
+
+if (!APPLY) {
+  console.log('\nDry-run only. Re-run with --apply to delete.');
+  await client.close();
+  process.exit(0);
+}
+
+// Preserve first, delete second — and one row per BOOK, carrying every value.
+const findOpts = { projection: Object.fromEntries([['id', 1], ...ORPHAN_FIELDS.map((f) => [f, 1])]) };
+if (LIMIT) findOpts.limit = LIMIT;
+const cursor = books.find({ $or: ORPHAN_FIELDS.map((f) => ({ [f]: { $exists: true } })) }, findOpts);
+if (LIMIT) console.log(`\nCANARY: limiting to ${LIMIT} books.`);
+
+let rows = 0, unset = 0;
+for await (const book of cursor) {
+  const removed = {};
+  for (const f of ORPHAN_FIELDS) if (f in book) removed[f] = book[f];
+  if (!Object.keys(removed).length) continue;
+
+  await recordSweepAction(db, {
+    sweep: SWEEP,
+    book_id: book.id || String(book._id),
+    action: 'orphan-fields-removed',
+    detail: { removed },
+  });
+  rows += 1;
+
+  const r = await books.updateOne(
+    { _id: book._id },
+    { $unset: Object.fromEntries(Object.keys(removed).map((f) => [f, ''])) },
+  );
+  unset += r.modifiedCount;
+}
+
+console.log(`\nsweep_log rows written : ${rows}`);
+console.log(`books modified         : ${unset}`);
+
+let residual = 0;
+for (const f of ORPHAN_FIELDS) residual += await books.countDocuments({ [f]: { $exists: true } }, { maxTimeMS: 60000 });
+// In canary mode a non-zero residual is the expected result, not a fault — the
+// run deliberately stopped early. Only a full run can claim "clean", and a
+// check that cries wolf is one people learn to ignore.
+const residualNote = LIMIT
+  ? '(expected — canary run stopped early)'
+  : residual === 0 ? '(clean)' : '(!! investigate)';
+console.log(`residual instances     : ${residual} ${residualNote}`);
+console.log(`\nRecover a book's values: db.sweep_log.find({ sweep: '${SWEEP}', book_id: '<id>' })`);
+
+await client.close();

--- a/scripts/maintenance/restore-orphan-book-fields.mjs
+++ b/scripts/maintenance/restore-orphan-book-fields.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * Undo `delete-orphan-book-fields.mjs` by replaying the `sweep_log` rows it wrote.
+ *
+ * This is the reason the deletion is safe to run at all. The deletion records
+ * every removed field and its value in a row keyed to the book BEFORE unsetting
+ * anything; this script reads those rows back and re-sets the values. A
+ * deletion you cannot reverse is a decision; a deletion you can reverse is an
+ * experiment.
+ *
+ * Test it on a canary batch BEFORE the full deletion — a restore path that has
+ * never been exercised is not a restore path.
+ *
+ * Only restores fields that are currently ABSENT, so re-running is safe and it
+ * can never clobber a value written after the deletion.
+ *
+ * USAGE
+ *   node --env-file=.env.production.local scripts/maintenance/restore-orphan-book-fields.mjs            # dry run
+ *   node --env-file=.env.production.local scripts/maintenance/restore-orphan-book-fields.mjs --apply
+ *   ... --book-id <id>    restore one book
+ */
+
+import { MongoClient } from 'mongodb';
+
+const SWEEP = 'orphan-field-deletion-2026-08';
+const APPLY = process.argv.includes('--apply');
+const BOOK_ID = (() => { const i = process.argv.indexOf('--book-id'); return i > -1 ? process.argv[i + 1] : null; })();
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('Missing MONGODB_URI'); process.exit(2); }
+
+const client = new MongoClient(uri, { serverSelectionTimeoutMS: 20000, socketTimeoutMS: 600000 });
+await client.connect();
+const db = client.db(process.env.DB_NAME || 'bookstore');
+const books = db.collection('books');
+
+const query = { sweep: SWEEP, action: 'orphan-fields-removed' };
+if (BOOK_ID) query.book_id = BOOK_ID;
+
+const rows = await db.collection('sweep_log').find(query).toArray();
+console.log(`Restore from sweep_log — ${rows.length} row(s)${BOOK_ID ? ` for book ${BOOK_ID}` : ''}`);
+console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+let restored = 0, fields = 0, missingBooks = 0, skippedPresent = 0;
+
+for (const row of rows) {
+  const removed = row.detail?.removed || {};
+  const names = Object.keys(removed);
+  if (!names.length) continue;
+
+  const book = await books.findOne({ id: row.book_id }, { projection: Object.fromEntries(names.map((f) => [f, 1])) });
+  if (!book) { missingBooks++; continue; }
+
+  // Only restore what is currently absent — never clobber a newer value.
+  const toSet = {};
+  for (const f of names) {
+    if (f in book) { skippedPresent++; continue; }
+    toSet[f] = removed[f];
+  }
+  if (!Object.keys(toSet).length) continue;
+
+  if (APPLY) {
+    const r = await books.updateOne({ id: row.book_id }, { $set: toSet });
+    restored += r.modifiedCount;
+  } else {
+    restored += 1;
+  }
+  fields += Object.keys(toSet).length;
+}
+
+console.log(`books ${APPLY ? 'restored' : 'that would be restored'}: ${restored}`);
+console.log(`field values                                : ${fields}`);
+console.log(`sweep_log rows whose book is gone           : ${missingBooks}`);
+console.log(`fields already present (left alone)         : ${skippedPresent}`);
+if (!APPLY) console.log('\nDry-run only. Re-run with --apply to restore.');
+
+await client.close();


### PR DESCRIPTION
## Applied to production

**3,467 field instances removed from 2,120 books. Residual 0, verified independently. 2,135 `sweep_log` rows preserve every removed value.**

This is the half of #3969 that actually shrinks the schema — the validator freezes the count, only this reduces it.

## The list is NOT the one the audits produced

Both reader surveys used `git grep -E "\bfield\b"`. **In this repo that matches nothing and exits 1** — BSD ERE has no `\b`. Verified directly: the pattern finds nothing in a file that plainly contains `pages_count`, while `-P` finds it. A silent false negative is indistinguishable from 'no references', which is the worst possible failure mode for a deletion decision.

Re-checking all 61 candidates with `git grep -P` across `src/`, `scripts/` and `mcp-server/`:
- **dropped 6** the first survey had called orphan — `free_tier`, `material`, `last_updated`, `cover`, `translator`, `archived_reason`
- **confirmed 50**

Excluded by design: fields read *only* by a cron. **`photo`** is the case in point — read solely by `sync-books-catalog.mjs`, feeding the public listing thumbnails through Supabase, invisible to any `src/`-only grep.

## Tested by reversibility, not by more grepping

'Nothing reads this' cannot be proved by grepping harder when grep is the thing that failed. So the property under test is that the deletion can be undone.

`restore-orphan-book-fields.mjs` replays the `sweep_log` rows and only fills fields that are currently **absent**, so it can never clobber a value written later. Proved on a 15-book canary **before** the full run:

| step | result |
|---|---|
| snapshot 15 books (16 values) | captured |
| delete → verify gone | **15 OK, 0 problems** |
| restore → compare to snapshot | **15 OK, 0 problems, byte-identical** |

Two limits worth stating: this cannot detect a *dynamic* reader (`book[someVar]`), and it cannot see consumers outside this repo. Mitigations are the small footprint (1–1,145 docs per field) and the proven restore.

## What the distribution shows

`acquisition_wave` and `acquisition_priority` at **1,145 each** — one sweep, two columns — are two-thirds of all instances. The rest is a long tail: 46 fields under 100, many in single digits. Exactly the '~140 sweeps, one column each' shape the issue describes.

## Ratchet

Per the protocol in `invariants/field-sprawl.md`: `--max-fields` 400 → **385**, and all 50 names appended to `--forbid`, so any writer that re-grows one fails the weekly watch. **Consolidation without a retired-list is undone by the next sweep** — `tenant_id` proved that at 4.16M rows.

## Also included: the first-translation card prior-suggester

`scripts/eval/card-prior-candidates.mjs` proposes catalogue-backed priors for **empty** translation cards (an empty card is a live absence claim readers see). It **never writes to a card** — the method requires a reviewer for anything that changes reader-visible text.

Measured across 599 empty cards: **293** authors absent from LoC/ESTC entirely, **301** present but with no title match, **3** worth a human look (an Aristophanes container card, plus near-misses on Paracelsus *Opera theologica* and Pico's *De Studio Divinae*). So the catalogue mostly **corroborates** the absence claims rather than refuting them — which is the evidence the card's 'here's where we looked' sentence wants.

Matching is anchored author + MARC `uniform_title` + title-token overlap. Two of my own bugs died on the way there: naive surname matching was ~100% false positives ('Ruel' matching *Bar*ruel), and the fixed version returned a flat zero until a positive control revealed cards write *Given Surname* while MARC writes *Surname, Given*.

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)