### PR TITLE
fix(slugs): transliterate Latin letters NFD cannot decompose, instead of deleting them

### DIFF
--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -60,18 +60,48 @@ export function isPlaceholderSlug(slug: string | null | undefined): boolean {
 }
 
 /**
+ * Latin letters that are NOT a base letter plus a combining mark, so NFD cannot
+ * decompose them and the `[^a-z0-9]` strip below DELETES them outright.
+ *
+ * That silent deletion lands hardest on exactly this library's corpus:
+ * `Ægyptiaca` slugged to `gyptiaca`, `iustitiæ christianæ quæ` to
+ * `iustiti christian qu`, `Œuvres` to `uvres`, and `Straßburg` to `stra-burg` —
+ * where the deletion also SPLIT the word, because a run of non-matching characters
+ * collapses to a single hyphen.
+ *
+ * `ſ` (long s) is here deliberately: early-modern printing uses it throughout, and
+ * `ſuper` losing its first letter is worse than a diacritic dropping an accent.
+ *
+ * Keyed on the LOWERCASE form — `.toLowerCase()` runs before this map and folds
+ * Æ→æ, Œ→œ, ẞ→ß, so uppercase inputs are already covered.
+ */
+const LATIN_TRANSLITERATIONS: Record<string, string> = {
+  'æ': 'ae', 'œ': 'oe', 'ß': 'ss',
+  'ø': 'o', 'þ': 'th', 'ð': 'd', 'ł': 'l', 'đ': 'd',
+  'ħ': 'h', 'ı': 'i', 'ĸ': 'k', 'ŋ': 'n', 'ſ': 's',
+};
+const TRANSLITERATION_RE = new RegExp(`[${Object.keys(LATIN_TRANSLITERATIONS).join('')}]`, 'g');
+
+/**
  * Sanitize text into a URL-safe slug segment.
  * - Lowercases
  * - Strips diacritics (ü → u, é → e)
+ * - Transliterates non-decomposable Latin letters (æ → ae, ß → ss)
  * - Replaces non-alphanumeric with hyphens
  * - Collapses multiple hyphens
  * - Trims to maxLength at a word boundary
+ *
+ * Non-Latin scripts (Greek, Hebrew, CJK, Tibetan…) still sanitize to nothing — that is
+ * the deliberate behaviour `generateBookSlug` handles by falling back to the author
+ * segment. This map only rescues Latin letters a reader expects to survive.
  */
 function slugifyText(text: string, maxLength: number): string {
   let slug = text
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '') // strip diacritics
     .toLowerCase()
+    // Must run BEFORE the [^a-z0-9] strip, or these letters are already gone.
+    .replace(TRANSLITERATION_RE, (ch) => LATIN_TRANSLITERATIONS[ch])
     .replace(/[^a-z0-9]+/g, '-')    // non-alphanum → hyphen
     .replace(/^-+|-+$/g, '')         // trim leading/trailing hyphens
     .replace(/-{2,}/g, '-');         // collapse double hyphens

--- a/tests/unit/slugify.test.ts
+++ b/tests/unit/slugify.test.ts
@@ -33,6 +33,47 @@ describe('generateBookSlug', () => {
       .toBe('corpus-hermeticum');
   });
 
+  /**
+   * Latin letters NFD cannot decompose (æ, œ, ß, ø, þ, ð, ł, đ, ſ) were DELETED by the
+   * `[^a-z0-9]` strip rather than transliterated — `Ægyptiaca` became `gyptiaca`. Two
+   * properties matter: the letter survives at all, and it does not SPLIT the word it
+   * sits inside (a run of stripped characters collapses to one hyphen).
+   */
+  it('transliterates æ rather than deleting it (Kircher, Oedipus Ægyptiacus)', () => {
+    expect(generateBookSlug('Ægyptiaca', 'Athanasius Kircher')).toBe('aegyptiaca-kircher');
+    expect(generateBookSlug('De priori iustitiæ christianæ parte, quæ', 'Jean Calvin'))
+      .toBe('de-priori-iustitiae-christianae-parte-quae-calvin');
+  });
+
+  it('does not split a word around the letter (ß was breaking Straßburg in two)', () => {
+    expect(generateBookSlug('Straßburg', 'Johann Grüninger')).toBe('strassburg-gruninger');
+  });
+
+  it('handles œ, þ/ð, ł, đ', () => {
+    expect(generateBookSlug('Œuvres complètes', 'Blaise Pascal')).toBe('oeuvres-completes-pascal');
+    expect(generateBookSlug('Þriðja bók', 'Snorri Sturluson')).toBe('thridja-bok-sturluson');
+    expect(generateBookSlug('Łukasz', 'Jan Kowalski')).toBe('lukasz-kowalski');
+    expect(generateBookSlug('Đại Việt', 'Ngo Si Lien')).toBe('dai-viet-lien');
+  });
+
+  it('transliterates the long s used throughout early-modern printing', () => {
+    expect(generateBookSlug('Ars ſignorum', 'George Dalgarno')).toBe('ars-signorum-dalgarno');
+  });
+
+  it('leaves ASCII and combining-diacritic slugs byte-identical', () => {
+    // Guard on the far larger set of already-published URLs: this change must be
+    // forward-only for new imports, never a rewrite of live slugs.
+    expect(generateBookSlug('Atalanta Fugiens', 'Michael Maier')).toBe('atalanta-fugiens-maier');
+    expect(generateBookSlug('Über die Natur', 'Johann Müller')).toBe('uber-die-natur-muller');
+    expect(generateBookSlug('Kāmasūtra of Vātsyāyana', 'Vātsyāyana'))
+      .toBe('kamasutra-of-vatsyayana-vatsyayana');
+  });
+
+  it('still degrades a wholly non-Latin title to the author segment', () => {
+    // Deliberate documented behaviour — not something this map should change.
+    expect(generateBookSlug('Τμῆμα πρῶτον', 'Markos Mousouros')).toBe('mousouros');
+  });
+
   it('handles Anonymous author (keeps it in slug unlike Unknown)', () => {
     // extractLastName returns 'anonymous' (lowercased), but only 'unknown' is stripped
     expect(generateBookSlug('Some Text', 'Anonymous'))


### PR DESCRIPTION
## The bug

`slugifyText` normalizes NFD and strips combining marks, so `ü→u` and `ā→a` work fine. But **æ, œ, ß, ø, þ, ð, ł, đ and ſ are single code points, not base+combining** — NFD leaves them intact, and the following `[^a-z0-9]` strip deletes them outright.

Measured against real titles in the corpus:

| Title | Slug today |
|---|---|
| `Ægyptiaca` | `gyptiaca` |
| `De priori iustitiæ christianæ parte, quæ` | `de-priori-iustiti-christian-parte-qu` |
| `Œuvres complètes` | `uvres-completes` |
| `Straßburg` | `stra-burg` |
| `Þriðja bók` | `ri-ja-bok` |
| `Łukasz` | `ukasz` |

Two distinct harms: the letter vanishes, **and** because a run of stripped characters collapses to a single hyphen it also *splits the word* — `stra-burg`. Latin `æ` is everywhere in this library's early-modern holdings, so this hits the titles the collection is actually built on. `ſ` (long s) is in the map deliberately: early-modern printing uses it throughout, and `ſuper` losing its first letter is worse than a dropped accent.

## Safety — forward-only

Book slugs are **stored on the document**, so nothing already published changes; only newly imported books get the better slug. A test pins that ASCII and combining-diacritic slugs stay **byte-identical**, so this cannot silently rewrite live URLs:

```
generateBookSlug('Atalanta Fugiens', 'Michael Maier')  === 'atalanta-fugiens-maier'
generateBookSlug('Über die Natur', 'Johann Müller')    === 'uber-die-natur-muller'
```

Also pinned: a wholly non-Latin title still degrades to the author segment, which is deliberate documented behaviour this map should not change.

## Explicitly out of scope

- **`authorSlug()` has the same bug**, but it is computed **live on every render** rather than stored — changing it would rewrite existing `/author/` URLs and needs the canonical-redirect map regenerated. Separate PR, genuinely different risk profile.
- **33 files build a slug with their own `[^a-z0-9]` regex** and never import this helper — and most of them live in `scripts/import/`, i.e. the exact path where a bad slug becomes a permanent public URL. (I first said ~54; that counted every file matching the regex, including normalization keys that are not slugs. 53 files match, 6 of those also import the helper, and 33 both build a `slug` and don't.) That is what produced `/book/kmastra-of-vtsyyana-with-jayamagal-commentary` for *"Kāmasūtra of Vātsyāyana"* — this helper renders that title correctly as `kamasutra-of-vatsyayana`, and a test now pins that too. Consolidating those call sites is its own change.

## Test plan

- `npx vitest run tests/unit/slugify.test.ts` — 24 passed
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
