### PR TITLE
feat(imprint): read-side place resolver for citation surfaces (#4043)

### DIFF
--- a/src/app/api/[tenant]/books/[id]/editions/front-matter/route.ts
+++ b/src/app/api/[tenant]/books/[id]/editions/front-matter/route.ts
@@ -4,6 +4,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { withAuth } from '@/lib/auth-helpers';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 interface RouteContext {
   params: Promise<{ tenant: string; id: string }>;
@@ -120,7 +121,8 @@ function buildBookContext(book: Book, pages: Page[]): string {
   parts.push(`Author: ${book.author}`);
   parts.push(`Language: ${book.language}`);
   parts.push(`Published: ${book.published}`);
-  if (book.place_published) parts.push(`Place of publication: ${book.place_published}`);
+  const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+  if (imprintPlace) parts.push(`Place of publication: ${imprintPlace}`);
   if (book.publisher) parts.push(`Printer/Publisher: ${book.publisher}`);
   if (book.ustc_id) parts.push(`USTC catalog number: ${book.ustc_id}`);
   if (bookAny.is_first_translation) parts.push('NOTE: This is believed to be the FIRST English translation of this work.');

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { citationYear, citationYearOrNd } from '@/lib/publication-date';
+import { resolveImprintPlace } from '@/lib/imprint';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
@@ -111,7 +112,10 @@ function generateCitations(
   // printing being translated — the bibliographic record of the original work,
   // distinct from the Source Library translation credit. Mirrors the "Cite"
   // dropdown (CiteButton) and the bibliographic panel (BibliographicInfo).
-  const pubImprint = [book.place_published, book.publisher].filter(Boolean).join(': ');
+  // Family resolver (#4043) — `place_published` alone misses the catalogue
+  // and OCR columns; 3,300 visible books held a place and cited none.
+  const imprintPlace = resolveImprintPlace(book)?.display;
+  const pubImprint = [imprintPlace, book.publisher].filter(Boolean).join(': ');
   const imprint = [pubImprint, book.format, book.ustc_id ? `USTC ${book.ustc_id}` : ''].filter(Boolean).join('. ');
   const imprintStr = imprint ? `${imprint}. ` : '';
 
@@ -132,7 +136,7 @@ function generateCitations(
     `  title = {${title}},`,
     `  year = {${year}},`,
   ];
-  if (book.place_published) bibtexLines.push(`  address = {${book.place_published}},`);
+  if (imprintPlace) bibtexLines.push(`  address = {${imprintPlace}},`);
   bibtexLines.push(`  publisher = {${book.publisher || 'Source Library'}},`);
   bibtexLines.push(`  translator = {Source Library},`);
   if (doi) {

--- a/src/app/api/books/[id]/editions/front-matter/route.ts
+++ b/src/app/api/books/[id]/editions/front-matter/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { withAuth } from '@/lib/auth-helpers';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -114,7 +115,8 @@ function buildBookContext(book: Book, pages: Page[]): string {
   parts.push(`Author: ${book.author}`);
   parts.push(`Language: ${book.language}`);
   parts.push(`Published: ${book.published}`);
-  if (book.place_published) parts.push(`Place of publication: ${book.place_published}`);
+  const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+  if (imprintPlace) parts.push(`Place of publication: ${imprintPlace}`);
   if (book.publisher) parts.push(`Printer/Publisher: ${book.publisher}`);
   if (book.ustc_id) parts.push(`USTC catalog number: ${book.ustc_id}`);
   if (bookAny.is_first_translation) parts.push('NOTE: This is believed to be the FIRST English translation of this work.');

--- a/src/app/api/dts/collection/route.ts
+++ b/src/app/api/dts/collection/route.ts
@@ -17,6 +17,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { resolveImprintPlace, IMPRINT_PLACE_PROJECTION } from '@/lib/imprint';
 
 const BASE = 'https://sourcelibrary.org';
 const PAGE_SIZE = 50;
@@ -89,7 +90,8 @@ function bookToResource(book: Record<string, unknown>) {
   };
 
   if (book.doi) dublinCore.identifier = `doi:${book.doi}`;
-  if (book.place_published) dublinCore.spatial = book.place_published;
+  const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+  if (imprintPlace) dublinCore.spatial = imprintPlace;
   if (book.publisher) dublinCore.publisher = book.publisher;
 
   const resource: Record<string, unknown> = {
@@ -193,7 +195,7 @@ export async function GET(request: NextRequest) {
           .project({
             id: 1, slug: 1, title: 1, display_title: 1, author: 1,
             published: 1, language: 1, pages_count: 1, doi: 1,
-            place_published: 1, publisher: 1, chapters: 1, collections: 1,
+            ...IMPRINT_PLACE_PROJECTION, publisher: 1, chapters: 1, collections: 1,
           })
           .toArray(),
         db.collection('books').countDocuments(filter),
@@ -244,7 +246,7 @@ export async function GET(request: NextRequest) {
         projection: {
           id: 1, slug: 1, title: 1, display_title: 1, author: 1,
           published: 1, language: 1, pages_count: 1, doi: 1,
-          place_published: 1, publisher: 1, chapters: 1,
+          ...IMPRINT_PLACE_PROJECTION, publisher: 1, chapters: 1,
           collections: 1, license: 1,
         },
       }

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { getPartnerByProvider, type LibraryPartner } from '@/lib/library-partners';
 import { isBookReadable } from '@/lib/book-access';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -317,10 +318,11 @@ export async function GET(
         value: { none: [book.published] },
       });
     }
-    if (book.place_published) {
+    const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+    if (imprintPlace) {
       metadata.push({
         label: { en: ['Place of Publication'] },
-        value: { none: [book.place_published] },
+        value: { none: [imprintPlace] },
       });
     }
     if (book.publisher) {

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -41,6 +41,9 @@ interface Book {
   ft_claim?: 'confirmed' | 'candidate';
   publisher?: string;
   place_of_publication?: string;
+  publication_place?: string;
+  place_published?: string;
+  place?: string;
   image_source?: { contributing_library?: string; provider_name?: string };
   // Used to split the bibliography (texts) from visual works (artworks).
   // See isArtworkRecord() — older records use resource_type instead.
@@ -104,7 +107,9 @@ const BOOK_PROJECTION = {
   'first_translation.verdict': 1, 'first_translation.evidence_strength': 1,
   'first_translation.our_completeness': 1,
   'source_language_screen.verdict': 1, 'translator_author_screen.verdict': 1,
-  publisher: 1, place_of_publication: 1, resource_type: 1, content_type: 1,
+  // The whole imprint-place family (#4043) — the resolver reads all four.
+  publisher: 1, place_of_publication: 1, publication_place: 1, place_published: 1, place: 1,
+  resource_type: 1, content_type: 1,
   'image_source.contributing_library': 1, 'image_source.provider_name': 1,
 };
 

--- a/src/app/book/[id]/guide/page.tsx
+++ b/src/app/book/[id]/guide/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Loader2, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import Image from 'next/image';
 import { Book, Page } from '@/lib/types';
+import { resolveImprintPlace } from '@/lib/imprint';
 import SectionsNav from '@/components/layout/SectionsNav';
 import { BookLoader } from '@/components/ui/BookLoader';
 import LikeButton from '@/components/ui/LikeButton';
@@ -260,10 +261,10 @@ export default function GuidePage({ params }: GuidePageProps) {
                 {book.author}
               </p>
 
-              {/* Publication Info */}
-              {(book.published || book.place_published) && (
+              {/* Publication Info — place via the family resolver (#4043) */}
+              {(book.published || resolveImprintPlace(book)) && (
                 <p className="text-sm mt-1" style={{ color: 'var(--text-muted)' }}>
-                  {[book.place_published, book.published].filter(Boolean).join(', ')}
+                  {[resolveImprintPlace(book)?.display, book.published].filter(Boolean).join(', ')}
                 </p>
               )}
 

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -7,6 +7,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { resolveImprintPlace } from '@/lib/imprint';
 import { displayPublished, citationYear } from '@/lib/publication-date';
 import { isHiddenBook } from '@/lib/book-access';
 import { artworkRedirectSlug } from '@/lib/artwork-slug';
@@ -990,7 +991,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           collections: (book as unknown as { collections?: string[] }).collections,
           language: book.language,
           year: relatedYear,
-          place: book.place_published,
+          place: resolveImprintPlace(book)?.display, // family resolver, #4043
         }, renderableCover, 12).catch(() => [] as CatalogBook[])
       : [] as CatalogBook[];
     const hasRelated = tagRelated.length > 0;
@@ -1041,7 +1042,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // Publisher / place only — the DATE is surfaced separately as a labelled
     // chip (heroDate) so it's clear, not buried at the end of the impressum.
     const impressum = (() => {
-      const place = book.place_published?.trim();
+      const place = resolveImprintPlace(book)?.display; // family resolver, #4043
       const publisher = book.publisher?.trim();
       return [place, publisher].filter(Boolean).join(': ');
     })();
@@ -1156,7 +1157,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     if (histInformative) {
       // Publisher/place only make sense for a printed impressum, not an ancient
       // composition date.
-      const detail = compDate ? undefined : ([book.place_published, book.publisher].filter(Boolean).join(' · ') || undefined);
+      const detail = compDate ? undefined : ([resolveImprintPlace(book)?.display, book.publisher].filter(Boolean).join(' · ') || undefined);
       rawTimeline.push({ ts: Number.NEGATIVE_INFINITY, key: 'published', dateText: histDate, label: 'Published', detail });
     }
     // An earlier English translation published elsewhere (credit the scholar).
@@ -1475,7 +1476,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
               )}
               <div className="w-1/3 flex-shrink-0 ml-auto grid grid-cols-3 rounded overflow-hidden divide-x [&_svg]:!w-[15px] [&_svg]:!h-[15px] [&_button]:!p-0 [&_button]:!w-full [&_button]:!h-full [&_button]:!justify-center [&_button]:!rounded-none" style={{ border: '1px solid rgba(245,240,232,0.2)', borderColor: 'rgba(245,240,232,0.2)' }}>
                 {[
-                  <CiteButton key="cite" bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={book.place_published} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100" iconOnly />,
+                  <CiteButton key="cite" bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100" iconOnly />,
                   <DownloadButton key="dl" bookId={book.id} bookTitle={book.display_title || book.title} hasTranslations={hasTranslations} hasOcr={hasOcr} hasImages={pages.length > 0} imageRestricted={imageRestricted} imageAccess={imageAccess} variant="header" iconOnly />,
                   <LikeButton key="like" targetType="book" targetId={book.id} size="sm" showCount={false} className="!text-stone-100" />,
                 ].map((el, i) => (
@@ -1631,7 +1632,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                       <span className="flex items-center gap-1.5 px-3 py-1.5 cursor-not-allowed text-[13px]" style={{ color: 'rgba(245,240,232,0.4)' }} title="Complete OCR, translation & summary first"><BookMarked className="w-4 h-4" />Publish</span>
                     )}
                   </AuthCheck>
-                  <CiteButton bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={book.place_published} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
+                  <CiteButton bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
                   <DownloadButton bookId={book.id} bookTitle={book.display_title || book.title} hasTranslations={hasTranslations} hasOcr={hasOcr} hasImages={pages.length > 0} imageRestricted={imageRestricted} imageAccess={imageAccess} variant="header" />
                   <BookShare bookId={book.slug || book.id} title={book.display_title || book.title} author={book.author || ''} year={book.published} doi={book.doi} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
                   <span className="w-px h-5 mx-1" style={{ background: 'rgba(245,240,232,0.18)' }} />
@@ -1806,7 +1807,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                   format as BphCatalogBrowser.formatImpressum so the book page
                   and catalogue rows line up. */}
               {(() => {
-                const place = book.place_published?.trim();
+                const place = resolveImprintPlace(book)?.display; // family resolver, #4043
                 const publisher = book.publisher?.trim();
                 const year = book.published ? String(book.published).trim() : '';
                 const placePub = [place, publisher].filter(Boolean).join(': ');
@@ -2029,7 +2030,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                       author={book.author}
                       year={book.published}
                       publisher={book.publisher}
-                      placePublished={book.place_published}
+                      placePublished={resolveImprintPlace(book)?.display}
                       format={book.format}
                       ustcId={book.ustc_id}
                       language={book.language}

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import { firstTranslationDescription } from '@/lib/first-translation-labels';
 import { getEffectiveByline } from '@/lib/byline';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 const FIELD_LABELS: Record<string, string> = {
   display_title: 'Display Title',
@@ -148,9 +149,10 @@ export default function BibliographicInfo({
       parts.push(`_${book.title}_`);
     }
 
-    // Publication info
+    // Publication info — place via the family resolver (#4043)
     const pubParts: string[] = [];
-    if (book.place_published) pubParts.push(book.place_published);
+    const citePlace = resolveImprintPlace(book)?.display;
+    if (citePlace) pubParts.push(citePlace);
     if (book.publisher) pubParts.push(book.publisher);
     if (book.published) pubParts.push(book.published);
     if (pubParts.length > 0) {
@@ -181,7 +183,8 @@ export default function BibliographicInfo({
     }
   };
 
-  const hasExtraInfo = book.place_published || book.publisher || book.format || book.ustc_id;
+  const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+  const hasExtraInfo = imprintPlace || book.publisher || book.format || book.ustc_id;
 
   return (
     <div className="mt-4">
@@ -302,10 +305,10 @@ export default function BibliographicInfo({
             )}
 
             {/* Publication details */}
-            {book.place_published && (
+            {imprintPlace && (
               <div className="flex gap-2">
                 <span className="text-stone-500 w-24 flex-shrink-0">Place:</span>
-                <span className="text-stone-200">{book.place_published}</span>
+                <span className="text-stone-200">{imprintPlace}</span>
               </div>
             )}
 

--- a/src/components/book/BookBiblioPanel.tsx
+++ b/src/components/book/BookBiblioPanel.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { ExternalLink } from 'lucide-react';
 import type { Book, SourceWorkDateLayer } from '@/lib/types/book';
 import { cleanOriginalTitle, isNonLatinScript } from '@/lib/original-title';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 /**
  * Light-themed bibliographic panel for the book page's "Bibliographic
@@ -34,7 +35,7 @@ export default function BookBiblioPanel({
 }) {
   const src = book.image_source;
   const layers = (book.source_work_dates ?? []) as SourceWorkDateLayer[];
-  const place = book.place_published?.trim();
+  const place = resolveImprintPlace(book)?.display; // family resolver, #4043
   const publisher = book.publisher?.trim();
   const impressum = [place, publisher].filter(Boolean).join(', ');
 

--- a/src/components/browse/AuthorBibliography.tsx
+++ b/src/components/browse/AuthorBibliography.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { LayoutGrid, List } from 'lucide-react';
 import CollectionBookCard from '@/components/CollectionBookCard';
 import { bookUrl } from '@/lib/slugify';
+import { resolveImprintPlace } from '@/lib/imprint';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 
 type ViewMode = 'grid' | 'list';
@@ -32,6 +33,9 @@ interface AuthorBook {
   ft_claim?: 'confirmed' | 'candidate';
   publisher?: string;
   place_of_publication?: string;
+  publication_place?: string;
+  place_published?: string;
+  place?: string;
 }
 
 export default function AuthorBibliography({ books }: { books: AuthorBook[] }) {
@@ -124,7 +128,7 @@ export default function AuthorBibliography({ books }: { books: AuthorBook[] }) {
                 const pct = book.translation_percent ?? 0;
                 const hasOriginalTitle = book.display_title && book.title !== book.display_title;
                 const publisher = book.publisher?.split('|')[0]?.trim();
-                const place = book.place_of_publication;
+                const place = resolveImprintPlace(book)?.display; // family resolver, #4043
 
                 return (
                   <tr key={book.id} className="group hover:bg-warm/50 transition-colors">

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, usePathname } from 'next/navigation';
 import { useStableSession } from '@/hooks/useStableSession';
+import { resolveImprintPlace } from '@/lib/imprint';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
 import { toast } from 'sonner';
 import Logo from '@/components/layout/Logo';
@@ -1542,7 +1543,7 @@ export default function TranslationEditor({
                   author={book.author || 'Anonymous'}
                   year={book.published}
                   publisher={book.publisher}
-                  placePublished={book.place_published}
+                  placePublished={resolveImprintPlace(book)?.display}
                   format={book.format}
                   ustcId={book.ustc_id}
                   language={book.language}

--- a/src/components/seo/SchemaOrgMetadata.tsx
+++ b/src/components/seo/SchemaOrgMetadata.tsx
@@ -4,6 +4,7 @@ import { BASE_URL, PUBLIC_DOMAIN_MARK_URL, getLicenseUrl } from './schema-utils'
 import { formatAuthor } from '@/lib/utils';
 import { jsonLdHtml } from '@/lib/json-ld';
 import { institutionalByline, bylineClaimsAuthorship } from '@/lib/corporate-bylines';
+import { resolveImprintPlace } from '@/lib/imprint';
 
 interface SchemaOrgMetadataProps {
   book: Book;
@@ -88,10 +89,11 @@ export default function SchemaOrgMetadata({
         name: book.publisher,
       },
     }),
-    ...(book.place_published && {
+    // Family resolver (#4043) — the place may live in a sibling column.
+    ...(resolveImprintPlace(book) && {
       locationCreated: {
         '@type': 'Place',
-        name: book.place_published,
+        name: resolveImprintPlace(book)!.display,
       },
     }),
     ...(book.ustc_id && {

--- a/src/lib/citation.ts
+++ b/src/lib/citation.ts
@@ -6,6 +6,7 @@
  * "Translated by Source Library" over an English book the translator's own
  * work — see the credit logic below and #3724.
  */
+import { resolveImprintPlace } from '@/lib/imprint';
 import { citationYear, citationYearOrNd } from '@/lib/publication-date';
 import { getShortUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
@@ -66,7 +67,11 @@ export function generateCitations(
   // printing being translated — the bibliographic record of the original work,
   // distinct from the Source Library translation credit. Mirrors the "Cite"
   // dropdown (CiteButton) and the bibliographic panel (BibliographicInfo).
-  const pubImprint = [book.place_published, book.publisher].filter(Boolean).join(': ');
+  // Place comes through the family resolver (#4043): four columns hold this
+  // fact, and citation surfaces reading only `place_published` left 3,300
+  // visible books citing no place while we held one.
+  const imprintPlace = resolveImprintPlace(book)?.display;
+  const pubImprint = [imprintPlace, book.publisher].filter(Boolean).join(': ');
   const imprint = [pubImprint, book.format, book.ustc_id ? `USTC ${book.ustc_id}` : ''].filter(Boolean).join('. ');
   const imprintStr = imprint ? `${imprint}. ` : '';
 
@@ -114,7 +119,7 @@ export function generateCitations(
     `  title = {${title}},`,
     `  year = {${year}},`,
   ];
-  if (book.place_published) bibtexLines.push(`  address = {${book.place_published}},`);
+  if (imprintPlace) bibtexLines.push(`  address = {${imprintPlace}},`);
   bibtexLines.push(`  publisher = {${book.publisher || 'Source Library'}},`);
   if (renderingCredit) bibtexLines.push(`  translator = {Source Library},`);
   if (doi) {

--- a/src/lib/imprint.ts
+++ b/src/lib/imprint.ts
@@ -1,0 +1,156 @@
+/**
+ * Read-side resolver for the imprint-place family (#4043).
+ *
+ * One fact — where a book was printed — lives in four columns, written by four
+ * different passes:
+ *
+ *   publication_place     enrich-from-catalogs.mjs (BPH + USTC)   catalogue tier
+ *   place_of_publication  extract-publisher-from-ocr.mjs, EFM     ocr/mixed tier
+ *   place_published       older imports                           import tier
+ *   place                 stray (1 document)
+ *
+ * Until this resolver, every citation surface read ONLY `place_published`:
+ * 3,300 visible books held a place in a sibling field and cited none.
+ *
+ * WHY THIS IS NOT A TIER-PRECEDENCE FALLBACK. Catalogue-beats-import is
+ * falsified in the destructive direction (measured on 53 books, see
+ * .claude/docs/invariants/field-sprawl.md): the catalogue field holds
+ * `s.l. (Germany)` — a true statement that the title page names no place —
+ * while the import field holds the actual city (Danzig, Prague, Frankfurt…).
+ * A value's ROLE lives in its own shape, never in the column it sits in. So
+ * the resolver classifies each value's shape first and only breaks ties
+ * within a shape by tier:
+ *
+ *   asserted       a bare place-name — someone is asserting where this was printed
+ *   conjectural    bracketed or hedged apparatus: `[Frankfurt]`, `[Halle? Helmstedt?]`,
+ *                  `"Amsterdam" [= Hannover]` — a source hedging or correcting
+ *   stated-absent  `s.l.`, `n.p.`, `z.p.`, `o.O.`, `sine loco`… — a statement
+ *                  that the book itself names none. Not a value; never allowed
+ *                  to beat one.
+ *
+ * READ-SIDE ONLY. Nothing here writes to `books`, and the winning value is
+ * returned VERBATIM (display only tidies `|` separators) — normalisation for
+ * comparison must never be written back, because `"Amsterdam" [= Hannover]`
+ * is a catalogue's statement that the imprint lies, not noise. The canonical
+ * stated/established/conjectural storage shape is later work in #4043; this
+ * resolver is the reversible first step.
+ */
+
+/** Trust order for tie-breaks WITHIN a shape class — never across shapes. */
+export const IMPRINT_PLACE_FIELDS = [
+  'publication_place',
+  'place_of_publication',
+  'place_published',
+  'place',
+] as const;
+
+export type ImprintPlaceField = (typeof IMPRINT_PLACE_FIELDS)[number];
+
+export type ImprintPlaceFields = Partial<
+  Record<ImprintPlaceField, string | null | undefined>
+>;
+
+export type ImprintValueShape = 'asserted' | 'conjectural' | 'stated-absent';
+
+export interface ResolvedImprintPlace {
+  /** Winning value, verbatim from the field (trimmed only). */
+  value: string;
+  /** `value` with multi-place `|` separators made readable ("Frankfurt and Leipzig"). */
+  display: string;
+  /** Which column the value came from — keep it; it is the only provenance we have. */
+  field: ImprintPlaceField;
+  shape: ImprintValueShape;
+}
+
+/**
+ * Mongo projection fragment: spread into any `findOne`/`find` projection that
+ * previously carried `place_published: 1`, so the resolver sees the whole family.
+ */
+export const IMPRINT_PLACE_PROJECTION: Record<ImprintPlaceField, 1> =
+  Object.fromEntries(IMPRINT_PLACE_FIELDS.map((f) => [f, 1])) as Record<
+    ImprintPlaceField,
+    1
+  >;
+
+/**
+ * Bibliographic markers for "the book itself states none": `s.l.` (sine loco),
+ * `n.p.` (no place), `z.p.` (zonder plaats), `o.O.` (ohne Ort), `s.n.` (sine
+ * nomine), `s.d.` — plus their spelled-out forms and the catalogue habit of
+ * qualifying them (`s.l. (Germany)`). Anchored at the start and requiring a
+ * word boundary so real places never match (Sneek, Slaný, Olomouc, S. Gallen
+ * all tested clean).
+ */
+const NO_VALUE_STATED =
+  /^(n\.?\s*p\.?|s\.?\s*l\.?|z\.?\s*p\.?|s\.?\s*n\.?|s\.?\s*d\.?|o\.?\s*o\.?|sine\s+loco|sine\s+nomine|zonder\s+plaats|ohne\s+ort|no\s+place|unknown)(\b|$)/i;
+
+/** Apparatus that marks a value as hedged/corrected rather than asserted. */
+const CONJECTURAL_MARKS = /[[\]?]|^["'“”‘’]|["'“”‘’]$/;
+
+/**
+ * Classify one raw field value. Returns null for empty/absent — a value that
+ * cannot participate at all.
+ */
+export function classifyImprintValue(raw: unknown): ImprintValueShape | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Test the stated-absent markers with apparatus stripped, so `[n.p.]` and
+  // `"s.l."` still rank as stated-absent rather than merely conjectural.
+  const bare = trimmed.replace(/[[\]"'“”‘’]/g, '').trim();
+  if (!bare || NO_VALUE_STATED.test(bare)) return 'stated-absent';
+
+  if (CONJECTURAL_MARKS.test(trimmed)) return 'conjectural';
+  return 'asserted';
+}
+
+const SHAPE_RANK: Record<ImprintValueShape, number> = {
+  asserted: 0,
+  conjectural: 1,
+  'stated-absent': 2,
+};
+
+/** Multi-place strings use `|` (`Frankfurt|Leipzig`); make that readable, and
+ *  drop dangling separators (`[Lyon?]|`). Display only — never written back. */
+function displayForm(value: string): string {
+  return value
+    .replace(/^\s*\|+/, '')
+    .replace(/\|+\s*$/, '')
+    .split('|')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join(' and ');
+}
+
+/**
+ * Pick the most citable place value a book holds.
+ *
+ * Best shape wins (asserted > conjectural > stated-absent); ties within a
+ * shape go to the more trusted column (catalogue > ocr > import > stray).
+ * Returns null when the book holds nothing — callers keep their existing
+ * "no place" behaviour.
+ */
+export function resolveImprintPlace(
+  // Loose on purpose: raw Mongo docs (`WithId<Document>`) flow in from route
+  // handlers; classifyImprintValue type-guards every value anyway.
+  book: ImprintPlaceFields | Record<string, unknown> | null | undefined,
+): ResolvedImprintPlace | null {
+  if (!book) return null;
+
+  let best: ResolvedImprintPlace | null = null;
+  let bestRank = Infinity;
+
+  for (const field of IMPRINT_PLACE_FIELDS) {
+    const raw = (book as Record<string, unknown>)[field];
+    const shape = classifyImprintValue(raw);
+    if (!shape) continue;
+    const rank = SHAPE_RANK[shape];
+    // Strict `<` keeps the first (most trusted) field at equal shape rank.
+    if (rank < bestRank) {
+      const value = (raw as string).trim();
+      best = { value, display: displayForm(value), field, shape };
+      bestRank = rank;
+    }
+  }
+  return best;
+}

--- a/src/lib/kdp-epub.ts
+++ b/src/lib/kdp-epub.ts
@@ -1,4 +1,5 @@
 import epub from 'epub-gen-memory';
+import { resolveImprintPlace } from '@/lib/imprint';
 import type { Book, Chapter } from '@/lib/types';
 import type { Page } from '@/lib/types';
 
@@ -382,8 +383,9 @@ export async function generateKdpEpub(
   if (book.published) {
     colophonHtml += `<p><span class="colophon-label">Published:</span> ${escapeXml(book.published)}</p>`;
   }
-  if (book.place_published) {
-    colophonHtml += `<p><span class="colophon-label">Place:</span> ${escapeXml(book.place_published)}</p>`;
+  const imprintPlace = resolveImprintPlace(book)?.display; // family resolver, #4043
+  if (imprintPlace) {
+    colophonHtml += `<p><span class="colophon-label">Place:</span> ${escapeXml(imprintPlace)}</p>`;
   }
   if (book.publisher) {
     colophonHtml += `<p><span class="colophon-label">Printer/Publisher:</span> ${escapeXml(book.publisher)}</p>`;

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -59,7 +59,12 @@ export interface Book {
 
   // USTC catalog fields
   ustc_id?: string;           // USTC catalog number (e.g., "2029384")
-  place_published?: string;   // City of publication (e.g., "Hamburg")
+  place_published?: string;   // City of publication (e.g., "Hamburg") — import tier
+  /** Same fact, other writers (#4043). Read via resolveImprintPlace() in
+   *  src/lib/imprint.ts — never pick one of these by hand. */
+  place_of_publication?: string;  // ocr/mixed tier
+  publication_place?: string;     // catalogue tier (BPH + USTC)
+  place?: string;                 // stray (1 document)
   publisher?: string;         // Printer/Publisher name
   format?: string;            // Book format (folio, quarto, octavo, etc.)
 

--- a/src/lib/zenodo.ts
+++ b/src/lib/zenodo.ts
@@ -10,6 +10,7 @@
  */
 
 import { TranslationEdition, Book } from './types';
+import { resolveImprintPlace } from './imprint';
 
 const ZENODO_API = process.env.ZENODO_SANDBOX === 'true'
   ? 'https://sandbox.zenodo.org/api'
@@ -405,7 +406,7 @@ function buildDescription(book: Book, edition: TranslationEdition): string {
     `<li>Author: ${author}</li>`,
     `<li>Language: ${book.language}</li>`,
     book.published ? `<li>Published: ${book.published}</li>` : '',
-    book.place_published ? `<li>Place: ${book.place_published}</li>` : '',
+    resolveImprintPlace(book) ? `<li>Place: ${resolveImprintPlace(book)!.display}</li>` : '',
     book.publisher ? `<li>Publisher: ${book.publisher}</li>` : '',
     book.ustc_id ? `<li>USTC: ${book.ustc_id}</li>` : '',
     '</ul>',

--- a/tests/unit/imprint-place-resolver.test.ts
+++ b/tests/unit/imprint-place-resolver.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The imprint-place resolver must read the VALUE's shape, not the column's
+ * tier (#4043).
+ *
+ * The case that killed tier precedence, measured on 53 production books: the
+ * catalogue field holds `s.l. (Germany)` — a true statement that the title
+ * page names no place — while the import field holds the actual city.
+ * Catalogue-wins would cite "place unknown" over Danzig. These tests pin the
+ * opposite behaviour, plus the classifier edges that make it safe.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyImprintValue,
+  resolveImprintPlace,
+  IMPRINT_PLACE_PROJECTION,
+} from '@/lib/imprint';
+
+describe('classifyImprintValue', () => {
+  it('classifies bare place-names as asserted', () => {
+    for (const v of ['Danzig', 'Roma', 'Coloniae Agrippinae', 'Frankfurt am Main', 'Nürnberg']) {
+      expect(classifyImprintValue(v)).toBe('asserted');
+    }
+  });
+
+  it('classifies stated-absent markers, qualified or bracketed, as stated-absent', () => {
+    for (const v of ['s.l.', 's.l. (Germany)', 'n.p.', '[n.p.]', 'z.p.', 'o.O.', 'sine loco', 'zonder plaats', 'No place', 'unknown', 'S. l.']) {
+      expect(classifyImprintValue(v)).toBe('stated-absent');
+    }
+  });
+
+  it('never mistakes a real place for a marker', () => {
+    // Sneek (s.n…), Slaný (s.l…), Olomouc (o.o…), S. Gallen, Naples (n.p…-adjacent)
+    for (const v of ['Sneek', 'Slaný', 'Olomouc', 'S. Gallen', 'Naples', 'Novi Pazar']) {
+      expect(classifyImprintValue(v)).toBe('asserted');
+    }
+  });
+
+  it('classifies bracketed and hedged apparatus as conjectural', () => {
+    for (const v of ['[Frankfurt]', '[Halle? Helmstedt?]', '"Amsterdam" [= Hannover]', 'Danzig?']) {
+      expect(classifyImprintValue(v)).toBe('conjectural');
+    }
+  });
+
+  it('returns null for empty and non-string values', () => {
+    expect(classifyImprintValue('')).toBeNull();
+    expect(classifyImprintValue('   ')).toBeNull();
+    expect(classifyImprintValue(null)).toBeNull();
+    expect(classifyImprintValue(undefined)).toBeNull();
+    expect(classifyImprintValue(42)).toBeNull();
+  });
+});
+
+describe('resolveImprintPlace', () => {
+  it('an asserted city beats a stated-absent marker in a more trusted column', () => {
+    // The destructive case tier-precedence gets wrong.
+    const r = resolveImprintPlace({
+      publication_place: 's.l. (Germany)', // catalogue tier
+      place_published: 'Danzig',           // import tier
+    });
+    expect(r).toMatchObject({ value: 'Danzig', field: 'place_published', shape: 'asserted' });
+  });
+
+  it('an asserted value beats a conjectural one', () => {
+    // De occulta philosophia: fictitious imprint vs true printing.
+    const r = resolveImprintPlace({
+      publication_place: '[Cologne]',
+      place_published: 'Lyon',
+    });
+    expect(r).toMatchObject({ value: 'Lyon', shape: 'asserted' });
+  });
+
+  it('within a shape, the more trusted column wins', () => {
+    const r = resolveImprintPlace({
+      publication_place: 'Roma',
+      place_published: 'Rome',
+    });
+    expect(r).toMatchObject({ value: 'Roma', field: 'publication_place' });
+  });
+
+  it('falls back to conjectural, then stated-absent, when nothing better exists', () => {
+    expect(resolveImprintPlace({ place_of_publication: '[Frankfurt]' })).toMatchObject({
+      value: '[Frankfurt]',
+      shape: 'conjectural',
+    });
+    expect(resolveImprintPlace({ publication_place: 's.l. (Germany)' })).toMatchObject({
+      shape: 'stated-absent',
+    });
+  });
+
+  it('resolves the 3,300-book case: a sibling field alone now cites', () => {
+    const r = resolveImprintPlace({ place_of_publication: 'Amsterdam' });
+    expect(r).toMatchObject({ value: 'Amsterdam', field: 'place_of_publication' });
+  });
+
+  it('returns null when the book holds nothing', () => {
+    expect(resolveImprintPlace({})).toBeNull();
+    expect(resolveImprintPlace(null)).toBeNull();
+    expect(resolveImprintPlace({ place_published: '' })).toBeNull();
+  });
+
+  it('display joins multi-place strings and drops dangling separators, value stays verbatim', () => {
+    const multi = resolveImprintPlace({ place_published: 'Frankfurt|Leipzig' });
+    expect(multi?.value).toBe('Frankfurt|Leipzig');
+    expect(multi?.display).toBe('Frankfurt and Leipzig');
+
+    const dangling = resolveImprintPlace({ place_of_publication: '[Lyon?]|' });
+    expect(dangling?.display).toBe('[Lyon?]');
+  });
+
+  it('never rewrites catalogue apparatus — the lie-marker survives to display', () => {
+    const r = resolveImprintPlace({ publication_place: '"Amsterdam" [= Hannover]' });
+    expect(r?.display).toBe('"Amsterdam" [= Hannover]');
+  });
+
+  it('projection fragment covers the whole family', () => {
+    expect(IMPRINT_PLACE_PROJECTION).toEqual({
+      publication_place: 1,
+      place_of_publication: 1,
+      place_published: 1,
+      place: 1,
+    });
+  });
+});


### PR DESCRIPTION
## What

The first unblocked sub-task of #4043: every citation surface read only `place_published` (import tier), while the same fact lives in three sibling columns — so **3,300 visible books held a place and cited none**, and 208 cited an import value while we held a catalogue one.

`src/lib/imprint.ts` resolves the family **by the value's shape, not the column's tier**:

- `asserted` (bare place-name) > `conjectural` (`[Frankfurt]`, `[Halle? Helmstedt?]`) > `stated-absent` (`s.l.`, `n.p.`, `z.p.`, `o.O.`…)
- ties within a shape break by trust order: catalogue > ocr > import > stray

Tier precedence alone is falsified in the destructive direction (53 measured books: catalogue `s.l. (Germany)` vs import `Danzig` — catalogue-wins cites "place unknown" over a real city; see `.claude/docs/invariants/field-sprawl.md`). Values return **verbatim** — `"Amsterdam" [= Hannover]` is a catalogue's statement that the imprint lies and survives to the reader; display only tidies `|` separators (`Frankfurt|Leipzig` → "Frankfurt and Leipzig").

## Wired surfaces

citation.ts (quote API + CiteButton), tenant quote route, both front-matter routes, IIIF manifest, DTS Dublin Core `spatial`, schema.org `locationCreated`, EPUB colophon, Zenodo description, BibliographicInfo, BookBiblioPanel, book page (impressum ×2, timeline, related-books seed, CiteButton ×3), guide page, author bibliography (+ projection). Projections that carried `place_published: 1` alone now spread `IMPRINT_PLACE_PROJECTION`.

## Out of scope (deliberately)

- **No writes to `books`** — the canonical stated/established/conjectural storage shape is a later #4043 sub-task; this is the reversible read-side step.
- **Supabase catalog surfaces** (`books-catalog.ts` BOOK_SELECT, related-books *candidates*) — the catalog table has no sibling columns; needs a sync-side change, separate PR.
- **Embed catalog pages** — their `place_published` mapping is a dead pass-through (display uses the catalog row's own `place`); left untouched.
- **Printer/publisher family** — messier (only 151/916 agree), needs its own pass.

## Tests

14 new unit tests pin the classifier edges (Sneek/Slaný/Olomouc never read as markers) and the destructive case (asserted city beats stated-absent marker in a *more trusted* column). Full suite: 2,858 pass; `tsc --noEmit` clean.

Closes nothing — ticks the first unchecked box of #4043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)