### PR TITLE
fix(artwork): make the /book → /artwork canonicalization a 308, not a 307

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { bylineClaimsAuthorship } from '@/lib/corporate-bylines';
 import { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
@@ -2378,7 +2378,10 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   // reason: /artwork has no preview twin, so a redirect would 404 the editor.
   if (!isEmbedded && !previewProposed && !allowHidden) {
     const artSlug = artworkRedirectSlug(earlyBook as unknown as { content_type?: string; resource_type?: string; slug?: string });
-    if (artSlug) redirect(`/artwork/${artSlug}`);
+    // 308, not 307: this is a canonicalization, so search engines must transfer
+    // authority to /artwork rather than keep indexing both. redirect() defaults to
+    // a temporary 307, which consolidates nothing — the whole point of the change.
+    if (artSlug) permanentRedirect(`/artwork/${artSlug}`);
   }
 
   return (


### PR DESCRIPTION
Follow-up to #4036.

That PR shipped the redirect with Next's `redirect()`, which defaults to a **temporary 307**. Verified on prod after deploy: `/book/<artwork-slug>` answered `307 → /artwork/<slug>`.

A 307 consolidates nothing — search engines keep both URLs indexed and split authority between them, which is the exact duplicate-content problem #4036 set out to fix. The redirect looked correct to a human following it and was inert for the only audience it was written for.

`permanentRedirect()` emits 308. Behaviour is otherwise unchanged: still skipped when embedded and on editor preview routes, still slug-only.

## Verified on prod (pre-change state)

| URL | Result |
|---|---|
| `sourcelibrary.org/book/<artwork>` | 307 → `/artwork/<slug>` (this PR makes it 308) |
| `sourcelibrary.org/book/zurich-zentralbibliothek-ms-rh-172-aquinas` | 200, no redirect |
| `bph.sourcelibrary.org/book/<artwork>` | redirect stays **on-host**, follows to 200 |
| `sourcelibrary.org/embed/bph/book/<artwork>` | 200, no redirect — embed guard holds |

The BPH row is the one worth noting: `/book/` is a *global* route on tenant subdomains (per the proxy's "Phase Final" comment), so `isEmbedded` is false there and the redirect does fire — but it resolves relative, stays on `bph.sourcelibrary.org`, and lands on a 200. No off-subdomain leak. The true embed route is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)