### PR TITLE
fix(review): accept signed-in account ids as volunteer_id

### DIFF
--- a/src/app/api/review/stats/route.ts
+++ b/src/app/api/review/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase';
+import { isValidVolunteerId } from '@/lib/review-queue';
 
 export const maxDuration = 5;
 
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest) {
     .not('note', 'is', null);
 
   let mine: number | null = null;
-  if (volunteerId && /^[0-9a-f-]{36}$/i.test(volunteerId)) {
+  if (volunteerId && isValidVolunteerId(volunteerId)) {
     const { count } = await supabaseAdmin
       .from('volunteer_ratings')
       .select('id', { count: 'exact', head: true })

--- a/src/app/api/review/submit/route.ts
+++ b/src/app/api/review/submit/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase';
-import { isValidRating, QUEUE_KEYS } from '@/lib/review-queue';
+import { isValidRating, isValidVolunteerId, QUEUE_KEYS } from '@/lib/review-queue';
 
 export const maxDuration = 5;
 
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
   if (rating === null && note === null) {
     return NextResponse.json({ error: 'a rating or a note is required' }, { status: 400 });
   }
-  if (!/^[0-9a-f-]{36}$/i.test(volunteerId)) {
+  if (!isValidVolunteerId(volunteerId)) {
     return NextResponse.json({ error: 'invalid volunteer_id' }, { status: 400 });
   }
 

--- a/src/lib/review-queue.ts
+++ b/src/lib/review-queue.ts
@@ -68,6 +68,22 @@ export const QUEUE_RATINGS: Record<string, RatingOption[]> = {
   ],
 };
 
+/**
+ * A volunteer_id has TWO valid shapes: the signed-in account id (NextAuth
+ * MongoDBAdapter ObjectId string — 24 hex chars, what useReviewQueue sends
+ * since ratings became account-attributed) or the anonymous per-browser uuid
+ * (36 chars, the signed-out fallback). The submit route validated only the
+ * uuid shape, so every signed-in submission 400'd — zero ratings landed
+ * between 2026-08-05 and 2026-08-19 while volunteers saw "Submit failed".
+ * Every route that checks a volunteer_id must use this, not its own regex.
+ */
+export function isValidVolunteerId(id: string): boolean {
+  return (
+    /^[0-9a-fA-F]{24}$/.test(id) ||
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)
+  );
+}
+
 export function isValidRating(queue: string, rating: string): boolean {
   return QUEUE_RATINGS[queue]?.some(r => r.rating === rating) ?? false;
 }


### PR DESCRIPTION
## What
`/api/review/submit` and `/api/review/stats` validated `volunteer_id` against a 36-char uuid regex. Since #3632 made ratings account-attributed, signed-in volunteers send `session.user.id` — a 24-hex Mongo ObjectId string — so **every signed-in submission was rejected with 400** and the UI showed "Submit failed — try again." Signed-out visitors can't submit at all (by design), so the review queues have been fully write-dead since 2026-08-05: `volunteer_ratings` has zero rows after that date (verified in Supabase).

Reported by Aline via email (scan-quality queue, screenshot of the failure, 2026-08-18). Reproduced with curl: a 24-hex `volunteer_id` → 400 `invalid volunteer_id`; uuid shape → 200.

## Fix
Shared `isValidVolunteerId()` in `src/lib/review-queue.ts` accepting both shapes (strict 24-hex ObjectId, strict 8-4-4-4-12 uuid — tighter than the old `[0-9a-f-]{36}` which accepted 36 dashes). Both routes now use it instead of private regexes.

## Out of scope
The stats route's `mine` count silently returning null for signed-in users was the same bug and is fixed by the same helper; no other `volunteer_id` validation sites exist (grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)