### PR TITLE
fix(librarian): stop telling readers with history that they have none (#4070)

### DIFF
--- a/scripts/maintenance/ensure-embassy-indexes.mjs
+++ b/scripts/maintenance/ensure-embassy-indexes.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Index the Librarian conversation collections.
+ *
+ * `embassy_threads` and `embassy_messages` carried nothing but `_id_`, so every
+ * sidebar load ran collection scans with in-memory sorts. Measured 2026-08-19
+ * on production: the per-thread preview query took ~528ms against 6,097
+ * messages, and the list route ran twenty of them per request. That is how a
+ * reader with 112 conversations was shown "No conversations yet" (#4070) — the
+ * request lost the race with the render, and the client had no loading state.
+ *
+ * These are read-shape indexes for the three queries that exist:
+ *   /api/embassy/threads?mine=true  → { creatorId, messageCount } sort lastMessageAt
+ *   /api/embassy/threads            → { visibility, messageCount } sort lastMessageAt
+ *   preview $lookup + thread detail → { threadId } sort createdAt
+ *
+ * Idempotent: createIndex is a no-op when the index already exists. Read-only
+ * with respect to documents — it adds no fields and rewrites no rows.
+ *
+ *   node --env-file=.env.production.local scripts/maintenance/ensure-embassy-indexes.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+
+const INDEXES = [
+  ['embassy_threads', { creatorId: 1, messageCount: 1, lastMessageAt: -1 }, 'creatorId_messageCount_lastMessageAt'],
+  ['embassy_threads', { visibility: 1, messageCount: 1, lastMessageAt: -1 }, 'visibility_messageCount_lastMessageAt'],
+  ['embassy_messages', { threadId: 1, createdAt: 1 }, 'threadId_createdAt'],
+];
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI is not set');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+
+for (const [collection, keys, name] of INDEXES) {
+  const created = await db.collection(collection).createIndex(keys, { name, background: true });
+  console.log(`${collection}: ${created}`);
+}
+
+for (const collection of ['embassy_threads', 'embassy_messages']) {
+  const names = (await db.collection(collection).indexes()).map(i => i.name);
+  console.log(`${collection} indexes now: ${names.join(', ')}`);
+}
+
+await client.close();

--- a/src/app/api/embassy/threads/route.ts
+++ b/src/app/api/embassy/threads/route.ts
@@ -1,12 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
 import { attribution, LISTED_VISIBILITY } from '@/lib/embassy/thread-visibility';
+
+type PreviewMessage = { authorType?: string; content?: string };
+
+type ThreadDoc = {
+  _id: ObjectId;
+  title?: string;
+  creatorName?: string | null;
+  messageCount?: number;
+  createdAt?: Date;
+  lastMessageAt?: Date;
+  firstMessages?: PreviewMessage[];
+};
 
 /**
  * GET /api/embassy/threads — List Embassy threads.
  * ?mine=true — list the current user's threads (auth required)
  * Default — list public threads (no auth required)
+ *
+ * The previews come from a single `$lookup` rather than one query per thread.
+ * The N+1 shape cost 20 round-trips per request and, with no index on
+ * `embassy_messages.threadId`, every one of them was a collection scan plus an
+ * in-memory sort (~500ms measured) — slow enough that the sidebar routinely
+ * rendered its "No conversations yet" empty state before the data arrived, and
+ * a reader with 112 conversations reported having none (#4070).
+ *
+ * A failure here MUST be a non-2xx response, never `{ threads: [] }`. An empty
+ * list is indistinguishable from "you have no history" on the client, and that
+ * is the same lie by a different route.
  */
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
@@ -14,57 +38,85 @@ export async function GET(request: NextRequest) {
   const offset = parseInt(url.searchParams.get('offset') || '0');
   const mine = url.searchParams.get('mine') === 'true';
 
-  const db = await getReadDb();
-
   let filter: Record<string, unknown>;
   if (mine) {
     const session = await auth();
     if (!session?.user?.id) {
-      return NextResponse.json({ threads: [] });
+      // Genuinely nothing to list: there is no reader to list it for. The
+      // client only asks for `mine=true` when it believes it is signed in, so
+      // say why rather than returning a bare empty list.
+      return NextResponse.json({ threads: [], signedIn: false }, { status: 401 });
     }
     filter = { creatorId: session.user.id, messageCount: { $gte: 2 } };
   } else {
     filter = { visibility: LISTED_VISIBILITY, messageCount: { $gte: 2 } };
   }
 
-  const threads = await db.collection('embassy_threads')
-    .find(filter)
-    .sort({ lastMessageAt: -1 })
-    .skip(offset)
-    .limit(limit)
-    .toArray();
-
-  // Get the first user message and first AI response for each thread (preview)
-  const threadPreviews = await Promise.all(
-    threads.map(async (thread) => {
-      const messages = await db.collection('embassy_messages')
-        .find({ threadId: thread._id })
-        .sort({ createdAt: 1 })
-        .limit(2)
-        .project({ authorType: 1, authorName: 1, content: 1, createdAt: 1 })
-        .toArray();
-
-      const userMsg = messages.find(m => m.authorType === 'human');
-      const aiMsg = messages.find(m => m.authorType === 'ai');
-
-      return {
-        id: thread._id.toString(),
-        title: thread.title,
-        // Only the reader's own list carries a name. The public feed is
-        // anonymised here rather than in the sidebar that renders it — the
-        // 2026-07-30 leak was in this payload, so a component-level fix would
-        // still be one `curl` away.
-        creatorName: attribution(thread.creatorName, mine),
-        messageCount: thread.messageCount,
-        createdAt: thread.createdAt,
-        lastMessageAt: thread.lastMessageAt,
-        preview: {
-          question: userMsg?.content?.slice(0, 200) || '',
-          answer: aiMsg?.content?.slice(0, 300) || '',
+  let threads: ThreadDoc[];
+  try {
+    const db = await getReadDb();
+    threads = await db.collection('embassy_threads')
+      .aggregate<ThreadDoc>([
+        { $match: filter },
+        { $sort: { lastMessageAt: -1 } },
+        { $skip: offset },
+        { $limit: limit },
+        {
+          $lookup: {
+            from: 'embassy_messages',
+            let: { tid: '$_id' },
+            pipeline: [
+              { $match: { $expr: { $eq: ['$threadId', '$$tid'] } } },
+              { $sort: { createdAt: 1 } },
+              { $limit: 2 },
+              { $project: { _id: 0, authorType: 1, content: 1 } },
+            ],
+            as: 'firstMessages',
+          },
         },
-      };
-    }),
-  );
+        {
+          $project: {
+            title: 1,
+            creatorName: 1,
+            messageCount: 1,
+            createdAt: 1,
+            lastMessageAt: 1,
+            firstMessages: 1,
+          },
+        },
+      ], { maxTimeMS: 15000 })
+      .toArray();
+  } catch (error) {
+    console.error('[embassy/threads] list failed', { mine, error });
+    return NextResponse.json({ error: 'Could not load conversations' }, { status: 503 });
+  }
 
-  return NextResponse.json({ threads: threadPreviews });
+  const threadPreviews = threads.map((thread) => {
+    const messages = thread.firstMessages ?? [];
+    const userMsg = messages.find(m => m.authorType === 'human');
+    const aiMsg = messages.find(m => m.authorType === 'ai');
+
+    return {
+      id: thread._id.toString(),
+      title: thread.title,
+      // Only the reader's own list carries a name. The public feed is
+      // anonymised here rather than in the sidebar that renders it — the
+      // 2026-07-30 leak was in this payload, so a component-level fix would
+      // still be one `curl` away.
+      creatorName: attribution(thread.creatorName, mine),
+      messageCount: thread.messageCount,
+      createdAt: thread.createdAt,
+      lastMessageAt: thread.lastMessageAt,
+      preview: {
+        question: userMsg?.content?.slice(0, 200) || '',
+        answer: aiMsg?.content?.slice(0, 300) || '',
+      },
+    };
+  });
+
+  return NextResponse.json(
+    { threads: threadPreviews, signedIn: mine || undefined },
+    // A reader's own list is per-account and must never be shared by a cache.
+    { headers: { 'Cache-Control': mine ? 'private, no-store' : 'private, max-age=0' } },
+  );
 }

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -384,6 +384,13 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   const [threadId, setThreadId] = useState<string | null>(null);
   const [threads, setThreads] = useState<ThreadPreview[]>([]);
   const [myThreads, setMyThreads] = useState<ThreadPreview[]>([]);
+  // A list has three states, not one. Collapsing them was the whole of #4070:
+  // an in-flight or failed fetch left the array empty, and empty rendered as
+  // "No conversations yet" — telling a reader with 112 conversations that they
+  // had none. Never infer emptiness from an array that hasn't loaded.
+  const [threadsState, setThreadsState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [myThreadsState, setMyThreadsState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [reloadMine, setReloadMine] = useState(0);
   const [sidebarTab, setSidebarTab] = useState<'recent' | 'mine'>('recent');
   // Default to "My Conversations" once signed in
   useEffect(() => {
@@ -476,10 +483,20 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
   // Fetch public threads
   useEffect(() => {
+    let live = true;
+    setThreadsState('loading');
     fetch('/api/embassy/threads?limit=50')
-      .then(r => r.json())
-      .then(data => { if (data.threads) setThreads(data.threads); })
-      .catch(() => { });
+      .then(async r => {
+        if (!r.ok) throw new Error(`threads ${r.status}`);
+        return r.json();
+      })
+      .then(data => {
+        if (!live) return;
+        setThreads(data.threads ?? []);
+        setThreadsState('ready');
+      })
+      .catch(() => { if (live) setThreadsState('error'); });
+    return () => { live = false; };
   }, []);
 
   // Blend up to two real visitor questions into the suggestion chips once
@@ -493,15 +510,30 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     setSuggestions(pickSuggestions(6, extras));
   }, [threads]);
 
-  // Fetch user's own threads when signed in
+  // Fetch the reader's own threads once the session resolves. While NextAuth is
+  // still deciding (`status === 'loading'`) this list is NOT empty — it is
+  // unknown, so it stays in the loading state rather than claiming there is no
+  // history.
   useEffect(() => {
-    if (status === 'authenticated') {
-      fetch('/api/embassy/threads?mine=true&limit=20')
-        .then(r => r.json())
-        .then(data => { if (data.threads) setMyThreads(data.threads); })
-        .catch(() => { });
+    if (status !== 'authenticated') {
+      if (status === 'unauthenticated') setMyThreadsState('ready');
+      return;
     }
-  }, [status]);
+    let live = true;
+    setMyThreadsState('loading');
+    fetch('/api/embassy/threads?mine=true&limit=20')
+      .then(async r => {
+        if (!r.ok) throw new Error(`mine ${r.status}`);
+        return r.json();
+      })
+      .then(data => {
+        if (!live) return;
+        setMyThreads(data.threads ?? []);
+        setMyThreadsState('ready');
+      })
+      .catch(() => { if (live) setMyThreadsState('error'); });
+    return () => { live = false; };
+  }, [status, reloadMine]);
 
   // Auto-scroll
   useEffect(() => {
@@ -1249,11 +1281,46 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                 )}
 
                 {(() => {
-                  const allThreads = sidebarTab === 'mine' ? myThreads : threads;
+                  const isMine = sidebarTab === 'mine';
+                  const allThreads = isMine ? myThreads : threads;
+                  const listState = isMine ? myThreadsState : threadsState;
+                  // Session still resolving means "we don't know yet", not "none".
+                  const loading = listState === 'loading' || (isMine && status === 'loading');
+
+                  if (loading) {
+                    return (
+                      <div className="space-y-3" aria-busy="true">
+                        {[0, 1, 2].map(i => (
+                          <div key={i} className="py-3 border-b border-[#e8e4dc] animate-pulse">
+                            <div className="h-3 bg-[#e8e4dc] rounded w-5/6 mb-2" />
+                            <div className="h-3 bg-[#eee9e1] rounded w-full mb-1.5" />
+                            <div className="h-3 bg-[#eee9e1] rounded w-2/3" />
+                          </div>
+                        ))}
+                        <span className="sr-only">Loading conversations…</span>
+                      </div>
+                    );
+                  }
+
+                  if (listState === 'error') {
+                    return (
+                      <p className="text-[#8a8480] text-sm font-body">
+                        Couldn&rsquo;t load {isMine ? 'your conversations' : 'recent conversations'}.{' '}
+                        <button
+                          onClick={() => { if (isMine) setReloadMine(n => n + 1); else window.location.reload(); }}
+                          className="text-[#9e4a3a] hover:underline"
+                        >
+                          Try again
+                        </button>
+                        .
+                      </p>
+                    );
+                  }
+
                   if (allThreads.length === 0) {
                     return (
                       <p className="text-[#8a8480] text-sm font-body">
-                        {sidebarTab === 'mine'
+                        {isMine
                           ? 'No conversations yet. Ask the Librarian something!'
                           : 'No conversations yet. Be the first to ask the Librarian something.'}
                       </p>

--- a/tests/unit/librarian-conversation-list.test.ts
+++ b/tests/unit/librarian-conversation-list.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * A reader with history must never be told they have none (#4070).
+ *
+ * Derek reported an empty "My Conversations" while holding 112 conversations.
+ * The list route's failure and empty-result paths were the same shape —
+ * `{ threads: [] }` with a 200 — so the sidebar could not tell "your history is
+ * empty" from "the query died", and rendered the first for both. These pin the
+ * distinction at the API boundary: only a genuinely empty result is a 200 with
+ * an empty array.
+ *
+ * Negative control run: reverting the route's catch block to
+ * `return NextResponse.json({ threads: [] })` turns the failure case red.
+ */
+
+let currentUserId: string | null = null;
+let dbFails = false;
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(async () =>
+    currentUserId ? { user: { id: currentUserId }, expires: 'later' } : null,
+  ),
+}));
+
+const THREAD = {
+  _id: { toString: () => '6a7ca639e9e3ddd465b53523' },
+  title: 'What is the prisca theologia?',
+  creatorName: 'Derek Lomas',
+  messageCount: 4,
+  createdAt: new Date(),
+  lastMessageAt: new Date(),
+  firstMessages: [
+    { authorType: 'human', content: 'What is the prisca theologia?' },
+    { authorType: 'ai', content: 'It is the doctrine that…' },
+  ],
+};
+
+let lastPipeline: unknown[] = [];
+
+vi.mock('@/lib/mongodb', () => ({
+  getReadDb: vi.fn(async () => {
+    if (dbFails) throw new Error('connection reset');
+    return {
+      collection: () => ({
+        aggregate: (pipeline: unknown[]) => {
+          lastPipeline = pipeline;
+          return { toArray: async () => [THREAD] };
+        },
+      }),
+    };
+  }),
+}));
+
+const { GET } = await import('@/app/api/embassy/threads/route');
+
+const req = (qs: string) => new Request(`http://localhost/api/embassy/threads${qs}`) as never;
+
+beforeEach(() => {
+  currentUserId = null;
+  dbFails = false;
+  lastPipeline = [];
+});
+
+describe('a signed-in reader asking for their own conversations', () => {
+  beforeEach(() => { currentUserId = 'user-derek-1'; });
+
+  it('gets them', async () => {
+    const res = await GET(req('?mine=true&limit=20'));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.threads).toHaveLength(1);
+    expect(data.threads[0].preview.question).toContain('prisca theologia');
+    expect(data.threads[0].preview.answer).toContain('doctrine');
+  });
+
+  it('is scoped to their own account id', async () => {
+    await GET(req('?mine=true'));
+    const match = lastPipeline.find(s => (s as Record<string, unknown>).$match) as
+      { $match: Record<string, unknown> };
+    expect(match.$match.creatorId).toBe('user-derek-1');
+  });
+
+  it('never has its list cached — it is one account’s history', async () => {
+    const res = await GET(req('?mine=true'));
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('is told the list FAILED, not that it is empty, when the query dies', async () => {
+    dbFails = true;
+    const res = await GET(req('?mine=true'));
+    // The whole bug: a 200 with an empty array here reads as "no history".
+    expect(res.status).toBe(503);
+    expect((await res.json()).threads).toBeUndefined();
+  });
+});
+
+describe('a visitor who is not signed in', () => {
+  it('cannot get a "mine" list, and is told so rather than shown an empty one', async () => {
+    const res = await GET(req('?mine=true'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).signedIn).toBe(false);
+  });
+
+  it('still gets the public Recent feed', async () => {
+    const res = await GET(req('?limit=50'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).threads).toHaveLength(1);
+  });
+
+  it('gets a failure status on the Recent feed too, not a silent empty feed', async () => {
+    dbFails = true;
+    const res = await GET(req('?limit=50'));
+    expect(res.status).toBe(503);
+  });
+});

--- a/tests/unit/librarian-thread-anonymity.test.ts
+++ b/tests/unit/librarian-thread-anonymity.test.ts
@@ -66,6 +66,11 @@ function fakeDb() {
               skip: () => ({ limit: () => ({ toArray: async () => [thread] }) }),
             }),
           }),
+          // The list route joins the first two messages in one pipeline rather
+          // than one query per thread, so the fake returns them pre-joined.
+          aggregate: () => ({
+            toArray: async () => [{ ...thread, firstMessages: MESSAGES }],
+          }),
         };
       }
       return {


### PR DESCRIPTION
Fixes #4070.

## What was actually wrong

The issue proposed a `session.user.id` string-vs-ObjectId mismatch (the #3448 class). **It isn't that.** Measured on production:

- Derek's ID → **131** threads, **112** with `messageCount >= 2`, all stored with `creatorId` as the `users._id` **string** — exactly what `?mine=true` queries. Nothing is orphaned, nothing is tenant-scoped away.
- The Recent feed is healthy too (608 public threads with >=2 messages), so the listing half of feedback `6a7ca639e9e3ddd465b53523` was already fixed by the listed-by-default change.

What remained is a race that the UI reported as a fact. Reproduced by the reporter on this PR's sibling account: the sidebar shows "No conversations yet", then fills in a moment later.

## Three causes, third is the visible one

**1. No indexes.** `embassy_threads` and `embassy_messages` carried only `_id_`. The list route ran one preview query per thread — each a COLLSCAN plus an in-memory SORT, **528 ms measured** against 6,097 messages — 20 per `mine=true` request, 50 per Recent request.

`scripts/maintenance/ensure-embassy-indexes.mjs` (idempotent; `createIndex` only, writes no document fields) — **already run against production**:

```
embassy_messages: threadId_createdAt
embassy_threads:  creatorId_messageCount_lastMessageAt
embassy_threads:  visibility_messageCount_lastMessageAt
```

Both list queries now do an indexed scan: 3 ms / 1 ms, 20 docs examined.

**2. N+1 previews → one `$lookup`.** 21 round-trips became 1. Warm `?limit=50` through a dev server: **0.34 s**.

**3. The lie.** A failure and an empty result were indistinguishable on *both* sides of the wire:

- the route returned `{ threads: [] }` with a 200 on any throw;
- the client did `.catch(() => {})` and the sidebar read `array.length === 0` as "No conversations yet";
- and while NextAuth was still `status === 'loading'`, `myThreads` was `[]` — unknown, rendered as none.

Now: 503 on query failure, 401 on unauthenticated `mine=true`, `Cache-Control: private, no-store` on a reader's own list. The sidebar tracks `loading | ready | error` per tab, shows a skeleton while the session is resolving, and offers a retry instead of an empty state.

## Verification

- `tests/unit/librarian-conversation-list.test.ts` — 7 tests pinning the failure/empty distinction at the API boundary. **Negative control run:** restoring `{ threads: [] }` in the catch turns 3 of 7 red.
- Full unit suite: 2781 passed / 203 files. `tests/integration/embassy-api.test.ts`: 15 passed. `npx tsc --noEmit` clean. `eslint` on the touched files reports the same 5 pre-existing problems as `main` — no new ones.
- Live dev server: Recent returns real previews with `creatorName: "A reader"` (anonymity invariant intact), anonymous `?mine=true` → 401, `/librarian` renders 200 with no console errors.

## Out of scope

- **The `messageCount: { $gte: 2 }` filter** hides 19 of Derek's 131 threads (and 26 signed-in threads overall) that never got an AI reply. That's deliberate — a thread with one orphan message has no preview to render — but it means "my conversations" is not literally all of them. Left alone; worth its own decision.
- **`embassy_threads` has 4 docs with no `creatorId` and a null `messageCount`.** Malformed, invisible to every list. Not touched.
- **No refresh of "My Conversations" after a new thread is created in-session.** The list is fetched once per auth transition. Separate change.