### PR TITLE
audit(imprint): 'shares no tokens' is a string verdict, not a conflict (#4043)

### DIFF
--- a/.claude/docs/invariants/field-sprawl.md
+++ b/.claude/docs/invariants/field-sprawl.md
@@ -92,8 +92,19 @@ those columns *say*, and a consolidation that assumes they say the same thing
 loses data silently. Measured on the imprint family, 2026-08-18
 (`scripts/audit/imprint-reconciliation.mjs`, #4043): **2,533** books carry two or
 more place fields, only 1,634 agree once case and catalogue apparatus are
-normalised, and **539 name flatly different cities**. Of 916 books holding both
+normalised, and **539 land in the `disjoint` bucket**. Of 916 books holding both
 printer fields, **151** agree.
+
+**But `disjoint` is a verdict about strings, not about bibliography, and reading
+it as one overstates the conflict roughly twofold.** Classified 2026-08-18,
+those 539 are: ~10% a *no-place marker against a city* (`s.l. (Germany)` vs
+`Danzig`), **≥40% an exonym or orthographic variant** (`Roma`/`Rome`,
+`Nürnberg`/`Nuremberg`, `Strassburg`/`Strasbourg`, `z.p.`/`n.p.`), and at most
+~50% genuinely different places — a ceiling, because the residue still visibly
+contains exonyms the edit distance missed (`Venezia`/`Venice`). Only that last
+bucket needs a person. **Before sizing a review queue off a normaliser's
+output, classify what the disagreements ARE**: a queue of 539 that is really
+~270 sends someone to adjudicate Rome against Roma.
 
 **Some of that disagreement is knowledge, not error.** *De occulta philosophia*
 holds `[Cologne]` in one field and `Lyon` in another — a fictitious imprint and
@@ -104,6 +115,18 @@ the most interesting bibliography we hold. So: measure the disagreement shapes
 choosing a canonical field, and check whether the conflict encodes a distinction
 worth keeping — *stated* vs *established* vs *conjectural* — rather than one
 value being wrong. Normalisation for comparison must never be written back.
+
+**A field's tier does not tell you the value's ROLE, so tier precedence is not a
+merge rule.** The obvious hypothesis — catalogue beats OCR beats import — is
+falsified in the destructive direction on 54 measured books: the *catalogue*
+field holds `s.l. (Germany)` (a true statement that the title page names no
+place) while the *import* field holds `Danzig`, `Prague`, `Frankfurt`,
+`Amsterdam`, `Eichstätt`. Catalogue-wins overwrites a real city with "place
+unknown". The same field also carries plainly established values (`Roma`,
+`Strasbourg`), so the role is a property of the **value's own shape** — `s.l.` /
+`n.p.` / `z.p.` and `[…?]` mark *stated-absent* and *conjectural*; a bare
+place-name marks an assertion — and never of the column it sits in. Read the
+value, not the field name.
 
 Rule of thumb for routing: **fields that merely duplicate a fact belong to #3969;
 fields that disagree about one belong to #4043.**

--- a/scripts/audit/imprint-reconciliation.mjs
+++ b/scripts/audit/imprint-reconciliation.mjs
@@ -14,12 +14,20 @@
  *     publisher            15,042 books      TWO populations: name-forms AND raw imprint strings
  *
  *   2,533 books carry two or more place fields. Only 1,634 agree once case,
- *   diacritics and catalogue apparatus are normalised; 539 name flatly
- *   DIFFERENT cities. Of 916 books holding both printer fields, 151 agree.
+ *   diacritics and catalogue apparatus are normalised. Of 916 books holding
+ *   both printer fields, 151 agree.
+ *
  *   A consolidation that picks a field wins or loses those books silently, and
  *   a facet built over the un-merged fields would publish the disagreement to
  *   readers. So the merge needs an adjudication rule first, and the rule needs
  *   to be measured before it is written.
+ *
+ *   The residue is NOT all conflict. Of the 539 place pairs that share no
+ *   tokens, ~10% are a no-place marker against a city (`s.l. (Germany)` vs
+ *   `Danzig`) and ≥40% are the same city in two languages (`Roma`/`Rome`,
+ *   `Nürnberg`/`Nuremberg`). Reporting the raw bucket as a review queue would
+ *   send someone to adjudicate Rome against Roma, so classifyConflict() splits
+ *   those out: for place the human queue is 472, not 740.
  *
  * WHAT THIS REPORTS
  *   1. Coverage and overlap for every field in the family.
@@ -29,7 +37,8 @@
  *   3. Conflicts bucketed by SHAPE, because the shape decides who can resolve
  *      it: containment ("Basel" vs "Basileae, apud Petrum Pernam") is
  *      mechanical; two different cities is not.
- *   4. What a precedence rule would decide, and how many books it cannot.
+ *   4. Those shapes rolled into the three tiers of who can resolve them —
+ *      mechanically, with an authority file, or only by a person.
  *
  * NORMALISATION IS FOR COMPARISON ONLY, NEVER FOR STORAGE. `"Amsterdam"
  * [= Hannover]` is not noise — it is a catalogue's statement that the imprint
@@ -57,11 +66,18 @@ const MONGODB_URI = process.env.MONGODB_URI;
 const MONGODB_DB = process.env.MONGODB_DB || 'bookstore';
 
 /**
- * The family, in precedence order — strongest provenance first.
+ * The family, ordered by provenance strength — strongest first.
  *
- * The order is a HYPOTHESIS this script exists to test, not a settled rule.
- * It says: a value a human catalogue asserted beats one a model read off a
- * title page, which beats one an importer copied from provider metadata.
+ * This order was a hypothesis: a value a human catalogue asserted beats one a
+ * model read off a title page, which beats one an importer copied from provider
+ * metadata. **As a MERGE rule it is now falsified**, and in the destructive
+ * direction: on 53 books the catalogue field holds `s.l. (Germany)` (a true
+ * statement that the title page names no place) while the import field holds a
+ * real city — Danzig, Prague, Frankfurt, Amsterdam, Eichstätt. Catalogue-wins
+ * overwrites the city with "unknown". The same field elsewhere holds plainly
+ * established values (`Roma`, `Strasbourg`), so the value's ROLE is not a
+ * property of the column: read the value's own shape instead. The order below
+ * is kept because it still ranks how much to TRUST a value, not which one wins.
  * `writer` names the script that populates each field, because the provenance
  * layer cannot answer it reliably yet: `books.field_provenance` is on 69,778
  * books, but written by 81 independent writers in 164 key shapes, only 23.7%
@@ -97,7 +113,43 @@ function normalise(raw) {
     .trim();
 }
 
-/** Bucket a disagreement by the shape that decides who can resolve it. */
+/**
+ * Bibliographic markers for "the book itself states none" — `s.l.` (sine loco),
+ * `n.p.`, `z.p.` (zonder plaats), `o.O.` (ohne Ort) for place; `s.n.` (sine
+ * nomine) for printer. These are not values and must never be adjudicated
+ * against one as though two sources disagreed. A catalogue writing
+ * `s.l. (Germany)` asserts that the title page is silent, which is perfectly
+ * compatible with an importer knowing the city from elsewhere.
+ */
+const NO_VALUE_STATED = /^(n\s*p|s\s*l|z\s*p|s\s*d|s\s*n|sine loco|sine nomine|zonder plaats|ohne ort|no place|unknown)\b/;
+
+/** Levenshtein distance. Cheap at city-name lengths. */
+function editDistance(a, b) {
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = [i];
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+    }
+    prev = cur;
+  }
+  return prev[b.length];
+}
+
+/**
+ * Bucket a disagreement by the shape that decides who can resolve it.
+ *
+ * "Shares no tokens" is a verdict about STRINGS. Reported raw it overstates the
+ * bibliographic conflict about twofold, because two of its populations are not
+ * conflicts at all — a no-value-stated marker against a real value, and the same
+ * value in two languages or spellings (Roma/Rome, Nürnberg/Nuremberg). Splitting
+ * those out is what keeps the review queue honest: only `different-value` needs
+ * a person, and even that is a CEILING — the edit-distance test misses wider
+ * exonym pairs (Venezia/Venice), which land in `different-value` rather than
+ * `variant-form`. Erring that way is deliberate: a variant wrongly queued costs
+ * a reviewer a moment, a real conflict wrongly auto-merged costs a book its
+ * imprint.
+ */
 function classifyConflict(a, b) {
   const na = normalise(a);
   const nb = normalise(b);
@@ -108,7 +160,16 @@ function classifyConflict(a, b) {
   const tb = new Set(nb.split(' '));
   const shared = [...ta].filter((t) => tb.has(t) && t.length > 2);
   if (shared.length) return 'partial-token-overlap';
-  return 'disjoint';
+
+  // Tested against the normalised form, where `s.l.` has become `s l`. A
+  // BRACKETED marker (`[n.p.]`) never reaches here: normalise() strips `[...]`,
+  // so it exits above as one-side-empty — which is the right destination, since
+  // a bracketed hedge is conjectural and wants a person either way.
+  if (NO_VALUE_STATED.test(na) || NO_VALUE_STATED.test(nb)) return 'no-value-stated-marker';
+  if (editDistance(na, nb) <= Math.max(2, Math.floor(Math.max(na.length, nb.length) * 0.45))) {
+    return 'variant-form';
+  }
+  return 'different-value';
 }
 
 async function main() {
@@ -145,8 +206,20 @@ async function main() {
     const examples = {};
     let multi = 0;
     let single = 0;
-    let resolvedByPrecedence = 0;
+    let mechanical = 0;
+    let needsAuthorityFile = 0;
     let needsJudgement = 0;
+
+    // Increasing severity — the worst pair a book holds decides its bucket.
+    const RANK = [
+      'agree-after-normalising',
+      'containment',
+      'variant-form',
+      'no-value-stated-marker',
+      'partial-token-overlap',
+      'different-value',
+      'one-side-empty-after-normalising',
+    ];
 
     for await (const doc of cursor) {
       const held = names.filter((n) => typeof doc[n] === 'string' && doc[n].trim() !== '');
@@ -155,12 +228,11 @@ async function main() {
 
       // Compare every pair the book actually holds, keep the worst shape.
       let worst = 'agree-after-normalising';
-      const rank = ['agree-after-normalising', 'containment', 'partial-token-overlap', 'disjoint', 'one-side-empty-after-normalising'];
       let worstPair = null;
       for (let i = 0; i < held.length; i++) {
         for (let j = i + 1; j < held.length; j++) {
           const shape = classifyConflict(doc[held[i]], doc[held[j]]);
-          if (rank.indexOf(shape) > rank.indexOf(worst)) {
+          if (RANK.indexOf(shape) > RANK.indexOf(worst)) {
             worst = shape;
             worstPair = [held[i], held[j]];
           }
@@ -168,10 +240,15 @@ async function main() {
       }
       buckets[worst] = (buckets[worst] || 0) + 1;
 
-      // Would the precedence order settle it? Only when the disagreement is
-      // mechanical (identical after normalising, or one string contains the
-      // other). Anything else is a genuine conflict of fact.
-      if (worst === 'agree-after-normalising' || worst === 'containment') resolvedByPrecedence++;
+      // Who can resolve this, in three tiers.
+      //
+      // Note what is NOT here: a tier-precedence rule. Catalogue-beats-OCR-beats-
+      // import is falsified in the destructive direction by no-place-marker-vs-
+      // city, where the catalogue field holds `s.l. (Germany)` and the import
+      // field holds `Danzig`. Precedence would overwrite the city with "unknown".
+      // Resolution has to read the VALUE's shape, not the column it sits in.
+      if (worst === 'agree-after-normalising' || worst === 'containment') mechanical++;
+      else if (worst === 'variant-form' || worst === 'no-value-stated-marker') needsAuthorityFile++;
       else needsJudgement++;
 
       if (!examples[worst]) examples[worst] = [];
@@ -190,7 +267,8 @@ async function main() {
       books_with_one_field: single,
       books_with_multiple_fields: multi,
       conflict_shapes: buckets,
-      precedence_would_settle: resolvedByPrecedence,
+      resolvable_mechanically: mechanical,
+      resolvable_with_an_authority_file: needsAuthorityFile,
       needs_human_judgement: needsJudgement,
       examples,
     };
@@ -209,8 +287,9 @@ async function main() {
     for (const [shape, n] of Object.entries(r.conflict_shapes).sort((a, b) => b[1] - a[1])) {
       console.log(`    ${shape.padEnd(34)} ${n}`);
     }
-    console.log(`  precedence order would settle              : ${r.precedence_would_settle}`);
-    console.log(`  needs a human                              : ${r.needs_human_judgement}`);
+    console.log(`  resolvable mechanically                    : ${r.resolvable_mechanically}`);
+    console.log(`  resolvable with an authority file         : ${r.resolvable_with_an_authority_file}  (variant forms, no-value-stated markers)`);
+    console.log(`  needs a human                              : ${r.needs_human_judgement}  (ceiling — still holds missed exonyms)`);
     for (const [shape, rows] of Object.entries(r.examples)) {
       if (shape === 'agree-after-normalising' || !rows.length) continue;
       console.log(`\n  -- ${shape} --`);


### PR DESCRIPTION
Follow-up to #4044, which landed the imprint measurement. Running it and reading the residue found that its headline number means something narrower than the epic (#4043) claimed.

## The correction

#4044 reported **539 place pairs as `disjoint`**, and #4043 wrote that up as "539 hold flatly different cities." `disjoint` is a verdict about *strings* — the two values share no token longer than two characters. Classified, those 539 are:

| | share | example |
|---|---|---|
| no-value-stated marker vs a real value | ~10% | `s.l. (Germany)` vs `Danzig` |
| same value, different language/spelling | ≥40% | `Roma`/`Rome`, `Nürnberg`/`Nuremberg`, `z.p.`/`n.p.` |
| genuinely different | ≤50% | `Basel` vs `Frankfurt am Main`, `Paris` vs `Erfurt` |

**The place review queue is 472, not 740.** Sizing it off the raw bucket would have sent a person to adjudicate Rome against Roma.

`different-value` stays a **ceiling**: the edit-distance test still misses wider exonym pairs (`Venezia`/`Venice` lands in it). That is the safe direction — a variant wrongly queued costs a reviewer a moment; a real conflict wrongly auto-merged costs a book its imprint.

## What this falsified

#4043 proposed a precedence rule, catalogue > OCR > import, and #4044's own header called it "a HYPOTHESIS this script exists to test." Tested, it **fails as a merge rule, in the destructive direction**.

On 53 books the catalogue field holds `s.l. (Germany)` — a true statement that the title page names no place — while the import field holds a real city:

```
Astronomia Nova          publication_place: s.l. (France)              place_published: Prague
Summum Bonum             publication_place: s.l. (Germany)             place_published: Frankfurt
De signatura rerum       publication_place: s.l. (Northern Netherlands) place_published: Amsterdam
Hortus Eystettensis      publication_place: s.l. (Germany)             place_of_publication: Eichstätt
```

Catalogue-wins overwrites the city with "unknown." And the same field elsewhere holds plainly established values (`Roma`, `Strasbourg`), so the tier does **not** tell you the value's role. `s.l.` / `n.p.` / `z.p.` and `[…?]` mark *stated-absent* and *conjectural*; a bare place-name marks an assertion. **Role is a property of the value's own shape, never of the column it sits in** — which is the constraint the canonical shape (sub-task 3 on #4043) has to be built around.

## Changes

- `classifyConflict()` splits `no-value-stated-marker` and `variant-form` out of the old `disjoint` bucket, and reports three resolution tiers — mechanical / needs an authority file / needs a person — instead of "precedence would settle."
- Buckets renamed family-neutral (`different-value`, not `different-place`): the same classifier runs over printers, where the marker is `s.n.` (*sine nomine*).
- `field-sprawl.md` corrected — it carried the "539 name flatly different cities" reading — plus the tier-is-not-role finding.

## Scope

**In:** classification and the doc correction. Still read-only; writes nothing.

**Out:** the merge, the canonical shape, the review queue, the facet — sub-tasks on #4043. Also out: a place authority file. 268 place and 53 printer cases are mechanically resolvable *given* a gazetteer, and we do not have one; nominating a source is its own decision.

## Not in this PR, but measured

Every citation surface in `src/` reads **`place_published`** — the import tier, the one with no current writer — for BibTeX `address`, the IIIF manifest, DTS Dublin Core `spatial`, front matter, the book page and the guide page. Nothing in `src/` reads `publication_place`, the catalogue tier. Consequence: **3,300 visible books hold a place in some field and emit none in their citations**, and of the 2,916 that do cite one, 208 disagree with a catalogue value we already hold. Filed for #4043 rather than fixed here — it is a reader-facing change and wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
