### PR TITLE
Deploy: exclude local datasets (scripts/output, eval results, .sibling-bak) from Vercel uploads

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -3,3 +3,8 @@ astrologuy
 tools-standlone-gemini-page-split
 ocr-output
 .claude
+
+# Local datasets / scratch — never part of a deploy (35K+ files broke the upload, 2026-08-18)
+scripts/output
+scripts/eval/results
+.sibling-bak


### PR DESCRIPTION
`npm run deploy:prod` failed tonight with Vercel's hard limit: "`files` should NOT have more than 15000 items, received 40,553". The overflow is `scripts/output` — 35,091 files, almost all the untracked Suda/SOL harvest dataset — plus `scripts/eval/results` (653) and `.sibling-bak` (59). None of these are ever part of a build.

Three lines in `.vercelignore`. Already applied locally to recover production (the GitHub-integration deploy of 4d819a8e had failed and the CLI fallback was blocked by exactly this); this PR commits the same change so every machine gets it.

Note for whoever looks next: the GitHub→Vercel integration deploys have been failing/canceling since ~Aug 17 under the `frondular` scope — separate problem, tracked in #4025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)