### PR TITLE
fix(reader): mark the AI description on illustration/diagram pages (#4069)

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -11,6 +11,7 @@ import { NOTE_TAG_STYLES } from '@/lib/style-constants';
 import { cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
 import { normalizeAnnotationSpans } from '@/lib/normalize-annotation-spans';
 import { applyNotesOff } from '@/lib/notes-off';
+import AiBadge from '@/components/ui/AiBadge';
 
 /**
  * Page types where the entire "translation" is AI-generated description (no
@@ -321,9 +322,20 @@ function preprocessBracketTags(text: string, showNotes: boolean): string {
 // is AI-generated description. The model wraps some of it in <note>/<image-desc> and
 // leaves the rest as plain prose, producing inconsistent half-highlighting. Since
 // there is no source text to distinguish from, unwrap those tags so the whole
-// description reads uniformly as plain text.
+// description reads uniformly.
+//
+// Unwrapping removes the per-chip highlight, so the *frame* has to carry the
+// provenance instead — see AiDescriptionFrame. Without it the AI's own prose
+// renders identically to transcribed text, which is what #2791 fixed for title
+// pages and what #4069 reported again on a pure `diagram` page: "the notes
+// aren't rendered with highlights". Uniform-and-marked, never unmarked.
 function unwrapDescriptionNotes(text: string): string {
   return text.replace(/<(note|image-desc)>([\s\S]*?)<\/\1>/gi, '$2');
+}
+
+/** "diagram" → "Diagram", "musical-score" → "Musical Score". */
+function formatPageTypeLabel(pageType: string): string {
+  return pageType.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 // Decide whether a page really is "description only". The page_type heuristic
@@ -820,6 +832,28 @@ function ColumnMarkdown({ text, showNotes, withNotes }: {
 }
 
 /**
+ * The highlight for a description-only page, carried by the frame rather than by
+ * per-chip <note> spans (those are unwrapped — see unwrapDescriptionNotes).
+ *
+ * Same tokens as the inline `image-description` block above: accent-gold tint,
+ * hairline accent-gold border, plus the shared AiBadge provenance chip. No new
+ * design primitives.
+ */
+function AiDescriptionFrame({ pageTypeLabel, children }: { pageTypeLabel: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-accent-gold/20 bg-accent-gold/8 px-4 py-3">
+      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-accent-gold-dark">
+        <AiBadge title="AI-generated description of the page image — not text from the book" />
+        <span>{pageTypeLabel} — description</span>
+      </div>
+      {/* The body keeps the normal reading colour — a long description tinted
+          gold is hard to read, and the badge + tinted frame already mark it. */}
+      {children}
+    </div>
+  );
+}
+
+/**
  * The full text pipeline, as a pure function so it can be exercised directly in
  * tests (the reader itself needs a DOM; this does not). Returns the markdown
  * string handed to the renderer, the extracted metadata panel content, and
@@ -919,7 +953,7 @@ export default function NotesRenderer({ text, className = '', showMetadata = tru
   if (isDescriptionOnly && !showNotes) {
     return (
       <div className={`text-[var(--text-muted)] italic text-sm ${className}`}>
-        {(metadata.pageType || pageType || 'Image').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())} page — toggle Notes to see description
+        {formatPageTypeLabel(metadata.pageType || pageType || 'Image')} page — toggle Notes to see description
       </div>
     );
   }
@@ -980,8 +1014,15 @@ export default function NotesRenderer({ text, className = '', showMetadata = tru
       {/* Collapsible metadata panel - hidden when showMetadata is false */}
       {showMetadata ? <MetadataPanel metadata={metadata} /> : null}
 
-      {/* Main text rendered as markdown */}
-      {columnSegments ? (
+      {/* Main text rendered as markdown. On a description-only page every word
+          is the AI's, and unwrapDescriptionNotes has removed the per-note
+          highlight chips — so the whole body goes inside one marked frame
+          (#4069). Ordinary pages are untouched: their notes keep their chips. */}
+      {isDescriptionOnly ? (
+        <AiDescriptionFrame pageTypeLabel={formatPageTypeLabel(metadata.pageType || pageType || 'Image')}>
+          <ColumnMarkdown text={processedText} showNotes={showNotes} withNotes={withNotes} />
+        </AiDescriptionFrame>
+      ) : columnSegments ? (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-0 border-stone-200 md:[&>*:first-child]:border-r md:[&>*:first-child]:pr-6">
           {columnSegments.map((segment, i) => (
             <div key={i}>

--- a/tests/unit/description-page-note-highlight.test.ts
+++ b/tests/unit/description-page-note-highlight.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { prepareNotesMarkdown } from '@/components/reader/NotesRenderer';
+
+/**
+ * #4069 — "The notes arent rendered with highlights", reported on
+ * /book/6a0b363e1615109dc53aee64/page/6a0b363e1615109dc53aee71 (page_type
+ * "diagram"). The whole translation on such a page is the AI's description of
+ * the plate, and unwrapDescriptionNotes() strips the <note> tags so it renders
+ * uniformly — which also stripped every visual mark, leaving AI prose reading
+ * exactly like the book's own transcribed text.
+ *
+ * The fix keeps the unwrap (no half-highlighting) and moves the mark to the
+ * frame: NotesRenderer wraps a description-only body in AiDescriptionFrame.
+ * That frame is JSX and these tests run in `node`, so what is pinned here is
+ * the flag that gates it plus the unwrap it compensates for. #2791's guard —
+ * pages carrying real transcription must NOT take this path — is pinned too.
+ */
+
+// pages/6a0b363e1615109dc53aee71 — verbatim stored `pages.translation.data`
+const DIAGRAM_PAGE = `<note>A large, complex astronomical or cosmological diagram consisting of concentric circular paths. On the left side of the diagram is a vertical column containing several rectangular vignettes with human figures engaged in various activities, possibly representing the Labors of the Months or mythological scenes.
+
+Moving inward, a thin circular band features miniature depictions of the signs of the zodiac and various constellations; recognizable figures include a scorpion (Scorpio), a crab (Cancer), a centaur with a bow (Sagittarius), and various animals.
+
+The image is a fine-lined print, likely an engraving or woodcut from an early modern scientific or astronomical treatise.</note>
+
+<summary>This page contains an astronomical/cosmological diagram illustrating celestial spheres and zodiacal signs.</summary>
+<keywords>zodiac, celestial spheres, sun, moon, astrology, astronomy, engraving</keywords>`;
+
+describe('description-only pages are marked as AI description (#4069)', () => {
+  it('flags the reported diagram page as description-only, so the frame renders', () => {
+    const { isDescriptionOnly } = prepareNotesMarkdown(DIAGRAM_PAGE, { showNotes: true, pageType: 'diagram' });
+    expect(isDescriptionOnly).toBe(true);
+  });
+
+  it('leaves the description with no inline highlight of its own — the frame must carry it', () => {
+    const { processedText } = prepareNotesMarkdown(DIAGRAM_PAGE, { showNotes: true, pageType: 'diagram' });
+    // The description survives...
+    expect(processedText).toContain('concentric circular paths');
+    expect(processedText).toContain('signs of the zodiac');
+    // ...unwrapped, in every paragraph (normalizeAnnotationSpans splits the
+    // multi-paragraph note, so a leftover chip would highlight only part of it).
+    expect(processedText).not.toMatch(/<\/?(note|image-desc)[\s>]/i);
+  });
+
+  it('does not take the frame path when the page carries real transcription (#2791)', () => {
+    // A title page: genuine transcribed title/imprint alongside an image note.
+    const TITLE_PAGE = `->## LE IMAGINI DE GLI DEI DEGLI ANTICHI<-
+
+->Di Vincenzo Cartari, In Venetia, Appresso Francesco Marcolini, 1571<-
+
+<note>An engraved title page within an architectural frame flanked by two allegorical figures.</note>`;
+    const { isDescriptionOnly, processedText } = prepareNotesMarkdown(TITLE_PAGE, { showNotes: true, pageType: 'frontispiece' });
+    expect(isDescriptionOnly).toBe(false);
+    // ...and here the note keeps its own inline highlight chip, because there is
+    // book text next to it that must stay distinguishable from the AI's prose.
+    expect(processedText).toMatch(/<note>[\s\S]*architectural frame[\s\S]*<\/note>/i);
+  });
+});


### PR DESCRIPTION
Closes #4069.

## The report

Footer feedback on `/book/6a0b363e1615109dc53aee64/page/6a0b363e1615109dc53aee71`:

> The notes arent rendered with highlights

Verified on production: the page's entire body renders as plain `<p>` prose, with zero `Editorial note` spans in the HTML.

## Root cause

The page is `page_type: "diagram"`. Its stored translation is a single `<note>` — the AI's description of the plate, nothing transcribed. `NotesRenderer` classifies that as description-only and calls `unwrapDescriptionNotes()`, which strips `<note>`/`<image-desc>` so the description doesn't render half-highlighted (the model wraps some of it and leaves the rest as bare prose). The unwrap works, but it also removes the *only* mark that the prose is AI-written — so it reads exactly like the book's own text.

#2791 fixed the same complaint for title pages, by keeping pages that carry real transcription out of the description-only path (their notes must keep their inline chips, because there is book text beside them to distinguish from). The pure illustration/diagram/map case still lands in the unwrap. This report is that remaining half.

Note the reported symptom is *not* about reader-authored highlights: `HighlightSelection` has been a pass-through stub since #1103 and `/api/highlights` has no UI consumers.

## The fix

Keep the unwrap (half-highlighting is the worse failure) and move the mark from the chips to the frame. A description-only body now renders inside one accent-gold panel headed with the shared `AiBadge` and `"<Page type> — description"`:

```
┌ [AI] DIAGRAM — DESCRIPTION ───────────────────┐
│ A large, complex astronomical or cosmological │
│ diagram consisting of concentric circular …   │
└───────────────────────────────────────────────┘
```

Same tokens as the existing inline `image-description` block (`accent-gold/8` fill, `accent-gold/20` hairline border, `accent-gold-dark` label) — no new design primitives. The body text keeps the normal reading colour; a full page of gold-tinted prose is hard to read, and the frame plus badge already carry the provenance.

## Verification

- Server-rendered the component on the reported page's verbatim stored translation: the frame and badge appear, and both description paragraphs sit inside it.
- Same render on an ordinary text page with a note: unchanged, still an inline `Editorial note` chip.
- New `tests/unit/description-page-note-highlight.test.ts` pins the gating flag, the unwrap it compensates for, and #2791's guard (a title page must *not* take the frame path).
- `npx tsc --noEmit` clean; `notes-off` + `notes-toggle-page-marks` suites still green (30 tests).

## Out of scope

- **The page's `<meta name="description">` leaks raw `<note>` tags** into search-engine output (visible in production HTML on this page). Real bug, different surface — worth its own issue/PR.
- Column-splitting is skipped inside the frame. A plate description is never a two-column body, and applying the midpoint-split fallback to it would only fragment one continuous paragraph.
- Description-only pages with Notes toggled *off* still show the existing "toggle Notes to see description" placeholder; that behaviour is unchanged.