### PR TITLE
fix(errors): stop the error reporter from reporting its own failures

### DIFF
--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -49,6 +49,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true, skipped: 'noise' });
     }
 
+    // Bound the write. This endpoint is public, unauthenticated, and its traffic
+    // RISES exactly when the database is unhealthy (every failing page reports).
+    // With no deadline each request holds a connection for the full maxDuration,
+    // so a stampede converts into connection-pool exhaustion — which is how
+    // 2026-08-18 took out unrelated API routes and production builds. Failing a
+    // log write fast is strictly better than holding a connection to complete it.
     const db = await getDb();
     await db.collection('application_errors').insertOne({
       message: String(message).slice(0, 2000),
@@ -59,7 +65,7 @@ export async function POST(request: NextRequest) {
       user_agent: userAgent ? String(userAgent).slice(0, 500) : undefined,
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || request.headers.get('x-real-ip'),
       timestamp: new Date(),
-    });
+    }, { maxTimeMS: 2000 });
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -12,7 +12,13 @@
  *   1. Always console.error a structured line so Vercel logs reliably catch
  *      it even when the Atlas write path itself is failing.
  *   2. Fire-and-forget POST to /api/errors so the row lands in
- *      `application_errors` when Atlas is healthy.
+ *      `application_errors` when Atlas is healthy — but never for an error on
+ *      /api/errors itself, and not at all while that path is failing.
+ *
+ * That second guard is load-bearing, not defensive dressing. The POST is a real
+ * HTTP request back into this deployment, so an unguarded reporter turns any
+ * failure of the reporting path into more traffic to the reporting path. See
+ * the comment at the POST for what that cost on 2026-08-18.
  */
 
 export function register() {
@@ -58,20 +64,64 @@ export async function onRequestError(
     digest,
   }));
 
-  // Best-effort POST to /api/errors. Uses the request's own host so it
-  // works in any environment (preview, prod, local). Swallows failures
-  // because the error path must never throw.
+  // NEVER report an error that happened ON the reporting endpoint.
+  //
+  // This POST is a real HTTP request back through Cloudflare into this same
+  // deployment. So when /api/errors itself fails, reporting that failure calls
+  // /api/errors again — a feedback loop with gain > 1. On 2026-08-18 it produced
+  // 389,193 gateway timeouts on /api/errors in 35 minutes while storing 161 rows,
+  // drove edge traffic from ~20K to ~357K requests per 5 minutes, and exhausted
+  // the Atlas connection pool (every POST wants a Mongo connection) until
+  // unrelated API routes and production builds could not get one.
+  //
+  // The console.error above already ran, so Vercel logs still capture it. That
+  // is the reliable channel here — the network hop is the optional one.
+  if (request.path.startsWith('/api/errors')) return;
+
+  // Circuit breaker: once the reporting path starts failing, stop feeding it.
+  //
+  // Self-recursion is the sharpest form of the loop, but not the only one — any
+  // widespread failure (Atlas unreachable) makes EVERY route error and each one
+  // POSTs. That is a stampede onto the exact dependency that is already down.
+  // After REPORT_FAILURE_LIMIT consecutive failures we stay silent for
+  // REPORT_COOLDOWN_MS, then allow one probe through to test recovery.
+  const now = Date.now();
+  if (reportCircuitOpenUntil > now) return;
+
   try {
     const host = request.headers.host;
     if (!host) return;
     const proto = request.headers['x-forwarded-proto'] || 'https';
-    await fetch(`${proto}://${host}/api/errors`, {
+    const res = await fetch(`${proto}://${host}/api/errors`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       keepalive: true,
+      // Without a deadline this await can occupy the function for the full
+      // platform timeout while the reporting path is wedged.
+      signal: AbortSignal.timeout(REPORT_TIMEOUT_MS),
     });
+    if (res.ok) consecutiveReportFailures = 0;
+    else noteReportFailure();
   } catch {
     // Already logged via console.error above.
+    noteReportFailure();
+  }
+}
+
+// Module scope: per server instance, which is the right granularity — each
+// Vercel instance throttles its own contribution to the stampede.
+const REPORT_FAILURE_LIMIT = 3;
+const REPORT_COOLDOWN_MS = 60_000;
+const REPORT_TIMEOUT_MS = 2_000;
+let consecutiveReportFailures = 0;
+let reportCircuitOpenUntil = 0;
+
+function noteReportFailure(): void {
+  consecutiveReportFailures += 1;
+  if (consecutiveReportFailures >= REPORT_FAILURE_LIMIT) {
+    reportCircuitOpenUntil = Date.now() + REPORT_COOLDOWN_MS;
+    consecutiveReportFailures = 0;
+    console.error('[onRequestError] error reporting is failing — pausing POSTs for 60s');
   }
 }

--- a/tests/unit/error-report-loop.test.ts
+++ b/tests/unit/error-report-loop.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * `onRequestError` reports server errors by POSTing to /api/errors — a real HTTP
+ * request back into the same deployment. Unguarded, an error ON that endpoint
+ * reports itself, and the loop has gain > 1.
+ *
+ * On 2026-08-18 that produced 389,193 gateway timeouts on /api/errors in 35
+ * minutes while storing 161 rows, took edge traffic from ~20K to ~357K requests
+ * per 5 minutes, and exhausted the Atlas connection pool until unrelated API
+ * routes and production builds could not get a connection.
+ *
+ * These pin the two guards. They are behavioural, not structural: they assert
+ * that no fetch leaves the process, so a refactor that keeps the comment and
+ * drops the guard still fails.
+ */
+
+const req = (path: string) => ({
+  path,
+  method: 'GET',
+  headers: { host: 'sourcelibrary.org', 'x-forwarded-proto': 'https' },
+});
+const ctx = {
+  routerKind: 'App Router' as const,
+  routePath: '/x',
+  routeType: 'route' as const,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('onRequestError does not feed its own reporting endpoint', () => {
+  it('POSTs a report for an ordinary route error', async () => {
+    const { onRequestError } = await import('@/instrumentation');
+    await onRequestError(new Error('boom'), req('/book/atalanta-fugiens-maier'), ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/errors');
+  });
+
+  it('sends NOTHING when the failing request is /api/errors itself', async () => {
+    const { onRequestError } = await import('@/instrumentation');
+    await onRequestError(new Error('gateway timeout'), req('/api/errors'), ctx);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still logs to console for a self-error, so the report is not lost', async () => {
+    const spy = vi.spyOn(console, 'error');
+    const { onRequestError } = await import('@/instrumentation');
+    await onRequestError(new Error('gateway timeout'), req('/api/errors'), ctx);
+    expect(spy).toHaveBeenCalled(); // Vercel logs remain the reliable channel
+  });
+
+  it('opens a circuit breaker after repeated reporting failures', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    const { onRequestError } = await import('@/instrumentation');
+    // Three failures trip the breaker...
+    for (let i = 0; i < 3; i++) await onRequestError(new Error('e'), req(`/book/${i}`), ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // ...after which further errors stop generating traffic at all.
+    for (let i = 0; i < 5; i++) await onRequestError(new Error('e'), req(`/book/x${i}`), ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('bounds the report request so a wedged endpoint cannot hold the function', async () => {
+    const { onRequestError } = await import('@/instrumentation');
+    await onRequestError(new Error('boom'), req('/search'), ctx);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What happened

`onRequestError` (`src/instrumentation.ts`) reports server errors by **POSTing to `/api/errors`** — a real HTTP request back through Cloudflare into the same deployment. So an error *on that endpoint* reported itself. The loop has gain > 1.

Measured on production today, 16:00–16:35Z via Cloudflare zone analytics:

| | |
|---|---|
| HTTP 504 on `/api/errors` | **389,193** (of 582,357 total 504s) |
| Rows actually written to `application_errors` | **161 — in three hours** |
| Edge traffic | ~20K → **~357K requests per 5 min**, still climbing |
| Collateral | Atlas connection pool exhausted: unrelated API routes 500'd after a 15s connection timeout, and **three production builds died** prerendering |

**389K requests producing 161 stored rows is the tell.** Almost none of this was a real error being recorded — it was the loop spinning. This is also the answer to "why was Atlas unreachable from Vercel": every POST wants a Mongo connection.

Diagnosed after Derek suggested bots. Bot volume was actually *below* median today (72K vs 141K yesterday) — the surge was self-inflicted.

## The fix

**1. Never POST when the failing path is `/api/errors`.** The `console.error` above it already ran, so Vercel logs still capture the error. That's the reliable channel here; the network hop is the optional one.

**2. A per-instance circuit breaker** — 3 consecutive reporting failures pause POSTs for 60s. Self-recursion is the sharpest form of the loop but not the only one: when Atlas is unreachable *every* route errors and each one POSTs, which is a stampede onto the dependency that is already down. Also bounds the report with a 2s `AbortSignal` so a wedged endpoint can't occupy the function for the full platform timeout.

**3. `maxTimeMS: 2000` on the insert in `POST /api/errors`.** That endpoint is public, unauthenticated, and its traffic *rises* exactly when the database is unhealthy. Without a deadline each request holds a connection for the full `maxDuration`, converting a stampede into pool exhaustion. Failing a log write fast beats holding a connection to complete it.

## Test plan

- `npx vitest run tests/unit/error-report-loop.test.ts` — 5 passed
- `npx tsc --noEmit` clean
- Tests assert **no fetch leaves the process**, so a refactor that keeps the comment and drops the guard still fails.

## Not in scope

- Client-side `reportError` is fire-and-forget with no retry, so it is not an amplifier — left alone.
- Rate-limiting `/api/errors` at the edge would add defence in depth, but the loop is the cause and this keeps the diff to it.
- The 329,203 rows already in `application_errors` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
