### PR TITLE
feat(artwork-links): resolver + review queue for artwork → book links (#4037)

### DIFF
--- a/.claude/handoffs/2026-08-19-artwork-book-linking.md
+++ b/.claude/handoffs/2026-08-19-artwork-book-linking.md
@@ -1,0 +1,108 @@
+# Artwork → book linking: state, and what the next session should do
+
+**Issue:** #4037. **Merged so far:** #4036, #4038 (canonical artwork URLs), #4041
+(invariants), #4042 (slug transliteration), #4045 (deploy purge gate), #4047
+(error-reporter loop). **Open:** #4050 — resolver + review queue, checks green.
+
+## Where the work stands
+
+`scripts/lib/artwork-work-resolver.mjs` resolves a name written by artwork
+enrichment to a book or an author. `scripts/artwork-links/build-review-queue.mjs`
+runs it over the corpus and writes a queue to `scripts/output/` (gitignored,
+~11MB). **Nothing is written to Mongo.** A resolved link renders as "read the
+full text with translation" — a public claim — so the write path is deliberately
+unbuilt until a human has read a slice of the queue.
+
+Run: `node --env-file=.env.production.local scripts/artwork-links/build-review-queue.mjs`
+
+Current result over 12,513 visible artworks / 15,190 references:
+
+| | |
+|---|---|
+| artworks with a **book** link | 1,946 (1,787 readable) |
+| artworks with an **author** link | 8,343 |
+| unresolved | 2,224 |
+| links to hidden books | 189 — flagged do-not-ship |
+| links to held-but-unprocessed books | 17 |
+
+## Does this need LLMs? Mostly NO — measured 2026-08-19
+
+The instinct is to reach for embeddings or a model. The corpus says the cheaper
+layers are not exhausted yet:
+
+- **`work_id` is NOT a shared external identity layer.** 76,194 books carry one,
+  but only **1,334 are Wikidata QIDs**; 61,531 are `local-synthetic` and 13,249
+  "other". It groups our own editions of one work — useful for picking the best
+  edition to link to, useless for cross-lingual aliases.
+- **Authors ARE externally anchored: 4,586 have `wikidata_id`.** That is a real
+  hook for multilingual name forms.
+- **But `authors.aliases[]` is empty on ALL 6,291 entries.** Nobody has pulled
+  the labels/aliases the QIDs already entitle us to. That is a fetch, not a model.
+- **Only 3,107 of 24,912 artworks carry `author_id`.** Person references are
+  being matched by string when an identity join is available for a fraction of
+  them and backfillable for the rest.
+
+So the ladder, cheapest first:
+
+1. **Backfill `authors.aliases[]` from the 4,586 Wikidata ids.** Deterministic,
+   verifiable, and directly raises recall on person references (the largest
+   bucket — 8,343 artworks). Verify each QID's `P31` before trusting it
+   (human vs work vs edition) — see `lesson_verify_every_wikidata_qid`.
+2. **Backfill artwork `author_id`** so person links resolve by identity.
+3. **Wikidata QIDs for WORKS**, obtained by title+author lookup. This is what
+   fixes "Golden Legend" ↔ "Legenda aurea" — a title-alias problem no amount of
+   string normalisation solves. Deterministic lookup, human-reviewed.
+4. **Embeddings** (`book_embeddings` in Supabase, see `.claude/docs/embeddings.md`)
+   as a fuzzy middle tier before any model — semantic title similarity, no
+   generation, no fabrication risk.
+5. **An LLM ONLY for the ambiguous tail**, and only producing citations into a
+   review queue. The tail is genuinely judgement: is "Book of Revelation" a link
+   to our Vulgate? "Islamic Geometric Patterns", "Gregorian Chant" and "Tarot de
+   Marseille" are references to *traditions*, not books, and should resolve to
+   nothing. Repo precedent says do not skip verification here — 12.2% fabrication
+   in the note-quality eval (#3308), and FT claims needed independent agents.
+
+**Do not start at step 5.** Steps 1–2 are a day's work and move the biggest bucket.
+
+## The four defects already found (all pinned by tests)
+
+Each produced a plausible-looking WRONG link, and each was caught by reading the
+sample rather than by anything failing:
+
+1. Person name resolving as a work — "Marsilio Ficino" prefix-matched the book
+   *Marsilio Ficino Epistolae*, aiming all 2,047 Ficino refs at one volume.
+2. Name-form variation — catalogue "Pico della Mirandola, Giovanni" vs
+   enrichment "Pico della Mirandola" missed, then fell through to *Opera Omnia*.
+3. Generic titles crossing authors — *Opera Omnia*; and "Ovid, Metamorphoses"
+   could land on Apuleius' *Metamorphoseon Libri XI*.
+4. "Author, Work" read as a person — "Raphael, Transfiguration" matched a book
+   by "Götz, Raphael".
+
+**The lesson to carry:** every one was found by reading actual rows. Aggregate
+counts looked fine throughout. Read the queue before trusting any number in it.
+
+## Next concrete steps
+
+1. Merge #4050 (green).
+2. Read ~50 rows of the queue, both `kind: work` and `kind: author`. Reject rate
+   is the number that decides whether a write path is safe.
+3. Steps 1–2 of the ladder above.
+4. THEN a write path: augment `enrichment.cross_references[]` in place (no new
+   top-level field on `books` — see `field-sprawl.md`), with `source_book`
+   reserved for hard provenance only.
+5. Separately: the hard-provenance channel — Deutsche Fotothek's `aus:` field
+   names the source book AND printed page in the Commons wikitext, and MS
+   shelfmarks identify manuscripts. That channel is what links the
+   *Aurora consurgens* ouroboros folio to the manuscript we hold complete
+   (`/book/zurich-zentralbibliothek-ms-rh-172-aquinas`, page 45).
+
+## Unrelated things this session surfaced, not yet acted on
+
+- `/api/presence/count` is now the top source of 504s (9,108/hour measured).
+- `authorSlug()` still deletes æ/œ/ß/ø/þ/ð/ł the way `slugifyText` no longer
+  does — but it is computed live, so changing it rewrites existing `/author/`
+  URLs and needs the canonical-redirect map regenerated.
+- 33 files build slugs with their own regex instead of importing `slugify.ts`;
+  most are in `scripts/import/`, where a bad slug becomes a permanent URL.
+- 22,767 books with >20pp OCR have no `visible` field at all — intentional QA
+  gate or drift is undetermined, and nobody can currently tell.

--- a/scripts/artwork-links/build-review-queue.mjs
+++ b/scripts/artwork-links/build-review-queue.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Build the artwork -> book link review queue. READ-ONLY. Writes no DB fields.
+ *
+ * #4037. A resolved link renders to readers as "read the full text with
+ * translation", so it is a public claim and must be reviewed before it exists
+ * ("ingest is actuation", #3776). This script produces the thing a human reads.
+ *
+ *   node --env-file=.env.production.local scripts/artwork-links/build-review-queue.mjs
+ *   ... --out scripts/output/artwork-links-queue.json
+ *   ... --limit 500        (sample, for a fast look)
+ *
+ * Output: one row per (artwork, reference) candidate, plus a summary. Nothing
+ * is written to Mongo — approving rows is a separate, deliberate step.
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { buildIndex, resolveName, linkQuality } from '../lib/artwork-work-resolver.mjs';
+
+const arg = (flag, dflt) => {
+  const i = process.argv.indexOf(flag);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+};
+const OUT = arg('--out', 'scripts/output/artwork-links-queue.json');
+const LIMIT = parseInt(arg('--limit', '0'), 10);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+
+// ── index every book that could be a link target ────────────────────────────
+// Include books that are NOT currently readable: a reference to something we
+// hold but have not processed is a *different* finding (a processing gap, not
+// an acquisition gap) and the queue should surface it rather than hide it.
+console.error('indexing candidate books…');
+const targets = await books.find(
+  { content_type: { $ne: 'artwork' } },
+  { projection: { id: 1, slug: 1, title: 1, english_title: 1, author: 1, visible: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, work_id: 1 } },
+).toArray();
+const index = buildIndex(targets);
+console.error(`  ${targets.length} books indexed, ${index.byTitle.size} distinct titles, ${index.byAuthor.size} authors`);
+
+// ── walk the artworks ───────────────────────────────────────────────────────
+const cursor = books.find(
+  { content_type: 'artwork', visible: true, 'enrichment.cross_references.0': { $exists: true } },
+  { projection: { id: 1, slug: 1, title: 1, display_title: 1, source_book: 1, 'enrichment.cross_references': 1 } },
+);
+
+const rows = [];
+const stats = { artworks: 0, withWorkLink: 0, withAuthorOnly: 0, unresolved: 0, refs: 0, alreadyHasSourceBook: 0 };
+const unresolvedNames = new Map();
+
+for await (const art of cursor) {
+  if (LIMIT && stats.artworks >= LIMIT) break;
+  stats.artworks++;
+  if (art.source_book) stats.alreadyHasSourceBook++;
+  let gotWork = false, gotAuthor = false;
+
+  for (const ref of art.enrichment?.cross_references || []) {
+    stats.refs++;
+    const hit = resolveName(index, ref.text_or_author);
+    if (!hit) {
+      const key = String(ref.text_or_author || '').trim();
+      if (key) unresolvedNames.set(key, (unresolvedNames.get(key) || 0) + 1);
+      continue;
+    }
+    if (hit.kind === 'work') gotWork = true; else gotAuthor = true;
+
+    const b = hit.book;
+    rows.push({
+      artwork: { id: art.id, slug: art.slug, title: art.display_title || art.title },
+      reference: {
+        name: ref.text_or_author,
+        relationship: ref.relationship,
+        confidence: ref.confidence,
+      },
+      target: {
+        kind: hit.kind,                       // 'work' -> /book/<slug>, 'author' -> /author/
+        how: hit.how,
+        matched_on: hit.matched,
+        book_id: b.id,
+        slug: b.slug,
+        title: b.title,
+        author: b.author,
+        visible: b.visible === true,
+        pages_ocr: b.pages_ocr || 0,
+        pages_translated: b.pages_translated || 0,
+        // 0 = hidden (do not link), 1 = held but nothing to read, 2..3 = readable
+        link_quality: linkQuality(b),
+      },
+    });
+  }
+  if (gotWork) stats.withWorkLink++;
+  else if (gotAuthor) stats.withAuthorOnly++;
+  else stats.unresolved++;
+}
+await client.close();
+
+// ── summarise ───────────────────────────────────────────────────────────────
+const workRows = rows.filter((r) => r.target.kind === 'work');
+const readable = workRows.filter((r) => r.target.link_quality >= 2);
+const heldNotReadable = workRows.filter((r) => r.target.link_quality === 1);
+const hidden = workRows.filter((r) => r.target.link_quality === 0);
+
+const summary = {
+  generated_at: new Date().toISOString(),
+  artworks_examined: stats.artworks,
+  references_examined: stats.refs,
+  artworks_with_a_book_link: stats.withWorkLink,
+  artworks_with_only_an_author_link: stats.withAuthorOnly,
+  artworks_unresolved: stats.unresolved,
+  artworks_already_having_source_book: stats.alreadyHasSourceBook,
+  candidate_links_total: rows.length,
+  work_links: workRows.length,
+  work_links_to_readable_books: readable.length,
+  work_links_to_held_but_unprocessed: heldNotReadable.length,
+  work_links_to_hidden_books_DO_NOT_SHIP: hidden.length,
+  author_links: rows.length - workRows.length,
+  distinct_unresolved_names: unresolvedNames.size,
+};
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, JSON.stringify({
+  summary,
+  rows,
+  unresolved_top: [...unresolvedNames.entries()].sort((a, b) => b[1] - a[1]).slice(0, 200)
+    .map(([name, n]) => ({ name, references: n })),
+}, null, 2));
+
+console.log('\n=== artwork → book link review queue ===');
+for (const [k, v] of Object.entries(summary)) console.log(`  ${k.padEnd(42)} ${v}`);
+console.log(`\nwritten to ${OUT}`);
+console.log('\nNOTHING was written to Mongo. Review the queue before any link is created.');
+
+// Judge a link by the REFERENCE it came from, not the artwork's own title — the
+// claim is "this reference names that book", and the artwork title is often
+// unrelated to it ("Cupid Bound" tells you nothing about a Ficino reference).
+console.log('\n--- 20 sample WORK links to readable books: REFERENCE → book ---');
+for (const r of readable.slice(0, 20)) {
+  console.log(`  ${String(r.reference.name).slice(0, 40).padEnd(42)} → ${String(r.target.title).slice(0, 38).padEnd(40)} [${r.target.how}]`);
+}
+console.log('\n--- 12 sample AUTHOR links (these go to /author/, not a book) ---');
+for (const r of rows.filter((x) => x.target.kind === 'author').slice(0, 12)) {
+  console.log(`  ${String(r.reference.name).slice(0, 40).padEnd(42)} → author "${String(r.target.author).slice(0, 34)}"`);
+}
+console.log('\n--- work links pointing at books we hold but have NOT processed ---');
+for (const r of heldNotReadable.slice(0, 10)) {
+  console.log(`  ${String(r.reference.name).slice(0, 34).padEnd(36)} → ${String(r.target.title).slice(0, 36).padEnd(38)} pages=${r.target.pages_ocr === 0 ? 'NO OCR' : r.target.pages_ocr}`);
+}

--- a/scripts/lib/artwork-work-resolver.mjs
+++ b/scripts/lib/artwork-work-resolver.mjs
@@ -1,0 +1,229 @@
+/**
+ * Resolve a work or author NAME (as written by artwork enrichment) to a book we hold.
+ *
+ * WHY (#4037): artworks and the books they came from live in the same `books`
+ * collection with 5 edges between them. 19,530 artworks already carry
+ * `enrichment.cross_references[]` naming texts and authors — 23,363 assertions
+ * that render as dead prose in the "Connected Texts" panel because nothing
+ * resolves them to a book.
+ *
+ * This module is the resolution half. It deliberately does NOT write anything:
+ * a resolved link renders as a public claim ("read the full text with
+ * translation"), so the write path must go through review.
+ *
+ * ── The specificity gate is the whole trick ──────────────────────────────────
+ * Measured 2026-08-18 over all 4,779 distinct cross-reference names: matching
+ * every name resolves 1,021; requiring >= 2 words AND >= 12 chars resolves 769.
+ * The 252 it drops were the WRONG ones. Single-word allegory and deity labels
+ * are the poison, because the corpus contains a book whose title starts with
+ * almost any of them:
+ *     "Prudence" -> "Klugheit vereint mit Tugend"
+ *     "Saturn"   -> "Saturn Gnosis" (a 20th-c occult periodical)
+ *     "Mercury"  -> "Mercury, or The Secret and Swift Messenger"
+ *     "Apollo"   -> "The Apollonian Harmony, Vol. 2"
+ *     "Justice"  -> "Archeion, or Of the High Court"
+ * Those are artworks depicting a personification, not editions of a text. With
+ * the gate, matches read as they should: "Ovid, Metamorphoses" -> the Aldine
+ * edition; "Robert Fludd, Utriusque Cosmi Historia" -> Utriusque Cosmi Vol. 1.
+ *
+ * ── A work reference and an author reference are different links ─────────────
+ * "Athanasius Kircher" resolves to *a* Kircher book (Iter Exstaticum Coeleste)
+ * — real, but not "the source". An author-only reference belongs on /author/,
+ * never on an arbitrary volume by that author. Callers get the kind back and
+ * must route accordingly.
+ */
+
+export function normalizeTitle(t) {
+  return String(t || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    // Non-decomposable Latin letters, same set slugifyText transliterates.
+    .replace(/æ/g, 'ae').replace(/œ/g, 'oe').replace(/ß/g, 'ss')
+    .replace(/ø/g, 'o').replace(/þ/g, 'th').replace(/ð/g, 'd')
+    .replace(/ł/g, 'l').replace(/đ/g, 'd').replace(/ſ/g, 's')
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|el|los|las)\s+/, '')
+    .replace(/\s*[([:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[)\]]?\s*$/, '')
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** >= 2 words AND >= 12 chars. See the gate note above. */
+export function isSpecificEnough(normalized) {
+  return normalized.split(' ').length >= 2 && normalized.length >= 12;
+}
+
+/**
+ * How good a link target is this book? Higher wins.
+ *
+ * DEFECT THIS FIXES: the prototype took whichever edition Mongo returned first
+ * for a normalized title. It filed *Atalanta Fugiens* as "unreadable" off a
+ * hidden 225-page copy while a visible 194-page copy with 167 pages translated
+ * sat beside it. Several editions of one work is the NORMAL case here, so
+ * picking deliberately is not an edge case.
+ */
+export function linkQuality(book) {
+  const visible = book.visible === true;
+  const ocr = book.pages_ocr || 0;
+  const translated = book.pages_translated || 0;
+  if (!visible) return 0;                     // never link a reader to a hidden book
+  if (ocr === 0) return 1;                    // exists, but there is nothing to read
+  return 2 + Math.min(1, translated / Math.max(1, ocr)); // 2..3, favouring translated
+}
+
+/**
+ * Person-name key: normalized words SORTED.
+ *
+ * Catalogue authors are "Ficino, Marsilio" while enrichment writes "Marsilio
+ * Ficino". Keying on sorted words makes the two the same key without a name
+ * parser, and without caring which half is the surname.
+ */
+export function authorKey(s) {
+  const n = normalizeTitle(s);
+  if (!n) return '';
+  return n.split(' ').filter((w) => w.length > 1).sort().join(' ');
+}
+
+/**
+ * Do two author strings name the same person?
+ *
+ * Deliberately loose: catalogue forms vary wildly ("Pico della Mirandola,
+ * Giovanni" vs "Giovanni Pico della Mirandola"), so agreement is "they share a
+ * distinctive name token". Short tokens are dropped because "della", "van",
+ * "de" and "saint" are shared by hundreds of unrelated people.
+ *
+ * Used as a REFUSAL test, not a discovery one: it only ever removes a match the
+ * title lookup already made, so being loose costs recall, never precision.
+ */
+export function authorsAgree(a, b) {
+  const A = new Set(authorKey(a).split(' ').filter((w) => w.length >= 4));
+  const B = new Set(authorKey(b).split(' ').filter((w) => w.length >= 4));
+  if (!A.size || !B.size) return false;
+  for (const w of A) if (B.has(w)) return true;
+  return false;
+}
+
+/**
+ * Build the lookup index over candidate books.
+ * Pass books already fetched by the caller (it owns the projection + filters).
+ */
+export function buildIndex(books) {
+  const byTitle = new Map();
+  const byAuthor = new Map();
+  const better = (a, b) => (!b || linkQuality(a) > linkQuality(b) ? a : b);
+
+  for (const b of books) {
+    for (const t of [b.title, b.english_title]) {
+      const k = normalizeTitle(t);
+      if (k.length > 5) byTitle.set(k, better(b, byTitle.get(k)));
+    }
+    const a = authorKey(b.author);
+    // Require a multi-word author so a bare surname cannot swallow a work name.
+    if (a && a.split(' ').length >= 2) byAuthor.set(a, better(b, byAuthor.get(a)));
+  }
+
+  // Token index over author names, because exact keys are too brittle.
+  // "Pico della Mirandola" (as enrichment writes it) and "Pico della Mirandola,
+  // Giovanni" (as the catalogue holds it) differ by one token, so an exact
+  // lookup missed — and the name then fell through to title matching and
+  // resolved as the WORK "Opera Omnia". Indexing by distinctive token and
+  // confirming with authorsAgree() tolerates the name-form variation that is
+  // normal across catalogues.
+  const byAuthorToken = new Map();
+  for (const b of books) {
+    for (const w of authorKey(b.author).split(' ')) {
+      if (w.length < 4) continue; // "de", "van", "della", "saint" are not identifying
+      if (!byAuthorToken.has(w)) byAuthorToken.set(w, []);
+      const list = byAuthorToken.get(w);
+      if (list.length < 60) list.push(b); // cap: common tokens would collect thousands
+    }
+  }
+  return { byTitle, byAuthor, byAuthorToken, titleKeys: [...byTitle.keys()] };
+}
+
+/** Best book by this person, or null. Fuzzy on name form; strict on agreement. */
+export function findByPerson(index, name) {
+  const tokens = authorKey(name).split(' ').filter((w) => w.length >= 4);
+  if (tokens.length < 1) return null;
+  const seen = new Map();
+  for (const t of tokens) {
+    for (const b of index.byAuthorToken?.get(t) || []) {
+      if (!authorsAgree(name, b.author)) continue;
+      const shared = new Set(authorKey(b.author).split(' ').filter((w) => w.length >= 4));
+      const overlap = tokens.filter((w) => shared.has(w)).length;
+      const prev = seen.get(b.id);
+      if (!prev || overlap > prev.overlap || (overlap === prev.overlap && linkQuality(b) > linkQuality(prev.book))) {
+        seen.set(b.id, { book: b, overlap });
+      }
+    }
+  }
+  if (!seen.size) return null;
+  // Most name tokens in common wins; ties go to the better link target.
+  return [...seen.values()].sort((x, y) => y.overlap - x.overlap || linkQuality(y.book) - linkQuality(x.book))[0].book;
+}
+
+/**
+ * Resolve one name. Returns { kind: 'work'|'author', book, how } or null.
+ *
+ * `kind` decides the link target: 'work' -> /book/<slug>, 'author' -> /author/.
+ */
+export function resolveName(index, rawName) {
+  const name = String(rawName || '').trim();
+  if (!name) return null;
+  const parts = name.split(',').map((s) => s.trim()).filter(Boolean);
+
+  const asWork = (c, requireSpecific = true) => {
+    const k = normalizeTitle(c);
+    if (requireSpecific && !isSpecificEnough(k)) return null;
+    if (k.length < 8) return null;
+    if (index.byTitle.has(k)) return { kind: 'work', book: index.byTitle.get(k), how: 'title-exact', matched: c };
+    const prefix = index.titleKeys.find((tk) => tk.startsWith(k + ' '));
+    if (prefix) return { kind: 'work', book: index.byTitle.get(prefix), how: 'title-prefix', matched: c };
+    const inside = index.titleKeys.find((tk) => tk.length > 12 && k.includes(tk));
+    if (inside) return { kind: 'work', book: index.byTitle.get(inside), how: 'title-contained', matched: c };
+    return null;
+  };
+
+  // 1. "Author, Work" — the work half is the most specific thing on offer.
+  //    Exempt from the 2-word gate: it is already qualified by the author half
+  //    ("Ovid, Metamorphoses"), so a single distinctive word is safe there.
+  //
+  //    BUT the qualification only counts if we CHECK it. Early-modern catalogues
+  //    are full of titles that are generic across authors — "Opera Omnia" is the
+  //    extreme case, and unchecked it matched whichever Opera Omnia happened to
+  //    index first, for any author. Worse, "Ovid, Metamorphoses" could land on
+  //    Apuleius' "Metamorphoseon Libri XI". So: the matched book's author must
+  //    agree with the author half, or the match is refused.
+  if (parts.length > 1) {
+    for (const p of parts.slice(1)) {
+      const hit = asWork(p, false);
+      if (hit && authorsAgree(parts[0], hit.book.author)) return { ...hit, how: `${hit.how}+author` };
+    }
+  }
+
+  // 2. IS THIS A PERSON? Must be asked BEFORE title matching.
+  //
+  //    A person's name frequently prefixes a book title in a catalogue —
+  //    "Marsilio Ficino" prefix-matches "Marsilio Ficino Epistolae", and
+  //    "Leonardo da Vinci" matches "Leonardo da Vinci: der Denker, Forscher".
+  //    Resolving those as WORKS pointed all 2,047 Ficino references at one
+  //    volume regardless of what the artwork depicted. A name we hold as an
+  //    author is an author reference; the right target is /author/, not a book.
+  //    Only the author HALF is a candidate person. Testing the whole
+  //    "Author, Work" string as a name matched "Raphael, Transfiguration" to a
+  //    book by "Götz, Raphael" — a different person who merely shares a given
+  //    name. With a comma present, parts[0] is the name and the rest is not.
+  for (const c of parts.length > 1 ? [parts[0]] : [name]) {
+    const k = authorKey(c);
+    if (!k || k.split(' ').length < 2) continue; // a bare surname is too ambiguous
+    if (index.byAuthor.has(k)) {
+      return { kind: 'author', book: index.byAuthor.get(k), how: 'author-name', matched: c };
+    }
+    const person = findByPerson(index, c);
+    if (person) return { kind: 'author', book: person, how: 'author-token', matched: c };
+  }
+
+  // 3. Otherwise treat the whole string as a work title, behind the full gate.
+  return asWork(name, true);
+}

--- a/tests/unit/artwork-work-resolver.test.ts
+++ b/tests/unit/artwork-work-resolver.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs script lib, no types
+import { buildIndex, resolveName, linkQuality, authorsAgree } from '../../scripts/lib/artwork-work-resolver.mjs';
+
+/**
+ * Every case here is a defect this resolver actually produced against the live
+ * corpus while building the #4037 review queue, caught by reading the sample.
+ * They are the reason the queue exists: each one looked like a plausible link.
+ */
+
+const book = (o: Record<string, unknown>) => ({
+  id: String(o.title), slug: 'x', visible: true, pages_ocr: 100, pages_translated: 90, ...o,
+});
+
+const index = buildIndex([
+  book({ title: 'Marsilio Ficino Epistolae', author: 'Ficino, Marsilio' }),
+  book({ title: 'Opera Omnia', author: 'Pico della Mirandola, Giovanni' }),
+  // english_title is indexed alongside title — that is how "The Golden Ass"
+  // reaches Apuleius' "Metamorphoseon Libri XI" in the live corpus.
+  book({ title: 'Metamorphoseon Libri XI', english_title: 'The Golden Ass of Apuleius', author: 'Apuleius' }),
+  book({ title: 'Ovid, Metamorphoses with Annotations', author: 'Ovid' }),
+  book({ title: 'Iconologia', author: 'Ripa, Cesare' }),
+  book({ title: 'Klugheit vereint mit Tugend', author: 'Anon' }),
+  book({ title: 'Saturn Gnosis', author: 'Anon' }),
+  book({ title: 'Atalanta Fugiens', author: 'Maier', visible: false, pages_ocr: 225, pages_translated: 225 }),
+  book({ title: 'Atalanta Fugiens', author: 'Maier', id: 'visible-atalanta', pages_ocr: 194, pages_translated: 167 }),
+  book({ title: 'A Life of Raphael', author: 'Götz, Raphael' }),
+]);
+
+describe('the specificity gate', () => {
+  it('refuses single-word allegory labels that prefix a real title', () => {
+    // "Prudence" prefix-matched "Klugheit…" only via an English title in prod;
+    // the gate is what stops this whole class, so assert the class.
+    expect(resolveName(index, 'Prudence')).toBeNull();
+    expect(resolveName(index, 'Saturn')).toBeNull();
+  });
+});
+
+describe('a person is not a work', () => {
+  it('resolves a bare personal name to an AUTHOR even though it prefixes a title', () => {
+    // Defect: "Marsilio Ficino" matched the work "Marsilio Ficino Epistolae",
+    // pointing all 2,047 Ficino references at one volume.
+    const hit = resolveName(index, 'Marsilio Ficino');
+    expect(hit.kind).toBe('author');
+  });
+
+  it('tolerates name-form variation between enrichment and the catalogue', () => {
+    // Defect: enrichment writes "Pico della Mirandola"; the catalogue holds
+    // "Pico della Mirandola, Giovanni". Exact-key lookup missed, and the name
+    // then resolved as the WORK "Opera Omnia".
+    const hit = resolveName(index, 'Pico della Mirandola');
+    expect(hit.kind).toBe('author');
+  });
+
+  it('does not read "Author, Work" as a person name', () => {
+    // Defect: "Raphael, Transfiguration" matched a book by "Götz, Raphael" on
+    // the shared given name alone.
+    const hit = resolveName(index, 'Raphael, Transfiguration');
+    expect(hit?.kind).not.toBe('author');
+  });
+});
+
+describe('author agreement guards generic titles', () => {
+  it('refuses a generic title whose author disagrees', () => {
+    // "Opera Omnia" is generic across early-modern authors; unchecked it matched
+    // whichever indexed first.
+    expect(resolveName(index, 'Erasmus, Opera Omnia')).toBeNull();
+  });
+
+  it('accepts the work half when the author agrees', () => {
+    expect(resolveName(index, 'Cesare Ripa, Iconologia').kind).toBe('work');
+    expect(resolveName(index, 'Apuleius, The Golden Ass').book.title).toBe('Metamorphoseon Libri XI');
+  });
+
+  it('keeps Ovid off Apuleius despite both being "Metamorphoses"', () => {
+    expect(resolveName(index, 'Ovid, Metamorphoses').book.author).toBe('Ovid');
+  });
+});
+
+describe('link target selection', () => {
+  it('prefers the visible edition over a hidden one with more OCR', () => {
+    // Defect: the prototype filed Atalanta Fugiens as unreadable off a hidden
+    // 225-page copy while a visible 194-page copy sat beside it.
+    const hit = resolveName(index, 'Atalanta Fugiens');
+    expect(hit.book.id).toBe('visible-atalanta');
+  });
+
+  it('scores a hidden book as unlinkable', () => {
+    expect(linkQuality({ visible: false, pages_ocr: 500, pages_translated: 500 })).toBe(0);
+  });
+
+  it('separates "held but unreadable" from "readable"', () => {
+    expect(linkQuality({ visible: true, pages_ocr: 0 })).toBe(1);
+    expect(linkQuality({ visible: true, pages_ocr: 10, pages_translated: 10 })).toBe(3);
+  });
+});
+
+describe('authorsAgree', () => {
+  it('ignores particles that thousands of people share', () => {
+    expect(authorsAgree('van der Meer', 'van der Berg')).toBe(false);
+  });
+  it('matches across name order', () => {
+    expect(authorsAgree('Marsilio Ficino', 'Ficino, Marsilio')).toBe(true);
+  });
+});


### PR DESCRIPTION
First step on #4037. **Writes nothing to Mongo** — a resolved link renders to readers as *"read the full text with translation"*, so it is a public claim and goes through review first ("ingest is actuation", #3776). This produces the thing a human reads.

Adds **no new top-level field** on `books` (per `field-sprawl.md`): `source_book` already exists for hard provenance, and cross-reference resolution will augment the existing `enrichment.cross_references[]` entries in place.

## Current run — 12,513 visible artworks, 15,190 references

| | |
|---|---|
| artworks that get a **book** link | **1,946** (1,787 to readable books) |
| artworks that get an **author** link | 8,343 |
| unresolved | 2,224 |
| work links pointing at **hidden** books | 189 — flagged do-not-ship |
| work links to books we hold but never processed | 17 |

## Four defects, found by reading the sample

Every one produced a plausible-looking wrong link. Each is fixed and pinned by a test.

**1. A person's name resolving as a WORK.** "Marsilio Ficino" prefix-matched the book *Marsilio Ficino Epistolae*, pointing all 2,047 Ficino references at one volume regardless of subject. The person test now runs *before* title matching.

**2. Name-form variation.** Enrichment writes "Pico della Mirandola"; the catalogue holds "Pico della Mirandola, Giovanni". Exact-key lookup missed, and the name fell through to the work *Opera Omnia*. Now indexed by distinctive token and confirmed with `authorsAgree()`.

**3. Generic titles crossing authors.** *Opera Omnia* is generic across early-modern printing — unchecked it matched whichever indexed first. Worse, "Ovid, Metamorphoses" could land on Apuleius' *Metamorphoseon Libri XI*. The work half is now accepted only when the book's author **agrees** with the author half.

**4. "Author, Work" read as a person.** "Raphael, Transfiguration" matched a book by "Götz, Raphael" on the shared given name alone. With a comma present, only `parts[0]` is a name candidate.

Plus the two defects named in the issue body: link targets are ranked so a **visible** edition beats a hidden one with more OCR (*Atalanta Fugiens* was filed unreadable off a hidden copy while a visible, translated one sat beside it), and author references are a different **kind** of link, routed to `/author/` rather than an arbitrary volume by that author.

## What good output looks like now

```
Ovid, Metamorphoses            → Ovid, Metamorphoses with Annotations   [title-exact+author]
Aristotle, Nicomachean Ethics  → Ethica Nicomachea (Argyropoulos)       [title-exact+author]
Apuleius, The Golden Ass       → Metamorphoseon Libri XI                [title-prefix+author]
Pliny the Elder, Naturalis…    → Naturalis Historia                     [title-exact+author]
Boethius, De institutione…     → De institutione musica (15th c. MS)    [title-prefix+author]
Sibylline Oracles              → Oracula Sibyllina (Editio Princeps)    [title-exact]
Marsilio Ficino                → author "Marsilio Ficino"
```

## Test plan

- `npx vitest run tests/unit/artwork-work-resolver.test.ts` — 12 passed, every case drawn from a real failure
- `npx tsc --noEmit` clean
- Queue output lands in `scripts/output/` (gitignored, ~11MB)

## Not in scope

- **No write path.** Approving rows is a separate, deliberate step — deliberately not built until the queue has been reviewed.
- The `authors` thesaurus (`author_id`) is not used yet; only 3,107 artworks carry one, so backfilling it is its own change and would raise recall further.
- Hard-provenance `source_book` backfill (Deutsche Fotothek `aus:` field, MS shelfmarks) is the other channel and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
