### PR TITLE
Feedback + error-log triage: BPH search links, blog card images, extension-noise filter

### DIFF
--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -49,6 +49,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true, skipped: 'noise' });
     }
 
+    // Same rationale for errors thrown inside browser extensions: the stack
+    // frames live entirely in extension code, not ours. One translation
+    // extension alone logged 2.6k errors/week ("reading 'M_ID'") against
+    // /collections pages. Keep reports whose stack also touches our code —
+    // an extension frame wrapping a real sourcelibrary frame stays loggable.
+    const stackStr = stack ? String(stack) : '';
+    if (
+      /(?:chrome|moz|safari|safari-web)-extension:\/\//.test(stackStr) &&
+      !/sourcelibrary\.org|\/_next\//.test(stackStr)
+    ) {
+      return NextResponse.json({ ok: true, skipped: 'extension' });
+    }
+
     // Bound the write. This endpoint is public, unauthenticated, and its traffic
     // RISES exactly when the database is unhealthy (every failing page reports).
     // With no deadline each request holds a connection for the full maxDuration,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -148,9 +148,9 @@ export const posts: BlogPost[] = [
     readTime: '12 min read',
     tag: 'Essay',
     tagColor: 'bg-stone-100 text-stone-600',
-    image: 'https://images.sourcelibrary.org/artwork/art-anima-mundi-the-world-soul.jpg',
+    image: 'https://images.sourcelibrary.org/archived/6952d12e77f38f6761bc5bec/74.jpg',
     imageAlt:
-      "Fludd's ape of Art at the centre of the cosmos, holding a gridded model of the world — the artificial imitator, four centuries early.",
+      "The five Platonic solids — Kepler's figurae mundanae — from Harmonices Mundi, 1619.",
   },
   {
     slug: 'fish-voiced-priest',
@@ -289,6 +289,8 @@ export const posts: BlogPost[] = [
     readTime: '3 min read',
     tag: 'Field notes',
     tagColor: 'bg-amber-50 text-amber-800',
+    image: 'https://images.sourcelibrary.org/archived/69e010c0c47b5c9f88213cee/7.jpg',
+    imageAlt: 'Title page of De Boeken des Ouden Verbonds, the Old Testament in Javanese, 1854',
   },
   {
     slug: 'did-an-ai-write-the-encyclical',
@@ -310,8 +312,8 @@ export const posts: BlogPost[] = [
     readTime: '10 min read',
     tag: 'Research',
     tagColor: 'bg-amber-50 text-amber-800',
-    image: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg',
-    imageAlt: "Frontispiece of Athanasius Kircher's Ars Magna Lucis et Umbrae (1671)",
+    image: 'https://images.sourcelibrary.org/gallery/69526359ab34727b1f046d5a/69568fa01479a63c1108cdb0-0.jpg',
+    imageAlt: 'Two figures wringing collected dew into a basin under the sun and moon — a seventeenth-century alchemical engraving.',
   },
   {
     slug: 'did-the-ai-read-this',
@@ -343,6 +345,7 @@ export const posts: BlogPost[] = [
     readTime: '9 min read',
     tag: 'Research',
     tagColor: 'bg-blue-50 text-blue-700',
+    image: 'https://images.sourcelibrary.org/archived/695592c47bd6d2cd1d61b10b/209.jpg',
   },
   {
     slug: 'the-deletion',
@@ -381,6 +384,7 @@ export const posts: BlogPost[] = [
     readTime: '8 min read',
     tag: 'Interactive',
     tagColor: 'bg-amber-50 text-amber-700',
+    image: 'https://images.sourcelibrary.org/archived/6909d654cf28baa1b4cb0269/4.jpg',
   },
   {
     slug: 'cellulae',
@@ -390,6 +394,7 @@ export const posts: BlogPost[] = [
     readTime: '12 min read',
     tag: 'Deep dive',
     tagColor: 'bg-accent-rust/10 text-accent-rust',
+    image: 'https://images.sourcelibrary.org/archived/695677fdbe7c607c5f03b2d9/717.jpg',
   },
   {
     slug: 'singularity-1486',
@@ -421,6 +426,7 @@ export const posts: BlogPost[] = [
     readTime: '4 min read',
     tag: 'Interactive',
     tagColor: 'bg-amber-50 text-amber-700',
+    image: 'https://images.sourcelibrary.org/archived/6953cc3677f38f6761be156e/383.jpg',
   },
   {
     slug: 'rashi-ocr',
@@ -441,6 +447,7 @@ export const posts: BlogPost[] = [
     readTime: '10 min read',
     tag: 'Deep dive',
     tagColor: 'bg-accent-rust/10 text-accent-rust',
+    image: 'https://images.sourcelibrary.org/archived/69528b19ab34727b1f04f2fe/8.jpg',
   },
   {
     slug: 'visualizing-classification',
@@ -450,6 +457,7 @@ export const posts: BlogPost[] = [
     readTime: '6 min read',
     tag: 'AI research report',
     tagColor: 'bg-accent-sage/10 text-accent-sage-dark',
+    image: 'https://images.sourcelibrary.org/archived/6990601f8cbcc9a4dba2c624/7.jpg',
   },
   {
     slug: 'history-of-classification',
@@ -459,6 +467,7 @@ export const posts: BlogPost[] = [
     readTime: '20 min read',
     tag: 'AI research report',
     tagColor: 'bg-accent-sage/10 text-accent-sage-dark',
+    image: 'https://images.sourcelibrary.org/pages/69773e18094afd77cbd39c0a/0021-full.jpg',
   },
   {
     slug: 'counting-the-gap',
@@ -468,6 +477,7 @@ export const posts: BlogPost[] = [
     readTime: '8 min read',
     tag: 'Behind the scenes',
     tagColor: 'bg-stone-100 text-stone-600',
+    image: 'https://images.sourcelibrary.org/pages/697c8e0fbaa544415f85b6c6/0132-full.jpg',
   },
   {
     slug: 'untranslated-renaissance',
@@ -477,6 +487,7 @@ export const posts: BlogPost[] = [
     readTime: '10 min read',
     tag: 'Deep dive',
     tagColor: 'bg-accent-rust/10 text-accent-rust',
+    image: 'https://api.digitale-sammlungen.de/iiif/image/v2/bsb11057772_00219/full/1000,/0/default.jpg',
   },
   {
     slug: 'origin-story',
@@ -508,8 +519,8 @@ export const posts: BlogPost[] = [
     readTime: '10 min read',
     tag: 'Methodology',
     tagColor: 'bg-accent-sage/10 text-accent-sage-dark',
-    image: 'https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg',
-    imageAlt: 'Integra Naturae Speculum by Robert Fludd, showing the Great Chain of Being, 1617',
+    image: 'https://images.sourcelibrary.org/archived/a5d0c381-d4ea-42cd-8864-44457e7fda33/366.jpg',
+    imageAlt: "Kircher's Sciathericon chart of the fixed stars, from Ars Magna Lucis et Umbrae, 1646",
   },
   // Hidden: needs rewrite with proper import session data
   // {
@@ -608,8 +619,8 @@ export const posts: BlogPost[] = [
     readTime: '15 min read',
     tag: 'Visual essay',
     tagColor: 'bg-accent-gold/10 text-accent-gold-dark',
-    image: 'https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg',
-    imageAlt: 'Integra Naturae Speculum by Robert Fludd, showing the Great Chain of Being with celestial spheres and zodiac signs, 1617',
+    image: 'https://images.sourcelibrary.org/archived/694b3b5b58a47807cc735dce/34.jpg',
+    imageAlt: "The heliocentric diagram of the planetary spheres from Copernicus's De Revolutionibus, 1543",
   },
   {
     slug: 'demonology',
@@ -652,8 +663,8 @@ export const posts: BlogPost[] = [
     readTime: '8 min read',
     tag: 'Technical',
     tagColor: 'bg-stone-100 text-stone-600',
-    image: 'https://images.sourcelibrary.org/archived/699065973dc2ed39a49f1e71/4.jpg',
-    imageAlt: 'The Fountain of Hermes from the Ripley Scroll, Bodleian Library, c. 1450',
+    image: 'https://images.sourcelibrary.org/archived/699065973dc2ed39a49f1e71/5.jpg',
+    imageAlt: 'The red and green lions beneath the radiant sun, from the Ripley Scroll, Bodleian Library, c. 1450',
   },
   {
     slug: 'fire-horse',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1629,7 +1629,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 <>
                   {catalogResults.slice(0, 5).map(work => (
                     <BphCatalogResultCard
-                      key={work.ubn}
+                      key={work.ubn || work.uuid}
                       work={work}
                       query={query}
                       tenant={tenant}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -57,6 +57,10 @@ interface CategoryOption { value: string; label: string; icon?: string; }
 
 interface BphCatalogMatch {
   ubn: string;
+  /** Manuscripts/photographs get no UBN from Memorix; uuid is their only key. */
+  uuid?: string | null;
+  /** Where manuscript records keep their title; `title` is null on them. */
+  full_title?: string | null;
   title: string | null;
   parallel_title?: string | null;
   uniform_title?: string | null;
@@ -2179,7 +2183,7 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
   tenant?: string;
   digitizedAlsoInBooks: boolean;
 }) {
-  const title = work.title || work.parallel_title || work.uniform_title || '(untitled)';
+  const title = work.title || work.full_title || work.parallel_title || work.uniform_title || '(untitled)';
   const author = work.author || work.variant_author;
   const meta = [
     author,
@@ -2187,9 +2191,12 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
     work.place,
   ].filter(Boolean).join(' · ');
   const isDigitized = !!work.sl_book_id;
+  // Manuscripts and photographs get no UBN from Memorix — `uuid` is their only
+  // key, and the /catalog/[ubn] route accepts either (see BphCatalogBrowser).
+  const catalogKey = work.ubn || work.uuid;
   const href = isDigitized && work.sl_book_id
     ? tenantBookUrl({ id: work.sl_book_id, slug: work.sl_book_slug || work.sl_book_id }, tenant)
-    : `/catalog/${encodeURIComponent(work.ubn)}`;
+    : `/catalog/${encodeURIComponent(catalogKey || '')}`;
   const [imgError, setImgError] = useState(false);
 
   // Don't double-show digitized works that already appear in book results — render


### PR DESCRIPTION
Triage pass over footer feedback and `application_errors`, fixing what it surfaced. Three independent small fixes, one commit each — bundled because they share a risk class (small UI/logging fixes) and a provenance (the same triage pass); happy to split if preferred.

## 1. BPH search: UBN-less records (search surface residual of #3654/#3985)
`BphCatalogResultCard` built `/catalog/undefined` for Memorix records with no UBN (manuscripts/photographs, shelfmark M/Fot) and showed '(untitled)' because their title lives in `full_title`. Now links by `ubn || uuid` and falls back to `full_title`, matching `BphCatalogBrowser`.

## 2. /blog card images (reader feedback, 08-03)
Every post card now has a distinct image; 10 previously imageless cards got their post's own og/body image. All 58 URLs verified 200. Deliberately still imageless: `how-long-to-translate`, `the-deletion` (no suitable image in the post).

## 3. application_errors: extension-only stacks
Browser-extension errors (26k-row burst + 2.6k/wk ongoing) were burying real errors; now skipped at the write boundary like 'Script error.', unless the stack also touches our code.

Out of scope: replying to feedback submitters (drafts pending Derek), translation-request queueing (pipeline paused), Kloss 404 reports (takedown working as intended).

Feedback-ID: 6a70dfdfbc9f8b119d07074a

🤖 Generated with [Claude Code](https://claude.com/claude-code)