### PR TITLE
mcp-server v4.6.0: images at parity with the remote server

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.6.0 (2026-08-18)
+
+### Images are first-class (parity with the remote server, #3937)
+
+- `search_images`: the first 5 results are attached as inline MCP `image` content blocks (audience `['user','assistant']` — the model can see them). Empty results carry an explanatory `note`; under `book_id` the artwork lane is skipped (artworks don't belong to books, so they can only un-scope a book-filtered call).
+- `get_quote`: new `include_image` param returns the scan of the cited leaf inline (display size, ≤1200px).
+- `get_book`: cover art attached inline on every call (`cover_thumb_url` / `cover_image_url` in the JSON).
+- Fetches are bounded: 5s timeout, 1MB cap per image, silent skip on failure.
+
+
 ## 4.3.0 (2026-05-18)
 
 ### Server-level orientation

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-library/mcp-server",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "mcpName": "io.github.Embassy-of-the-Free-Mind/source-library",
   "description": "Search, read, and cite ~22,000 rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. CLI + MCP server, no API key needed.",
   "type": "module",

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -368,8 +368,16 @@ export async function listBooks(args: {
 export async function getBook(args: { book_id: string }) {
   const result = await apiGet(`/books/${args.book_id}`, new URLSearchParams({ pages: "nav" })) as Record<string, unknown>;
 
+  // Cover art, preferring the canonical R2 fields (cover-write contract).
+  // cover_thumb_url feeds the inline image block in index.ts; the full
+  // display URL rides alongside for callers that want to link it.
+  const coverThumb = (result.image_thumb || result.thumbnail_blob || result.image_display || result.thumbnail) as string | undefined;
+  const coverFull = (result.image_display || result.thumbnail || result.image_thumb || result.thumbnail_blob) as string | undefined;
+
   return {
     id: result.id,
+    ...(coverThumb ? { cover_thumb_url: coverThumb } : {}),
+    ...(coverFull ? { cover_image_url: coverFull } : {}),
     title: result.display_title || result.title,
     original_title: result.title !== (result.display_title || result.title) ? result.title : undefined,
     author: result.author,
@@ -517,8 +525,12 @@ const OCR_ORIGINAL_TIP =
 export async function getQuote(args: {
   book_id: string;
   page: number;
+  include_image?: boolean;
 }) {
   const params = new URLSearchParams({ page: String(args.page) });
+  // Opt-in scan of the cited leaf (#3937): the response then carries
+  // quote.page_image_url and index.ts attaches the image inline.
+  if (args.include_image === true) params.set("include_image", "true");
   const result = await apiGet(`/books/${args.book_id}/quote`, params) as Record<string, unknown>;
 
   const quote = result.quote as Record<string, unknown> | undefined;
@@ -678,8 +690,11 @@ export async function searchImages(args: {
 
   // For 'all', request both halves at full limit, then interleave so the
   // caller never sees a single source dominate just because it returns first.
+  // Under book_id the artwork lane is skipped: artworks don't belong to books
+  // (the artwork API's book_id means "this artwork"), so including them can
+  // only un-scope a book-filtered call (#3936).
   const wantGallery = source === "all" || source === "gallery";
-  const wantArtworks = source === "all" || source === "artworks";
+  const wantArtworks = (source === "all" || source === "artworks") && !args.book_id;
 
   const [galleryItems, artworkItems] = await Promise.all([
     wantGallery
@@ -712,5 +727,14 @@ export async function searchImages(args: {
     source,
     counts: { gallery: galleryItems.length, artworks: artworkItems.length },
     images,
+    // An empty scoped result must SAY so — silence is how the book_id no-op
+    // went unnoticed on the remote server (#3936).
+    ...(images.length === 0
+      ? {
+          note: args.book_id
+            ? "This book has no catalogued images matching the query. Its illustrations may not have been extracted yet — absence here does not mean the physical book has no plates."
+            : "No images matched. Try a broader query, or drop filters (type/subject/year) one at a time.",
+        }
+      : {}),
   };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -310,7 +310,7 @@ const TOOLS: Tool[] = [
     name: "get_book",
     title: "Get Book",
     description:
-      "Get a book's AI-generated summary, chapter list, index stats, edition metadata, DOI, page counts, and processing status. THIS IS THE RIGHT FIRST CALL whenever the user has named a specific author or work — the summary is typically a multi-paragraph orientation covering the book's argument, structure, and significance, often answering the question without any further searching. Pair with get_book_text to read selected chapters, or search_within_book to locate passages inside it.",
+      "Get a book's AI-generated summary, chapter list, index stats, edition metadata, DOI, page counts, processing status, and cover image (attached inline so you and the user can see the book). THIS IS THE RIGHT FIRST CALL whenever the user has named a specific author or work — the summary is typically a multi-paragraph orientation covering the book's argument, structure, and significance, often answering the question without any further searching. Pair with get_book_text to read selected chapters, or search_within_book to locate passages inside it.",
     annotations: { title: "Get Book", readOnlyHint: true },
     inputSchema: {
       type: "object" as const,
@@ -389,6 +389,10 @@ const TOOLS: Tool[] = [
           type: "number",
           description: "Page number to quote from",
         },
+        include_image: {
+          type: "boolean",
+          description: "Also return the scan of the cited leaf as an inline image (display size, ≤1200px). Set this when the user would benefit from SEEING the page — an illustrated leaf, a title page, a diagram, disputed OCR — or asks to see it.",
+        },
       },
       required: ["book_id", "page"],
     },
@@ -399,7 +403,7 @@ const TOOLS: Tool[] = [
     name: "search_images",
     title: "Search Images",
     description:
-      "Search the visual collection: 50,000+ illustrations extracted from book pages PLUS 23,000+ standalone artworks (paintings, frescoes, prints, sculptures from Met, Rijksmuseum, Wikimedia, NGA). Filter by type, subject, figure, symbol, year, book, or text query. Each result has a `source` field — `gallery` (illustration in a book) or `artwork` (standalone museum work). Use `type=painting` or `type=fresco` to find standalone works; `type=woodcut`, `type=engraving`, `type=emblem` etc. surface mostly book illustrations. The `source` parameter narrows the search: 'all' (default), 'gallery' (illustrations only), or 'artworks' (standalone works only).",
+      "Search the visual collection: 50,000+ illustrations extracted from book pages PLUS 23,000+ standalone artworks (paintings, frescoes, prints, sculptures from Met, Rijksmuseum, Wikimedia, NGA). Filter by type, subject, figure, symbol, year, book, or text query. Each result has a `source` field — `gallery` (illustration in a book) or `artwork` (standalone museum work). Use `type=painting` or `type=fresco` to find standalone works; `type=woodcut`, `type=engraving`, `type=emblem` etc. surface mostly book illustrations. The `source` parameter narrows the search: 'all' (default), 'gallery' (illustrations only), or 'artworks' (standalone works only). The first few results also return as inline images YOU can see — some chat clients show them only inside the collapsed tool-result view, so never tell the user images are \"rendered above\"; describe what you see and give each image's url link instead. If images.length is 0, read the note field — an empty result under book_id means that book has no EXTRACTED images yet, not that the physical book has no plates.",
     annotations: { title: "Search Images", readOnlyHint: true },
     inputSchema: {
       type: "object" as const,
@@ -609,6 +613,80 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
+// ── Inline image attachments (#3937: parity with the remote server) ──
+//
+// Tools whose results carry imagery return image URLs in their JSON; this
+// layer turns the first few into MCP `image` content blocks so clients
+// render them inline. audience includes 'assistant' so the model can SEE
+// the plates it cites, not just relay them.
+const MAX_INLINE_IMAGES = 5;
+const IMAGE_AUDIENCE = { audience: ["user", "assistant"] };
+
+async function fetchImageBase64(url: string): Promise<{ data: string; mimeType: string } | null> {
+  try {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!resp.ok) return null;
+    const contentType = resp.headers.get("content-type") || "image/jpeg";
+    const mimeType = contentType.split(";")[0].trim();
+    const buffer = await resp.arrayBuffer();
+    // Skip images larger than 1MB to keep responses reasonable
+    if (buffer.byteLength > 1_000_000) return null;
+    return { data: Buffer.from(buffer).toString("base64"), mimeType };
+  } catch {
+    return null;
+  }
+}
+
+// Try candidate URLs in order until one fetches within the size cap.
+async function fetchFirstImage(urls: Array<string | undefined | null>): Promise<{ data: string; mimeType: string } | null> {
+  for (const url of urls) {
+    if (!url) continue;
+    const img = await fetchImageBase64(url);
+    if (img) return img;
+  }
+  return null;
+}
+
+interface ImageAttachment {
+  urls: Array<string | undefined | null>;
+  caption: string;
+}
+
+function collectImageAttachments(name: string, result: unknown): ImageAttachment[] {
+  if (!result || typeof result !== "object") return [];
+  const r = result as Record<string, unknown>;
+
+  if (name === "search_images" && Array.isArray(r.images)) {
+    return (r.images as Array<Record<string, unknown>>)
+      .slice(0, MAX_INLINE_IMAGES)
+      .filter((img) => typeof img.image_url === "string")
+      .map((img) => ({
+        urls: [img.image_url as string],
+        caption: `${(img.description as string) || (img.title as string) || "Image"}\n${img.url as string}`,
+      }));
+  }
+
+  if (name === "get_quote") {
+    const quote = r.quote as Record<string, unknown> | undefined;
+    if (typeof quote?.page_image_url === "string") {
+      return [{
+        urls: [quote.page_image_url],
+        caption: `Scan of the cited leaf — p. ${quote.page}, ${quote.author || quote.book_title}`,
+      }];
+    }
+    return [];
+  }
+
+  if (name === "get_book" && typeof r.cover_thumb_url === "string") {
+    return [{
+      urls: [r.cover_thumb_url, r.cover_image_url as string | undefined],
+      caption: `Cover — ${r.title}${r.author ? `, ${r.author}` : ""}`,
+    }];
+  }
+
+  return [];
+}
+
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
@@ -666,6 +744,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return { content: [{ type: "text" as const, text: result }] };
     }
 
+    // Attach inline image blocks for tools whose results carry imagery
+    // (search_images results, get_quote page scans, get_book covers).
+    const attachments = collectImageAttachments(name, result);
+    if (attachments.length > 0) {
+      const content: Array<
+        { type: "text"; text: string } |
+        { type: "image"; data: string; mimeType: string; annotations?: { audience: string[] } }
+      > = [{ type: "text" as const, text: JSON.stringify(result, null, 2) }];
+      const fetched = await Promise.all(attachments.map((a) => fetchFirstImage(a.urls)));
+      for (let i = 0; i < attachments.length; i++) {
+        const img = fetched[i];
+        if (img) {
+          content.push({ type: "image" as const, data: img.data, mimeType: img.mimeType, annotations: IMAGE_AUDIENCE });
+          content.push({ type: "text" as const, text: attachments[i].caption });
+        }
+      }
+      return { content };
+    }
+
     return {
       content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
     };
@@ -689,7 +786,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`Source Library MCP server v4.5.0 running (${TOOLS.length} tools)`);
+  console.error(`Source Library MCP server v4.6.0 running (${TOOLS.length} tools)`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes the last slice of #3937 — the npm stdio package (`npx @source-library/mcp-server`) was the only remaining text-only surface.

Ported from the remote server: inline image blocks on `search_images` (first 5, audience `['user','assistant']`), `include_image` on `get_quote` (cited-leaf scan), inline cover on `get_book`, empty-result notes, and book_id no longer leaks into the artwork lane. Bounded fetches (5s / 1MB / silent skip). Version 4.5.0 → 4.6.0 with CHANGELOG entry.

Verified: `tsc` clean; stdio smoke test returns `[text, image, text, image, text]` with 77KB JPEG blocks and correct audience.

Out of scope: `npm publish` (needs npm auth; prepublishOnly builds) — noted for Derek or a follow-up once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)