### PR TITLE
fix(e2e): unbreak the two Librarian assertions #4007 invalidated

### DIFF
--- a/e2e/embassy.spec.ts
+++ b/e2e/embassy.spec.ts
@@ -63,11 +63,26 @@ test.describe('Librarian', () => {
     // than a hard disabled-input gate.
     await expect(page.locator('textarea')).toBeEnabled();
     await expect(page.locator('textarea')).toHaveAttribute('placeholder', 'Ask the Librarian...');
-    await expect(page.getByText('to save your conversations and keep them private')).toBeVisible();
+    // Assert the nudge STRUCTURALLY — the sign-in link plus the fact that it
+    // sits below the composer — not on its wording. #4007 reworded this line
+    // ("to save your conversations and keep them private" → "to keep your
+    // conversations and come back to them later") and broke the test the next
+    // morning; the behaviour under test (a soft prompt, not a hard gate) never
+    // changed. What matters is that anonymous visitors get a link, not a wall.
+    // Match the composer nudge by its exact href, not by role+name: the header
+    // UserMenu also renders a "Sign in" link (bare /auth/signin), so a name
+    // locator would pass even if the nudge below the input disappeared.
+    await expect(
+      page.locator('a[href="/auth/signin?callbackUrl=/librarian"]')
+    ).toBeVisible();
   });
 
   test('shows Recent tab', async ({ page }) => {
-    await expect(page.locator('button', { hasText: 'Recent' })).toBeVisible();
+    // `exact: true` is load-bearing. #4007 made conversations listed by
+    // default, which renders a "Listed (shown in Recent, never under your
+    // name)" toggle above the composer — a second button containing the word
+    // "Recent", so the old substring locator became a strict-mode violation.
+    await expect(page.getByRole('button', { name: 'Recent', exact: true })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
Fixes the daily E2E failure tracked in #3990.

## What broke

Two assertions in `e2e/embassy.spec.ts` were pinned to details that **#4007** ("list conversations by default, never under a name", merged 2026-08-17 08:15Z — after that morning's run) legitimately changed. Both failed all three attempts in the 08-18 run, so this is not a flake, and neither is a product bug:

| Test | Failure | Cause |
|---|---|---|
| `anonymous visitors can use the Librarian input` | `getByText('to save your conversations and keep them private')` — element not found | #4007 reworded the nudge to "(free) to keep your conversations and come back to them later" |
| `shows Recent tab` | strict mode violation, `locator('button', { hasText: 'Recent' })` resolved to 2 elements | #4007 renders a "Listed **(shown in Recent**, never under your name)" toggle above the composer |

## The fix

Both assertions are now structural rather than copy-pinned:

1. The sign-in nudge is located by its exact href, `a[href="/auth/signin?callbackUrl=/librarian"]`. Role+name would **not** work here — the header `UserMenu` also renders a "Sign in" link (bare `/auth/signin`), so a name locator would keep passing even if the nudge below the composer disappeared. The behaviour under test (soft prompt, not a hard disabled-input gate) is unchanged and still asserted.
2. The Recent tab uses `getByRole('button', { name: 'Recent', exact: true })`. `exact: true` is load-bearing and commented as such.

## Verification

Against `https://sourcelibrary.org`:

- `e2e/embassy.spec.ts` — **12 passed**
- full suite — **72 passed, 7 skipped, 0 failed** (including the link-follower crawl)

## Out of scope

The 08-14 and 08-16 failures had a **different, transient cause**: a single `403` in ~27ms on `/collections/history-political-thought` during the link-follower crawl — an edge block of the runner IP, not an origin error. That URL serves 200 now, the crawl passed in the 08-18 run and in my local full-suite run, and 08-15/08-17 were green. Nothing to fix in the tests; if it recurs the fix belongs in the crawler-access gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
