### PR TITLE
docs: session handoff + refresh the field-sprawl invariant to current state

### DIFF
--- a/.claude/docs/invariants/field-sprawl.md
+++ b/.claude/docs/invariants/field-sprawl.md
@@ -20,18 +20,21 @@ Build import documents with `makeBookDoc()` / `makePageDoc()` from `scripts/lib/
 
 `books` reached **477 top-level fields with only 17 on ≥99% of documents**, ~140 written by a single sweep and then abandoned. Compare `books_warehouse`, the newest book collection: 129 fields, 25 core. The difference is not complexity; it is accretion.
 
+**Current state: 423 fields** (2026-08-18), after three families were consolidated and 53 dead fields deleted. The live count is tracked in `scripts/lib/books-known-fields.json` — read it rather than any number written in prose, including this one.
+
 ## The lesson that cost the most: consolidation without enforcement is a treadmill
 
 PR #2085 (2026-05-27) fully consolidated the tenant family — 45K books and 6.4M pages cleaned, writers stripped from `src/`, readers migrated, canonical field declared. It explicitly left the "one-shot historical import scripts" alone as already-run.
 
 **Those scripts are the standard route for 429-prone sources and are reused constantly.** Within three months the field was back on 20,010 books and 4,156,480 pages (#3983 stripped 62 write sites across 36 scripts; the data was re-cleaned 2026-08-13/14).
 
-So: **a cleanup is not done when the data is clean. It is done when something standing prevents the regrowth.** The four layers, strongest first:
+So: **a cleanup is not done when the data is clean. It is done when something standing prevents the regrowth.** The five layers, strongest first:
 
 1. **The DB refuses it.** `$jsonSchema` + `additionalProperties: false` on `books`. Installing it needs `dbAdmin`; the app credential is `readWriteAnyDatabase` and cannot run `collMod` — that privilege split is what makes it a boundary rather than a convention. Generate with `field-sprawl.mjs --emit-validator` (full scan only — a sampled validator rejects legitimate writes to ~80 rare fields).
-2. **The easy path is the correct path.** The constructors above. One hand-rolled literal per script is why one bug shipped 62 times.
-3. **CI notices drift.** `field-sprawl-watch.yml`, weekly. `--max-fields` ratchets DOWN after each consolidation; `--forbid` lists retired names and fails on reappearance.
-4. **This document.** Weakest layer; the other three exist because it is.
+2. **A PR that adds a field fails.** `scripts/audit/new-field-writes.mjs` flags any `$set` of an unknown top-level `books` field, on every `pull_request`, in ~12s with no database. This is the layer that catches the ACTUAL mechanism of sprawl: the constructors below guard inserts, but the ~140 dead fields came from maintenance sweeps doing `$set`. Baseline in `books-field-write-baseline.json` — a list to shrink, never grow.
+3. **The easy path is the correct path.** The constructors above. One hand-rolled literal per script is why one bug shipped 62 times.
+4. **CI notices drift.** `field-sprawl-watch.yml`, weekly. `--max-fields` ratchets DOWN after each consolidation; `--forbid` lists retired names and fails on reappearance.
+5. **This document.** Weakest layer; the others exist because it is.
 
 ## Adding a legitimate field
 

--- a/.claude/handoffs/2026-08-18-field-sprawl-consolidation.md
+++ b/.claude/handoffs/2026-08-18-field-sprawl-consolidation.md
@@ -1,0 +1,76 @@
+# Field sprawl: three families consolidated, four guards built — 2026-08-13/18
+
+`books` went **476 → 423 top-level fields**. Issue #3969. Everything below is merged and
+applied to production unless marked otherwise.
+
+## What shipped
+
+| PR | what |
+|---|---|
+| #3983 | stripped 62 `tenant_id: 'default'` writes from 36 import scripts |
+| #3984 | `scripts/lib/sweep-log.mjs` + `scripts/lib/book-docs.mjs` (whitelisted constructors) |
+| #3986 | `hide_reason` → `hidden_reason` migration |
+| #3993 | weekly `field-sprawl-watch.yml` |
+| #3998 | `--max-nested` ceiling + `.claude/docs/invariants/field-sprawl.md` |
+| #3999 | 50 import scripts adopted the constructors |
+| #4000 | restore path stops carrying archive-only/retired fields (closed #3997) |
+| #4001 | tracked `install-collection-validator.mjs` |
+| #4008 | DB-side entities-sweep interlock (`entities-sweep-active.mjs`) |
+| #4011 | **deleted 50 orphan fields** — 3,467 instances / 2,120 books |
+| #4012 | **PR-time lint** `new-field-writes.mjs` + the grep trap documented |
+| #4013 | field ceiling applies to the FULL count, not just the sample |
+| #4014/#4016 | **deleted `pageCount`+`page_count`** — 13,328 books; ratchet closed |
+
+Data applied: tenant cleanup (20,010 books + 4,156,480 pages), `hide_reason` (500),
+orphans (3,467), page count (13,328). **Every removed value is preserved** as a
+`sweep_log` row; `restore-orphan-book-fields.mjs --sweep <name>` replays them.
+
+## The four prevention layers (strongest first)
+
+1. **`$jsonSchema` validator** — installed in `warn` mode by Mayank (#4002). ⚠️ It was
+   generated pre-deletion, so it still **permits the 50 deleted fields**. Needs one
+   re-run; step 2 will now print **423**.
+2. **PR-time lint** — `new-field-writes.mjs` fails any PR that `$set`s an unknown
+   `books` field. Runs on every `pull_request` (~12s, no DB). Baseline:
+   `scripts/lib/books-field-write-baseline.json` (24 accepted — shrink, never grow).
+3. **Weekly watch** — `--max-fields 383 --max-nested 65 --forbid <54 retired names>`.
+4. **Constructors** — `makeBookDoc`/`makePageDoc`, adopted in 50 import scripts.
+
+`scripts/lib/books-known-fields.json` (423 fields, 54 retired) is the **single source of
+truth** shared by the lint and the validator. Adding a field = edit it in the same PR.
+
+## Corrections this session made — the durable part
+
+- **`git grep -E "\bfield\b"` matches NOTHING here** (BSD ERE has no `\b`) and exits 1 —
+  indistinguishable from "no references". Two reader surveys used it; re-checking 61
+  candidates with `-P` found **six live fields** in their orphan lists. Documented in
+  `invariants/field-sprawl.md`.
+- **A reader hides in two places grep won't look**: cron-only (`photo` → Supabase →
+  public thumbnails) and dynamic (`book[someVar]`).
+- **Delete by proving reversibility, not by grepping harder.** Restore path first,
+  canary round-trip byte-identical, then the full run. Used for both deletions.
+- **`pageCount` held a stale PRE-SPLIT count on 186 books** (181 visible) — 90 vs 179,
+  65 vs 129, with real page docs matching `pages_count`. Nothing read it; it was a
+  loaded gun for the next query that reached for the plausible name.
+- **Family 4's plan in the issue is a category error** (posted, not executed):
+  `image_resolution_*` (1,987 docs, **0 artwork**, 303-page books) and
+  `image_upgrade*`/`upgrade_source` (674 docs, **all artwork**) are two subsystems, not
+  three spellings of one. And **`image_resolution_upgrade_source` holds a pixel width**
+  (3888, 3504), not a source.
+- **FT cards**: `reference_translations` has no `work_id`/translator/URL — raw MARC,
+  cards are QID-keyed. The "126K records to promote" framing was wrong. What the data
+  gives is **corroboration**: across 599 empty cards, 293 authors absent from LoC/ESTC,
+  301 present-no-match, **3 for human review**. Recorded in non-rendered
+  `search.catalogue_checks`; reader-visible text byte-identical.
+
+## Next
+
+- **Mayank**: re-run the validator install so it reflects 423 (#4002 has the corrected steps).
+- **Family 4a**: consolidate the artwork upgrade pair — needs *value* normalization
+  (`commons` vs `Commons alternate`), has live writers and a live reader. Full ladder.
+- **Family 4b**: rename `image_resolution_upgrade_source` → `..._width`. Cheap, removes a trap.
+- Then: language (18 fields); `books.tenant` (148 docs — ritman catalogue provenance
+  misnamed, read by `/api/catalog` as 'location': rename, don't unset).
+- **8 UNCERTAIN fields** from the audit (collection-name collisions) still unresolved.
+- Error-mode flip: needs a quiet week of Atlas logs **and** `restored_from` added
+  deliberately — no scan will ever contain it until a book is restored.


### PR DESCRIPTION
Down-ratchet pass at `gnite`. `CLAUDE.md` is **228 lines**, inside the ~250 budget, so nothing needed demoting.

Two things `invariants/field-sprawl.md` had gone stale on:

- It stated the **477-field peak** but never said where the collection actually **is**. Now records **423** (2026-08-18) and — more usefully — points at `scripts/lib/books-known-fields.json` as the live count, so the next reader checks the file rather than a number in prose. Including the number in that very sentence, which is the failure mode being described.
- The layer list **predated the PR-time lint**, which is the layer that catches the *actual* mechanism of sprawl. The constructors guard inserts; the ~140 dead fields came from maintenance sweeps doing `$set`. Four layers → five, reordered by strength.

Plus the session handoff (technical postmortem, no PII or business material — deliberate `git add -f` per the repo rule): three families consolidated, 476 → 423 fields, the four data applications with their `sweep_log` reversals, and the corrections that outlast them — the `git grep -E "\b"` trap, cron-only and dynamic readers, deletion-by-reversibility, and family 4's plan being a category error.

Part of #3969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)