### PR TITLE
docs(email): feedback letter SENT; cohort-audience ledger points at ops-repo exports

### DIFF
--- a/.claude/docs/newsletter-queue.md
+++ b/.claude/docs/newsletter-queue.md
@@ -58,8 +58,16 @@ than a gap.
 
 ## Queue
 
-### 1. "Can I get your feedback?" — READY, awaiting send
+### 1. "Can I get your feedback?" — SENT 2026-08-19
 `scripts/email/feedback-newsletter-2026-08.body.html`
+
+Sent 2026-08-19 13:28 UTC as subject "Can I get your feedback on Source
+Library?" (Resend broadcast `77b35192`, 5,538 contacts), after a nine-day
+stall on a Resend contacts-quota block (2026-08-10) resolved by a billing fix.
+Two things learned at send time, both already fixed: the book count had
+drifted (19,420 → 22,069, re-measured per the rule above, PR #3880), and a
+single `@example.com` test contact in the audience makes Resend 422 the whole
+broadcast (filtered at three layers, PR #4077).
 
 Ask: **report anything that looks wrong.** Shows the three places to leave
 feedback, with screenshots, and makes the trust argument (don't trust any

--- a/scripts/send-user-broadcast.mjs
+++ b/scripts/send-user-broadcast.mjs
@@ -40,8 +40,12 @@
  * opened/clicked (engagement). Only sends AFTER the subdomain went live carry
  * click data.
  *
- * SENT LEDGER (audiences already emailed — exclude all of these from new
- * cohorts; tracking was OFF for the first three so they have no click data):
+ * SENT LEDGER — the audiences below were DELETED from Resend on 2026-08-10
+ * to free contact quota (their welcome-backlog job was done; Cohort 7 cleared
+ * it). The IDs are dead. Full contact exports live in the private ops repo:
+ * ~/sourcelibrary-ops/email-campaign/audience-exports/2026-08-10/. If a new
+ * cohort is ever built, exclude the union of THOSE FILES, not these audiences.
+ * (Historical record — tracking was OFF for the first three, no click data):
  *   - 725ada69-...  Batch 1            200  subj "A new Renaissance — by translating the first"
  *   - 33bc889e-...  Recent Week        200  subj "...has never been read"  (wrong word, shipped)
  *   - 7137b7fe-...  Cohort 2           200  subj "...has never been translated"


### PR DESCRIPTION
Doc-status ratchet from the 2026-08-10→08-19 send saga, no behavior change.

- `newsletter-queue.md`: item 1 marked SENT 2026-08-19 (broadcast 77b35192, 5,538 contacts), with the two send-time lessons and their fixing PRs (#3880, #4077).
- `send-user-broadcast.mjs` header: the cohort audiences were deleted from Resend on 2026-08-10 — the ledger now says so and points future cohort builds at the contact exports in the private ops repo instead of the dead audience IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)