### PR TITLE
fix(books): stop writing the pageCount twin (#3969 family 3)

### DIFF
--- a/scripts/iiif-discovery/import-leiden-artworks.mjs
+++ b/scripts/iiif-discovery/import-leiden-artworks.mjs
@@ -118,7 +118,7 @@ for (const c of cands) {
     language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
     published: c.date_text || 'Unknown', ...(year ? { year } : {}),
     thumbnail: thumbUrl, image_display: displayUrl, image_source_url: fullUrl, commons_full_url: fullUrl,
-    pageCount: 1, pages_count: 1, pages_ocr: 0, pages_translated: 0,
+    pages_count: 1, pages_ocr: 0, pages_translated: 0,
     content_type: 'artwork', resource_type: RESOURCE_TYPE,
     status: PUBLISH ? 'live' : 'draft', hidden: !PUBLISH, visible: PUBLISH,
     // Keep out of the OCR/translation cron: 'leiden' isn't in the orchestrator's

--- a/scripts/import/import-artwork.mjs
+++ b/scripts/import/import-artwork.mjs
@@ -401,7 +401,6 @@ async function createArtworkDoc(db, artwork, entry) {
     thumbnail: artwork.url,
     image_display: artwork.url,
     image_source_url: artwork.url,
-    pageCount: 1,
     pages_count: 1,
     pages_ocr: 0,
     pages_translated: 0,

--- a/scripts/maintenance/dedup-ia-trailing-pages.mjs
+++ b/scripts/maintenance/dedup-ia-trailing-pages.mjs
@@ -19,7 +19,9 @@
  *        (per the atlas-search convention: hidden/deduped pages live at
  *        page_number ≤ 0). The page immediately before the run is preserved as
  *        the visible keep page.
- *     4. Decrement book.pages_count by run_len. Don't touch pageCount.
+ *     4. Decrement book.pages_count by run_len. (The camelCase `pageCount`
+ *        twin this once avoided was retired in #3969 — nothing read it, and on
+ *        186 books it held a stale PRE-SPLIT count, roughly half the truth.)
  *
  * Why byte-size and not dhash:
  *   IA's trash pages are generated from the same template — they hit R2
@@ -89,7 +91,7 @@ async function main() {
   if (PROVIDER) query['image_source.provider'] = PROVIDER;
 
   const cursor = db.collection('books').find(query, {
-    projection: { id: 1, title: 1, slug: 1, pages_count: 1, pageCount: 1 },
+    projection: { id: 1, title: 1, slug: 1, pages_count: 1 },
   }).sort({ pages_count: -1 });
   if (BOOK_LIMIT > 0) cursor.limit(BOOK_LIMIT);
   const books = await cursor.toArray();

--- a/scripts/maintenance/delete-orphan-book-fields.mjs
+++ b/scripts/maintenance/delete-orphan-book-fields.mjs
@@ -70,6 +70,16 @@ export const ORPHAN_FIELDS = [
 ];
 
 const APPLY = process.argv.includes('--apply');
+// --fields a,b : delete a DIFFERENT set through the same proven machinery
+// (preserve to sweep_log, then $unset, canary-able, reversible via
+// restore-orphan-book-fields.mjs). Reusing this beats writing a second deleter
+// per family, which is how two implementations drift apart.
+const FIELDS_OVERRIDE = (() => {
+  const i = process.argv.indexOf('--fields');
+  return i > -1 ? process.argv[i + 1].split(',').map((f) => f.trim()).filter(Boolean) : null;
+})();
+// --sweep <name> : label the sweep_log rows for this run.
+const SWEEP_OVERRIDE = (() => { const i = process.argv.indexOf('--sweep'); return i > -1 ? process.argv[i + 1] : null; })();
 // --limit N: canary mode. Delete from at most N books, so the sweep_log
 // round-trip can be proved on a small set before the full run.
 const LIMIT = (() => { const i = process.argv.indexOf('--limit'); return i > -1 ? Number(process.argv[i + 1]) : 0; })();
@@ -81,13 +91,15 @@ await client.connect();
 const db = client.db(process.env.DB_NAME || 'bookstore');
 const books = db.collection('books');
 
-console.log(`Orphan field deletion — ${ORPHAN_FIELDS.length} fields`);
+const FIELDS = FIELDS_OVERRIDE || ORPHAN_FIELDS;
+const SWEEP_NAME = SWEEP_OVERRIDE || SWEEP;
+console.log(`Book field deletion — ${FIELDS.length} field(s), sweep '${SWEEP_NAME}'`);
 console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
 
 // Exact per-field counts. Sampling is not admissible for a deletion decision:
 // on this collection a 3,000-doc sample missed ~95 fields entirely.
 const counts = [];
-for (const f of ORPHAN_FIELDS) {
+for (const f of FIELDS) {
   const n = await books.countDocuments({ [f]: { $exists: true } }, { maxTimeMS: 60000 });
   counts.push([f, n]);
 }
@@ -97,10 +109,10 @@ for (const [f, n] of counts) console.log(`  ${f.padEnd(34)} ${n}`);
 const live = counts.filter(([, n]) => n > 0);
 const totalFieldInstances = counts.reduce((s, [, n]) => s + n, 0);
 const affected = await books.countDocuments(
-  { $or: ORPHAN_FIELDS.map((f) => ({ [f]: { $exists: true } })) },
+  { $or: FIELDS.map((f) => ({ [f]: { $exists: true } })) },
   { maxTimeMS: 120000 },
 );
-console.log(`\nfields with >0 docs : ${live.length} of ${ORPHAN_FIELDS.length}`);
+console.log(`\nfields with >0 docs : ${live.length} of ${FIELDS.length}`);
 console.log(`field instances     : ${totalFieldInstances}`);
 console.log(`distinct books      : ${affected}`);
 
@@ -111,19 +123,19 @@ if (!APPLY) {
 }
 
 // Preserve first, delete second — and one row per BOOK, carrying every value.
-const findOpts = { projection: Object.fromEntries([['id', 1], ...ORPHAN_FIELDS.map((f) => [f, 1])]) };
+const findOpts = { projection: Object.fromEntries([['id', 1], ...FIELDS.map((f) => [f, 1])]) };
 if (LIMIT) findOpts.limit = LIMIT;
-const cursor = books.find({ $or: ORPHAN_FIELDS.map((f) => ({ [f]: { $exists: true } })) }, findOpts);
+const cursor = books.find({ $or: FIELDS.map((f) => ({ [f]: { $exists: true } })) }, findOpts);
 if (LIMIT) console.log(`\nCANARY: limiting to ${LIMIT} books.`);
 
 let rows = 0, unset = 0;
 for await (const book of cursor) {
   const removed = {};
-  for (const f of ORPHAN_FIELDS) if (f in book) removed[f] = book[f];
+  for (const f of FIELDS) if (f in book) removed[f] = book[f];
   if (!Object.keys(removed).length) continue;
 
   await recordSweepAction(db, {
-    sweep: SWEEP,
+    sweep: SWEEP_NAME,
     book_id: book.id || String(book._id),
     action: 'orphan-fields-removed',
     detail: { removed },
@@ -141,7 +153,7 @@ console.log(`\nsweep_log rows written : ${rows}`);
 console.log(`books modified         : ${unset}`);
 
 let residual = 0;
-for (const f of ORPHAN_FIELDS) residual += await books.countDocuments({ [f]: { $exists: true } }, { maxTimeMS: 60000 });
+for (const f of FIELDS) residual += await books.countDocuments({ [f]: { $exists: true } }, { maxTimeMS: 60000 });
 // In canary mode a non-zero residual is the expected result, not a fault — the
 // run deliberately stopped early. Only a full run can claim "clean", and a
 // check that cries wolf is one people learn to ignore.
@@ -149,6 +161,6 @@ const residualNote = LIMIT
   ? '(expected — canary run stopped early)'
   : residual === 0 ? '(clean)' : '(!! investigate)';
 console.log(`residual instances     : ${residual} ${residualNote}`);
-console.log(`\nRecover a book's values: db.sweep_log.find({ sweep: '${SWEEP}', book_id: '<id>' })`);
+console.log(`\nRecover a book's values: db.sweep_log.find({ sweep: '${SWEEP_NAME}', book_id: '<id>' })`);
 
 await client.close();


### PR DESCRIPTION
Family 3 of #3969 — the four-way page-count split. **Writers first**: a field cleaned while its writers are alive re-pollutes, which is what `tenant_id` proved at 4.16M rows.

## Measured (read-only, production)

| field | docs |
|---|---:|
| `pages_count` | 104,690 (core) |
| `pageCount` | 13,324 |
| `page_count` | 4 |

- **`books.pageCount` has no reader.** `src/` never touches it — all 44 hits there are batch-job DTOs (`pageCount: j.page_count`). Its only writers were two artwork importers writing a literal `1` *alongside* `pages_count: 1`, and the single script that projected it never used the value.
- **Zero** books carry `pageCount` without a `pages_count` field, so nothing depends on it for a count's existence.
- On **186 books (181 visible)** the two disagree — and `pageCount` is a stale **pre-split** count:

| pageCount | pages_count | actual page docs |
|---:|---:|---:|
| 90 | 179 | 179 |
| 65 | 129 | 129 |
| 170 | 320 | 320 |

Roughly half, every time, with the real page documents matching `pages_count`. Anything that had read `pageCount` there would have under-reported by half — the exact 'confident, well-formed, wrong answer' this issue exists to stop.

## In this PR
- Remove the two writes (`import-artwork.mjs`, `import-leiden-artworks.mjs`) and the dead projection.
- Fix a comment that instructed future readers to preserve the twin.
- Generalize `delete-orphan-book-fields.mjs` with `--fields` / `--sweep`, so the next family reuses machinery already canary-proved reversible instead of growing a second deleter that drifts from the first.

## Out of scope
**No data is touched.** The 13,328 field instances stay until the deletion is approved separately — dry-run numbers are in hand and the same preserve-to-`sweep_log` + canary round-trip procedure applies.

`page_count_source` (28,189) is a different concept — provenance, not a count — and stays.

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)