### PR TITLE
docs(invariants): a detector that cannot run must go RED, never file a finding (#4071)

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -225,3 +225,67 @@ about a rival vendor's model, about someone else's scholarship, about your own
 pipeline being fine — that is the result to attack with a control first. Every
 retraction this session was predicted by an adversarial self-critique pass that
 cost nothing; running the controls it named cost about four cents.
+
+## A detector that cannot run must go RED, never file a finding
+
+Discovered 2026-08-19 by reading the *body* of four open issues that everyone had
+been reading by title. **#3572, #3862, #4009** ("Image/text misalignment found in
+weekly sample", three consecutive Mondays) and **#4023** ("Field sprawl breach on
+books") were not findings. Each fenced payload was the script's own error:
+
+```
+MONGODB_URI not set — source .env.production.local first
+```
+
+`gh secret list` on this repo returns four secrets — `CF_ZONE_ID`,
+`CLOUDFLARE_API_TOKEN`, `CRON_SECRET`, `HETZNER_SSH_KEY` — and **no
+`MONGODB_URI`**. All three DB-backed scheduled detectors had therefore run blind
+since the day they were added: the weekly image/text alignment sample (the
+standing detector for #3368-class archiver drift), the weekly `books` field-sprawl
+census (the ratchet half of #3969), and the daily feedback-symptom clustering.
+Zero measurements, across weeks, while the backlog carried four issues asserting
+the corpus was broken. Restoration is #4071; the exit-code fix is #4072.
+
+**Both failure directions were live at once, which is why nothing caught it:**
+
+- **Loudly wrong.** `bulk-archive-alignment.mjs` exited `1` for "found
+  misalignment" *and* for "no MONGODB_URI", and the workflow files a finding issue
+  on `1`. `field-sprawl-watch.yml` filed on `fired != '0'`, sweeping its script's
+  correct exit `2` into the finding branch. Four false issues.
+- **Silently wrong.** `feedback-symptom-clusters.mjs` exits `2` and its job files
+  only on `1` — green every day since July, never having clustered a report. This
+  is the direction that leaves no trace at all, and it is why "could not run" must
+  be red rather than merely "not a finding".
+
+`set +e` (needed to capture the code) meant every run reported **success** in the
+Actions UI, so the filed issues were the only signal and they pointed at the
+corpus instead of at the harness.
+
+**The rule.** Every detector gets a three-value exit contract, and the caller
+reads all three:
+
+| code | meaning | caller |
+|---|---|---|
+| `0` | ran, clean | pass |
+| `1` | ran, **found something** | file the finding |
+| `2` | **could not run** | fail the job RED |
+
+- **Never branch a finding on `!= 0`.** That is the single line that turned an
+  infrastructure failure into three weeks of fabricated corpus findings.
+- **An uncaught throw is `2`, not `1`.** A crash is an instrument failure; only a
+  measurement can be a finding.
+- **A job that swallows the exit code must re-raise it.** If you need `set +e`,
+  add an explicit step that fails on any code outside `{0,1}` and names the
+  missing input in the annotation.
+- **Verify a detector by making it fail.** The only proof the wiring works is
+  running it with the input removed and seeing red. A green scheduled run proves
+  nothing about a detector whose failure mode is silence.
+
+**Diagnostic tell for the next person:** an auto-filed issue whose fenced block is
+an *error message* rather than a *measurement*. Read the body before believing the
+title — and when a watchdog has filed the same title on a regular cadence with no
+one acting on it, suspect the watchdog before the corpus.
+
+Related: the same self-referential shape as the error reporter that reported its
+own failures (#4045/#4047), and the inverse of "absence is not failure — no silent
+skips" (#3740): here the failure was not silent, it was *disguised as a finding*.

--- a/.claude/handoffs/2026-08-19-blind-detectors-and-false-findings.md
+++ b/.claude/handoffs/2026-08-19-blind-detectors-and-false-findings.md
@@ -1,0 +1,118 @@
+# Three scheduled detectors were blind, and two of them filed their own error as a finding
+
+**Date:** 2026-08-19
+**Session:** issue close-out sweep ("any recent issues to close out")
+**Outcome:** 4 issues closed as artifacts, 1 PR merged, 1 issue filed and assigned, 1 invariant written
+
+## What happened
+
+Started as a routine backlog sweep. The four most recent auto-filed issues turned
+out to share a single cause that nobody had looked at, because everyone had been
+reading them by title.
+
+**#3572, #3862, #4009** — "Image/text misalignment found in weekly sample", three
+consecutive Mondays (Aug 3, 10, 17). **#4023** — "Field sprawl breach on books".
+The fenced payload in every one of them is the script's own error:
+
+```
+MONGODB_URI not set — source .env.production.local first
+```
+
+`gh secret list` returns exactly four secrets: `CF_ZONE_ID`,
+`CLOUDFLARE_API_TOKEN`, `CRON_SECRET`, `HETZNER_SSH_KEY`. There is no
+`MONGODB_URI`. Three scheduled jobs reference `secrets.MONGODB_URI` and have
+therefore never opened a database connection:
+
+| workflow / job | cadence | state |
+|---|---|---|
+| `corpus-integrity-watch.yml` → `alignment-sample` | weekly Mon 07:00 UTC | never sampled a book |
+| `corpus-integrity-watch.yml` → `feedback-clusters` | daily 08:00 UTC | never clustered a report |
+| `field-sprawl-watch.yml` → `field-sprawl` | weekly Tue 07:30 UTC | never counted a field |
+
+The PR-time `field-write-lint` job in the same workflow needs no database and has
+been working — the static half of the #3969 ratchet held.
+
+## Why it hid for weeks
+
+Both failure directions were live simultaneously.
+
+- **Loudly wrong.** `bulk-archive-alignment.mjs` exited `1` for "found
+  misalignment" *and* for "no MONGODB_URI"; the workflow files a finding issue on
+  `1`. `field-sprawl-watch.yml` filed on `fired != '0'`, which swept its script's
+  correct exit `2` into the finding branch.
+- **Silently wrong.** `feedback-symptom-clusters.mjs` exits `2` and its job files
+  only on `1` — green daily since July, zero reports clustered, no trace anywhere.
+
+`set +e` (needed to capture the exit code) meant every run reported **success** in
+the Actions UI. So the four filed issues were the only visible signal, and they
+pointed at the corpus rather than at the harness.
+
+## Files modified
+
+- `scripts/audit/bulk-archive-alignment.mjs` — exit `2` on missing `MONGODB_URI`
+  and on uncaught throw; `1` reserved for a real finding
+- `.github/workflows/field-sprawl-watch.yml` — files on `fired == '1'` (was
+  `!= '0'`); new step fails the job on anything outside `{0,1}`
+- `.github/workflows/corpus-integrity-watch.yml` — same failure step on both jobs
+- `.claude/docs/invariants/measurement-instruments.md` — new section "A detector
+  that cannot run must go RED, never file a finding"
+- `CLAUDE.md` — routing line extended to cover scheduled detectors; fixed the
+  fresh-worktree lamejs command, which was missing its `mkdir -p` and fails as
+  written (cost one failed commit this session)
+
+## Verification
+
+With `MONGODB_URI` unset, all three scripts now exit `2`
+(`bulk-archive-alignment.mjs --sample 1`, `field-sprawl.mjs --collection books`,
+`feedback-symptom-clusters.mjs --days 14`). Both workflow YAMLs parse;
+`node --check` passes on the script. PR #4072 green on `test`/DCO/field-write-lint,
+merged as `6aba91ac`. No deploy owed — `.github/` + `scripts/` only.
+
+The behaviour with a *working* secret is untestable until the secret exists.
+
+## State / what's next
+
+- **#4071 is open and assigned to `Mayank-PPL`.** It needs a `MONGODB_URI` repo
+  secret. Deliberately **not** the personal full-access URI in
+  `.env.production.local` — this repo is public and all three jobs are read-only
+  censuses; the right credential is a new read-only Atlas user.
+- **Permission split, discovered while writing the handoff comment:** Mayank has
+  `write`, not `admin`, and GitHub requires admin to set a repo secret. So
+  `gh secret set` must be Derek. Mayank can do the Atlas half (create
+  `ci-readonly` with *Only read any database*; open Network Access to `0.0.0.0/0`
+  — GitHub runners have no stable egress range) and hand the URI over
+  out-of-band, never in the public thread.
+- Verification is step 4 of #4071: `gh workflow run corpus-integrity-watch.yml`
+  and `gh workflow run field-sprawl-watch.yml`. After #4072, a still-broken secret
+  produces a **red run**, not a fifth false issue.
+- Nothing is known about whether the corpus is actually misaligned or sprawling.
+  It has not been measured since these detectors were added; it becomes knowable
+  when the secret lands.
+
+## Also noted, not acted on
+
+Two other issues are one action from closing, both blocked on Derek specifically:
+
+- **#3991** — `@source-library/mcp-server` is 4.6.0 in-repo, 4.5.0 on npm since
+  2026-06-28. Derek is the sole npm maintainer: `cd mcp-server && npm publish`.
+  That also closes the last open half of **#3937** (stdio-package users have no
+  images).
+- **#4025** — the `frondular` Vercel scope watching this repo produces the failing
+  deploy statuses. Vercel → frondular → sourcelibrary-v2 → Settings → Git →
+  Disconnect closes #4025 and #4060 together; real builds run on
+  `dereklomas-projects`.
+
+Checked the last 25 merged PRs for `Closes #` links pointing at still-open issues
+— none. Merge hygiene is clean. Backlog is 275 open after this sweep.
+
+## The transferable lesson
+
+Every detector gets a three-value exit contract — `0` clean, `1` finding, `2`
+could-not-run — and the caller reads all three. Never branch a finding on `!= 0`.
+An uncaught throw is `2`, not `1`. And verify a detector by making it *fail*: a
+green scheduled run proves nothing about an instrument whose failure mode is
+silence. Written up in `measurement-instruments.md`.
+
+Diagnostic tell: an auto-filed issue whose fenced block is an error message rather
+than a measurement. When a watchdog files the same title on a regular cadence and
+nobody acts, suspect the watchdog before the corpus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 - Active worktrees: `git worktree list`
 - Worktrees live in `.claude/worktrees/`
 - **`vercel` from a fresh worktree silently creates a NEW Vercel project** (named after the worktree dir) and deploys it as that project's Production — the link file `.vercel/project.json` is gitignored and absent from new checkouts. Before any `vercel` invocation in a worktree: `mkdir -p .vercel && cp <main-dir>/.vercel/project.json .vercel/`. Junk project cleanup: `vercel remove <name> --yes`.
-- **Fresh worktrees fail the pre-commit `check-imports` hook** because `src/lib/vendor/lamejs-bundle.js` is gitignored and absent from a new checkout. Before your first commit, copy it from the main checkout: `cp <main-dir>/src/lib/vendor/lamejs-bundle.js src/lib/vendor/`.
+- **Fresh worktrees fail the pre-commit `check-imports` hook** because `src/lib/vendor/lamejs-bundle.js` is gitignored and absent from a new checkout. Before your first commit, copy it from the main checkout: `mkdir -p src/lib/vendor && cp <main-dir>/src/lib/vendor/lamejs-bundle.js src/lib/vendor/`. The `mkdir` is load-bearing and was missing until 2026-08-19 — `src/lib/vendor/` contains nothing but the gitignored bundle, so the directory does not exist in a fresh worktree and the bare `cp` fails.
 - **Worktrees accumulate structurally, not from sloppiness.** A worktree can't be removed while its PR is open, and the PR merges *after* the creating session ends — so nothing is left to reap it. Per-session `ExitWorktree` discipline cannot fix this. `/gnite` runs the reaper, and `/reap-worktrees` runs it on demand.
 - **Judge a worktree by occupancy, never by a global session count.** `reap-worktrees.mjs` keeps a worktree iff a live process has its cwd inside it (`lsof -d cwd`), its git lock names a running pid, or it holds real uncommitted work. Everything else is an orphan. Asked per worktree the question is exact, so reaping is safe with other sessions open — which is what lets `/gnite` reap one window at a time. The old `ps | grep -i claude` count reported **34 sessions on a machine running 3** (it matched the desktop app, the dashboard, and MCP helpers), so `--apply` always refused and the habit became `--force` — the one genuinely dangerous flag. A noisy safety check doesn't fail closed; it trains people to bypass it.
 - **`git worktree remove --force` refuses a *locked* worktree** — git wants `-f -f`. Don't force twice. `EnterWorktree` writes its session pid into the lock reason, so a dead pid means a stale lock (unlock, then reap) and a live pid means someone is working (keep). Locking is a deliberate "don't touch" signal; the reaper honors it.
@@ -169,7 +169,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - Client components on ISR routes, reader panels, root layout, page `metadata` → `rendering-and-seo.md`
 
 **Measuring anything**
-- Quoting a usage number, analytics read/write paths, alarms, health probes, **or using a model as a judge/screen** → `measurement-instruments.md`
+- Quoting a usage number, analytics read/write paths, alarms, health probes, **a scheduled detector that files its findings as issues**, or using a model as a judge/screen → `measurement-instruments.md`
 - Writing a test that pins behaviour, or a fixture for one → `tests-that-are-not-guards.md`
 - Normalising, folding, comparing or validating TEXT (names, quotes, dedup keys, detectors) → `non-latin-text-operations.md`
 


### PR DESCRIPTION
The gnite ratchet for today's session, both directions.

## Up — new invariant

Four issues closed today (#3572, #3862, #4009, #4023) were not corpus findings; they were three scheduled detectors reporting their own inability to reach a database that no `MONGODB_URI` secret ever gave them. Root cause in **#4071**, exit-code fix merged in **#4072**.

`measurement-instruments.md` gains a section stating the contract that was missing:

| code | meaning | caller |
|---|---|---|
| `0` | ran, clean | pass |
| `1` | ran, found something | file the finding |
| `2` | could not run | fail the job RED |

Plus the four rules that follow from it — never branch a finding on `!= 0`; an uncaught throw is `2`, not `1`; a job that swallows the exit code must re-raise it; and verify a detector by making it *fail*, since a green scheduled run proves nothing about an instrument whose failure mode is silence.

Both failure directions are documented, because both were live at once: two detectors filed their error as a finding, and the third (`feedback-clusters`) exited `2` into a workflow that files only on `1` — green daily since July, never having clustered a report. That second one is why "could not run" has to be red rather than merely "not a finding".

Diagnostic tell for the next person: an auto-filed issue whose fenced block is an error message rather than a measurement.

**Tier choice:** this fires only when touching a scheduled detector, so it belongs in `invariants/`, not the body of `CLAUDE.md`. The routing line is extended from "alarms, health probes" to also name "a scheduled detector that files its findings as issues" — the phrasing someone would actually match on.

## Down — one stale instruction fixed in place

The fresh-worktree setup note said:

> `cp <main-dir>/src/lib/vendor/lamejs-bundle.js src/lib/vendor/`

`src/lib/vendor/` contains nothing but that gitignored bundle, so the directory does not exist in a new checkout and the bare `cp` fails. It cost a failed pre-commit run today. Now `mkdir -p src/lib/vendor && cp …`, with a note saying why the `mkdir` is load-bearing.

`CLAUDE.md` stays at **230 lines**, under the ~250 budget — nothing needed demoting.

## Out of scope

- Restoring the detectors. That needs the secret (#4071), which needs Atlas console work and an admin-level `gh secret set`.
- Whether the corpus is actually misaligned or sprawling — unmeasured since these detectors were added, and unknowable until the secret lands.

Session handoff included: `.claude/handoffs/2026-08-19-blind-detectors-and-false-findings.md` (added with `git add -f`; the directory is gitignored, and this one is a purely technical postmortem with no PII, secrets, or business material).