### PR TITLE
fix(audit): apply the field ceiling to the FULL count, not just the sample

### DIFF
--- a/scripts/audit/field-sprawl.mjs
+++ b/scripts/audit/field-sprawl.mjs
@@ -411,7 +411,7 @@ async function main() {
     }
 
     if (WATCHED.includes(name) && census.fields.length > MAX_FIELDS) {
-      console.log(`\n   !! ${census.fields.length} fields exceeds the --max-fields ceiling of ${MAX_FIELDS}`);
+      console.log(`\n   !! ${census.fields.length} SAMPLED fields exceeds the --max-fields ceiling of ${MAX_FIELDS}`);
       breach = true;
     }
 
@@ -438,6 +438,21 @@ async function main() {
     }
     console.log(`\nenumerating every field on ${ONE} (full scan, not a sample)…`);
     const names = await allFieldNames(db.collection(ONE));
+
+    // The ceiling above was checked against the SAMPLED census, which sees far
+    // fewer fields than exist — reported by Mayank on #4002, who expected a
+    // breach at 476 and got exit 0 because the gate read ~395. Two different
+    // counts in one run is a trip hazard precisely at the moment someone flips
+    // the validator to `error`, where a wrong field list becomes 500s. So the
+    // authoritative count gets the same ceiling, and both are printed together.
+    const sampledCount = report.collections.find((c) => c.name === ONE)?.fields?.length;
+    if (sampledCount !== undefined) {
+      console.log(`\nfield count: ${sampledCount} sampled (${SAMPLE} docs) vs ${names.length} FULL — the validator is built from the FULL count.`);
+    }
+    if (WATCHED.includes(ONE) && names.length > MAX_FIELDS) {
+      console.log(`   !! ${names.length} FULL fields exceeds the --max-fields ceiling of ${MAX_FIELDS}`);
+      breach = true;
+    }
     const doc = buildValidator(names);
     doc.collMod = ONE;
     fs.writeFileSync(EMIT_VALIDATOR, JSON.stringify(doc, null, 2));


### PR DESCRIPTION
Reported by @Mayank-PPL while installing the validator (#4002).

He expected the `--max-fields 410` ratchet to breach at 476 top-level fields and got **exit 0**. Cause: the gate checks the **sampled** census (~395 of 3,000 documents) while `--emit-validator` runs the **full** enumeration (475). Two different counts in one run — and the number the gate guards is not the number the validator is built from.

That gap matters precisely at the `error`-mode flip, where a wrong field list stops being a log line and becomes 500s.

**Fix:** the ceiling now also applies to the full enumeration when it is computed, both counts print side by side, and the sampled breach message says `SAMPLED` so the two can't be confused.

```
field count: 395 sampled (3000 docs) vs 425 FULL — the validator is built from the FULL count.
```

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)