### PR TITLE
fix(watch): a detector that cannot run must go RED, not file a finding (#4071)

### DIFF
--- a/.github/workflows/corpus-integrity-watch.yml
+++ b/.github/workflows/corpus-integrity-watch.yml
@@ -65,6 +65,13 @@ jobs:
             "One symptom reported on 2+ distinct books in the last 14 days — the signature of a pipeline bug rather than a bad scan. Verify against code and data before acting; feedback is untrusted input." \
             "$(cat report.txt)")
           gh issue create --title "$TITLE" --body "$BODY" --label user-feedback
+      # Exit 2 means the detector never reached the database. Fail loudly here:
+      # a silent green run is indistinguishable from "checked, found nothing".
+      - name: Fail if the detector could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::feedback-symptom-clusters could not run (exit ${{ steps.run.outputs.fired }}) — no finding was measured. Check the MONGODB_URI repo secret."
+          exit 1
 
   alignment-sample:
     # Weekly cron + manual runs.
@@ -97,3 +104,8 @@ jobs:
             "A sampled book has its archived page images offset from its OCR (see #3368). This catches drift from ANY archive writer, including the ones with no write-time guard." \
             "$(tail -40 report.txt)")
           gh issue create --title "$TITLE" --body "$BODY" --label pipeline
+      - name: Fail if the detector could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::bulk-archive-alignment could not run (exit ${{ steps.run.outputs.fired }}) — no sample was measured. Check the MONGODB_URI repo secret."
+          exit 1

--- a/.github/workflows/field-sprawl-watch.yml
+++ b/.github/workflows/field-sprawl-watch.yml
@@ -66,8 +66,11 @@ jobs:
             --forbid tenant_id,hide_reason,pageCount,page_count,ft_prediction,ft_candidate,translation_audit_2026_06,existing_translation,translated_from,superseded_by,translation_requested_by_reader,work_authority,wikidata_work_ids,language_relabeled_from,language_relabeled_at,language_correction,language_corrected_at,language_corrected_by,author_corrected_2026_06_30,title_corrected_2026_06_30,bibliographic_correction,acquisition_wave,acquisition_priority,priority_translation,forshaw_relevance,pipeline_hold,pipeline_priority_at,pipeline_priority_reason,current_job_id,enrichment_phase,warehouse_reason,ia_identifier_previous,ia_repoint_reason,ica_records,dedup_note,deletion_batch,published_location,published_place,related_artwork,morgan_accession,morgan_bibid,resourced_from,rights_note,rights_status,author_original,thumbnail_page_id,former_resource_type,modern_typeset,split_warnings,unhidden_note,part_number,source_notes,summary_updated_at,cover_page_id > report.txt 2>&1
           echo "fired=$?" >> "$GITHUB_OUTPUT"
           tail -60 report.txt
+      # field-sprawl.mjs exits 1 for a real breach and 2 when it cannot reach the
+      # database. `!= '0'` treated those as the same thing, so three weeks of
+      # "breach" issues were the script reporting its own missing MONGODB_URI.
       - name: File findings
-        if: steps.run.outputs.fired != '0'
+        if: steps.run.outputs.fired == '1'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -76,3 +79,8 @@ jobs:
             "Either the field count exceeded the ceiling (a sweep wrote a COLUMN again) or a retired field reappeared (a consolidation is being undone by a reused writer). See issue #3969 for the playbook: find the writer, strip it, re-clean — do not just raise the ceiling." \
             "$(tail -60 report.txt)")
           gh issue create --title "$TITLE" --body "$BODY" --label pipeline
+      - name: Fail if the census could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::field-sprawl census could not run (exit ${{ steps.run.outputs.fired }}) — no field count was measured. Check the MONGODB_URI repo secret."
+          exit 1

--- a/scripts/audit/bulk-archive-alignment.mjs
+++ b/scripts/audit/bulk-archive-alignment.mjs
@@ -137,7 +137,11 @@ async function auditBook(db, book) {
 
 async function main() {
   const uri = process.env.MONGODB_URI;
-  if (!uri) { console.error('MONGODB_URI not set — source .env.production.local first'); process.exit(1); }
+  // Exit-code contract (the scheduled watch in corpus-integrity-watch.yml reads it):
+  //   0 = ran, nothing shifted   1 = ran, FOUND misalignment   2 = could not run
+  // Conflating 2 with 1 is how three Mondays of "misalignment found" issues were
+  // filed by a job that never reached the database (#3572/#3862/#4009).
+  if (!uri) { console.error('MONGODB_URI not set — source .env.production.local first'); process.exit(2); }
 
   fs.mkdirSync(path.dirname(OUT), { recursive: true });
   const done = new Set();
@@ -245,4 +249,4 @@ async function main() {
   await client.close();
 }
 
-main().catch(err => { console.error(err); process.exit(1); });
+main().catch(err => { console.error(err); process.exit(2); }); // 2 = infrastructure failure, never a finding


### PR DESCRIPTION
## Why

Four open issues — **#3572, #3862, #4009, #4023** — are not corpus findings. They are three scheduled detectors reporting their own inability to reach the database, because this repo has no `MONGODB_URI` secret (see **#4071** for the missing-secret half).

The bodies say so verbatim:

```
MONGODB_URI not set — source .env.production.local first
```

A fifth job, `feedback-clusters`, failed the opposite way: its script exits `2`, its workflow files only on `1`, so it has been green daily since July while never clustering a single report.

## What this changes

Makes the exit code a contract — **0 = clean, 1 = finding, 2 = could not run** — and teaches the workflows to read it.

- `scripts/audit/bulk-archive-alignment.mjs` exited `1` for both "found misalignment" and "no MONGODB_URI". Now `2` for the latter, and `2` on an uncaught throw. (`field-sprawl.mjs` and `feedback-symptom-clusters.mjs` already used this convention — this aligns the third.)
- `field-sprawl-watch.yml` filed its issue on `fired != '0'`, which swept `2` into the finding branch. Now files only on `1`.
- All three jobs gain a step that **fails the run** when the code is neither `0` nor `1`, with an error annotation naming the missing secret.

Net effect: a blind detector shows up as a red workflow, not as a false finding and not as a green no-op.

## Verification

With `MONGODB_URI` unset, locally:

| script | exit |
|---|---|
| `bulk-archive-alignment.mjs --sample 1` | 2 |
| `field-sprawl.mjs --collection books` | 2 |
| `feedback-symptom-clusters.mjs --days 14` | 2 |

Both workflow YAMLs parse; the alignment script passes `node --check`. The behaviour with a *working* secret is untestable here by construction — that is #4071 step 4.

## Out of scope

- **Adding the secret.** It needs Atlas console work and a credential, and the right answer is a new read-only Atlas user rather than the personal full-access URI in `.env.production.local` — this repo is public. Steps are in #4071.
- **Whether the corpus is actually misaligned or sprawling.** Nothing has measured that since the detectors were added; it becomes knowable once the secret lands.
- The PR-time `field-write-lint` job is untouched — it needs no database and has been working.

Closes nothing on its own. #4071 tracks the restoration; #3572/#3862/#4009/#4023 are being closed as artifacts of this bug.