### PR TITLE
Deploy: re-include tracked build-import JSONs in .vercelignore (gilgamesh build fix)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -4,7 +4,12 @@ tools-standlone-gemini-page-split
 ocr-output
 .claude
 
-# Local datasets / scratch — never part of a deploy (35K+ files broke the upload, 2026-08-18)
-scripts/output
+# Local datasets / scratch — never part of a deploy (35K+ files broke the upload, 2026-08-18).
+# Three tracked JSONs are BUILD-TIME IMPORTS (read/gilgamesh page) and must be re-included —
+# a blanket ignore broke npm run build with Module-not-found (2026-08-18, second incident same day).
+scripts/output/*
+!scripts/output/gilgamesh-tablets.json
+!scripts/output/cuneiform-corpus.json
+!scripts/output/hieroglyph-eval.json
 scripts/eval/results
 .sibling-bak


### PR DESCRIPTION
The #4024 blanket `scripts/output` ignore broke `npm run build`: `src/app/read/gilgamesh/page.tsx` has imported `scripts/output/gilgamesh-tablets.json` at build time since April (#1299), and three files under `scripts/output` are actually tracked. The first post-ignore build passed on Vercel's build cache; the next failed with Module-not-found and took a production deploy attempt down with it.

Fix: `scripts/output/*` with negation patterns re-including the three tracked JSONs (`git ls-files scripts/output/` is exactly these three). Already applied locally and deployed — prod is current, gilgamesh page 200, MCP gallery click-fix bundle serving.

Lesson applied from PR Conventions: ignoring/archiving is deletion-class — grep for inbound refs first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)