### PR TITLE
feat(artwork-links): resolver token-coverage fix + author identity backfills (#4037)

### DIFF
--- a/.claude/handoffs/2026-08-19-artwork-book-linking.md
+++ b/.claude/handoffs/2026-08-19-artwork-book-linking.md
@@ -106,3 +106,54 @@ counts looked fine throughout. Read the queue before trusting any number in it.
   most are in `scripts/import/`, where a bad slug becomes a permanent URL.
 - 22,767 books with >20pp OCR have no `visible` field at all — intentional QA
   gate or drift is undetermined, and nobody can currently tell.
+
+---
+
+## Session 2 (2026-08-19, late): queue read + identity backfills — DONE
+
+**The 50-row read (step 2 above) — reject rates by bucket, not overall:**
+- work links (30 read): 0 wrong. Caveats only: multi-volume sets always pick one
+  volume (every "Ovid, Metamorphoses" → Aldine Vol. 3), and generic scripture
+  ("New Testament") lands on whatever edition we hold (a German NT). Ranking
+  refinements, not wrong links.
+- author links via `author-name` exact key (13 read): 0 wrong.
+- author links via `author-token` (12 read): **10 wrong (~85%)** — every wrong
+  row in the whole sample. One shared given-name token was enough: "Gospel of
+  John" → John Dee, "Paolo Veronese" → Lomazzo, "Matthäus Merian" → Schorer,
+  "Ezekiel 37" → Burridge. 3,947 of 4,911 token rows shared only ONE token.
+
+**Fixed in `artwork-work-resolver.mjs`** (pinned by 4 new tests, 16/16 green):
+token matches now need ≥2 shared distinctive tokens, or full mutual coverage
+("Rudolf II" ↔ "Rudolf, II." still links). Queue after the fix: 2,569 book /
+4,962 author-only / 4,982 unresolved — bad author links became honest
+unresolveds, and freed strings became correct work links ("Book of Tobit" →
+our Aramaic Tobit).
+
+**Ladder step 1 — `authors.aliases[]` backfilled:** 4,129 of 4,586 QID-anchored
+authors now carry Wikidata labels+aliases (16 languages). P31 verified per QID;
+9 non-person QIDs refused and reported (Vishnu, Chiron, Liezi→the *book*,
+Pers→the publishing firm) in `scripts/output/author-aliases-backfill-report.json`.
+Nothing in src/ reads `authors.aliases` yet — inert until a reader opts in.
+sweep_log: `author-aliases-wikidata-2026-08`, 4,129 rows + 1 repair row.
+
+**Ladder step 2 — artwork `author_id`:** `backfill-author-canonical-links.mjs`
+grew an `--artworks` lane (the old live filter requires `pages_count>0`, which
+only 97 of 24,912 artworks pass — the scoping-bug shape). Applied 46/46 links
+(run id `backfill-2250-artworks`, reversible). Small on purpose: reading the
+69-row dry run caught **Wikidata aliases linking the wrong person** — Caccini's
+genuine historical nickname "Giulio Romano" staged 21 painter references onto
+the composer, and `jordanes` carried the PAINTER Jacob Jordaens' QID (Q270658;
+now repaired to Q131548 — P31 can't catch wrong-person, only wrong-kind). New
+guard: alias-only matches need a shared rare token (thesaurus freq ≤3 — admits
+surnames, refuses given names).
+
+**The real artwork gap is a MINT gap, not a match gap.** The thesaurus is built
+from text authors; Raphael (1,032 artworks), Goltzius (852), Sadeler (445),
+Merian (349), Callot (307), Rembrandt (201), Titian (118)… have no author doc
+at all. Top-400 unlinked painters cover 9,824 visible artworks —
+`scripts/output/artwork-painter-mint-candidates.json`. Minting is a public-
+surface decision (new /author/ pages) — propose via issue, don't bulk-run.
+
+**Next:** (a) painter mint decision; (b) make the RESOLVER consult
+authors.aliases for person references (it still walks books.author strings);
+(c) work-QID lookup (ladder step 3); (d) then the write path per above.

--- a/scripts/artwork-links/backfill-author-aliases.mjs
+++ b/scripts/artwork-links/backfill-author-aliases.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Backfill `authors.aliases[]` from Wikidata labels + aliases. (#4037, ladder step 1)
+ *
+ * WHY: 4,586 of 6,291 authors carry a `wikidata_id`, but no author holds the
+ * multilingual name forms those QIDs entitle us to — so artwork cross-reference
+ * names ("Erasmus of Rotterdam") miss catalogue forms ("Erasmus von Rotterdam")
+ * that Wikidata knows are the same person. This is a fetch, not a model.
+ *
+ * `aliases` is a NEW field on `authors`: external-authority name forms, kept
+ * deliberately separate from `variants[]` (catalogue-observed forms, which
+ * drive /author/ URL resolution and carry their own provenance). Nothing in
+ * src/ reads `authors.aliases` today, so writing it actuates nothing.
+ *
+ * Every QID's P31 is verified before its aliases are trusted
+ * (lesson_verify_every_wikidata_qid: an id that denotes a WORK or an EDITION
+ * instead of a person is a real and observed failure). Non-person P31s are
+ * never written; they land in the report as suspect wikidata_ids.
+ *
+ *   node --env-file=.env.production.local scripts/artwork-links/backfill-author-aliases.mjs           (dry run)
+ *   node --env-file=.env.production.local scripts/artwork-links/backfill-author-aliases.mjs --apply
+ *
+ * Writes (with --apply): authors.aliases[] + one sweep_log row per author.
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const SWEEP = 'author-aliases-wikidata-2026-08';
+const OUT = 'scripts/output/author-aliases-backfill-report.json';
+
+// Name-form languages that actually occur in our catalogue + enrichment output.
+const LANGS = 'en|de|fr|it|nl|es|pt|la|el|grc|cs|pl|sv|da|hu|ru';
+
+// P31 values we accept as "this QID denotes a person (or person-shaped
+// tradition-bearer our catalogue legitimately files as an author)".
+const PERSON_P31 = new Map([
+  ['Q5', 'human'],
+  ['Q20643955', 'human biblical figure'],
+  ['Q21070568', 'human whose existence is disputed'],
+  ['Q22988604', 'legendary figure'],
+  ['Q4271324', 'mythical character'],
+]);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const authors = db.collection('authors');
+
+const docs = await authors
+  .find(
+    { wikidata_id: { $exists: true, $nin: [null, ''] } },
+    { projection: { canonical_name: 1, variants: 1, wikidata_id: 1, aliases: 1 } },
+  )
+  .toArray();
+console.error(`${docs.length} authors carry a wikidata_id`);
+
+// Several authors can share one QID (duplicate headings); fetch each QID once.
+const byQid = new Map();
+for (const d of docs) {
+  const qid = String(d.wikidata_id).trim();
+  if (!/^Q\d+$/.test(qid)) {
+    console.error(`  malformed wikidata_id ${JSON.stringify(qid)} on ${d._id} — skipped`);
+    continue;
+  }
+  if (!byQid.has(qid)) byQid.set(qid, []);
+  byQid.get(qid).push(d);
+}
+const qids = [...byQid.keys()];
+console.error(`${qids.length} distinct QIDs to fetch`);
+
+const entities = new Map(); // qid -> wbgetentities entity (or {missing})
+for (let i = 0; i < qids.length; i += 50) {
+  const batch = qids.slice(i, i + 50);
+  const url =
+    'https://www.wikidata.org/w/api.php?action=wbgetentities' +
+    `&ids=${batch.join('|')}&props=labels|aliases|claims&languages=${LANGS}` +
+    '&format=json&maxlag=5';
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'SourceLibraryBot/1.0 (https://sourcelibrary.org)' },
+  });
+  if (!res.ok) throw new Error(`wbgetentities HTTP ${res.status} on batch at ${i}`);
+  const data = await res.json();
+  if (data.error) throw new Error(`wbgetentities error: ${JSON.stringify(data.error)}`);
+  for (const [id, ent] of Object.entries(data.entities || {})) entities.set(id, ent);
+  process.stderr.write(`\r  fetched ${Math.min(i + 50, qids.length)}/${qids.length}`);
+  await new Promise((r) => setTimeout(r, 250));
+}
+console.error('');
+
+const p31Of = (ent) =>
+  (ent?.claims?.P31 || [])
+    .map((c) => c?.mainsnak?.datavalue?.value?.id)
+    .filter(Boolean);
+
+const norm = (s) => String(s || '').normalize('NFC').trim().toLowerCase();
+
+const report = {
+  generated_at: new Date().toISOString(),
+  apply: APPLY,
+  authors_with_qid: docs.length,
+  distinct_qids: qids.length,
+  written: 0,
+  no_new_aliases: 0,
+  suspect_non_person: [], // wikidata_id does not denote a person — do NOT trust it
+  missing_or_redirected: [],
+  p31_distribution: {},
+};
+
+let writes = 0;
+for (const [qid, authorDocs] of byQid) {
+  const ent = entities.get(qid);
+  if (!ent || ent.missing !== undefined) {
+    report.missing_or_redirected.push({ qid, authors: authorDocs.map((d) => d._id) });
+    continue;
+  }
+  const p31 = p31Of(ent);
+  for (const p of p31.length ? p31 : ['(none)']) {
+    report.p31_distribution[p] = (report.p31_distribution[p] || 0) + 1;
+  }
+  const accepted = p31.some((p) => PERSON_P31.has(p));
+  if (!accepted) {
+    report.suspect_non_person.push({
+      qid,
+      p31,
+      authors: authorDocs.map((d) => ({ id: d._id, name: d.canonical_name })),
+    });
+    continue;
+  }
+
+  const forms = [];
+  for (const l of Object.values(ent.labels || {})) forms.push(l.value);
+  for (const arr of Object.values(ent.aliases || {})) for (const a of arr) forms.push(a.value);
+
+  for (const doc of authorDocs) {
+    const known = new Set([norm(doc.canonical_name), ...(doc.variants || []).map(norm)]);
+    const seen = new Set();
+    const fresh = [];
+    for (const f of forms) {
+      const n = norm(f);
+      if (!n || n.length < 3 || known.has(n) || seen.has(n)) continue;
+      seen.add(n);
+      fresh.push(f.normalize('NFC').trim());
+      if (fresh.length >= 60) break;
+    }
+    if (!fresh.length) {
+      report.no_new_aliases++;
+      continue;
+    }
+    if (APPLY) {
+      const r = await authors.updateOne({ _id: doc._id }, { $set: { aliases: fresh } });
+      if (r.modifiedCount !== 1 && r.matchedCount !== 1) {
+        throw new Error(`update did not match author ${doc._id}`);
+      }
+      await recordSweepAction(db, {
+        sweep: SWEEP,
+        book_id: String(doc._id),
+        action: 'aliases-backfilled',
+        detail: { collection: 'authors', qid, alias_count: fresh.length },
+      });
+      writes++;
+    } else {
+      writes++; // dry-run: count what WOULD be written
+    }
+  }
+}
+report.written = writes;
+
+mkdirSync('scripts/output', { recursive: true });
+writeFileSync(OUT, JSON.stringify(report, null, 2));
+
+console.error(`\n${APPLY ? 'WROTE' : 'DRY RUN — would write'} aliases on ${writes} authors`);
+console.error(`no new forms: ${report.no_new_aliases}`);
+console.error(`suspect non-person QIDs: ${report.suspect_non_person.length}`);
+console.error(`missing/redirected QIDs: ${report.missing_or_redirected.length}`);
+console.error(`report: ${OUT}`);
+if (!APPLY) console.error('\nNothing written. Re-run with --apply after reading the report.');
+await client.close();

--- a/scripts/lib/artwork-work-resolver.mjs
+++ b/scripts/lib/artwork-work-resolver.mjs
@@ -142,7 +142,23 @@ export function buildIndex(books) {
   return { byTitle, byAuthor, byAuthorToken, titleKeys: [...byTitle.keys()] };
 }
 
-/** Best book by this person, or null. Fuzzy on name form; strict on agreement. */
+/**
+ * Best book by this person, or null. Fuzzy on name form; strict on agreement.
+ *
+ * DEFECT THE COVERAGE RULE FIXES (found reading the queue, 2026-08-19): a
+ * single shared given name was enough for authorsAgree, so the token path
+ * matched "Paolo Veronese" → "Giovanni Paolo Lomazzo", "Gospel of John" →
+ * "John Dee", "Matthäus Merian" → "Schorer, Matthäus", "Ezekiel 37" →
+ * "Burridge, Ezekiel" — 3,947 of 4,911 token-matched queue rows shared only
+ * ONE token, and a read of that bucket put its wrong-rate near 85%. So a
+ * candidate must now share >= 2 distinctive tokens, OR the two names must
+ * consist of exactly the same distinctive tokens ("Rudolf II" ↔ "Rudolf, II."
+ * — one token each, fully covered). One shared token with unexplained extras
+ * on either side is how every observed mismatch happened. Under-merge over
+ * mis-merge (#2218): the cost is epithet forms like "Bonaventure of
+ * Bagnoregio" vs the catalogue's apparatus-laden heading, which belong to the
+ * thesaurus-alias join, not this string walk.
+ */
 export function findByPerson(index, name) {
   const tokens = authorKey(name).split(' ').filter((w) => w.length >= 4);
   if (tokens.length < 1) return null;
@@ -152,6 +168,8 @@ export function findByPerson(index, name) {
       if (!authorsAgree(name, b.author)) continue;
       const shared = new Set(authorKey(b.author).split(' ').filter((w) => w.length >= 4));
       const overlap = tokens.filter((w) => shared.has(w)).length;
+      const covered = overlap >= 2 || (overlap === tokens.length && overlap === shared.size);
+      if (!covered) continue;
       const prev = seen.get(b.id);
       if (!prev || overlap > prev.overlap || (overlap === prev.overlap && linkQuality(b) > linkQuality(prev.book))) {
         seen.set(b.id, { book: b, overlap });

--- a/scripts/maintenance/backfill-author-canonical-links.mjs
+++ b/scripts/maintenance/backfill-author-canonical-links.mjs
@@ -59,10 +59,23 @@ const UNDO = process.argv.includes('--undo');
  * strings skipped, provenance written, reversible via --undo.
  */
 const INCLUDE_BACKLOG = process.argv.includes('--include-backlog');
-const liveScope = INCLUDE_BACKLOG ? {} : { visible: { $ne: false }, pages_count: { $gt: 0 } };
-// Separate run id so a backlog pass can be reverted on its own, without also
-// undoing the live linkage an earlier run wrote.
-const RUN_ID = INCLUDE_BACKLOG ? 'backfill-2250-backlog' : 'backfill-2250';
+
+/**
+ * --artworks: link ARTWORK records instead of texts (#4037).
+ *
+ * The live filter below requires `pages_count > 0`, and an artwork is a single
+ * image — measured 2026-08-19, only 97 of 24,912 artworks pass it, which is why
+ * the artwork shelf never acquired author_id (the "scoping bug wearing drift's
+ * clothes" shape from field-sprawl.md). For an artwork, "live" means visible;
+ * there are no pages. Linking rule is unchanged and exact.
+ */
+const ARTWORKS = process.argv.includes('--artworks');
+const liveScope = ARTWORKS
+  ? { content_type: 'artwork', ...(INCLUDE_BACKLOG ? {} : { visible: { $ne: false } }) }
+  : INCLUDE_BACKLOG ? {} : { visible: { $ne: false }, pages_count: { $gt: 0 } };
+// Separate run id so a backlog or artwork pass can be reverted on its own,
+// without also undoing the live linkage an earlier run wrote.
+const RUN_ID = ARTWORKS ? 'backfill-2250-artworks' : INCLUDE_BACKLOG ? 'backfill-2250-backlog' : 'backfill-2250';
 
 const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().trim();
 
@@ -103,22 +116,60 @@ const allAuthors = await authors
   .find({
     ...(INCLUDE_INSTITUTIONS ? {} : { is_person: { $ne: false } }),
     merged_into: { $exists: false },
-  }, { projection: { slug: 1, canonical_name: 1, variants: 1, entity_ids: 1, viaf_id: 1, wikidata_id: 1 } })
+  }, { projection: { slug: 1, canonical_name: 1, variants: 1, aliases: 1, entity_ids: 1, viaf_id: 1, wikidata_id: 1 } })
   .toArray();
+// `aliases` are Wikidata-sourced name forms (backfill-author-aliases.mjs,
+// #4037): "Cornelis Drebbel" (artwork entity spelling) reaches "Cornelius
+// Drebbel" (our heading) only through them. But an alias is a claim about a
+// DIFFERENT person's name-space than our catalogue observed, and Wikidata
+// aliases include historical nicknames that collide with other people:
+// Caccini's genuine alias "Giulio Romano" staged 21 painter references onto
+// the composer (caught reading the dry-run rows, 2026-08-19). So an
+// alias-only match must ALSO share a rare token with the doc's own catalogue
+// forms — thesaurus-wide frequency <= 3, which admits surnames (drebbel: 1,
+// hokusai: 1) and refuses given names (giulio: 5, jacob: 75).
+const tokensOf = (s) => norm(s).replace(/[^\w\s]/g, ' ').split(/\s+/).filter((t) => t.length >= 4);
+const tokenFreq = new Map();
 const nameMap = new Map();
+const aliasOnly = new Set(); // `${normForm}|${slug}` — reachable via alias alone
 const entityToDocs = new Map(); // entity_id (string) -> [canonical docs] (for the entity-linked phase)
 for (const a of allAuthors) {
+  const docToks = new Set();
   for (const v of [a.canonical_name, ...(a.variants || [])]) {
     if (!v) continue;
+    for (const t of tokensOf(v)) docToks.add(t);
     const n = norm(v);
     if (!nameMap.has(n)) nameMap.set(n, []);
     if (!nameMap.get(n).some((d) => d.slug === a.slug)) nameMap.get(n).push(a);
+  }
+  for (const t of docToks) tokenFreq.set(t, (tokenFreq.get(t) || 0) + 1);
+  a._catalogueTokens = docToks;
+  for (const v of (a.aliases || [])) {
+    if (!v) continue;
+    const n = norm(v);
+    if (!nameMap.has(n)) nameMap.set(n, []);
+    if (!nameMap.get(n).some((d) => d.slug === a.slug)) {
+      nameMap.get(n).push(a);
+      aliasOnly.add(`${n}|${a.slug}`);
+    }
   }
   for (const e of (a.entity_ids || [])) {
     const k = String(e);
     if (!entityToDocs.has(k)) entityToDocs.set(k, []);
     if (!entityToDocs.get(k).some((d) => d.slug === a.slug)) entityToDocs.get(k).push(a);
   }
+}
+
+/** nameMap hits for this string, with the alias-only rare-token guard applied. */
+function lookupPerson(raw) {
+  const n = norm(raw);
+  const hits = nameMap.get(n);
+  if (!hits) return null;
+  const kept = hits.filter((doc) => {
+    if (!aliasOnly.has(`${n}|${doc.slug}`)) return true; // catalogue-observed form
+    return tokensOf(raw).some((t) => doc._catalogueTokens.has(t) && (tokenFreq.get(t) || 0) <= 3);
+  });
+  return kept.length ? kept : null;
 }
 
 // 2. Entity-LESS live books with an author string and no canonical link yet.
@@ -140,7 +191,7 @@ const stamp = new Date().toISOString();
 const ops = [];
 let ambiguous = 0, noMatch = 0, anchored = 0, unanchored = 0, withEntityBackfill = 0;
 for (const b of liveUnlinked) {
-  const ds = nameMap.get(norm(b.author));
+  const ds = lookupPerson(b.author);
   if (!ds) { noMatch++; continue; }
   if (ds.length > 1) { ambiguous++; continue; }
   const doc = ds[0];
@@ -183,16 +234,43 @@ const liveEntityLinked = await books
       author_entity_id: { $nin: [null, ''] },
       author_id: { $exists: false },
     },
-    { projection: { id: 1, author_entity_id: 1 } },
+    { projection: { id: 1, author: 1, author_entity_id: 1 } },
   )
   .toArray();
 
-let entAmbiguous = 0, entOrphan = 0;
+// Artwork lane: the artwork pipeline minted its OWN person entities, so nearly
+// every artwork entity is orphan here (measured 2026-08-19: 7,045 of 7,045
+// visible ones — 198 distinct entities, zero owned by a thesaurus doc). For an
+// orphan, fall back to the entity's NAME (then the artwork's author string)
+// under the same rule as Phase A: verbatim NFD match to EXACTLY ONE person.
+const orphanEntityName = new Map();
+if (ARTWORKS) {
+  const ids = [...new Set(liveEntityLinked.map((b) => String(b.author_entity_id)))]
+    .filter((s) => ObjectId.isValid(s) && !entityToDocs.has(s));
+  const ents = await db.collection('entities')
+    .find({ _id: { $in: ids.map((s) => new ObjectId(s)) }, type: 'person' }, { projection: { name: 1 } })
+    .toArray();
+  for (const e of ents) orphanEntityName.set(String(e._id), e.name);
+}
+
+let entAmbiguous = 0, entOrphan = 0, entNameMatched = 0;
 for (const b of liveEntityLinked) {
   const ds = entityToDocs.get(String(b.author_entity_id));
-  if (!ds) { entOrphan++; continue; }          // entity not owned by any canonical person
-  if (ds.length > 1) { entAmbiguous++; continue; }
-  const doc = ds[0];
+  let doc, method, matched;
+  if (ds && ds.length > 1) { entAmbiguous++; continue; }
+  if (ds) {
+    doc = ds[0]; method = 'entity-id-link'; matched = b.author_entity_id;
+  } else {
+    // entity not owned by any canonical person — artwork-lane name fallback
+    const entName = orphanEntityName.get(String(b.author_entity_id));
+    for (const cand of [entName, b.author]) {
+      const hits = cand ? lookupPerson(cand) : null;
+      if (hits && hits.length === 1) { doc = hits[0]; method = 'entity-name-match'; matched = cand; break; }
+      if (hits && hits.length > 1) { entAmbiguous++; matched = 'AMBIG'; break; }
+    }
+    if (!doc) { if (matched !== 'AMBIG') entOrphan++; continue; }
+    entNameMatched++;
+  }
   ops.push({
     updateOne: {
       filter: { _id: b._id },
@@ -201,11 +279,13 @@ for (const b of liveEntityLinked) {
         $push: {
           author_link_provenance: {
             run: RUN_ID,
-            method: 'entity-id-link',
-            matched: b.author_entity_id,
+            method,
+            matched,
             authors_slug: doc.slug,
             anchored: !!(doc.viaf_id || doc.wikidata_id),
-            confidence: 'high', // the build already adjudicated this entity = this person
+            // entity-id links were adjudicated by the thesaurus build; a name
+            // fallback is an exact string claim, one notch below.
+            confidence: method === 'entity-id-link' ? 'high' : 'medium',
             at: stamp,
           },
         },
@@ -215,14 +295,17 @@ for (const b of liveEntityLinked) {
 }
 
 console.log('=== backfill-author-canonical-links (#2250) ===');
-console.log(`scope: ${INCLUDE_BACKLOG ? 'ALL books (live + hidden/unprocessed backlog)' : 'LIVE books only (visible && pages_count>0) — pass --include-backlog for the rest'}`);
+console.log(`scope: ${
+  ARTWORKS ? `ARTWORKS${INCLUDE_BACKLOG ? ' (all, incl. hidden)' : ' (visible)'} — content_type: artwork`
+  : INCLUDE_BACKLOG ? 'ALL books (live + hidden/unprocessed backlog)'
+  : 'LIVE books only (visible && pages_count>0) — pass --include-backlog for the rest'}`);
 console.log(`mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (no writes)'}`);
 console.log('--- Phase A: entity-less books (exact author-string match) ---');
-console.log(`  scanned: ${liveUnlinked.length} | writes staged: ${ops.length - (liveEntityLinked.length - entAmbiguous - entOrphan)}`);
+console.log(`  scanned: ${liveUnlinked.length} | writes staged: ${anchored + unanchored}`);
 console.log(`    anchored=high: ${anchored} | unanchored=medium: ${unanchored} | also set author_entity_id: ${withEntityBackfill}`);
 console.log(`    skipped: ambiguous ${ambiguous}, no-match ${noMatch}`);
 console.log('--- Phase B: entity-linked books (author_entity_id -> authors doc) ---');
-console.log(`  scanned: ${liveEntityLinked.length} | writes staged: ${liveEntityLinked.length - entAmbiguous - entOrphan}`);
+console.log(`  scanned: ${liveEntityLinked.length} | writes staged: ${ops.length - (anchored + unanchored)} (name-fallback: ${entNameMatched})`);
 console.log(`    skipped: entity owned by >1 person ${entAmbiguous}, orphan entity (no canonical owner) ${entOrphan}`);
 console.log(`=> TOTAL author_id writes staged: ${ops.length}`);
 
@@ -236,6 +319,15 @@ if (APPLY && ops.length) {
   }
   console.log(`\nAPPLIED: modifiedCount = ${modified} / ${ops.length} staged.`);
 } else if (!APPLY) {
+  // Reading actual rows is what has caught every defect in this area (#4037) —
+  // aggregate counts looked fine each time. Print what a small run would do.
+  if (ops.length <= 100) {
+    console.log('\nStaged links (reference → canonical slug):');
+    for (const op of ops) {
+      const p = op.updateOne.update.$push.author_link_provenance;
+      console.log(`  [${p.method}] ${JSON.stringify(p.matched)} → ${p.authors_slug}`);
+    }
+  }
   console.log('\nDry run — pass --apply to write. Reversible via --undo --apply.');
 }
 

--- a/tests/unit/artwork-work-resolver.test.ts
+++ b/tests/unit/artwork-work-resolver.test.ts
@@ -103,3 +103,38 @@ describe('authorsAgree', () => {
     expect(authorsAgree('Marsilio Ficino', 'Ficino, Marsilio')).toBe(true);
   });
 });
+
+describe('one shared given name is not a person match (2026-08-19 queue read)', () => {
+  // Every case below is a live queue row that resolved WRONG: the token path
+  // accepted any candidate sharing a single >=4-char name token. 3,947 of
+  // 4,911 author-token rows shared only one token; a read of that bucket put
+  // its wrong-rate near 85%.
+  const painters = buildIndex([
+    book({ title: 'Trattato dell arte della pittura', author: 'Giovanni Paolo Lomazzo' }),
+    book({ title: 'Private Diary of Dr. John Dee', author: 'John Dee' }),
+    book({ title: 'De transactionibus theses LXIV', author: 'Schorer, Matthäus' }),
+    book({ title: 'Historia nuperae rerum mutationis in Anglia', author: 'Burridge, Ezekiel' }),
+    book({ title: 'Berg-Ordnung im Hertzogthum Schlesien', author: 'Rudolf, II.' }),
+    book({ title: 'Opera Omnia Erasmi', author: 'Erasmus von Rotterdam' }),
+  ]);
+
+  it('refuses a match on a shared given name alone', () => {
+    expect(resolveName(painters, 'Paolo Veronese')).toBeNull();
+    expect(resolveName(painters, 'Matthäus Merian')).toBeNull();
+  });
+
+  it('refuses biblical book titles that carry a personal name', () => {
+    expect(resolveName(painters, 'Gospel of John')).toBeNull();
+    expect(resolveName(painters, 'Ezekiel 37')).toBeNull();
+  });
+
+  it('still accepts full mutual coverage on a single distinctive token', () => {
+    // "Rudolf II" and the catalogue's "Rudolf, II." are the same one-token name.
+    expect(resolveName(painters, 'Rudolf II')?.kind).toBe('author');
+  });
+
+  it('still accepts two-token agreement across language forms', () => {
+    // enrichment "Erasmus of Rotterdam" vs catalogue "Erasmus von Rotterdam"
+    expect(resolveName(painters, 'Erasmus of Rotterdam')?.kind).toBe('author');
+  });
+});


### PR DESCRIPTION
Part of #4037, continuing #4050. Three things, all driven by reading actual queue rows (the aggregate counts looked fine throughout):

## Resolver fix (scripts/lib/artwork-work-resolver.mjs)
A ~50-row read of the review queue found every wrong link in one bucket: `author-token` matches accepted any candidate sharing a single ≥4-char name token — "Gospel of John" → John Dee, "Paolo Veronese" → Giovanni Paolo Lomazzo, "Ezekiel 37" → Burridge, Ezekiel. 3,947 of 4,911 token rows shared only one token; the read put that bucket's wrong-rate near 85%. Work links and exact author-name links read 0 wrong.

Fix: `findByPerson` requires ≥2 shared distinctive tokens, or full mutual coverage ("Rudolf II" ↔ "Rudolf, II." still links). 4 new regression tests; 16/16 green. Rebuilt queue: 2,569 book links / 4,962 author / 4,982 unresolved — the bad author links became honest unresolveds and freed strings became correct work links.

## authors.aliases[] backfill (new script, ALREADY APPLIED)
`scripts/artwork-links/backfill-author-aliases.mjs` fills a new `authors.aliases[]` field from each author's `wikidata_id`: 4,129 of 4,586 written, 16 languages, P31 verified per QID (9 non-person QIDs refused — including Liezi pointing at the *book* and Pers at the publishing firm). Nothing in src/ reads the field yet; it exists for identity joins in scripts. Run logged to `sweep_log` (`author-aliases-wikidata-2026-08`).

## Artwork author_id lane (ALREADY APPLIED, 46 links, reversible)
`backfill-author-canonical-links.mjs` grew `--artworks`: the live filter's `pages_count>0` excludes all but 97 of 24,912 artworks (the field-sprawl.md "scoping bug wearing drift's clothes" shape). Also an orphan-entity name fallback (every artwork entity is orphan — the artwork pipeline minted its own person entities) and a **rare-token guard on alias-only matches**: reading the 69-row dry run caught Caccini's genuine historical nickname "Giulio Romano" staging 21 painter references onto the composer, and the `jordanes` doc carrying the painter Jacob Jordaens' QID (Q270658 → repaired to Q131548; P31 verification cannot catch wrong-person, only wrong-kind). Applied 46/46, run id `backfill-2250-artworks`, undoable via `--undo`.

## Out of scope, deliberately
- **Painter minting**: Raphael (1,032 artworks), Goltzius (852), Merian (349)… have no author doc at all — top-400 unlinked painters cover 9,824 visible artworks (`scripts/output/artwork-painter-mint-candidates.json`). New public /author/ pages ⇒ needs its own issue/review.
- **Write path for links** and making the resolver consult `authors.aliases` — next steps in the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)