### PR TITLE
fix(search): stop object-shaped summaries from crashing the search page

### DIFF
--- a/src/components/search/HighlightedText.tsx
+++ b/src/components/search/HighlightedText.tsx
@@ -35,10 +35,15 @@ function escapeHtml(s: string): string {
  * injection surface.
  */
 export default function HighlightedText({ text, query, className }: HighlightedTextProps) {
+  // Callers pass fields straight off API responses, and one non-string value
+  // (books.summary is an object on ~17k rows) took down the whole /search page
+  // via the error boundary. A snippet renderer must never be the thing that
+  // crashes the page: tolerate any input.
+  const safeText = typeof text === 'string' ? text : text == null ? '' : String(text);
   const html =
-    !query || !text
-      ? escapeHtml(text ?? '')
-      : splitByMatches(text, query)
+    !query || !safeText
+      ? escapeHtml(safeText)
+      : splitByMatches(safeText, query)
           .map((segment) =>
             segment.highlight
               ? `<mark class="${MARK_CLASS}">${escapeHtml(segment.text)}</mark>`

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -29,6 +29,12 @@ const clampAspect = (r: number) => Math.min(3, Math.max(0.33, r));
 export function artworkToGalleryItem(a: any) {
   const image = a.image_display || a.image_full || a.image_thumb || a.thumbnail_blob || a.thumbnail || '';
   const thumb = a.image_thumb || a.thumbnail_blob || a.thumbnail || a.image_display || image;
+  // books.summary has two shapes: legacy plain string, or the enrich-worker
+  // wrapper { data, generated_at, model, ... } (~17k books each). Passing the
+  // wrapper object through as `description` crashed /search client-side
+  // ("e.normalize is not a function" in the highlighter) for any query whose
+  // AI expansion surfaced such an artwork.
+  const summaryText = typeof a.summary === 'string' ? a.summary : a.summary?.data;
   const year = typeof a.year === 'number' ? a.year : (parseInt(a.published, 10) || undefined);
   const w = a.full_width || a.commons_width;
   const h = a.full_height || a.commons_height;
@@ -45,7 +51,7 @@ export function artworkToGalleryItem(a: any) {
     bookTitle: a.display_title || a.title || 'Untitled',
     author: a.author,
     year,
-    description: a.summary || a.display_title || a.title || '',
+    description: summaryText || a.display_title || a.title || '',
     type: a.resource_type,
     source: 'artwork' as const,
     // /artwork is the canonical route for a standalone artwork. This field is


### PR DESCRIPTION
## What
https://sourcelibrary.org/search?q=couple&mode=images died with the global error boundary ("Something went wrong") — reported by Aline, reproduced in a browser: `TypeError: e.normalize is not a function`.

## Root cause
`artworkToGalleryItem` (src/lib/gallery-merge.ts) sets `description: a.summary || …`. But `books.summary` has two live shapes: legacy plain string (16,742 rows) and the enrich-worker wrapper `{data, generated_at, model, …}` (16,808 rows — measured in prod Mongo). The wrapper object is truthy, passes the `||` chain, and reaches `HighlightedText` → `splitByMatches` → `text.normalize()` → TypeError → error boundary kills the entire search page.

Trigger: any query whose gallery search lane (title-match or semantic artwork lane, incl. AI-expansion supplementary queries) surfaces an artwork whose summary is object-shaped. Positive control: `/api/gallery?q=two%20figures` returns "Recto Two Figures of Aphrodite" with an object description.

## Fix (two layers)
- `gallery-merge.ts`: unwrap with the codebase idiom `typeof summary === 'string' ? summary : summary?.data` (same as book/[id]/page.tsx, iiif manifest, embed bph, etc.)
- `HighlightedText`: coerce non-string input to a string — a snippet renderer should degrade, never crash the page

## Out of scope
The `mapPlate`/gallery_images lanes pass `d.description` raw, but gallery_images has 0 non-string descriptions (measured); left alone. A repo-wide audit of raw `.summary` reads is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)