### PR TITLE
fix(artwork): one canonical URL per artwork — /book/<slug> redirects to /artwork/

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -665,9 +665,12 @@ async function searchImages(args: Record<string, unknown>) {
     url: item.source === 'artwork'
       ? `https://sourcelibrary.org${item.link || `/book/${item.bookId}`}`
       : `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
+    // A standalone artwork IS its own record — there is no separate book to
+    // point at, so book_url mirrors the canonical /artwork URL rather than
+    // minting a second /book/<id> twin for the client to cite.
     book_url: item.bookId
       ? (item.source === 'artwork'
-        ? `https://sourcelibrary.org/book/${item.bookId}`
+        ? `https://sourcelibrary.org${item.link || `/book/${item.bookId}`}`
         : `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}`)
       : undefined,
   })) || [];

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2,12 +2,13 @@ import { Suspense, cache } from 'react';
 import { Metadata } from 'next';
 import { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { displayPublished, citationYear } from '@/lib/publication-date';
 import { isHiddenBook } from '@/lib/book-access';
+import { artworkRedirectSlug } from '@/lib/artwork-slug';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { getBookDetail, browseBooks, getLanguageCounts, type CatalogBook } from '@/lib/books-catalog';
 import { Calendar, Globe, FileText, BookMarked, Images, BookOpen } from 'lucide-react';
@@ -2341,6 +2342,21 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   // (not on a session check) keeps the public route statically cacheable.
   if (isHiddenBook(earlyBook) && !allowHidden) {
     notFound();
+  }
+
+  // Artworks have their own canonical route. /book/<slug> renders them too
+  // (BookInfo branches to <ArtworkInfo> on resource_type), so every artwork had
+  // TWO fully-rendering URLs, each emitting a self-referential canonical — the
+  // duplicate-content shape Google penalises. Send the /book form to /artwork.
+  //
+  // Deliberately NOT applied when embedded: `/embed/[tenant]/book/[slug]` re-exports
+  // this component, and there is no `/embed/[tenant]/artwork` route — redirecting a
+  // partner subdomain's reader out of its embed shell breaks the tenant lockdown.
+  // Editor preview routes (previewProposed/allowHidden) are excluded for the same
+  // reason: /artwork has no preview twin, so a redirect would 404 the editor.
+  if (!isEmbedded && !previewProposed && !allowHidden) {
+    const artSlug = artworkRedirectSlug(earlyBook as unknown as { content_type?: string; resource_type?: string; slug?: string });
+    if (artSlug) redirect(`/artwork/${artSlug}`);
   }
 
   return (

--- a/src/lib/artwork-slug.ts
+++ b/src/lib/artwork-slug.ts
@@ -29,6 +29,34 @@ export interface ArtworkCandidate {
   visible?: boolean | null;
 }
 
+/**
+ * Where a `/book/<id>` request should be sent instead, or null to render it as a book.
+ *
+ * `/book/[id]` renders artworks too (BookInfo branches to <ArtworkInfo> on
+ * `resource_type`), so every artwork had two fully-rendering URLs, each emitting a
+ * self-referential canonical. This is the predicate that collapses them onto /artwork.
+ *
+ * It has to agree with BOTH ends or it strands a working page:
+ *   - the `isVisualArt` branch in src/app/book/[id]/page.tsx — what /book renders as art
+ *   - getArtwork() in src/app/artwork/[slug]/page.tsx — what /artwork will accept:
+ *     `resource_type` present, `content_type !== 'book'`, and matched BY SLUG ONLY
+ * Anything failing either test keeps its /book rendering. A redirect into a 404 is
+ * strictly worse than the duplicate URL this cleans up, so every branch here fails
+ * toward "keep rendering where you are".
+ */
+export function artworkRedirectSlug(book: {
+  content_type?: string | null;
+  resource_type?: string | null;
+  slug?: string | null;
+}): string | null {
+  // 'text' is handled by TextReader upstream; 'book' is refused by /artwork outright.
+  if (book.content_type === 'text' || book.content_type === 'book') return null;
+  // Mirrors isVisualArt: a resource_type that is neither of the two textual kinds.
+  if (!book.resource_type || book.resource_type === 'printed_book' || book.resource_type === 'manuscript') return null;
+  // /artwork resolves by slug ($in on [slug, `art-${slug}`]), never by id.
+  return book.slug || null;
+}
+
 // Unconstrained in T so callers keep their own document type (the route passes
 // raw Mongo documents straight through to the renderer); the two fields it
 // actually reads are narrowed internally.

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -48,7 +48,13 @@ export function artworkToGalleryItem(a: any) {
     description: a.summary || a.display_title || a.title || '',
     type: a.resource_type,
     source: 'artwork' as const,
-    link: `/book/${a.slug || a.id}`,
+    // /artwork is the canonical route for a standalone artwork. This field is
+    // consumed by GalleryClient tiles AND handed to MCP clients verbatim as the
+    // public URL, so a `/book/...` here is how AI answers ended up citing the
+    // non-canonical twin. `/artwork` also resolves on tenant subdomains.
+    // Falls back to the id only when a slug is missing — /artwork matches by
+    // slug, so an id-only record has to keep the /book form.
+    link: a.slug ? `/artwork/${a.slug}` : `/book/${a.id}`,
     likeCount: 0,
     likedByVisitor: false,
   };

--- a/tests/unit/artwork-canonical-url.test.ts
+++ b/tests/unit/artwork-canonical-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { artworkRedirectSlug } from '@/lib/artwork-slug';
+import { artworkToGalleryItem } from '@/lib/gallery-merge';
+
+/**
+ * Every standalone artwork had TWO fully-rendering URLs — `/artwork/<slug>` and
+ * `/book/<slug>` — because `/book/[id]` branches to <ArtworkInfo> on `resource_type`
+ * rather than refusing artworks. Both routes emitted a self-referential canonical, and
+ * the gallery/MCP layer handed out the `/book` form, so AI clients cited the twin.
+ *
+ * These are the two ends of the fix. They are pinned separately because they fail in
+ * opposite directions: the emitter failing means a non-canonical URL leaks out again
+ * (cosmetic, recoverable); the redirect predicate failing means a live page 404s
+ * (visible, and worse than the problem it fixes).
+ */
+
+const artwork = { content_type: 'artwork', resource_type: 'print', slug: 'art-ouroboros-emblem-1598' };
+
+describe('artworkRedirectSlug — what /book/[id] hands to /artwork', () => {
+  it('redirects a standalone artwork to its slug', () => {
+    expect(artworkRedirectSlug(artwork)).toBe('art-ouroboros-emblem-1598');
+  });
+
+  it('redirects the manuscript-illumination kind too (resource_type is not one enum)', () => {
+    // Real record: e-codices zbz-Ms-Rh-0172 f.44, a folio of Aurora consurgens.
+    expect(artworkRedirectSlug({
+      content_type: 'artwork', resource_type: 'manuscript-illumination', slug: 'e-codices-zbz-ms-rh-0172-044-max-copy',
+    })).toBe('e-codices-zbz-ms-rh-0172-044-max-copy');
+  });
+
+  it('leaves readable books alone', () => {
+    expect(artworkRedirectSlug({ resource_type: 'printed_book', slug: 'pandora-reusner' })).toBeNull();
+    expect(artworkRedirectSlug({ resource_type: 'manuscript', slug: 'aurora-consurgens' })).toBeNull();
+    expect(artworkRedirectSlug({ slug: 'no-resource-type-at-all' })).toBeNull();
+  });
+
+  it('leaves text-only works alone — TextReader owns them, /artwork would 404', () => {
+    expect(artworkRedirectSlug({ content_type: 'text', resource_type: 'text', slug: 'javanese-wikisource' })).toBeNull();
+  });
+
+  it('never redirects a content_type:"book" record — getArtwork() refuses those', () => {
+    // The guard that keeps a mis-tagged textual book from being bounced into a 404.
+    expect(artworkRedirectSlug({ content_type: 'book', resource_type: 'print', slug: 'some-book' })).toBeNull();
+  });
+
+  it('keeps the /book form when there is no slug — /artwork matches by slug only', () => {
+    expect(artworkRedirectSlug({ content_type: 'artwork', resource_type: 'print', slug: null })).toBeNull();
+  });
+});
+
+describe('artworkToGalleryItem — the URL handed to tiles and MCP clients', () => {
+  it('emits the canonical /artwork link', () => {
+    expect(artworkToGalleryItem({ id: 'abc123', slug: 'art-ouroboros-emblem-1598', title: 'Ouroboros' }).link)
+      .toBe('/artwork/art-ouroboros-emblem-1598');
+  });
+
+  it('falls back to /book/<id> only when the record has no slug', () => {
+    expect(artworkToGalleryItem({ id: 'abc123', title: 'Untitled' }).link).toBe('/book/abc123');
+  });
+});


### PR DESCRIPTION
## What

Every standalone artwork had **two fully-rendering public URLs**. `/book/[id]` never refused artworks — it derives `isVisualArt` from `resource_type` and renders the same `<ArtworkInfo>` that `/artwork/[slug]` does. Both routes then emitted a **self-referential canonical**, so search engines saw two canonical URLs for one object across ~24.9K artworks.

The `/book` form wasn't merely reachable, it was **advertised**: `gallery-merge` built every standalone-artwork tile with `link: /book/<slug>`, and the MCP server passed that straight through to clients as the public URL (plus a second `/book/<id>` as `book_url`). That's why AI answers cite the non-canonical twin — the site's own UI surfaces (collection cards, `CollectionAllBooks`, author pages, search image cards) have used `/artwork/` all along.

Found while asking why `sourcelibrary.org/book/e-codices-zbz-ms-rh-0172-044-max-copy` isn't an `/artwork/` URL.

## Changes

- `src/lib/gallery-merge.ts` — emit `/artwork/<slug>`, falling back to `/book/<id>` only when a record has no slug (`/artwork` resolves by slug, never by id)
- `src/app/api/mcp/route.ts` — `book_url` mirrors the canonical artwork URL rather than minting a `/book/<id>` twin for a record that has no separate book
- `src/app/book/[id]/page.tsx` — redirect artworks to `/artwork/<slug>` **before streaming**, so the status is a real 308 rather than a 200 with redirect UI
- `src/lib/artwork-slug.ts` — the predicate lives beside `pickArtworkRecord`, which already owns "how artwork slugs resolve"
- `tests/unit/artwork-canonical-url.test.ts` — pins both ends

## Safety

The redirect is **deliberately not applied when embedded**. `embed/[tenant]/book/[slug]` re-exports this component and there is no embed artwork route, so redirecting a partner subdomain's reader out of its embed shell would break tenant lockdown. Editor preview routes are excluded for the same reason — `/artwork` has no preview twin.

`artworkRedirectSlug` must agree with **both** the `isVisualArt` branch and `getArtwork()`'s accept rules (`resource_type` present, `content_type !== 'book'`, matched by slug only). Every branch fails toward "keep rendering where you are" — a redirect into a 404 is strictly worse than the duplicate URL this cleans up.

Verified `/artwork/<slug>` returns 200 on `bph.sourcelibrary.org`, so the new gallery link is safe on tenant hosts too.

## Out of scope

Artworks still don't link to the source book they're a folio or plate **of** — `books.source_book` is set on **5 of 24,912** artworks. Filed separately; that's the substantive fix, this is the plumbing.

## Test plan

- `npx tsc --noEmit` clean
- `npx vitest run tests/unit/artwork-canonical-url.test.ts tests/unit/artwork-slug-shadow.test.ts` — 14 passed
- After deploy: `/book/art-theosophie-und-alchemie-ouroboros-emblem-1598` should 308 to `/artwork/...`; the same path on `bph.sourcelibrary.org` should still render 200 in the embed shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)