### PR TITLE
fix(deploy): don't purge the CDN when the build failed, or when the origin can't refill it

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "deploy:prod": "./scripts/deploy-prod.sh",
+    "deploy:purge-warm": "./scripts/purge-warm.sh",
     "lint": "eslint",
     "test": "vitest run && vitest run --config vitest.integration.config.ts",
     "test:smoke": "vitest run --config vitest.smoke.config.ts",

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -113,8 +113,13 @@ npx tsc --noEmit
 #    Do NOT let a nonzero exit from the CLI abort the script before the purge:
 #    `vercel --prod` can deploy SUCCESSFULLY and then exit nonzero on a
 #    post-deploy status-poll timeout (ETIMEDOUT against api.vercel.com — bit us
-#    2026-06-04). Skipping the purge is far worse than purging after a failed
-#    deploy (a purge is always safe; stale HTML pointing at purged CSS is not).
+#    2026-06-04), and skipping the purge after a real deploy leaves the
+#    stale-HTML/dead-CSS gap this script exists to close.
+#
+#    This used to be justified as "a purge is always safe". It is not, and that
+#    belief cost us on 2026-08-18: a purge is only safe when the deploy actually
+#    shipped AND the origin can re-render what it evicts. Both are now checked —
+#    the ship test is below, the origin-health gate lives in purge-warm.sh.
 #    Resolve the CLI: prefer a global `vercel`, fall back to `npx vercel` so the
 #    script self-heals if ~/.npm-global/bin/vercel ever goes dangling (a removed
 #    global package left a broken symlink behind — bit us 2026-06-26).
@@ -126,39 +131,78 @@ else
 fi
 echo "▸ Deploying to production (${VERCEL[*]} --prod)…"
 DEPLOY_EXIT=0
-"${VERCEL[@]}" --prod || DEPLOY_EXIT=$?
-if [ "$DEPLOY_EXIT" -ne 0 ]; then
-  echo "  ⚠ vercel exited $DEPLOY_EXIT — verifying whether the deployment actually shipped…" >&2
-  PROD_OK=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://sourcelibrary.org/" || echo 000)
-  echo "  prod / responds: HTTP $PROD_OK — continuing to purge + warm regardless." >&2
-fi
+DEPLOY_LOG="$(mktemp -t deploy-prod)"
+trap 'rm -f "$DEPLOY_LOG"' EXIT
+"${VERCEL[@]}" --prod 2>&1 | tee "$DEPLOY_LOG" || DEPLOY_EXIT=${PIPESTATUS[0]}
 
-# 6. Purge the CDN so cached HTML can't outlive the assets it references.
-echo "▸ Purging Cloudflare cache (purge_everything)…"
-PURGE=$(curl -s -X POST \
-  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  --data '{"purge_everything":true}')
-if echo "$PURGE" | grep -q '"success":true'; then
-  echo "  ✓ Cloudflare cache purged."
+# DID IT ACTUALLY SHIP?
+#
+# The old check here curled `https://sourcelibrary.org/` and, on HTTP 200,
+# announced "continuing to purge + warm regardless". That test cannot fail: a
+# 200 from the alias only proves the PREVIOUS deployment is still serving, which
+# is exactly as true when the build died as when it succeeded. On 2026-08-18 it
+# reported "shipped" for three consecutive builds that all failed prerendering,
+# and purged the CDN each time.
+#
+# Ask Vercel about the deployment we just created instead. `vercel --prod` prints
+# its URL, so inspect that specific deployment rather than the alias.
+DEPLOY_SHIPPED="unknown"
+DEPLOY_URL="$(grep -oE 'https://[a-z0-9-]+\.vercel\.app' "$DEPLOY_LOG" | tail -1 || true)"
+if [ "$DEPLOY_EXIT" -ne 0 ]; then
+  echo "  ⚠ vercel exited $DEPLOY_EXIT — asking Vercel whether the deployment shipped…" >&2
+  if [ -n "$DEPLOY_URL" ]; then
+    INSPECT="$("${VERCEL[@]}" inspect "$DEPLOY_URL" 2>&1 || true)"
+    if grep -qE '●[[:space:]]*Ready' <<<"$INSPECT"; then
+      DEPLOY_SHIPPED="yes"
+      echo "  → $DEPLOY_URL is Ready: it SHIPPED despite the nonzero exit (post-deploy poll timeout)." >&2
+    elif grep -qE '●[[:space:]]*(Error|Canceled)' <<<"$INSPECT"; then
+      DEPLOY_SHIPPED="no"
+      echo "  → $DEPLOY_URL reports Error/Canceled: the build FAILED, nothing new is live." >&2
+    else
+      echo "  → could not read a state from 'vercel inspect $DEPLOY_URL'." >&2
+    fi
+  else
+    echo "  → no deployment URL in the CLI output to inspect." >&2
+  fi
 else
-  echo "  ✗ Cloudflare purge failed: $PURGE" >&2
-  echo "    (Pages may serve stale HTML/dead CSS until this is re-run.)" >&2
-  exit 1
+  DEPLOY_SHIPPED="yes"
 fi
 
-# 7. Re-warm top pages so the next visitor gets a fresh, styled page from cache.
-echo "▸ Warming caches (/api/deploy-warm)…"
-WARM_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-  "https://sourcelibrary.org/api/deploy-warm" \
-  -H "Authorization: Bearer ${CRON_SECRET}" \
-  -H "Content-Type: application/json" \
-  --max-time 300 || true)
-echo "  deploy-warm → HTTP $WARM_CODE"
+# A FAILED BUILD MUST NOT PURGE.
+#
+# The original rationale ("a purge is always safe; stale HTML pointing at purged
+# CSS is not") holds only while the ORIGIN CAN REFILL THE CACHE. When the build
+# failed, no new asset hashes exist, so there is no stale-HTML/dead-CSS gap to
+# close — the purge has nothing to fix and every cached page to lose. And if the
+# origin is unhealthy (see the health gate below), purging is actively harmful.
+if [ "$DEPLOY_SHIPPED" = "no" ]; then
+  echo "" >&2
+  echo "✗ Build failed — skipping the Cloudflare purge and the warm." >&2
+  echo "  Nothing new shipped, so there is no dead-CSS gap to close, and purging" >&2
+  echo "  would evict good cached pages for no benefit." >&2
+  echo "  Inspect the failure:  ${VERCEL[*]} inspect --logs $DEPLOY_URL" >&2
+  exit "$DEPLOY_EXIT"
+fi
+# 6. Purge + warm, behind an origin-health gate.
+#
+#    Delegated to scripts/purge-warm.sh so the SAME gate and the same purge run
+#    whether they are reached through a deploy or invoked standalone for
+#    recovery. The gate refuses to purge when the origin cannot re-render — see
+#    that script for why `/` is the wrong thing to probe.
+echo "▸ Purging + warming…"
+PW_EXIT=0
+./scripts/purge-warm.sh || PW_EXIT=$?
+if [ "$PW_EXIT" -ne 0 ]; then
+  echo "" >&2
+  echo "⚠ The deployment SHIPPED but the purge/warm did not complete." >&2
+  echo "  Until it runs, cached HTML can point at asset hashes this deploy replaced" >&2
+  echo "  (the unstyled-page failure this script exists to prevent)." >&2
+  echo "  Re-run once the cause is cleared:  npm run deploy:purge-warm" >&2
+  exit "$PW_EXIT"
+fi
 
 if [ "$DEPLOY_EXIT" -ne 0 ]; then
-  echo "⚠ Purge + warm completed, but the vercel CLI exited $DEPLOY_EXIT — verify the deployment shipped (vercel ls sourcelibrary-v2 | head -2)." >&2
-  exit "$DEPLOY_EXIT"
+  echo "✓ Deploy shipped (vercel CLI exited $DEPLOY_EXIT on a post-deploy poll, but the deployment is Ready) → purged → warmed."
+  exit 0
 fi
 echo "✓ Production deploy complete (deployed → purged → warmed)."

--- a/scripts/purge-warm.sh
+++ b/scripts/purge-warm.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Purge the Cloudflare CDN and re-warm the top pages.
+#
+# Normally invoked by scripts/deploy-prod.sh as its last two steps. Standalone,
+# it is the RECOVERY tool for the case where a deploy shipped but the purge did
+# not run — a CLI crash mid-poll, or the origin-health gate below refusing to
+# purge while the database was unreachable. Run it once the origin recovers.
+#
+#   npm run deploy:purge-warm
+#
+# Requires CLOUDFLARE_API_TOKEN (Cache Purge scope — CF_API_TOKEN is WAF-scoped
+# only and fails auth here), CLOUDFLARE_ZONE_ID and CRON_SECRET in
+# .env.production.local.
+#
+# FORCE_PURGE=1 skips the origin-health gate.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -f .env.production.local ]; then
+  echo "✗ .env.production.local not found — cannot read CLOUDFLARE_API_TOKEN/ZONE_ID/CRON_SECRET." >&2
+  exit 1
+fi
+set -a; source .env.production.local; set +a
+
+for var in CLOUDFLARE_API_TOKEN CLOUDFLARE_ZONE_ID CRON_SECRET; do
+  if [ -z "${!var:-}" ]; then
+    echo "✗ $var is not set in .env.production.local." >&2
+    exit 1
+  fi
+done
+
+# ORIGIN HEALTH GATE — a purge is only safe if the origin can refill the cache.
+#
+# `purge_everything` throws away every cached page and bets the origin can
+# re-render them. On 2026-08-18 Atlas was unreachable from Vercel (dynamic API
+# routes 500ing after a 15s connection timeout) while CDN-cached pages still
+# served fine at 200 — so the cache was the only thing keeping the site usable,
+# and deploy-prod.sh purged it twice on failed builds.
+#
+# Probe something DATA-BACKED and uncacheable, never `/`: a cached homepage
+# answers 200 with the database on fire, which is exactly how the old check in
+# deploy-prod.sh fooled itself.
+if [ "${FORCE_PURGE:-}" != "1" ]; then
+  echo "▸ Checking the origin can refill the cache…"
+  HEALTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 40 \
+    -H 'Cache-Control: no-cache' -H 'Pragma: no-cache' \
+    -A 'Mozilla/5.0 (deploy purge origin health check)' \
+    "https://sourcelibrary.org/api/books/library?limit=1&_purgecheck=$(date +%s)" || echo 000)
+  if [ "$HEALTH_CODE" = "200" ]; then
+    echo "  ✓ origin healthy (data route → HTTP $HEALTH_CODE)."
+  else
+    echo "" >&2
+    echo "✗ Origin data route returned HTTP $HEALTH_CODE — REFUSING to purge." >&2
+    echo "  Cached pages may currently be the only thing serving readers; purging" >&2
+    echo "  now would evict them with nothing able to re-render them." >&2
+    echo "  Usual cause: the database is unreachable from Vercel (check the Atlas" >&2
+    echo "  IP access list and cluster state), not a problem with the deploy." >&2
+    echo "  Re-run this once the origin recovers, or FORCE_PURGE=1 to override." >&2
+    exit 1
+  fi
+fi
+
+echo "▸ Purging Cloudflare cache (purge_everything)…"
+PURGE=$(curl -s -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"purge_everything":true}')
+if echo "$PURGE" | grep -q '"success":true'; then
+  echo "  ✓ Cloudflare cache purged."
+else
+  echo "  ✗ Cloudflare purge failed: $PURGE" >&2
+  echo "    (Pages may serve stale HTML/dead CSS until this is re-run.)" >&2
+  exit 1
+fi
+
+echo "▸ Warming caches (/api/deploy-warm)…"
+WARM_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  "https://sourcelibrary.org/api/deploy-warm" \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H "Content-Type: application/json" \
+  --max-time 300 || true)
+echo "  deploy-warm → HTTP $WARM_CODE"
+if [ "$WARM_CODE" != "200" ]; then
+  # Non-fatal: the purge is the part that must not be skipped. A failed warm
+  # only means the first visitor to each page pays the render cost.
+  echo "  ⚠ warm did not return 200 — pages will re-render on first visit." >&2
+fi
+
+echo "✓ Purge + warm complete."


### PR DESCRIPTION
Two defects in `scripts/deploy-prod.sh`, both exposed today when three consecutive production builds failed while Atlas was unreachable from Vercel.

## 1. The "did it ship?" check could not fail

On a nonzero `vercel` exit it curled `https://sourcelibrary.org/` and, on HTTP 200, printed *"continuing to purge + warm regardless"*.

A 200 from the alias only proves the **previous** deployment is still serving — equally true whether the build succeeded or died. So the check reported "shipped" for three builds that never landed, and purged the CDN each time.

Now it captures the deployment URL the CLI prints and asks Vercel about **that deployment**:

- `● Ready` → it shipped despite the nonzero exit (the real 2026-06-04 poll-timeout case this branch exists for) → purge
- `● Error` / `● Canceled` → nothing shipped → skip the purge, exit with the failure

## 2. "A purge is always safe" was the stated rationale. It is false.

The old comment justified purging unconditionally that way. `purge_everything` discards every cached page and bets the origin can re-render them — and today that bet was unpayable: dynamic API routes were 500ing after a 15s Mongo connection timeout **while CDN-cached pages still served at 200**. The cache was the only thing keeping the site usable, and this script purged it twice.

Added an **origin-health gate** that probes a data-backed, cache-busted route (`/api/books/library?limit=1`) instead of `/`. A cached homepage answers 200 with the database on fire — precisely how the old check fooled itself. Non-200 → refuse to purge, and say why (pointing at the Atlas IP access list, the usual cause). `FORCE_PURGE=1` overrides.

## Also: a real recovery command

Purge + warm now live in `scripts/purge-warm.sh` (`npm run deploy:purge-warm`), so the same gate runs whether reached through a deploy or standalone. That is the recovery path for *"the deploy shipped but the purge didn't run"* — which CLAUDE.md currently documents as a hand-pasted multi-line curl, the shape that once let a purge fail silently against a dead token for weeks.

## Verification

- The gate's probe returned **500** during the outage and **200** after recovery, so both branches are driven by a real signal rather than a hypothetical.
- `bash -n` clean on both scripts; `package.json` still parses.
- Deliberately not exercised end-to-end against a *failing* build, since manufacturing one costs a 6-minute production build; the branch is a single string comparison on an inspected state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)