### PR TITLE
fix(review): volunteer_id column uuid → text (migration record)

### DIFF
--- a/supabase/migrations/20260819000000_volunteer_id_text.sql
+++ b/supabase/migrations/20260819000000_volunteer_id_text.sql
@@ -1,0 +1,10 @@
+-- volunteer_id: uuid → text.
+--
+-- Ratings are attributed to the signed-in account since #3632: the client
+-- sends session.user.id, which is the NextAuth MongoDBAdapter ObjectId as a
+-- 24-hex STRING, not a uuid. The uuid column type rejected every such insert
+-- (22P02), which — combined with the API's uuid-shaped regex, fixed in #4052 —
+-- kept the review queues write-dead from 2026-08-05 to 2026-08-19.
+-- The anonymous per-browser uuid remains a valid value; text admits both.
+ALTER TABLE volunteer_ratings
+  ALTER COLUMN volunteer_id TYPE text USING volunteer_id::text;


### PR DESCRIPTION
## What
Second half of #4052. Even with the API accepting 24-hex account ids, `volunteer_ratings.volunteer_id` was typed `uuid` in Supabase, so every signed-in insert failed with 22P02 (`invalid input syntax for type uuid`) → 500 → "Submit failed — try again."

## Status
**Already applied to production** (2026-08-19, via SUPABASE_DB_URL): `ALTER TABLE volunteer_ratings ALTER COLUMN volunteer_id TYPE text USING volunteer_id::text`. Verified `data_type` is now `text` and an end-to-end submit with an account-shaped id returns 200 (test row deleted after). This PR just records the migration so the repo matches production (per the committed-migration-≠-production lesson).

## Notes
Existing anonymous-uuid rows cast cleanly; the `(volunteer_id, created_at DESC)` index survives the type change. No FK/views/RLS reference the column's type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)