### PR TITLE
fix(newsletter): never sync test addresses into the Resend audience

### DIFF
--- a/scripts/workers/refresh-newsletter-audience.mjs
+++ b/scripts/workers/refresh-newsletter-audience.mjs
@@ -29,7 +29,9 @@ const AUDIENCE_NAME = process.env.NEWSLETTER_AUDIENCE_NAME || 'Source Library Ne
 const H = { Authorization: `Bearer ${RESEND_API_KEY}`, 'Content-Type': 'application/json' };
 
 const norm = (e) => (e || '').trim().toLowerCase();
-const valid = (e) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(e);
+// example.com/.test/.invalid are test artifacts; Resend refuses to send a
+// broadcast if the audience contains ANY such address (422), so never sync them.
+const valid = (e) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(e) && !/@(?:[^@\s]+\.)?example\.com$|\.(?:test|invalid|localhost)$/.test(e);
 
 if (!MONGODB_URI || !RESEND_API_KEY) {
   console.error('Missing MONGODB_URI or RESEND_API_KEY in env. Aborting.');


### PR DESCRIPTION
## What
One-line filter in `scripts/workers/refresh-newsletter-audience.mjs`: reject `@example.com` (any subdomain) and reserved test TLDs (`.test`, `.invalid`, `.localhost`) when building the audience union.

## Why
Two June funnel-test contacts (`test-signin-check@example.com`, `test-funnel-21e00aac@example.com`) were synced into the Source Library Newsletter audience by this cron. Resend refuses to send a broadcast when the audience contains ANY `@example.com` address — the 2026-08-19 feedback letter send 422'd on exactly this until the contacts were deleted by hand. Without this filter the daily 09:00 UTC refresh would have re-added them from Mongo tomorrow and re-blocked the next send.

## Also done outside this PR
The source rows were deleted directly: 2 from `signup_interest`, 5 from `verification_tokens` (exact-match on the two test addresses). This PR is the guard so future test runs can't repopulate.

## Out of scope
The `--validate` mode of the sign-in nudge script also uses an `@example.com` address but cleans up after itself; no change needed there.

Deploys via Hetzner auto-pull of main — no Vercel implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)