### PR TITLE
feat(i18n): /es/book is the English book page in Spanish (#4082 phase 2)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -43,11 +43,24 @@ shown with the original beneath it (`originalTitleIfDifferent`).
 5. **The locale is the URL prefix, and it stays.** `localeFromPathname` reads
    `/es`; the header/footer localize themselves from it. Every link on a
    localized surface keeps the prefix when a twin route exists —
-   `LOCALIZED_PATHS` / `LOCALIZED_PREFIXES` in `src/lib/i18n.ts` is the single
-   registry of which paths have one; `localeHref()` builds the switch link.
-   Twin routes are THIN: `src/app/es/<path>` renders the same data with a
-   `lang` prop (see `src/app/es/collections/[id]/page.tsx`,
-   `src/lib/es-collections.ts`), and sets `alternates.languages` for SEO.
+   `LOCALIZED_PATHS` / `LOCALIZED_PATTERNS` in `src/lib/locale-path.ts` is the
+   single registry of which paths have one. `localeHref()` builds the EN/ES
+   switch link; **`localePath(href, lang)`** (server) and **`useLocalePath()`**
+   (client) keep an ordinary internal link on its locale. Both are
+   registry-guarded, so a path with NO twin comes back untouched instead of
+   pointing at a 404 — `/es/book/x/overview` is served by nothing. That is why
+   the registry lists route SHAPES (`/book/<id>/page/<pageId>`) and not a bare
+   `/book` prefix: a missing pattern costs an English page, a wrong one costs a
+   404. Twin routes are THIN: `src/app/es/<path>` renders the same component
+   with a `lang` prop and sets `alternates.languages` for SEO.
+
+   **Where the primitives live:** the pure ones (`Locale`, `localeFromPathname`,
+   `canonicalPath`, `localeHref`, `localePath`, the registry) are in
+   `src/lib/locale-path.ts`, which imports nothing from React. `src/lib/i18n.ts`
+   re-exports all of them and adds the two hooks that read the current URL —
+   importing IT from a server component is an error in Next 16, because it pulls
+   in `usePathname`. Server code imports `@/lib/locale-path`; client code can use
+   either.
 6. **Reading language follows the reader off the prefix.** `src/lib/reading-language.ts`
    (localStorage): a `/es` visit or `?lang=es` stores it; the reader toggle
    persists it. This is what lets the cache-shared `/book/*` pages stay
@@ -66,9 +79,31 @@ shown with the original beneath it (`originalTitleIfDifferent`).
 4. `localize-metadata.mjs --lang=<iso> --books-with-editions`.
 5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts` and the reader toggle.
 
+## The book page: ONE page, two URLs
+
+`src/app/book/[id]/page.tsx` renders under both `/book/…` and `/es/book/…`;
+`src/app/es/book/[id]/page.tsx` is a re-export that passes `lang='es'` (#4082
+phase 2). The first attempt was a second, hand-written Spanish page — the wrong
+shape, because two pages describing one book drift apart with every change to
+the English one. Copy that pattern for the next localized surface:
+
+- the page takes `lang: Locale`, defaulting to `'en'`, and derives
+  `t = BOOK_STRINGS[lang]` and `lp = (href) => localePath(href, lang)`;
+- **client** children take no `lang` prop — they call `useLocale()` /
+  `useLocalePath()`, because the pathname already says which language they are
+  in (`PagesGrid`, `BookIndex`, `CollectionBookCard`, `ChaptersDropdown`);
+- **server** children take an explicit locale prop (`RelatedEditions`);
+- a child that has NOT been threaded stays English **and is listed** — see the
+  note at the foot of `src/lib/book-i18n.ts`. Nothing is machine-translated at
+  render time (rule 4).
+
+Mind the TWO top-level returns in `BookInfo` (#3916): the standard layout and
+the embed-only one. Only the standard layout is localized; tenant reading rooms
+keep the proven English/embed layout (tenant-lockdown.md).
+
 ## Known gap (tracked)
 
-The book page (`/book/[id]`, 2,400 lines, two top-level returns — #3916) has
-no twin yet: from `/es/collections/...` a click leaves the prefix. The reader
-still opens in Spanish via the stored preference. Plan and phases: issue
-**#4082** (`/es/book/[id]` thin twin → string extraction → full chrome).
+The **reader** (`/es/book/[id]/page/[pageId]`) re-exports the English reader
+verbatim, so its chrome is still English — header title, chapter dropdown,
+Image/OCR/Read/Edit/Cite/Notes/Info/Copy, "Like this page", the search
+placeholder. Same rule, same dictionary; tracked as phase 2b on **#4082**.

--- a/src/app/book/[id]/page-number/[num]/route.ts
+++ b/src/app/book/[id]/page-number/[num]/route.ts
@@ -1,46 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';
-import { findBookByIdOrSlug } from '@/lib/book-lookup';
-import { getTenantContextFromRequest } from '@/lib/tenant-context';
-import { resolvePageByNumber } from '@/lib/page-number-resolve';
+import { NextRequest } from 'next/server';
+import { pageNumberRedirect } from '@/lib/page-number-redirect';
 
 interface RouteContext {
   params: Promise<{ id: string; num: string }>;
 }
 
 export async function GET(request: NextRequest, { params }: RouteContext) {
-  const { id, num } = await params;
-  const pageNumber = parseInt(num, 10);
-
-  if (isNaN(pageNumber)) {
-    return new NextResponse('Not Found', { status: 404 });
-  }
-
-  const db = await getReadDb();
-  const ctx = getTenantContextFromRequest(request);
-
-  const result = await findBookByIdOrSlug(db, id, { id: 1, slug: 1 }, ctx.id ?? undefined);
-  if (!result) {
-    return new NextResponse('Not Found', { status: 404 });
-  }
-
-  const bookId = (result.book.id || result.book._id?.toString()) as string;
-  const bookSlug = (result.book.slug || bookId) as string;
-
-  // Resolve with a nearest-page fallback so a chapter whose printed page
-  // number doesn't land on an exact pages.page_number value still lands the
-  // reader on the closest page instead of a hard 404. Only 404s when the book
-  // has no pages at all.
-  const page = await resolvePageByNumber(db, bookId, pageNumber);
-
-  if (!page) {
-    return new NextResponse('Not Found', { status: 404 });
-  }
-
-  const pageId = page.id || page._id?.toString();
-  const destination = new URL(`/book/${bookSlug}/page/${pageId}`, request.url);
-  // Preserve the incoming query string (e.g. ?highlight=, ?v=) so search-result
-  // links that land here still highlight/pin on the resolved page reader.
-  destination.search = request.nextUrl.search;
-  return NextResponse.redirect(destination, 308);
+  return pageNumberRedirect(request, await params);
 }

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -80,6 +80,10 @@ import { hasPublishablePriorTranslation, priorTranslationSentence, priorLinkLabe
 import type { PriorTranslationCredit, TranslationVerification } from '@/lib/types/book';
 import { getEffectiveByline } from '@/lib/byline';
 import AuthorName from '@/components/AuthorName';
+import { localePath, type Locale } from '@/lib/locale-path';
+import { BOOK_STRINGS, languageName } from '@/lib/book-i18n';
+import { localizedTitle, originalTitleIfDifferent } from '@/lib/localized';
+import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import CatalogueBreadcrumb from '@/components/book/CatalogueBreadcrumb';
 import type { TenantContext } from '@/lib/tenant-context';
@@ -112,6 +116,12 @@ interface PageProps {
   // editor-gated /book/[id]/preview route. The public ISR route leaves this
   // false so hidden books 404 uniformly (cache-safe — no per-user branch).
   allowHidden?: boolean;
+  // Which language this URL is. Set by the thin `/es/book/[id]` twin, which
+  // re-exports this page — ONE page, two URLs, so the two can never diverge
+  // (#4082). It decides the chrome dictionary, which title/summary/chapter
+  // text is shown, and the prefix every internal link keeps. Defaults to the
+  // English route. See .claude/docs/i18n.md.
+  lang?: Locale;
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
@@ -224,7 +234,7 @@ async function getBookForMetadata(id: string, tenantId?: string | null, tenantSl
 
 
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export async function generateMetadata({ params, lang = 'en' }: PageProps): Promise<Metadata> {
   const { id } = await params;
   let book: Book | null;
   try {
@@ -240,7 +250,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {
       title: 'Book Not Found - Source Library',
       robots: { index: false, follow: false },
-      alternates: { canonical: `/book/${id}` },
+      alternates: { canonical: localePath(`/book/${id}`, lang) },
     };
   }
 
@@ -251,7 +261,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     return {
       title: 'Book Not Found - Source Library',
       robots: { index: false, follow: false },
-      alternates: { canonical: `/book/${id}` },
+      alternates: { canonical: localePath(`/book/${id}`, lang) },
     };
   }
 
@@ -338,6 +348,30 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   });
   const bookUrl = `/book/${book.slug || book.id}`;
 
+  // ---- Localized twin (`/es/book/…`) --------------------------------------
+  // Same record, different indexable page. The gloss and the Spanish summary
+  // live in the one language-keyed `localized` map; the Supabase catalog
+  // fast-path does not carry it, so ask Atlas rather than silently emitting an
+  // English title under a Spanish URL. On a miss the ORIGINAL title is shown
+  // (localizedTitle's fallback), never the English gloss.
+  let localizedMeta: { title?: string; summary?: string } | undefined;
+  if (lang !== 'en') {
+    let map = (book as unknown as { localized?: Record<string, { title?: string; summary?: string }> }).localized;
+    if (!map && bookRec.id) {
+      try {
+        const ldb = await getReadDb();
+        const doc = await ldb.collection('books').findOne(
+          { id: bookRec.id },
+          { projection: { _id: 0, localized: 1 }, maxTimeMS: 3000 },
+        ) as { localized?: Record<string, { title?: string; summary?: string }> } | null;
+        map = doc?.localized;
+        if (map) (book as unknown as { localized?: unknown }).localized = map;
+      } catch { /* fall back to the original title */ }
+    }
+    localizedMeta = map?.[lang];
+  }
+  const localizedTitleText = lang === 'en' ? null : localizedTitle(book, lang);
+
   // Get publication date for OG tags
   const currentEdition = (book.editions as TranslationEdition[] | undefined)?.find(e => e.status === 'published') || (book.editions as TranslationEdition[] | undefined)?.find(e => e.status === 'draft');
   const publishedDate = currentEdition?.published_at
@@ -402,24 +436,36 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     || pagesOcr > 3
     || (pagesOcr > 0 && (pagesTranslated ?? 0) > 0);
 
+  // On the localized twin the page IS a different document: its own canonical,
+  // hreflang pair, title and description. The Google Scholar `citation_*` block
+  // and the DTS ld+json stay on the English page only — that is the citable
+  // edition, and emitting them twice would mint a second scholarly record for
+  // one book.
+  const isTwin = lang !== 'en';
+  const twinUrl = `/${lang}${bookUrl}`;
+  const localizedDescription = localizedMeta?.summary?.slice(0, 200) || description;
+
   return {
-    title: seoTitle,
-    description,
+    title: isTwin && localizedTitleText ? `${localizedTitleText} | Source Library` : seoTitle,
+    description: isTwin ? localizedDescription : description,
     ...(!shouldIndex && { robots: { index: false, follow: true } }),
-    alternates: {
-      canonical: bookUrl,
-      types: {
-        'application/ld+json': `https://sourcelibrary.org/api/dts/collection?id=${book.id}`,
+    alternates: isTwin
+      ? { canonical: twinUrl, languages: { en: bookUrl, [lang]: twinUrl, 'x-default': bookUrl } }
+      : {
+        canonical: bookUrl,
+        languages: { en: bookUrl, 'x-default': bookUrl },
+        types: {
+          'application/ld+json': `https://sourcelibrary.org/api/dts/collection?id=${book.id}`,
+        },
       },
-    },
-    other: scholarMeta,
+    ...(isTwin ? {} : { other: scholarMeta }),
     openGraph: {
-      title: ogTitle,
-      description,
+      title: isTwin && localizedTitleText ? localizedTitleText : ogTitle,
+      description: isTwin ? localizedDescription : description,
       type: 'article',
       siteName: 'Source Library',
-      locale: 'en_US',
-      url: bookUrl,
+      locale: isTwin ? 'es_ES' : 'en_US',
+      url: isTwin ? twinUrl : bookUrl,
       // OG image generated by opengraph-image.tsx (branded 1200x630 card)
       ...(publishedDate && { publishedTime: publishedDate }),
       ...(modifiedDate && { modifiedTime: modifiedDate }),
@@ -429,8 +475,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      title: ogTitle,
-      description,
+      title: isTwin && localizedTitleText ? localizedTitleText : ogTitle,
+      description: isTwin ? localizedDescription : description,
       // Twitter image generated by opengraph-image.tsx
     },
   };
@@ -703,7 +749,12 @@ function PagesGridSkeleton() {
 }
 
 // Book info component (streams in via Suspense)
-async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = false, previewProposed = false, allowHidden = false }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy; isEmbedded?: boolean; previewProposed?: boolean; allowHidden?: boolean }) {
+async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = false, previewProposed = false, allowHidden = false, lang = 'en' }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy; isEmbedded?: boolean; previewProposed?: boolean; allowHidden?: boolean; lang?: Locale }) {
+  // Chrome words for this URL's language, and the link prefix that keeps a
+  // reader on it. `lp` is registry-guarded (src/lib/i18n.ts): a path with no
+  // Spanish twin comes back unprefixed rather than pointing at a 404.
+  const t = BOOK_STRINGS[lang];
+  const lp = (href: string) => localePath(href, lang);
   let data;
   try {
     data = await getBook(id, tenantId, tenantSlug);
@@ -713,9 +764,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     return (
       <div className="flex items-center justify-center py-20">
         <div className="text-center max-w-md px-6">
-          <h2 className="text-2xl font-display text-primary mb-3">Temporarily Unavailable</h2>
-          <p className="text-secondary mb-6">This book is taking longer than expected to load. Please try again in a moment.</p>
-          <Link href={`/${tenantSlug || ''}`} className="text-accent-rust hover:underline">Return to Library</Link>
+          <h2 className="text-2xl font-display text-primary mb-3">{t.temporarilyUnavailable}</h2>
+          <p className="text-secondary mb-6">{t.temporarilyUnavailableBody}</p>
+          <Link href={lp(`/${tenantSlug || ''}`)} className="text-accent-rust hover:underline">{t.returnToLibrary}</Link>
         </div>
       </div>
     );
@@ -890,6 +941,16 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
   if (!isEmbedded) {
     const heroByline = getEffectiveByline(book);
     const bookSlug = book.slug || book.id;
+    // What this URL's language SHOWS. Title: the gloss for `lang`, falling back
+    // to the original (never the English gloss under Spanish chrome — rule 4).
+    // Summary and chapter titles come from the same one language-keyed map;
+    // where a book has none, the English text is shown and LABELLED rather than
+    // machine-translated at render time.
+    const shownTitle = localizedTitle(book, lang);
+    const titleBeneath = originalTitleIfDifferent(book, lang);
+    const localizedBook = lang === 'en' ? undefined : (book as unknown as { localized?: Record<string, { summary?: string; chapters?: string[] }> }).localized?.[lang];
+    const localizedChapters = localizedBook?.chapters;
+    const localizedSummary = localizedBook?.summary;
     // Hero cover: prefer the stored cover only when it's on a host the CSP allows
     // (rehosted R2 / blob / Wikimedia). Freshly-imported books keep a raw
     // source URL (archive.org, …) that the browser blocks — in that case fall
@@ -960,7 +1021,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       const src = img.thumbnail_url || img.extracted_url || img.image_url;
       if (!src) return null;
       const pageId = img.id.match(/^(.+)[:\-]\d+$/)?.[1];
-      const href = pageId ? `/book/${bookSlug}/page/${pageId}` : `/gallery/image/${img.id}`;
+      const href = pageId ? lp(`/book/${bookSlug}/page/${pageId}`) : `/gallery/image/${img.id}`;
       return { src, fallback: img.extracted_url || img.image_url, href, label: img.description };
     }).filter((p): p is Plate => p !== null);
     const readHref = (() => {
@@ -968,10 +1029,10 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       const firstChapterPageNumber = book.chapters?.length
         ? (book.chapters as { pageNumber?: number }[])[0]?.pageNumber
         : null;
-      if (typeof firstChapterPageNumber === 'number') return `/book/${bookSlug}/page-number/${firstChapterPageNumber}`;
+      if (typeof firstChapterPageNumber === 'number') return lp(`/book/${bookSlug}/page-number/${firstChapterPageNumber}`);
       const skipTo = totalPages >= 20 ? 4 : totalPages >= 10 ? 2 : 0;
       const readPage = pages[skipTo] || pages[0];
-      return readPage ? `/book/${bookSlug}/page/${readPage.id}` : null;
+      return readPage ? lp(`/book/${bookSlug}/page/${readPage.id}`) : null;
     })();
     const hasContents = !!(book.chapters?.length || (book as unknown as { index?: { entries?: unknown[] } }).index?.entries?.length || hasSummary);
     // The related rail only shows books with a CSP-renderable cover (rehosted to
@@ -1061,8 +1122,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     const NONINFO_DATE = /^\s*(unknown|undated|n\.?\s?d\.?|\?+|[-—]+)?\s*$/i;
     const heroDate = (() => {
       const pub = book.published ? String(book.published).trim() : '';
-      if (pub && !NONINFO_DATE.test(pub)) return { label: 'Published', value: pub };
-      if (compDateDisplay) return { label: 'Written', value: compDateDisplay };
+      if (pub && !NONINFO_DATE.test(pub)) return { label: t.published, value: pub };
+      if (compDateDisplay) return { label: t.written, value: compDateDisplay };
       return null;
     })();
     // Meta line: publisher/place, plus the source-work line ONLY when its author
@@ -1106,7 +1167,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // An editor-chosen About visual (BookAboutPicker) overrides the auto-pick.
     const aboutOverride = (book as unknown as { about_visual?: { src?: string; href?: string; caption?: string } | null }).about_visual;
     const sideVisual = (aboutOverride && aboutOverride.src)
-      ? { src: aboutOverride.src, href: aboutOverride.href || `/book/${bookSlug}`, caption: aboutOverride.caption }
+      ? { src: aboutOverride.src, href: lp(aboutOverride.href || `/book/${bookSlug}`), caption: aboutOverride.caption }
       : (() => {
       // Only use a gallery plate if a non-provenance one exists; otherwise fall
       // through to a real interior page rather than showing a bookplate.
@@ -1116,7 +1177,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         const src = plate.extracted_url || plate.image_url || plate.thumbnail_url;
         if (src) {
           const pageId = plate.id.match(/^(.+)[:\-]\d+$/)?.[1];
-          return { src, href: pageId ? `/book/${bookSlug}/page/${pageId}` : `/gallery/image/${plate.id}`, caption: plate.description };
+          return { src, href: pageId ? lp(`/book/${bookSlug}/page/${pageId}`) : `/gallery/image/${plate.id}`, caption: plate.description };
         }
       }
       // Show a picture if the book has one WORTH showing, else a page of the
@@ -1131,7 +1192,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       for (const pg of [interiorIllusPage, interiorTextPage]) {
         if (!pg) continue;
         const src = getPageImageUrl(pg as Parameters<typeof getPageImageUrl>[0], 'display');
-        if (src && notCover(src)) return { src, href: `/book/${bookSlug}/page/${pg.id}`, caption: pg.page_number ? `p. ${pg.page_number}` : undefined };
+        if (src && notCover(src)) return { src, href: lp(`/book/${bookSlug}/page/${pg.id}`), caption: pg.page_number ? t.pageAbbrev(pg.page_number) : undefined };
       }
       return null;
     })();
@@ -1158,7 +1219,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       // Publisher/place only make sense for a printed impressum, not an ancient
       // composition date.
       const detail = compDate ? undefined : ([resolveImprintPlace(book)?.display, book.publisher].filter(Boolean).join(' · ') || undefined);
-      rawTimeline.push({ ts: Number.NEGATIVE_INFINITY, key: 'published', dateText: histDate, label: 'Published', detail });
+      rawTimeline.push({ ts: Number.NEGATIVE_INFINITY, key: 'published', dateText: histDate, label: t.published, detail });
     }
     // An earlier English translation published elsewhere (credit the scholar).
     // A verified `prior_translation` credit carries the richest info; otherwise
@@ -1180,8 +1241,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       rawTimeline.push({
         ts: yearTs(timelinePrior.year),
         key: 'prior-translation',
-        dateText: timelinePrior.year ? String(timelinePrior.year) : 'Earlier',
-        label: 'Earlier English translation',
+        dateText: timelinePrior.year ? String(timelinePrior.year) : t.tlEarlier,
+        label: t.tlEarlierEnglishTranslation,
         detail: (
           <>
             {priorTranslationSentence(timelinePrior)}
@@ -1196,17 +1257,17 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       const bits = [ev.translator ? `trans. ${ev.translator}` : null, ev.publisher || null].filter(Boolean).join(', ');
       const summary = ev.english_title
         ? `${ev.english_title}${bits ? ` — ${bits}` : ''}`
-        : (bits || 'An earlier English translation of this work has been published.');
+        : (bits || t.tlEarlierTranslationExists);
       rawTimeline.push({
         ts: yearTs(ev.pub_year),
         key: 'existing-translation',
-        dateText: ev.pub_year ? String(ev.pub_year) : 'Earlier',
-        label: 'Earlier English translation',
+        dateText: ev.pub_year ? String(ev.pub_year) : t.tlEarlier,
+        label: t.tlEarlierEnglishTranslation,
         detail: (
           <>
             {summary}
             {ev.url && embedPolicy.showExternalLinks && (
-              <>{' '}<a href={ev.url} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>View →</a></>
+              <>{' '}<a href={ev.url} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>{t.view}</a></>
             )}
           </>
         ),
@@ -1226,16 +1287,16 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         dateText: my,
         label: i === 0
           ? (ftClaim === 'confirmed'
-            ? 'First English translation published'
-            : 'English edition published')
-          : 'New edition published',
+            ? t.tlFirstEnglishPublished
+            : t.tlEnglishEditionPublished)
+          : t.tlNewEditionPublished,
         detail: (
           <>
-            An AI-assisted English translation of the original, produced and published by{' '}
+            {t.tlAiTranslationBy}{' '}
             <span style={{ color: '#2b2620', fontWeight: 500 }}>Source Library</span>.
             {(e.version || doiHref) && (
               <span className="block mt-1" style={{ color: '#948d80' }}>
-                {e.version ? `Version ${e.version}` : null}
+                {e.version ? t.tlVersion(e.version) : null}
                 {doiHref ? (
                   <>{e.version ? ' · ' : ''}<a href={doiHref} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>DOI ↗</a></>
                 ) : null}
@@ -1259,7 +1320,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           ts: +dd,
           key: 'digitized',
           dateText: my,
-          label: digitizer ? `Digitized by ${digitizer}` : 'Digitized',
+          label: digitizer ? t.tlDigitizedBy(digitizer) : t.tlDigitized,
         });
       }
     }
@@ -1272,7 +1333,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         ts: +new Date(book.created_at),
         key: 'added',
         dateText: my,
-        label: 'Added to Source Library',
+        label: t.tlAddedToSourceLibrary,
         // No digitizer sub-line here — without a digitization DATE it reads as if
         // the item was digitized on the "added" date, which is wrong. The
         // digitizer is credited in the Bibliographic panel + Pages subtitle.
@@ -1300,10 +1361,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           <AISection kind="reading-guide" className="card reveal-in">
             <details className="group sl-collapse">
               <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
-                <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Reading guide</h3>
+                <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>{t.readingGuide}</h3>
                 <PlusToggle />
               </summary>
               <div className="px-4 pb-4 md:px-6 md:pb-6">
+                {lang !== 'en' && <p className="mb-3 text-sm" style={{ color: '#948d80' }}>{t.englishText}</p>}
                 <ExpandableGuide bookId={book.id} detailedSummary={readingGuideText} defaultExpanded hideIllustrations />
               </div>
             </details>
@@ -1313,7 +1375,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {(!!book.chapters?.length || !!tocPage) && (
         <details id="contents" className="card group scroll-mt-24 sl-collapse reveal-in">
           <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
-            <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Contents</h3>
+            <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>{t.contents}</h3>
             <PlusToggle />
           </summary>
           <div className="px-4 pb-4 md:px-6 md:pb-6">
@@ -1321,7 +1383,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             {tocPage && (() => {
               const tocThumb = getPageImageUrl(tocPage as Parameters<typeof getPageImageUrl>[0], 'thumb');
               return (
-                <Link href={`/book/${bookSlug}/page/${tocPage.id}`} className="flex items-center gap-4 border px-4 py-3 mb-5 transition-colors" style={{ borderColor: '#e6e0d3', background: '#fdfbf6' }}>
+                <Link href={lp(`/book/${bookSlug}/page/${tocPage.id}`)} className="flex items-center gap-4 border px-4 py-3 mb-5 transition-colors" style={{ borderColor: '#e6e0d3', background: '#fdfbf6' }}>
                   <div className="w-[38px] h-[48px] flex-shrink-0 overflow-hidden border" style={{ borderColor: '#d8d0bf', background: '#fff' }}>
                     {tocThumb && (
                       /* eslint-disable-next-line @next/next/no-img-element */
@@ -1329,10 +1391,10 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                     )}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className="text-[13.5px] font-semibold" style={{ color: '#2b2620' }}>Contents — as printed</div>
-                    <div className="text-[12.5px]" style={{ color: '#948d80' }}>p. {tocPage.page_number}</div>
+                    <div className="text-[13.5px] font-semibold" style={{ color: '#2b2620' }}>{t.contentsAsPrinted}</div>
+                    <div className="text-[12.5px]" style={{ color: '#948d80' }}>{t.pageAbbrev(tocPage.page_number)}</div>
                   </div>
-                  <span className="text-[13px] font-medium whitespace-nowrap" style={{ color: '#a5503d' }}>View scan →</span>
+                  <span className="text-[13px] font-medium whitespace-nowrap" style={{ color: '#a5503d' }}>{t.viewScan}</span>
                 </Link>
               );
             })()}
@@ -1342,12 +1404,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 {(book.chapters as Array<{ title: string; titleEn?: string; pageNumber?: number; level?: number }>).map((ch, i) => (
                   <Link
                     key={i}
-                    href={typeof ch.pageNumber === 'number' ? `/book/${bookSlug}/page-number/${ch.pageNumber}` : `/book/${bookSlug}`}
+                    href={lp(typeof ch.pageNumber === 'number' ? `/book/${bookSlug}/page-number/${ch.pageNumber}` : `/book/${bookSlug}`)}
                     className="flex items-baseline justify-between gap-4 py-2 border-b transition-colors hover:bg-[#f4efe6]"
                     style={{ borderColor: '#ece6da', paddingLeft: `${(ch.level || 0) * 14}px` }}
                   >
-                    <span className="font-display text-[14.5px] leading-snug" style={{ color: '#4a443b' }}>{ch.titleEn || ch.title}</span>
-                    {typeof ch.pageNumber === 'number' ? <span className="font-mono text-[12px] whitespace-nowrap" style={{ color: '#a09884' }}>p. {ch.pageNumber}</span> : null}
+                    <span className="font-display text-[14.5px] leading-snug" style={{ color: '#4a443b' }}>{localizedChapters?.[i] || ch.titleEn || ch.title}</span>
+                    {typeof ch.pageNumber === 'number' ? <span className="font-mono text-[12px] whitespace-nowrap" style={{ color: '#a09884' }}>{t.pageAbbrev(ch.pageNumber)}</span> : null}
                   </Link>
                 ))}
               </div>
@@ -1368,7 +1430,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {/* Bibliographic information — the source's own record only. */}
         <details className="card group sl-collapse reveal-in">
           <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
-            <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Bibliographic information</h3>
+            <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>{t.bibliographicInformation}</h3>
             <PlusToggle />
           </summary>
           <div className="px-4 pb-4 md:px-6 md:pb-6">
@@ -1399,6 +1461,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 language={(book as unknown as { language?: string }).language}
                 editionKey={(book as unknown as { edition_key?: string }).edition_key}
                 editionKeyQuality={(book as unknown as { edition_key_quality?: string }).edition_key_quality}
+                locale={lang}
               /></Suspense>
             )}
             {embedPolicy.showIndexCatalogStatus && (
@@ -1412,13 +1475,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             (editions + prior translations appear as timeline entries) and nests
             the staff processing log + editions tooling under "Added to Source
             Library". */}
-        <div className="reveal-in"><BookTimeline events={timelineEvents} /></div>
+        <div className="reveal-in"><BookTimeline events={timelineEvents} title={t.bookHistory} /></div>
 
         {/* Search this book — styled like a dropdown card but always open; the
             card grows to show results (max-height + scroll) as you type. */}
         <div className="card p-4 md:p-6 reveal-in">
-          <h3 className="font-display font-medium text-[17px] md:text-[22px] mb-4" style={{ color: '#2b2620' }}>Search this book</h3>
-          <SearchPanel bookId={book.id} inline theme="light" placeholder="Find a word, name, or phrase…" />
+          <h3 className="font-display font-medium text-[17px] md:text-[22px] mb-4" style={{ color: '#2b2620' }}>{t.searchThisBook}</h3>
+          <SearchPanel bookId={book.id} inline theme="light" placeholder={t.searchPlaceholder} />
         </div>
       </>
     );
@@ -1471,7 +1534,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             <div className="flex items-center">
               {embedPolicy.showBookReadCta && readHref && (
                 <Link href={readHref} className="inline-flex items-center gap-2 px-4 py-2.5 text-[13px] font-semibold text-white transition-colors hover:brightness-110" style={{ background: '#a5503d' }}>
-                  <BookOpen className="w-4 h-4" />Read this book
+                  <BookOpen className="w-4 h-4" />{t.readThisBook}
                 </Link>
               )}
               <div className="w-1/3 flex-shrink-0 ml-auto grid grid-cols-3 rounded overflow-hidden divide-x [&_svg]:!w-[15px] [&_svg]:!h-[15px] [&_button]:!p-0 [&_button]:!w-full [&_button]:!h-full [&_button]:!justify-center [&_button]:!rounded-none" style={{ border: '1px solid rgba(245,240,232,0.2)', borderColor: 'rgba(245,240,232,0.2)' }}>
@@ -1522,9 +1585,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 <div className="uppercase text-[10.5px] md:text-[13px] tracking-[0.1em] font-medium mb-1.5 md:mb-2" style={{ color: '#d98a72' }}>
                   {embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
                     <Link href={authorUrl(book.author)!} className="hover:opacity-80 transition-opacity">
-                      {heroByline.role === 'editor' ? <>edited by <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />}
+                      {heroByline.role === 'editor' ? <>{t.editedBy} <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />}
                     </Link>
-                  ) : (heroByline.role === 'editor' ? <>edited by <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />)}
+                  ) : (heroByline.role === 'editor' ? <>{t.editedBy} <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />)}
                   {/* The name stays clickable and searchable — a byline is how a
                       reader REACHES a book, and for the Bhutanese manuscript
                       volumes the monastery is the only handle they have. What
@@ -1536,10 +1599,10 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 </div>
               )}
               <h1 className="font-display font-medium text-lg sm:text-2xl md:text-[52px] leading-[1.14] md:leading-[1.04] tracking-[-0.01em] mb-3 md:mb-4 break-words" style={{ color: '#f7f2ea' }}>
-                {book.display_title || book.title}
+                {shownTitle}
               </h1>
-              {book.display_title && book.title !== book.display_title && (() => {
-                const original = cleanOriginalTitle(book.title);
+              {titleBeneath && (() => {
+                const original = cleanOriginalTitle(titleBeneath);
                 if (!original) return null;
                 const latin = !isNonLatinScript(original);
                 return (
@@ -1561,15 +1624,15 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                     )}
                     {book.language && (
                       <span className={chip} style={{ color: 'rgba(245,240,232,0.88)' }}>
-                        <Globe className={chipIcon} />{book.language}
+                        <Globe className={chipIcon} />{languageName(book.language, lang)}
                       </span>
                     )}
-                    <span className={chip} style={{ color: 'rgba(245,240,232,0.88)' }} title="Scanned images, including covers and blanks.">
-                      <FileText className={chipIcon} />{totalPages} scans
+                    <span className={chip} style={{ color: 'rgba(245,240,232,0.88)' }} title={t.scansTooltip}>
+                      <FileText className={chipIcon} />{t.scans(totalPages)}
                     </span>
                     {imageCount > 0 && (
                       <Link href={`/gallery?bookId=${book.id}`} className={`${chip} transition-colors hover:opacity-80`} style={{ color: 'rgba(245,240,232,0.88)' }}>
-                        <Images className={chipIcon} />{imageCount} image{imageCount === 1 ? '' : 's'}
+                        <Images className={chipIcon} />{t.images(imageCount)}
                       </Link>
                     )}
                   </div>
@@ -1586,31 +1649,31 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                   into a pane that had nothing to show. */}
               {ocrPct === 0 && (
                 <div className="flex flex-wrap items-center gap-x-3 md:gap-x-4 gap-y-1 mt-3 md:mt-4 text-[10.5px] md:text-[13.5px] font-medium">
-                  <span title={`${totalPages} scans available; no pages transcribed yet`} style={{ color: 'rgba(245,240,232,0.55)' }}>
-                    Scans only — not transcribed yet
+                  <span title={t.notTranscribedTooltip(totalPages)} style={{ color: 'rgba(245,240,232,0.55)' }}>
+                    {t.notTranscribed}
                   </span>
                 </div>
               )}
               {ocrPct > 0 && (
                 <div className="flex flex-wrap items-center gap-x-3 md:gap-x-4 gap-y-1 mt-3 md:mt-4 text-[10.5px] md:text-[13.5px] font-medium">
-                  <span title={`${ocrCount} of ${totalPages} pages transcribed`} style={{ color: '#8fbfe6' }}>
-                    {ocrPct >= 100 ? '✓' : `${ocrPct}%`} OCR
+                  <span title={t.ocrTooltip(ocrCount, totalPages)} style={{ color: '#8fbfe6' }}>
+                    {ocrPct >= 100 ? '✓' : `${ocrPct}%`} {t.ocr}
                   </span>
                   {translatedPct > 0 && (
-                    <span title={`${translatedCount} pages translated to English`} style={{ color: '#86c98f' }}>
-                      {translatedPct >= 100 ? '✓' : `${translatedPct}%`} Translated
+                    <span title={t.translatedTooltip(translatedCount)} style={{ color: '#86c98f' }}>
+                      {translatedPct >= 100 ? '✓' : `${translatedPct}%`} {t.translated}
                     </span>
                   )}
                   {!!book.is_first_translation && translatedCount > 0 && ftClause && (
                     <span
                       title={
                         ftClaim === 'confirmed'
-                          ? 'First translation into English'
-                          : 'We searched the catalogues and found no earlier English translation — a record of the search, not proof none exists'
+                          ? t.firstTranslationTooltip
+                          : t.noPriorTranslationTooltip
                       }
                       style={{ color: ftClaim === 'confirmed' ? '#e0b46a' : '#948d80' }}
                     >
-                      {ftClaim === 'confirmed' ? 'First translation' : 'No prior translation found'}
+                      {ftClaim === 'confirmed' ? t.firstTranslation : t.noPriorTranslation}
                     </span>
                   )}
                 </div>
@@ -1621,7 +1684,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
               <div className="hidden md:flex flex-wrap items-center gap-2.5 mt-6">
                 {embedPolicy.showBookReadCta && readHref && (
                   <Link href={readHref} className="inline-flex items-center gap-2.5 px-6 py-3 text-[15px] font-semibold text-white transition-colors hover:brightness-110" style={{ background: '#a5503d' }}>
-                    <BookOpen className="w-[18px] h-[18px]" />Read this book
+                    <BookOpen className="w-[18px] h-[18px]" />{t.readThisBook}
                   </Link>
                 )}
                 <div className="hidden md:flex flex-wrap items-center gap-1 px-1.5 py-1" style={{ background: 'rgba(12,9,6,0.82)', border: '1px solid rgba(245,240,232,0.16)' }}>
@@ -1657,9 +1720,24 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             dropdowns on the left, an interesting non-cover plate on the right. */}
         <div className="reveal-in">
           <AboutVariants
-            content={hasSummary ? linkEntities(summaryText!, summaryEntities) : null}
+            heading={t.summary}
+            content={
+              localizedSummary
+                // A translated summary is prose in the reader's language; entity
+                // links are built from the ENGLISH index terms and would not
+                // match it, so it renders plain.
+                ? localizedSummary
+                : hasSummary
+                  ? (
+                    <>
+                      {linkEntities(summaryText!, summaryEntities)}
+                      {lang !== 'en' && <span className="block mt-3 text-sm" style={{ color: '#948d80' }}>{t.summaryIsEnglish}</span>}
+                    </>
+                  )
+                  : null
+            }
             visual={sideVisual}
-            tags={hasSummary ? subjectTags : []}
+            tags={hasSummary || !!localizedSummary ? subjectTags : []}
             belowContent={readingDropdowns}
             bookId={book.id}
             bookSlug={bookSlug}
@@ -1674,8 +1752,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             {(() => {
               const digitizer = book.image_source?.digitized_by || book.image_source?.contributing_library || book.image_source?.provider_name;
               const pagesSubtitle = digitizer
-                ? `Every page scanned from the original, digitized by ${digitizer}.`
-                : 'Every page of the original scan, in reading order.';
+                ? t.pagesDigitizedBy(digitizer)
+                : t.pagesInReadingOrder;
               const pagesEl = <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={totalPages} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} overviewHref={embedPolicy.showBookOverviewLink ? `/book/${bookSlug}/overview` : undefined} subtitle={pagesSubtitle} />;
               const membersOnlyUntil = (book as unknown as { members_only_until?: string }).members_only_until;
               if (membersOnlyUntil && new Date(membersOnlyUntil) > new Date()) {
@@ -1690,14 +1768,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {galleryPlates.length > 0 && (
           <section id="illustrations" style={{ background: 'linear-gradient(180deg, #fdfcf9 0%, #f8f2ea 100%)' }} className="border-t border-[#e6e0d3] py-14 scroll-mt-4">
             <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 reveal-in">
-              <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>Illustrations</h2>
-              <p className="text-sm md:text-[15px] mb-6" style={{ color: '#8a8170' }}>Plates, diagrams, and figures detected in the scanned pages.</p>
+              <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>{t.illustrations}</h2>
+              <p className="text-sm md:text-[15px] mb-6" style={{ color: '#8a8170' }}>{t.illustrationsNote}</p>
               <GalleryMasonry plates={galleryPlates} />
               {imageCount > galleryPlates.length && (
                 <div className="mt-8 text-center">
                   <Link href={`/gallery?bookId=${book.id}`} className="inline-flex items-center gap-2 px-6 py-2.5 bg-stone-900 text-white rounded-lg hover:bg-stone-800 transition-colors text-sm font-medium">
                     <Images className="w-4 h-4" />
-                    View all {imageCount} illustrations
+                    {t.viewAllIllustrations(imageCount)}
                   </Link>
                 </div>
               )}
@@ -1713,9 +1791,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {hasRelated && (
           <section id="related" style={{ background: 'linear-gradient(180deg, #fdfcf9 0%, #f8f2ea 100%)' }} className="py-14 border-t border-[#e6e0d3] scroll-mt-4">
             <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 reveal-in">
-              <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>Related books</h2>
-              <p className="text-sm md:text-[15px] mb-5" style={{ color: '#8a8170' }}>Other volumes close to this one by author, subject, place, and period.</p>
-              <BookSlider books={tagRelated as unknown as MiniBook[]} />
+              <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>{t.relatedBooks}</h2>
+              <p className="text-sm md:text-[15px] mb-5" style={{ color: '#8a8170' }}>{t.relatedBooksNote}</p>
+              <BookSlider books={tagRelated as unknown as MiniBook[]} lang={lang} />
             </div>
           </section>
         )}
@@ -2335,7 +2413,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
   );
 }
 
-export default async function BookDetailPage({ params, tenantContext, previewProposed = false, allowHidden = false }: PageProps) {
+export default async function BookDetailPage({ params, tenantContext, previewProposed = false, allowHidden = false, lang = 'en' }: PageProps) {
   const { id } = await params;
   const ctx = tenantContext ?? null;
   const embedPolicy = getEmbedUiPolicy(ctx);
@@ -2377,6 +2455,15 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   // partner subdomain's reader out of its embed shell breaks the tenant lockdown.
   // Editor preview routes (previewProposed/allowHidden) are excluded for the same
   // reason: /artwork has no preview twin, so a redirect would 404 the editor.
+  // The proxy canonicalises /book/<id> → /book/<slug>, but its matcher is
+  // English-only (`^/book/([^/]+)$`), so the localized twin does it here. Safe
+  // on a streamed page only because nothing has rendered yet — redirect() is a
+  // no-op after the first flush (#4036).
+  if (lang !== 'en') {
+    const canonicalSlug = (earlyBook as { slug?: string }).slug;
+    if (canonicalSlug && id !== canonicalSlug) permanentRedirect(`/${lang}/book/${canonicalSlug}`);
+  }
+
   if (!isEmbedded && !previewProposed && !allowHidden) {
     const artSlug = artworkRedirectSlug(earlyBook as unknown as { content_type?: string; resource_type?: string; slug?: string });
     // 308, not 307: this is a canonicalization, so search engines must transfer
@@ -2386,7 +2473,11 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   }
 
   return (
-    <div className={isEmbedded ? "" : "min-h-screen bg-cream"}>
+    <div className={isEmbedded ? "" : "min-h-screen bg-cream"} lang={lang === 'en' ? undefined : lang}>
+      {/* Arriving on a localized book URL is itself a statement about which
+          language you read, so the reader opens in it — and keeps it after the
+          reader's own toggle overrides this. See src/lib/reading-language.ts. */}
+      {lang !== 'en' && <ReadingLanguagePreference lang={lang} />}
       {!isEmbedded && <ConditionalSiteHeader variant="dark" />}
 
       {/* Tenant reading rooms (EFM/BPH iframe + subdomains) get a breadcrumb
@@ -2400,12 +2491,12 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
         <>
           <BookInfoSkeleton />
           <main className="max-w-[1500px] mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <h2 className="text-xl font-semibold text-stone-900 mb-6">Pages</h2>
+            <h2 className="text-xl font-semibold text-stone-900 mb-6">{BOOK_STRINGS[lang].pagesHeading}</h2>
             <PagesGridSkeleton />
           </main>
         </>
       }>
-        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} isEmbedded={isEmbedded} previewProposed={previewProposed} allowHidden={allowHidden} />
+        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} isEmbedded={isEmbedded} previewProposed={previewProposed} allowHidden={allowHidden} lang={lang} />
       </Suspense>
       {!isEmbedded && (
         <SignUpCTA

--- a/src/app/es/book/[id]/page-number/[num]/route.ts
+++ b/src/app/es/book/[id]/page-number/[num]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server';
+import { pageNumberRedirect } from '@/lib/page-number-redirect';
+
+/**
+ * Spanish twin of `/book/[id]/page-number/[num]` (#4082). Same resolver, and
+ * it lands the reader on `/es/book/…/page/…` so the locale survives the hop —
+ * chapter links and index page-references both come through here.
+ */
+interface RouteContext {
+  params: Promise<{ id: string; num: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  return pageNumberRedirect(request, await params, '/es');
+}

--- a/src/app/es/book/[id]/page.tsx
+++ b/src/app/es/book/[id]/page.tsx
@@ -1,195 +1,33 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { notFound, permanentRedirect } from 'next/navigation';
-import { ArrowLeft, BookOpen } from 'lucide-react';
-import { getReadDb } from '@/lib/mongodb';
-import { findBookByIdOrSlug } from '@/lib/book-lookup';
-import { isHiddenBook } from '@/lib/book-access';
-import { getBookThumbnailUrl } from '@/lib/utils';
-import { authorUrl } from '@/lib/slugify';
-import { displayPublished } from '@/lib/publication-date';
-import { isPublishedFirstTranslation } from '@/lib/book';
-import { getEffectiveByline } from '@/lib/byline';
-import { localizedTitle, originalTitleIfDifferent, type LocalizedBookMap } from '@/lib/localized';
-import { BOOK_STRINGS, languageName } from '@/lib/book-i18n';
-import { spanishPageHref, startPageNumber } from '@/lib/es-collections';
-import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
-import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
-import AuthorName from '@/components/AuthorName';
-import type { Chapter } from '@/lib/types';
+import BookDetailPage, { generateMetadata as baseMetadata } from '@/app/book/[id]/page';
 
 /**
- * Spanish book page — the thin twin of /book/[id] (#4082 phase 1).
+ * Spanish book page — the SAME page as `/book/[id]`, rendered with `lang='es'`
+ * (#4082 phase 2).
  *
- * What a Spanish reader needs from a book page: what this is (title gloss +
- * original), who wrote it, when and in what language, what it is about, its
- * contents, and ONE button that opens it in Spanish — without ever leaving /es.
- * The 2,400-line English page (editions, bibliography, illustrations, first-
- * translation evidence…) is linked, labelled as English. Phase 2 extracts that
- * page's strings so the two can converge; this page is deliberately small so
- * it can ship first.
+ * Phase 1 shipped a thin, hand-written Spanish page. It was the wrong shape:
+ * two pages describing one book drift apart with every change to the English
+ * one, and a Spanish reader got a lesser record. So this is now a re-export.
+ * Everything the reader sees — the hero, the About text, contents, the pages
+ * grid, illustrations, related books — comes from one component; `lang`
+ * decides the chrome dictionary (`src/lib/book-i18n.ts`), which title/summary/
+ * chapter text is shown (`books.localized.es`), and the `/es` prefix that every
+ * internal link keeps. What has no Spanish text stays English and is labelled;
+ * nothing is machine-translated at render time (`.claude/docs/i18n.md` rule 4).
  */
-export const revalidate = 3600;
+
+// Segment config must be a static literal (Next parses it at build time) —
+// keep in step with src/app/book/[id]/page.tsx.
+export const revalidate = 86400;
+export const preferredRegion = 'fra1';
 export const dynamicParams = true;
-export const maxDuration = 60;
-
-const t = BOOK_STRINGS.es;
-
-const PROJECTION = {
-  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, localized: 1, author: 1, editor: 1, language: 1, published: 1,
-  pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1, is_first_translation: 1, ft_disposition: 1,
-  thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, visible: 1, chapters: 1,
-  'index.bookSummary.brief': 1, 'summary.data': 1, resource_type: 1,
-};
-
-type EsBook = {
-  id: string; slug?: string; title: string; display_title?: string; localized?: LocalizedBookMap; author?: string; editor?: string | null;
-  language?: string; published?: string; pages_count?: number; pages_translated?: number; pages_translated_es?: number;
-  is_first_translation?: boolean; ft_disposition?: string; thumbnail?: string; thumbnail_blob?: string; image_display?: string; image_thumb?: string;
-  visible?: boolean; chapters?: Chapter[]; index?: { bookSummary?: { brief?: string } }; summary?: { data?: string } | string; resource_type?: string;
-};
-
-async function load(id: string) {
-  const db = await getReadDb();
-  const result = await findBookByIdOrSlug(db, id, PROJECTION);
-  const book = (result?.book ?? null) as unknown as EsBook | null;
-  if (!book) return null;
-  // First readable page: first chapter, else skip the binding leaves (same rule as the English page).
-  const start = startPageNumber(book);
-  const page = await db.collection('pages').findOne(
-    { book_id: book.id, page_number: { $gte: start } },
-    { projection: { _id: 0, id: 1, page_number: 1 }, sort: { page_number: 1 } },
-  ) || await db.collection('pages').findOne({ book_id: book.id }, { projection: { _id: 0, id: 1, page_number: 1 }, sort: { page_number: 1 } });
-  return { book, firstPageId: (page?.id as string | undefined) ?? null };
-}
 
 type Props = { params: Promise<{ id: string }> };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
-  const data = await load(id);
-  if (!data || isHiddenBook(data.book)) return { title: 'Libro no encontrado | Source Library', robots: { index: false, follow: true } };
-  const { book } = data;
-  const title = localizedTitle(book, 'es');
-  const path = `/book/${book.slug || book.id}`;
-  const description = book.localized?.es?.summary?.slice(0, 200) || `${title} — ${book.author || ''}. Edición en español en Source Library.`;
-  return {
-    title: `${title} | Source Library`,
-    description,
-    alternates: { canonical: `/es${path}`, languages: { en: path, es: `/es${path}`, 'x-default': path } },
-    openGraph: { title, description, locale: 'es_ES', url: `https://sourcelibrary.org/es${path}` },
-  };
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  return baseMetadata({ ...props, lang: 'es' });
 }
 
-export default async function EsBookPage({ params }: Props) {
-  const { id } = await params;
-  const data = await load(id);
-  if (!data) notFound();
-  const { book, firstPageId } = data;
-  if (isHiddenBook(book)) notFound();
-  if (book.resource_type) permanentRedirect(`/artwork/${book.slug || book.id}`);
-  // Keep the address bar on the slug, like the English page does.
-  if (book.slug && id !== book.slug) permanentRedirect(`/es/book/${book.slug}`);
-
-  const title = localizedTitle(book, 'es');
-  const original = originalTitleIfDifferent(book, 'es');
-  const cover = getBookThumbnailUrl(book, 'display');
-  const byline = getEffectiveByline({ ...book, author: book.author || '' });
-  const authorHref = book.author ? authorUrl(book.author) : null;
-  const esPages = book.pages_translated_es ?? 0;
-  const enPages = book.pages_translated ?? 0;
-  const hasSpanish = esPages > 0;
-  const readHref = firstPageId ? spanishPageHref(book, firstPageId) : null;
-  const summaryEs = book.localized?.es?.summary;
-  const summaryEn = book.index?.bookSummary?.brief || (typeof book.summary === 'string' ? book.summary : book.summary?.data);
-  const chapters = (book.chapters || []).filter((c) => c.level <= 2);
-  const chapterTitlesEs = book.localized?.es?.chapters;
-  const when = displayPublished(book.published);
-
-  return (
-    <div className="min-h-screen bg-cream" lang="es">
-      <ReadingLanguagePreference lang="es" />
-      <ConditionalSiteHeader variant="light" />
-
-      <div className="max-w-[1100px] mx-auto px-6 pt-8 pb-20">
-        <Link href="/es/collections/en-espanol" className="inline-flex items-center gap-2 text-sm text-muted hover:text-accent-rust transition-colors mb-8">
-          <ArrowLeft className="w-4 h-4" /> {t.backToCollection}
-        </Link>
-
-        <div className="grid md:grid-cols-[260px_minmax(0,1fr)] gap-8 md:gap-12 items-start">
-          {/* Cover */}
-          <div className="w-[200px] md:w-full mx-auto">
-            <div className="relative aspect-[3/4] border border-border-light bg-warm overflow-hidden">
-              {cover ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={cover} alt={title} className="absolute inset-0 w-full h-full object-cover" />
-              ) : null}
-              {(isPublishedFirstTranslation(book) || hasSpanish) && (
-                <div className="absolute top-2 right-2 flex flex-col gap-1.5 items-end">
-                  {hasSpanish && <span className="text-[10px] font-medium text-white px-2 py-1 backdrop-blur-sm" style={{ background: 'rgba(20,16,12,0.5)' }}>{t.spanishEdition}</span>}
-                  {isPublishedFirstTranslation(book) && <span className="text-[10px] font-medium text-white px-2 py-1 backdrop-blur-sm" style={{ background: 'rgba(20,16,12,0.5)' }}>{t.firstTranslation}</span>}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Identity + CTA */}
-          <div>
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-display text-primary leading-tight mb-2">{title}</h1>
-            {original && <p className="text-lg text-secondary italic mb-3" lang="">{original}</p>}
-            <p className="text-base text-secondary mb-5">
-              {byline.role === 'editor'
-                ? <>{t.editedBy} <AuthorName author={byline.editor} /></>
-                : (authorHref ? <Link href={authorHref} className="hover:text-accent-rust">{book.author}</Link> : book.author)}
-            </p>
-
-            <dl className="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-3 text-sm mb-7">
-              {book.language && (<div><dt className="text-muted text-xs uppercase tracking-wider">{t.originalLanguage}</dt><dd className="text-primary capitalize">{languageName(book.language, 'es')}</dd></div>)}
-              {when && (<div><dt className="text-muted text-xs uppercase tracking-wider">{t.published}</dt><dd className="text-primary">{when}</dd></div>)}
-              {(book.pages_count ?? 0) > 0 && (<div><dt className="text-muted text-xs uppercase tracking-wider">{t.pages}</dt><dd className="text-primary">{book.pages_count!.toLocaleString('es-ES')}</dd></div>)}
-              {hasSpanish && (<div><dt className="text-muted text-xs uppercase tracking-wider">{t.spanishEdition}</dt><dd className="text-primary">{t.spanishEditionOf(esPages, Math.max(enPages, esPages))}</dd></div>)}
-            </dl>
-
-            {readHref && (
-              <Link
-                href={readHref}
-                className="inline-flex items-center gap-2 px-6 py-3 text-base font-medium text-white transition-all hover:brightness-110"
-                style={{ background: 'var(--accent-rust)' }}
-              >
-                <BookOpen className="w-5 h-5" /> {hasSpanish ? t.readInSpanish : t.read}
-              </Link>
-            )}
-
-            {(summaryEs || summaryEn) && (
-              <section className="mt-10">
-                <h2 className="text-xl font-display text-primary mb-3">{t.summary}</h2>
-                <p className="text-base leading-relaxed text-primary/90 whitespace-pre-line" lang={summaryEs ? 'es' : 'en'}>{summaryEs || summaryEn}</p>
-                {!summaryEs && <p className="mt-2 text-sm text-muted">{t.summaryIsEnglish}</p>}
-              </section>
-            )}
-
-            {chapters.length > 0 && (
-              <section className="mt-10">
-                <h2 className="text-xl font-display text-primary mb-3">{t.contents}</h2>
-                <ol className="divide-y divide-border-light border-y border-border-light">
-                  {chapters.map((c, i) => (
-                    <li key={`${c.pageId}-${i}`}>
-                      <Link href={spanishPageHref(book, c.pageId)} className={`flex items-baseline justify-between gap-4 py-2.5 hover:text-accent-rust ${c.level > 1 ? 'pl-5 text-sm' : ''}`}>
-                        <span>{chapterTitlesEs?.[book.chapters!.indexOf(c)] || c.titleEn || c.title}</span>
-                        <span className="text-xs text-muted tabular-nums">{c.pageNumber}</span>
-                      </Link>
-                    </li>
-                  ))}
-                </ol>
-              </section>
-            )}
-
-            <p className="mt-10 text-sm text-muted">
-              <Link href={`/book/${book.slug || book.id}`} className="underline hover:text-accent-rust">{t.fullPage}</Link>: {t.fullPageNote}
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+export default async function EsBookPage(props: Props) {
+  return BookDetailPage({ ...props, lang: 'es' });
 }

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -12,7 +12,7 @@ import BookCoverPlaceholder from '@/components/BookCoverPlaceholder';
 import { getEffectiveByline } from '@/lib/byline';
 import { useEmbed, useEmbedHref } from '@/lib/EmbedContext';
 import PlaceholderCover from '@/components/book/PlaceholderCover';
-import type { Locale } from '@/lib/i18n';
+import { useLocalePath, type Locale } from '@/lib/i18n';
 import { localizedTitle, originalTitleIfDifferent, type LocalizedBookMap } from '@/lib/localized';
 
 export interface CollectionBook {
@@ -119,6 +119,10 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   const [useFallback, setUseFallback] = useState(false);
   const embedHref = useEmbedHref();
   const embed = useEmbed();
+  // A card rendered on a localized surface links to that surface's twin —
+  // /es/collections/… → /es/book/… — so the prefix never drops on a click.
+  // localePath is registry-guarded, so /artwork/… (no twin) is untouched.
+  const localePath = useLocalePath();
 
   const isArtwork = !!book.resource_type;
   const pageCount = book.pages_count || book.pages || 0;
@@ -127,8 +131,8 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
   const slug = book.slug || book.id || book.bookId || '';
 
-  const bookHref = embedHref(`${bookUrlPrefix || ''}/book/${encodeURIComponent(slug)}`);
-  const artworkHref = embedHref(`${bookUrlPrefix || ''}/artwork/${encodeURIComponent(slug)}`);
+  const bookHref = localePath(embedHref(`${bookUrlPrefix || ''}/book/${encodeURIComponent(slug)}`));
+  const artworkHref = localePath(embedHref(`${bookUrlPrefix || ''}/artwork/${encodeURIComponent(slug)}`));
 
   const ocrPct = pctOf(book.pages_ocr, pageCount);
   const translatedPct = pctOf(book.pages_translated, pageCount);

--- a/src/components/book/AboutVariants.tsx
+++ b/src/components/book/AboutVariants.tsx
@@ -14,6 +14,7 @@ type PlateLite = { id: string; thumbnail_url?: string; extracted_url?: string; i
  * tags below, and the reading-guide / contents dropdowns under that.
  */
 export default function AboutVariants({
+  heading = 'About this book',
   content,
   visual,
   tags = [],
@@ -23,6 +24,8 @@ export default function AboutVariants({
   pages,
   plates,
 }: {
+  /** Section heading — localized by the page (see src/lib/book-i18n.ts). */
+  heading?: string;
   /** About prose. When null, the heading + prose are omitted and only the
    *  dropdowns render in the left column (the plate still shows on the right). */
   content?: ReactNode | null;
@@ -52,7 +55,7 @@ export default function AboutVariants({
           <div className="order-2 md:order-1 md:col-span-3">
             {content != null && (
               <>
-                <h2 className="hidden md:block font-display font-medium text-[22px] md:text-[28px] mb-3 md:mb-4" style={{ color: '#2b2620' }}>About this book</h2>
+                <h2 className="hidden md:block font-display font-medium text-[22px] md:text-[28px] mb-3 md:mb-4" style={{ color: '#2b2620' }}>{heading}</h2>
                 <div className="font-display text-[15px] md:text-[21px] leading-[1.6] md:leading-[1.62]" style={{ color: '#2b2620' }}>{content}</div>
                 {tagRow}
               </>

--- a/src/components/book/BookIndex.tsx
+++ b/src/components/book/BookIndex.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import PlusToggle from './PlusToggle';
+import { useLocale, useLocalePath } from '@/lib/i18n';
+import { BOOK_STRINGS } from '@/lib/book-i18n';
 
 interface IndexEntry {
   term: string;
@@ -26,6 +28,10 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
   const [filter, setFilter] = useState('');
   const params = useParams<{ tenant: string }>();
   const tenantPrefix = params?.tenant ? `/${params.tenant}` : '';
+  // Chrome follows the URL's locale; the index TERMS stay as generated (English
+  // entity labels) — they are content, not chrome.
+  const str = BOOK_STRINGS[useLocale()];
+  const localePath = useLocalePath();
 
   const { themes, indexEntries } = useMemo(() => {
     const themeThreshold = Math.max(totalPages * THEME_THRESHOLD, 10);
@@ -59,8 +65,8 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
     <details className="card group sl-collapse">
       <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
         <div className="flex items-baseline gap-3">
-          <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Index</h3>
-          <span className="text-xs" style={{ color: '#a09884' }}>{entries.length} terms</span>
+          <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>{str.index}</h3>
+          <span className="text-xs" style={{ color: '#a09884' }}>{str.indexTerms(entries.length)}</span>
         </div>
         <PlusToggle />
       </summary>
@@ -69,7 +75,7 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
         {themes.length > 0 && (
           <div className="mb-5">
             <p className="text-xs font-medium text-stone-500 uppercase tracking-wide mb-2">
-              Major Themes
+              {str.majorThemes}
             </p>
             <div className="flex flex-wrap gap-1.5">
               {themes.map((t) => (
@@ -92,7 +98,7 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
               type="text"
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
-              placeholder={`Filter ${indexEntries.length} index entries...`}
+              placeholder={str.filterIndex(indexEntries.length)}
               className="w-full px-3 py-2 text-sm border border-stone-200 rounded-lg bg-white focus:outline-none focus:ring-1 focus:ring-accent-rust/30 focus:border-accent-rust/50 placeholder:text-stone-400"
             />
           </div>
@@ -116,7 +122,7 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
                       </span>
                     ) : (
                       <Link
-                        href={`${tenantPrefix}/book/${bookSlug}/page-number/${p}`}
+                        href={localePath(`${tenantPrefix}/book/${bookSlug}/page-number/${p}`)}
                         className="text-accent-rust hover:text-accent-gold-dark hover:underline"
                       >
                         p.&thinsp;{p}
@@ -126,7 +132,7 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
                 ))}
                 {entry.pages.length > MAX_PAGES_INLINE && (
                   <span className="text-stone-300 ml-1">
-                    +{entry.pages.length - MAX_PAGES_INLINE} more
+                    {str.more(entry.pages.length - MAX_PAGES_INLINE)}
                   </span>
                 )}
               </span>
@@ -137,13 +143,13 @@ export default function BookIndex({ entries, bookSlug, totalPages, isEmbedded = 
         {/* Footer */}
         {!filter && indexEntries.length > MAX_INDEX_VISIBLE && (
           <p className="text-xs text-stone-400 mt-4 pt-3 border-t border-stone-100">
-            Showing {MAX_INDEX_VISIBLE} of {indexEntries.length} entries.
-            {hapaxCount > 0 && ` ${hapaxCount} single-mention terms hidden.`}
+            {str.indexShowing(MAX_INDEX_VISIBLE, indexEntries.length)}
+            {hapaxCount > 0 && str.indexHiddenHapax(hapaxCount)}
           </p>
         )}
         {filter && filtered.length === 0 && (
           <p className="text-xs text-stone-400 py-4">
-            No entries matching &ldquo;{filter}&rdquo;
+            {str.indexNoMatch(filter)}
           </p>
         )}
       </div>

--- a/src/components/book/BookLibrarySection.tsx
+++ b/src/components/book/BookLibrarySection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useLocalePath } from '@/lib/i18n';
 import { ArrowRight } from 'lucide-react';
 
 export interface LibrarySectionData {
@@ -25,6 +26,8 @@ const fmt = (n: number) => n.toLocaleString('en-US');
  * (falling back to a single representative image).
  */
 export default function BookLibrarySection({ data }: { data: LibrarySectionData }) {
+  // Cover links keep the locale of the page this section is mounted on.
+  const localePath = useLocalePath();
   const covers = data.covers.filter((c) => c.thumbnail).slice(0, 10);
   const hasCovers = covers.length >= 4;
 
@@ -38,7 +41,7 @@ export default function BookLibrarySection({ data }: { data: LibrarySectionData 
     <div className={`-mx-6 px-6 md:mx-0 md:px-0 overflow-x-auto md:overflow-visible snap-x snap-mandatory scroll-px-6 [scrollbar-width:none] [-webkit-overflow-scrolling:touch] ${className}`}>
       <div className="flex gap-3 md:grid md:grid-cols-5">
         {covers.map((c) => (
-          <Link key={c.slug} href={`/book/${c.slug}`} className="block flex-shrink-0 w-[104px] md:w-auto snap-start group">
+          <Link key={c.slug} href={localePath(`/book/${c.slug}`)} className="block flex-shrink-0 w-[104px] md:w-auto snap-start group">
             <div className="aspect-[3/4] overflow-hidden border transition-shadow group-hover:shadow-md" style={{ borderColor: '#e6e0d3', background: '#fff' }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={c.thumbnail} alt={c.title} className="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105" loading="lazy" />

--- a/src/components/book/BookTimeline.tsx
+++ b/src/components/book/BookTimeline.tsx
@@ -20,13 +20,13 @@ export interface TimelineEvent {
  * edition(s)/translation(s) appeared, and when it joined Source Library.
  * Rendered as a dropdown card matching the other book-page dropdowns.
  */
-export default function BookTimeline({ events }: { events: TimelineEvent[] }) {
+export default function BookTimeline({ events, title = 'Book history' }: { events: TimelineEvent[]; title?: string }) {
   if (!events || events.length === 0) return null;
 
   return (
     <details className="card group sl-collapse">
       <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
-        <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Book history</h3>
+        <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>{title}</h3>
         <PlusToggle />
       </summary>
       <div className="px-4 pb-5 md:px-6 md:pb-6">

--- a/src/components/book/ChaptersDropdown.tsx
+++ b/src/components/book/ChaptersDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useLocalePath } from '@/lib/i18n';
 import Link from 'next/link';
 import { ChevronDown, List } from 'lucide-react';
 import { useEmbedHref } from '@/lib/EmbedContext';
@@ -15,6 +16,8 @@ interface Chapter {
 export default function ChaptersDropdown({ chapters, bookSlug }: { chapters: Chapter[]; bookSlug: string }) {
   const [open, setOpen] = useState(false);
   const embedHref = useEmbedHref();
+  // Chapter jumps keep the locale of the reader they were opened from.
+  const localePath = useLocalePath();
 
   return (
     <div className="card mt-6 overflow-hidden">
@@ -34,7 +37,7 @@ export default function ChaptersDropdown({ chapters, bookSlug }: { chapters: Cha
             {chapters.map((ch) => (
               <Link
                 key={`${ch.pageNumber}-${ch.title}`}
-                href={embedHref(`/book/${bookSlug}/page-number/${ch.pageNumber}`)}
+                href={localePath(embedHref(`/book/${bookSlug}/page-number/${ch.pageNumber}`))}
                 className="flex items-baseline gap-2 py-1.5 px-2 -mx-2 rounded hover:bg-stone-100 dark:hover:bg-stone-800/50 transition-colors group"
                 style={{ paddingLeft: `${(ch.level - 1) * 1.25 + 0.5}rem` }}
               >

--- a/src/components/book/PagesGrid.tsx
+++ b/src/components/book/PagesGrid.tsx
@@ -5,6 +5,8 @@ import { CheckCircle2, GripVertical, Loader2, ImageIcon, FileText, RefreshCw, La
 import type { Page } from '@/lib/types';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import { useEmbedHref } from '@/lib/EmbedContext';
+import { useLocale, useLocalePath } from '@/lib/i18n';
+import { BOOK_STRINGS } from '@/lib/book-i18n';
 
 function PageImage({ src, alt, className, natural }: { src: string; alt: string; className?: string; natural?: boolean }) {
   const [loaded, setLoaded] = useState(false);
@@ -79,6 +81,10 @@ export default function PagesGrid({
   subtitle,
 }: PagesGridProps) {
   const embedHref = useEmbedHref();
+  // The grid takes its language and its URL prefix from the page it is mounted
+  // on: /es/book/… renders Spanish chrome and keeps /es on every page link.
+  const t = BOOK_STRINGS[useLocale()];
+  const localePath = useLocalePath();
   const displayTotal = totalCount || pages.length;
   // CSS brightness filter — only apply when not default (1.0)
   const brightnessStyle = brightness && brightness !== 1.0
@@ -87,9 +93,9 @@ export default function PagesGrid({
   return (
     <div>
       <div className="flex items-baseline justify-between gap-4 mb-1">
-        <h2 className="font-display font-medium text-2xl md:text-[28px]" style={{ color: 'var(--text-primary)' }}>Pages</h2>
+        <h2 className="font-display font-medium text-2xl md:text-[28px]" style={{ color: 'var(--text-primary)' }}>{t.pagesHeading}</h2>
         <span className="text-sm text-stone-500 whitespace-nowrap">
-          {Math.min(visibleCount, pages.length)} of {displayTotal}
+          {t.pagesShownOf(Math.min(visibleCount, pages.length), displayTotal)}
         </span>
       </div>
       {subtitle && <p className="text-sm md:text-[15px] mb-6" style={{ color: '#8a8170' }}>{subtitle}</p>}
@@ -99,7 +105,7 @@ export default function PagesGrid({
           <div className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4" style={{ background: 'var(--bg-warm)' }}>
             <FileText className="w-8 h-8" style={{ color: 'var(--text-faint)' }} />
           </div>
-          <h3 className="text-lg font-medium" style={{ color: 'var(--text-secondary)' }}>No pages yet</h3>
+          <h3 className="text-lg font-medium" style={{ color: 'var(--text-secondary)' }}>{t.noPagesYet}</h3>
           <p className="text-sm mt-1" style={{ color: 'var(--text-muted)' }}>Upload pages to start processing</p>
         </div>
       ) : (
@@ -181,7 +187,7 @@ export default function PagesGrid({
             return (
               <div key={page.id} className="group relative">
                 <a
-                  href={embedHref(`/book/${bookPath || bookId}/page/${page.id}`)}
+                  href={localePath(embedHref(`/book/${bookPath || bookId}/page/${page.id}`))}
                 >
                   <div className="bg-white border border-stone-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow relative" style={brightnessStyle}>
                     {imageUrl ? (
@@ -226,16 +232,16 @@ export default function PagesGrid({
               className="inline-flex items-center gap-2 px-6 py-2.5 bg-stone-900 text-white rounded-lg hover:bg-stone-800 transition-colors text-sm font-medium"
             >
               <RefreshCw className="w-4 h-4" />
-              Load more ({displayTotal - visibleCount} remaining)
+              {t.loadMore(displayTotal - visibleCount)}
             </button>
           )}
           {overviewHref && (
             <a
-              href={embedHref(overviewHref)}
+              href={localePath(embedHref(overviewHref))}
               className="inline-flex items-center gap-2 px-6 py-2.5 bg-stone-900 text-white rounded-lg hover:bg-stone-800 transition-colors text-sm font-medium"
             >
               <LayoutGrid className="w-4 h-4" />
-              Overview
+              {t.overview}
             </a>
           )}
         </div>

--- a/src/components/book/RelatedEditions.tsx
+++ b/src/components/book/RelatedEditions.tsx
@@ -1,4 +1,5 @@
 import { getReadDb } from '@/lib/mongodb';
+import { localePath, type Locale } from '@/lib/locale-path';
 import Link from 'next/link';
 import { Library, ScanSearch } from 'lucide-react';
 import { isTrustedEditionKey } from '@/lib/edition-key';
@@ -35,6 +36,9 @@ interface RelatedEditionsProps {
    * when this is full-quality. */
   editionKey?: string | null;
   editionKeyQuality?: string | null;
+  /** Locale of the page mounting this — sibling links keep its URL prefix.
+   *  Named `locale` because `lang` already means the BOOK's language here. */
+  locale?: Locale;
 }
 
 interface Sibling {
@@ -64,8 +68,8 @@ const PROJ = {
   'image_source.provider_name': 1,
 };
 
-function bookHref(b: Sibling): string {
-  return `/book/${encodeURIComponent(b.slug || b.id || '')}`;
+function bookHref(b: Sibling, locale: Locale): string {
+  return localePath(`/book/${encodeURIComponent(b.slug || b.id || '')}`, locale);
 }
 
 function transPct(b: Sibling): number {
@@ -73,7 +77,7 @@ function transPct(b: Sibling): number {
 }
 
 export default async function RelatedEditions({
-  bookId, workId, language, editionKey, editionKeyQuality,
+  bookId, workId, language, editionKey, editionKeyQuality, locale = 'en',
 }: RelatedEditionsProps) {
   const db = await getReadDb();
 
@@ -116,7 +120,7 @@ export default async function RelatedEditions({
     const pct = transPct(b);
     return (
       <li key={b.id}>
-        <Link href={bookHref(b)} className="group/re flex items-baseline gap-2 py-1 text-sm">
+        <Link href={bookHref(b, locale)} className="group/re flex items-baseline gap-2 py-1 text-sm">
           <span className="text-accent-gold group-hover/re:text-accent-gold/80 truncate">
             {b.display_title || b.title}
           </span>

--- a/src/lib/alias-host-scope.ts
+++ b/src/lib/alias-host-scope.ts
@@ -1,3 +1,5 @@
+import { canonicalPath } from '@/lib/locale-path';
+
 /**
  * Scoping non-canonical hosts to the surface they exist for.
  *
@@ -144,9 +146,21 @@ export function aliasPolicyForHost(host: string): AliasPolicy | null {
   return null;
 }
 
-/** Is this a content path the preview policy withholds from anonymous callers? */
+/**
+ * Is this a content path the preview policy withholds from anonymous callers?
+ *
+ * Matched on the LOCALE-STRIPPED path: `/es/book/x` is the same book as
+ * `/book/x` and must be gated identically. Matching the raw pathname left the
+ * Spanish twin wide open on every preview from the day `/es/book` shipped —
+ * `/book/dawn-rising-boehme` 403'd and `/es/book/dawn-rising-boehme` returned
+ * the whole record. Because it strips ANY prefixed locale, a future `/fr` is
+ * covered the moment the locale is registered, with no edit here.
+ */
 export function isPreviewGatedPath(pathname: string): boolean {
-  return PREVIEW_GATED_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/'));
+  const canonical = canonicalPath(pathname);
+  return PREVIEW_GATED_PREFIXES.some(
+    (p) => canonical === p || canonical.startsWith(p + '/'),
+  );
 }
 
 /** Plain-text body for the anonymous-on-preview refusal. */

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -1,29 +1,107 @@
-import type { Locale } from '@/lib/i18n';
+import type { Locale } from '@/lib/locale-path';
 
 /**
- * Strings for the thin book-page twin (`/es/book/[id]`, #4082 phase 1). The
- * English book page (`/book/[id]`) still carries its own literal copy; these
- * are the words the TWIN needs. When the big page's strings are extracted
- * (phase 2) they merge into this dictionary, not a second one.
+ * Strings for the book page and its reader-facing furniture.
+ *
+ * Since #4082 phase 2 there is ONE book page: `src/app/book/[id]/page.tsx`
+ * renders under both `/book/…` and `/es/book/…`, taking a `lang` prop. These
+ * are the words it writes, plus the chrome of the child components it mounts
+ * (pages grid, index, timeline). Anything still hard-coded in English is
+ * listed in the "Not localized yet" note at the bottom of this file — a
+ * component that has not been threaded stays English on purpose; nothing is
+ * machine-translated at render time (see `.claude/docs/i18n.md` rule 4).
+ *
+ * Adding a language means adding a KEY here, not a second dictionary.
  */
 export interface BookStrings {
+  // ---- identity / hero ----
   backToCollection: string;
   read: string;
   readInSpanish: string;
+  readThisBook: string;
   originalTitle: string;
   originalLanguage: string;
   published: string;
+  written: string;
   pages: string;
   spanishEdition: string;
   spanishEditionOf: (es: number, total: number) => string;
-  summary: string;
-  summaryIsEnglish: string;
-  contents: string;
-  fullPage: string;
-  fullPageNote: string;
   firstTranslation: string;
+  noPriorTranslation: string;
   author: string;
   editedBy: string;
+  scans: (n: number) => string;
+  scansTooltip: string;
+  images: (n: number) => string;
+  notTranscribed: string;
+  ocr: string;
+  translated: string;
+  ocrTooltip: (done: number, total: number) => string;
+  translatedTooltip: (n: number) => string;
+  notTranscribedTooltip: (total: number) => string;
+  firstTranslationTooltip: string;
+  noPriorTranslationTooltip: string;
+  pageAbbrev: (n: number) => string;
+
+  // ---- about / dropdowns ----
+  summary: string;
+  summaryIsEnglish: string;
+  readingGuide: string;
+  englishText: string;
+  contents: string;
+  contentsAsPrinted: string;
+  viewScan: string;
+  index: string;
+  indexTerms: (n: number) => string;
+  majorThemes: string;
+  filterIndex: (n: number) => string;
+  indexShowing: (shown: number, total: number) => string;
+  indexHiddenHapax: (n: number) => string;
+  indexNoMatch: (q: string) => string;
+  more: (n: number) => string;
+  bibliographicInformation: string;
+  bookHistory: string;
+  searchThisBook: string;
+  searchPlaceholder: string;
+
+  // ---- pages grid ----
+  pagesHeading: string;
+  pagesShownOf: (shown: number, total: number) => string;
+  pagesDigitizedBy: (who: string) => string;
+  pagesInReadingOrder: string;
+  loadMore: (remaining: number) => string;
+  overview: string;
+  noPagesYet: string;
+
+  // ---- sections ----
+  illustrations: string;
+  illustrationsNote: string;
+  viewAllIllustrations: (n: number) => string;
+  relatedBooks: string;
+  relatedBooksNote: string;
+
+  // ---- book-history timeline ----
+  tlEarlierEnglishTranslation: string;
+  tlFirstEnglishPublished: string;
+  tlEnglishEditionPublished: string;
+  tlNewEditionPublished: string;
+  tlEarlier: string;
+  tlAiTranslationBy: string;
+  tlVersion: (v: string) => string;
+  tlDigitizedBy: (who: string) => string;
+  tlDigitized: string;
+  tlAddedToSourceLibrary: string;
+  tlEarlierTranslationExists: string;
+  view: string;
+
+  // ---- failure / fallback ----
+  temporarilyUnavailable: string;
+  temporarilyUnavailableBody: string;
+  returnToLibrary: string;
+
+  // ---- the thin-twin footer (kept: still used where a page has no twin) ----
+  fullPage: string;
+  fullPageNote: string;
 }
 
 export const BOOK_STRINGS: Record<Locale, BookStrings> = {
@@ -31,41 +109,180 @@ export const BOOK_STRINGS: Record<Locale, BookStrings> = {
     backToCollection: 'Books in Spanish',
     read: 'Read',
     readInSpanish: 'Read in Spanish',
+    readThisBook: 'Read this book',
     originalTitle: 'Original title',
     originalLanguage: 'Original language',
     published: 'Published',
+    written: 'Written',
     pages: 'pages',
     spanishEdition: 'Spanish edition',
     spanishEditionOf: (es, total) => `${es} of ${total} pages in Spanish`,
-    summary: 'About this book',
-    summaryIsEnglish: 'Summary available in English.',
-    contents: 'Contents',
-    fullPage: 'Full record (in English)',
-    fullPageNote: 'bibliography, editions, illustrations, citations.',
     firstTranslation: 'First translation',
+    noPriorTranslation: 'No prior translation found',
     author: 'Author',
     editedBy: 'edited by',
+    scans: (n) => `${n} scans`,
+    scansTooltip: 'Scanned images, including covers and blanks.',
+    images: (n) => `${n} image${n === 1 ? '' : 's'}`,
+    notTranscribed: 'Scans only — not transcribed yet',
+    ocr: 'OCR',
+    translated: 'Translated',
+    ocrTooltip: (done, total) => `${done} of ${total} pages transcribed`,
+    translatedTooltip: (n) => `${n} pages translated to English`,
+    notTranscribedTooltip: (total) => `${total} scans available; no pages transcribed yet`,
+    firstTranslationTooltip: 'First translation into English',
+    noPriorTranslationTooltip: 'We searched the catalogues and found no earlier English translation — a record of the search, not proof none exists',
+    pageAbbrev: (n) => `p. ${n}`,
+
+    summary: 'About this book',
+    summaryIsEnglish: 'Summary available in English.',
+    readingGuide: 'Reading guide',
+    englishText: 'In English.',
+    contents: 'Contents',
+    contentsAsPrinted: 'Contents — as printed',
+    viewScan: 'View scan →',
+    index: 'Index',
+    indexTerms: (n) => `${n} terms`,
+    majorThemes: 'Major Themes',
+    filterIndex: (n) => `Filter ${n} index entries...`,
+    indexShowing: (shown, total) => `Showing ${shown} of ${total} entries.`,
+    indexHiddenHapax: (n) => ` ${n} single-mention terms hidden.`,
+    indexNoMatch: (q) => `No entries matching “${q}”`,
+    more: (n) => `+${n} more`,
+    bibliographicInformation: 'Bibliographic information',
+    bookHistory: 'Book history',
+    searchThisBook: 'Search this book',
+    searchPlaceholder: 'Find a word, name, or phrase…',
+
+    pagesHeading: 'Pages',
+    pagesShownOf: (shown, total) => `${shown} of ${total}`,
+    pagesDigitizedBy: (who) => `Every page scanned from the original, digitized by ${who}.`,
+    pagesInReadingOrder: 'Every page of the original scan, in reading order.',
+    loadMore: (remaining) => `Load more (${remaining} remaining)`,
+    overview: 'Overview',
+    noPagesYet: 'No pages yet',
+
+    illustrations: 'Illustrations',
+    illustrationsNote: 'Plates, diagrams, and figures detected in the scanned pages.',
+    viewAllIllustrations: (n) => `View all ${n} illustrations`,
+    relatedBooks: 'Related books',
+    relatedBooksNote: 'Other volumes close to this one by author, subject, place, and period.',
+
+    tlEarlierEnglishTranslation: 'Earlier English translation',
+    tlFirstEnglishPublished: 'First English translation published',
+    tlEnglishEditionPublished: 'English edition published',
+    tlNewEditionPublished: 'New edition published',
+    tlEarlier: 'Earlier',
+    tlAiTranslationBy: 'An AI-assisted English translation of the original, produced and published by',
+    tlVersion: (v) => `Version ${v}`,
+    tlDigitizedBy: (who) => `Digitized by ${who}`,
+    tlDigitized: 'Digitized',
+    tlAddedToSourceLibrary: 'Added to Source Library',
+    tlEarlierTranslationExists: 'An earlier English translation of this work has been published.',
+    view: 'View →',
+
+    temporarilyUnavailable: 'Temporarily Unavailable',
+    temporarilyUnavailableBody: 'This book is taking longer than expected to load. Please try again in a moment.',
+    returnToLibrary: 'Return to Library',
+
+    fullPage: 'Full record (in English)',
+    fullPageNote: 'bibliography, editions, illustrations, citations.',
   },
   es: {
     backToCollection: 'Libros en español',
     read: 'Leer',
     readInSpanish: 'Leer en español',
+    readThisBook: 'Leer este libro',
     originalTitle: 'Título original',
     originalLanguage: 'Lengua original',
     published: 'Publicado',
+    written: 'Escrito',
     pages: 'páginas',
     spanishEdition: 'Edición en español',
     spanishEditionOf: (es, total) => `${es} de ${total} páginas en español`,
-    summary: 'Sobre este libro',
-    summaryIsEnglish: 'Resumen disponible en inglés.',
-    contents: 'Contenido',
-    fullPage: 'Ficha completa (en inglés)',
-    fullPageNote: 'bibliografía, ediciones, ilustraciones, citas.',
     firstTranslation: 'Primera traducción',
+    noPriorTranslation: 'No se ha encontrado ninguna traducción anterior',
     author: 'Autor',
     editedBy: 'editado por',
+    scans: (n) => `${n} escaneos`,
+    scansTooltip: 'Imágenes escaneadas, incluidas cubiertas y páginas en blanco.',
+    images: (n) => `${n} ${n === 1 ? 'imagen' : 'imágenes'}`,
+    notTranscribed: 'Solo escaneos — todavía sin transcribir',
+    ocr: 'OCR',
+    translated: 'Traducido',
+    ocrTooltip: (done, total) => `${done} de ${total} páginas transcritas`,
+    translatedTooltip: (n) => `${n} páginas traducidas al inglés`,
+    notTranscribedTooltip: (total) => `${total} escaneos disponibles; ninguna página transcrita todavía`,
+    firstTranslationTooltip: 'Primera traducción al inglés',
+    noPriorTranslationTooltip: 'Hemos buscado en los catálogos y no hemos encontrado ninguna traducción al inglés anterior — es el registro de una búsqueda, no la prueba de que no exista',
+    pageAbbrev: (n) => `pág. ${n}`,
+
+    summary: 'Sobre este libro',
+    summaryIsEnglish: 'Resumen disponible en inglés.',
+    readingGuide: 'Guía de lectura',
+    englishText: 'En inglés.',
+    contents: 'Contenido',
+    contentsAsPrinted: 'Índice — tal como está impreso',
+    viewScan: 'Ver el escaneo →',
+    index: 'Índice analítico',
+    indexTerms: (n) => `${n} términos`,
+    majorThemes: 'Temas principales',
+    filterIndex: (n) => `Filtrar ${n} entradas del índice...`,
+    indexShowing: (shown, total) => `Se muestran ${shown} de ${total} entradas.`,
+    indexHiddenHapax: (n) => ` ${n} términos con una sola mención ocultos.`,
+    indexNoMatch: (q) => `Ninguna entrada coincide con «${q}»`,
+    more: (n) => `+${n} más`,
+    bibliographicInformation: 'Información bibliográfica',
+    bookHistory: 'Historia del ejemplar',
+    searchThisBook: 'Buscar en este libro',
+    searchPlaceholder: 'Busca una palabra, un nombre o una frase…',
+
+    pagesHeading: 'Páginas',
+    pagesShownOf: (shown, total) => `${shown} de ${total}`,
+    pagesDigitizedBy: (who) => `Todas las páginas escaneadas del original, digitalizadas por ${who}.`,
+    pagesInReadingOrder: 'Todas las páginas del escaneo original, en orden de lectura.',
+    loadMore: (remaining) => `Cargar más (quedan ${remaining})`,
+    overview: 'Vista general',
+    noPagesYet: 'Todavía no hay páginas',
+
+    illustrations: 'Ilustraciones',
+    illustrationsNote: 'Láminas, diagramas y figuras detectadas en las páginas escaneadas.',
+    viewAllIllustrations: (n) => `Ver las ${n} ilustraciones`,
+    relatedBooks: 'Libros relacionados',
+    relatedBooksNote: 'Otros volúmenes cercanos a este por autor, materia, lugar y época.',
+
+    tlEarlierEnglishTranslation: 'Traducción al inglés anterior',
+    tlFirstEnglishPublished: 'Primera traducción al inglés publicada',
+    tlEnglishEditionPublished: 'Edición en inglés publicada',
+    tlNewEditionPublished: 'Nueva edición publicada',
+    tlEarlier: 'Anterior',
+    tlAiTranslationBy: 'Una traducción al inglés del original, asistida por IA, producida y publicada por',
+    tlVersion: (v) => `Versión ${v}`,
+    tlDigitizedBy: (who) => `Digitalizado por ${who}`,
+    tlDigitized: 'Digitalizado',
+    tlAddedToSourceLibrary: 'Incorporado a Source Library',
+    tlEarlierTranslationExists: 'Ya se ha publicado una traducción al inglés anterior de esta obra.',
+    view: 'Ver →',
+
+    temporarilyUnavailable: 'No disponible por el momento',
+    temporarilyUnavailableBody: 'Este libro está tardando más de lo previsto en cargarse. Inténtalo de nuevo en un momento.',
+    returnToLibrary: 'Volver a la biblioteca',
+
+    fullPage: 'Ficha completa (en inglés)',
+    fullPageNote: 'bibliografía, ediciones, ilustraciones, citas.',
   },
 };
+
+/**
+ * Not localized yet (stays English under `/es`, deliberately — #4082 phase 2):
+ * the bibliographic panel (`BookBiblioPanel`, `TranslationCardPanel`,
+ * `RelatedEditions`), the reading guide's own prose, the processing log
+ * (`PublicBookHistory`), the citation / download / share menus, the
+ * contributing-library section, the sign-up call to action, and the index
+ * TERMS themselves (English entity labels). Each is a component with its own
+ * strings; thread `lang` (or `useLocale()` for client components) and move its
+ * words into the dictionary above when it is done.
+ */
 
 /** Spanish names for the `books.language` values a Spanish reader will meet most. */
 const LANGUAGE_NAMES_ES: Record<string, string> = {

--- a/src/lib/es-collections.ts
+++ b/src/lib/es-collections.ts
@@ -109,33 +109,18 @@ function spanishCopy(doc: Record<string, unknown>) {
 }
 
 /**
- * First page worth opening — the same heuristic the English book page uses for
- * its "Start reading" link: the first chapter when the book has a table of
- * contents, else skip the binding/title leaves on longer books.
- */
-function startPageNumber(book: { pages_count?: number; chapters?: { pageNumber?: number }[] }): number {
-  const fromChapters = book.chapters?.[0]?.pageNumber;
-  if (typeof fromChapters === 'number' && fromChapters > 0) return fromChapters;
-  const n = book.pages_count || 0;
-  return n >= 20 ? 5 : n >= 10 ? 3 : 1;
-}
-
-/**
- * Where a Spanish-surface card sends the reader. Since #4082 that is the Spanish
- * BOOK PAGE (`/es/book/<slug>`), whose "Leer en español" button opens the Spanish
- * reader — the prefix never drops. `startPageNumber` still decides where that
- * button lands (exported for the page).
+ * Where a card on a Spanish surface sends the reader: the Spanish book page,
+ * which since #4082 phase 2 IS the English book page rendered with `lang='es'`.
+ * Its "Leer en español" button opens the reader — and every link on it keeps
+ * the `/es` prefix, so the locale never drops mid-visit.
+ *
+ * `pages_count` / `chapters` are accepted (and ignored) so existing callers
+ * that pass a whole book document keep type-checking; where the reader LANDS is
+ * decided by the book page itself.
  */
 export function spanishReaderHref(book: { slug?: string; id: string; pages_count?: number; chapters?: { pageNumber?: number }[] }): string {
   return `/es/book/${encodeURIComponent(book.slug || book.id)}`;
 }
-
-/** Direct reader link for a Spanish surface, when a page id is already known. */
-export function spanishPageHref(book: { slug?: string; id: string }, pageId: string): string {
-  return `/es/book/${encodeURIComponent(book.slug || book.id)}/page/${pageId}`;
-}
-
-export { startPageNumber };
 // READING_LANGUAGE_PARAM stays exported for the legacy ?lang=es links still in the wild.
 export { READING_LANGUAGE_PARAM };
 
@@ -211,11 +196,13 @@ export async function getEsCollection(slug: string): Promise<EsCollectionDetail 
   const truncated = rawBooks.length > ES_COLLECTION_BOOK_CAP;
   type RawBook = Omit<EsCollectionBook, 'href'> & { chapters?: { pageNumber?: number }[]; read_count?: number };
   const books: EsCollectionBook[] = (rawBooks as unknown as RawBook[]).slice(0, ES_COLLECTION_BOOK_CAP).map((b) => {
-    const hasSpanish = (b.pages_translated_es ?? 0) > 0;
     const { chapters: _ch, read_count: _rc, ...rest } = b;
     return {
       ...rest,
-      href: hasSpanish ? spanishReaderHref(b) : `/book/${encodeURIComponent(b.slug || b.id)}`,
+      // Every book now has a Spanish page, whether or not it has Spanish TEXT —
+      // one without shows the record in Spanish chrome and the English reader,
+      // which beats dropping the reader out of /es on the click.
+      href: spanishReaderHref(b),
     };
   });
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,78 +1,26 @@
 import { usePathname } from 'next/navigation';
+import { localeFromPathname, localePath, type Locale } from '@/lib/locale-path';
 
-// Lightweight locale primitive shared across the site shell (header, footer,
-// etc.). Locale is derived from the URL prefix (`/es`, `/es/...`) rather than a
-// cookie or Accept-Language header, so it never branches edge-cached HTML and
-// every localized route is its own indexable page. Client components read it
-// with useLocale(); server components pass their known locale explicitly.
-//
-// To add a language: add it to Locale + SUPPORTED_LOCALES, extend the prefix
-// check in localeFromPathname, and fill in the dictionaries (NAV_STRINGS here,
-// HOME_STRINGS in home-i18n.ts). Keep the prefixes disjoint from tenant slugs.
-
-export type Locale = 'en' | 'es';
-
-export const SUPPORTED_LOCALES: Locale[] = ['en', 'es'];
-
-/** Map a pathname to its locale by URL prefix. Defaults to English. */
-export function localeFromPathname(pathname: string | null | undefined): Locale {
-  if (pathname === '/es' || (pathname?.startsWith('/es/') ?? false)) return 'es';
-  return 'en';
-}
+// The site-shell locale layer: the pure primitives (re-exported from
+// `locale-path.ts` so every existing `@/lib/i18n` import keeps working) plus
+// the two hooks that read the CURRENT url. Server components must import from
+// `@/lib/locale-path` instead — this module pulls in `usePathname`, and Next 16
+// rejects that in a server component.
+export * from '@/lib/locale-path';
 
 /** Client hook: current locale from the URL. */
 export function useLocale(): Locale {
   return localeFromPathname(usePathname());
 }
 
-// ---------- Locale switching (sitewide EN/ES toggle, #2763) ----------
-
-// EN base paths that have a real Spanish (`/es…`) twin route. Keep this in sync
-// with the `src/app/es/**` route folders: the homepage plus the acquisition
-// funnel (`/support`, `/auth/signin`). The header toggle is shown on EVERY page,
-// but on a page with no twin the ES link falls back to the Spanish homepage
-// (`/es`) as a front door rather than dead-ending on a 404 — the thin-i18n
-// bargain (deep pages rely on the browser's own translate).
-export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin']);
-
-// Path FAMILIES with a Spanish twin: `/collections` and every
-// `/collections/<slug>` render under `/es/collections/…` (Spanish chrome, Spanish
-// collection names; see src/app/es/collections). Kept separate from the exact-
-// match set so a new deep route is not localized by accident.
-const LOCALIZED_PREFIXES = ['/collections', '/book'];
-
-function hasLocalizedPath(canonical: string): boolean {
-  if (LOCALIZED_PATHS.has(canonical)) return true;
-  return LOCALIZED_PREFIXES.some((p) => canonical === p || canonical.startsWith(`${p}/`));
-}
-
-/** Strip the `/es` locale prefix to get the canonical English path. */
-export function canonicalPath(pathname: string | null | undefined): string {
-  if (!pathname || pathname === '/es') return '/';
-  if (pathname.startsWith('/es/')) return pathname.slice(3); // '/es/x' → '/x'
-  return pathname;
-}
-
 /**
- * Whether the current page has a real Spanish twin (i.e. switching to ES keeps
- * the reader on the same page rather than dumping them on the `/es` homepage).
- * The header uses this to HIDE the EN/ES toggle on deep, English-only pages —
- * the thin-i18n bargain — so clicking ES never bounces you to the front page.
+ * Client hook: `localePath` bound to the locale of the page being rendered.
+ * A client component that builds `/book/...` links can call this instead of
+ * taking a `lang` prop — the URL already says which language it is.
  */
-export function hasLocalizedTwin(pathname: string | null | undefined): boolean {
-  return hasLocalizedPath(canonicalPath(pathname));
-}
-
-/**
- * Href for switching the current page to `target` locale.
- * - English: the canonical page (any `/es` prefix dropped) so the reader stays put.
- * - Spanish: the `/es` twin when one exists, else the Spanish homepage (`/es`).
- */
-export function localeHref(target: Locale, pathname: string | null | undefined): string {
-  const canonical = canonicalPath(pathname);
-  if (target === 'en') return canonical;
-  if (hasLocalizedPath(canonical)) return canonical === '/' ? '/es' : `/es${canonical}`;
-  return '/es';
+export function useLocalePath(): (href: string) => string {
+  const lang = useLocale();
+  return (href: string) => localePath(href, lang);
 }
 
 // ---------- Shared site-shell strings (header nav) ----------

--- a/src/lib/locale-path.ts
+++ b/src/lib/locale-path.ts
@@ -1,0 +1,108 @@
+// Pure locale primitives — NO React, NO next/navigation, so a SERVER component
+// can import them. The client hooks that read the current URL (`useLocale`,
+// `useLocalePath`) live in `src/lib/i18n.ts`, which re-exports everything here;
+// importing that module from a server component is an error in Next 16, which
+// is exactly why this split exists.
+//
+// Locale is derived from the URL prefix (`/es`, `/es/...`) rather than a cookie
+// or Accept-Language header, so it never branches edge-cached HTML and every
+// localized route is its own indexable page.
+//
+// To add a language: add it to Locale + SUPPORTED_LOCALES, extend the prefix
+// check in localeFromPathname, add its route shapes to LOCALIZED_PATTERNS, and
+// fill in the dictionaries (NAV_STRINGS in i18n.ts, HOME_STRINGS in
+// home-i18n.ts). Keep the prefixes disjoint from tenant slugs.
+
+export type Locale = 'en' | 'es';
+
+export const SUPPORTED_LOCALES: Locale[] = ['en', 'es'];
+
+/** Map a pathname to its locale by URL prefix. Defaults to English. */
+export function localeFromPathname(pathname: string | null | undefined): Locale {
+  if (pathname === '/es' || (pathname?.startsWith('/es/') ?? false)) return 'es';
+  return 'en';
+}
+
+// ---------- Locale switching (sitewide EN/ES toggle, #2763) ----------
+
+// EN base paths that have a real Spanish (`/es…`) twin route. Keep this in sync
+// with the `src/app/es/**` route folders: the homepage plus the acquisition
+// funnel (`/support`, `/auth/signin`). The header toggle is shown on EVERY page,
+// but on a page with no twin the ES link falls back to the Spanish homepage
+// (`/es`) as a front door rather than dead-ending on a 404 — the thin-i18n
+// bargain (deep pages rely on the browser's own translate).
+export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin']);
+
+// Path SHAPES with a Spanish twin. One pattern per `src/app/es/**` route —
+// deliberately exact, not a bare `/book` prefix: `/book/<id>` and
+// `/book/<id>/page/<pageId>` have twins while `/book/<id>/overview`,
+// `/guide`, `/search`, `/qa`, … do NOT, and a prefix match would send a
+// Spanish reader to `/es/book/x/overview`, which no route serves. A missing
+// pattern costs an English page; a wrong one costs a 404.
+//
+// Keep in sync with the route folders under `src/app/es/`.
+const LOCALIZED_PATTERNS: RegExp[] = [
+  /^\/collections$/,
+  /^\/collections\/[^/]+$/,
+  /^\/book\/[^/]+$/,
+  /^\/book\/[^/]+\/page\/[^/]+$/,
+  /^\/book\/[^/]+\/page-number\/[^/]+$/,
+];
+
+function hasLocalizedPath(canonical: string): boolean {
+  if (LOCALIZED_PATHS.has(canonical)) return true;
+  return LOCALIZED_PATTERNS.some((re) => re.test(canonical));
+}
+
+/** Strip the `/es` locale prefix to get the canonical English path. */
+export function canonicalPath(pathname: string | null | undefined): string {
+  if (!pathname || pathname === '/es') return '/';
+  if (pathname.startsWith('/es/')) return pathname.slice(3); // '/es/x' → '/x'
+  return pathname;
+}
+
+/**
+ * Whether the current page has a real Spanish twin (i.e. switching to ES keeps
+ * the reader on the same page rather than dumping them on the `/es` homepage).
+ * The header uses this to HIDE the EN/ES toggle on deep, English-only pages —
+ * the thin-i18n bargain — so clicking ES never bounces you to the front page.
+ */
+export function hasLocalizedTwin(pathname: string | null | undefined): boolean {
+  return hasLocalizedPath(canonicalPath(pathname));
+}
+
+/**
+ * Href for switching the current page to `target` locale.
+ * - English: the canonical page (any `/es` prefix dropped) so the reader stays put.
+ * - Spanish: the `/es` twin when one exists, else the Spanish homepage (`/es`).
+ */
+export function localeHref(target: Locale, pathname: string | null | undefined): string {
+  const canonical = canonicalPath(pathname);
+  if (target === 'en') return canonical;
+  if (hasLocalizedPath(canonical)) return canonical === '/' ? '/es' : `/es${canonical}`;
+  return '/es';
+}
+
+/**
+ * Keep an internal link on the current locale.
+ *
+ * Rule 5 of `.claude/docs/i18n.md`: the locale is the URL prefix and it stays —
+ * but only where a twin route actually exists. The registry above
+ * (`LOCALIZED_PATHS` / `LOCALIZED_PREFIXES`) is the single source of truth, so
+ * a path with no twin (`/gallery`, `/search`, `/author/…`) is returned
+ * UNTOUCHED rather than pointed at a 404. That asymmetry is deliberate: a
+ * Spanish reader following an unprefixed link lands on an English page, which
+ * is honest; following a prefixed one would land on nothing.
+ *
+ * Absolute URLs, anchors and already-prefixed paths pass through unchanged, so
+ * this is safe to apply blindly at a link site.
+ */
+export function localePath(href: string, lang: Locale): string {
+  if (lang === 'en' || !href || !href.startsWith('/')) return href;
+  const prefix = `/${lang}`;
+  if (href === prefix || href.startsWith(`${prefix}/`)) return href;
+  if (href === '/') return prefix; // the localized home is `/es`, not `/es/`
+  const path = href.split(/[?#]/)[0];
+  return hasLocalizedPath(path) ? `${prefix}${href}` : href;
+}
+

--- a/src/lib/locale-path.ts
+++ b/src/lib/locale-path.ts
@@ -17,9 +17,22 @@ export type Locale = 'en' | 'es';
 
 export const SUPPORTED_LOCALES: Locale[] = ['en', 'es'];
 
+/**
+ * The locales that own a URL prefix. English is the ROOT — `/book/x`, not
+ * `/en/book/x` — because every DOI, shortlink and citation ever minted points
+ * there. A new language is added here and gets its prefix for free; nothing
+ * below hard-codes `/es`.
+ */
+export const PREFIXED_LOCALES: Exclude<Locale, 'en'>[] = SUPPORTED_LOCALES.filter(
+  (l): l is Exclude<Locale, 'en'> => l !== 'en',
+);
+
 /** Map a pathname to its locale by URL prefix. Defaults to English. */
 export function localeFromPathname(pathname: string | null | undefined): Locale {
-  if (pathname === '/es' || (pathname?.startsWith('/es/') ?? false)) return 'es';
+  if (!pathname) return 'en';
+  for (const l of PREFIXED_LOCALES) {
+    if (pathname === `/${l}` || pathname.startsWith(`/${l}/`)) return l;
+  }
   return 'en';
 }
 
@@ -54,10 +67,22 @@ function hasLocalizedPath(canonical: string): boolean {
   return LOCALIZED_PATTERNS.some((re) => re.test(canonical));
 }
 
-/** Strip the `/es` locale prefix to get the canonical English path. */
+/**
+ * Strip the locale prefix to get the canonical English path.
+ *
+ * Every gate and matcher that reasons about a PATH FAMILY — the preview
+ * content gate, the crawler rules, anything keyed on `/book` — must run on
+ * this, not on the raw pathname. `/es/book/x` is the same content surface as
+ * `/book/x`; a matcher that only knows the English form leaves the localized
+ * twin ungated, silently, for as long as nobody looks (found on the #4082
+ * preview: `/book/…` 403'd for anonymous callers and `/es/book/…` served).
+ */
 export function canonicalPath(pathname: string | null | undefined): string {
-  if (!pathname || pathname === '/es') return '/';
-  if (pathname.startsWith('/es/')) return pathname.slice(3); // '/es/x' → '/x'
+  if (!pathname) return '/';
+  for (const l of PREFIXED_LOCALES) {
+    if (pathname === `/${l}`) return '/';
+    if (pathname.startsWith(`/${l}/`)) return pathname.slice(l.length + 1); // '/es/x' → '/x'
+  }
   return pathname;
 }
 

--- a/src/lib/localized.ts
+++ b/src/lib/localized.ts
@@ -1,4 +1,4 @@
-import type { Locale } from '@/lib/i18n';
+import type { Locale } from '@/lib/locale-path';
 
 /**
  * Localized METADATA — titles, collection names, intros — for non-English surfaces.

--- a/src/lib/page-number-redirect.ts
+++ b/src/lib/page-number-redirect.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { resolvePageByNumber } from '@/lib/page-number-resolve';
+
+/**
+ * `/book/<id>/page-number/<n>` → the reader for that printed page.
+ *
+ * Shared by the English route and its localized twins: `prefix` is the locale
+ * segment ('' or '/es') the redirect must PRESERVE. A chapter link that dropped
+ * the prefix here would silently bounce a Spanish reader back to the English
+ * reader, which is the whole failure #4082 exists to fix.
+ */
+export async function pageNumberRedirect(
+  request: NextRequest,
+  params: { id: string; num: string },
+  prefix = '',
+): Promise<NextResponse> {
+  const pageNumber = parseInt(params.num, 10);
+
+  if (isNaN(pageNumber)) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+
+  const db = await getReadDb();
+  const ctx = getTenantContextFromRequest(request);
+
+  const result = await findBookByIdOrSlug(db, params.id, { id: 1, slug: 1 }, ctx.id ?? undefined);
+  if (!result) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+
+  const bookId = (result.book.id || result.book._id?.toString()) as string;
+  const bookSlug = (result.book.slug || bookId) as string;
+
+  // Resolve with a nearest-page fallback so a chapter whose printed page
+  // number doesn't land on an exact pages.page_number value still lands the
+  // reader on the closest page instead of a hard 404. Only 404s when the book
+  // has no pages at all.
+  const page = await resolvePageByNumber(db, bookId, pageNumber);
+
+  if (!page) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+
+  const pageId = page.id || page._id?.toString();
+  const destination = new URL(`${prefix}/book/${bookSlug}/page/${pageId}`, request.url);
+  // Preserve the incoming query string (e.g. ?highlight=, ?v=) so search-result
+  // links that land here still highlight/pin on the resolved page reader.
+  destination.search = request.nextUrl.search;
+  return NextResponse.redirect(destination, 308);
+}

--- a/tests/unit/alias-host-scope.test.ts
+++ b/tests/unit/alias-host-scope.test.ts
@@ -105,6 +105,26 @@ describe('proxy() on preview deployments', () => {
     }
   });
 
+  it('gates the LOCALIZED twin of a content path, not just the English one', async () => {
+    // `/es/book/x` is the same book as `/book/x`. The gate matched the raw
+    // pathname, so from the day the Spanish twin shipped every preview served
+    // the whole record to anonymous callers while the English URL 403'd.
+    // Matching on the locale-stripped path also covers a future `/fr`.
+    for (const p of ['/es/book/some-slug', '/es/book/some-slug/page/abc', '/es/book/some-slug/page-number/9']) {
+      const res = await proxy(req(`${PREVIEW}${p}`));
+      expect(res?.status, p).toBe(403);
+      expect(res?.headers.get('location'), p).toBeNull();
+    }
+  });
+
+  it('does not gate a localized NON-content path', async () => {
+    // The stripping must not turn every /es page into book content.
+    for (const p of ['/es', '/es/collections', '/es/support']) {
+      const res = await proxy(req(`${PREVIEW}${p}`));
+      expect(res?.status, p).not.toBe(403);
+    }
+  });
+
   it('lets a signed-in dev review the branch', async () => {
     const res = await proxy(
       req(`${PREVIEW}/book/some-slug`, { cookie: '__Secure-authjs.session-token=tok' })

--- a/tests/unit/i18n-locale-href.test.ts
+++ b/tests/unit/i18n-locale-href.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canonicalPath, localeHref, localeFromPathname, LOCALIZED_PATHS } from '@/lib/i18n';
+import { canonicalPath, localeHref, localeFromPathname, localePath, LOCALIZED_PATHS } from '@/lib/i18n';
 
 describe('canonicalPath', () => {
   it('drops the /es prefix', () => {
@@ -39,6 +39,10 @@ describe('localeHref (sitewide toggle, #2763)', () => {
     // Deep pages (no /es twin) front-door to /es rather than 404.
     expect(localeHref('es', '/gallery')).toBe('/es');
     expect(localeHref('es', '/bookshelf')).toBe('/es'); // prefix match is segment-wise, not string-wise
+    // Book SUB-routes without a twin must not be claimed by the /book family:
+    // /es/book/x/overview is served by nothing (#4082).
+    expect(localeHref('es', '/book/foo/overview')).toBe('/es');
+    expect(localeHref('es', '/book/foo/guide')).toBe('/es');
   });
 
   it('round-trips a localized twin path', () => {
@@ -60,5 +64,38 @@ describe('localeFromPathname (unchanged, guarded here)', () => {
     expect(localeFromPathname('/es/support')).toBe('es');
     expect(localeFromPathname('/')).toBe('en');
     expect(localeFromPathname('/esoterica')).toBe('en');
+  });
+});
+
+describe('localePath (keep an internal link on its locale, #4082)', () => {
+  it('is a no-op in English', () => {
+    expect(localePath('/book/foo', 'en')).toBe('/book/foo');
+    expect(localePath('/gallery', 'en')).toBe('/gallery');
+  });
+
+  it('prefixes paths that have a twin route', () => {
+    expect(localePath('/book/foo', 'es')).toBe('/es/book/foo');
+    expect(localePath('/book/foo/page/bar', 'es')).toBe('/es/book/foo/page/bar');
+    expect(localePath('/book/foo/page-number/12', 'es')).toBe('/es/book/foo/page-number/12');
+    expect(localePath('/collections/alchemy', 'es')).toBe('/es/collections/alchemy');
+    expect(localePath('/', 'es')).toBe('/es');
+  });
+
+  it('leaves a path with NO twin alone rather than minting a 404', () => {
+    expect(localePath('/book/foo/overview', 'es')).toBe('/book/foo/overview');
+    expect(localePath('/gallery?bookId=x', 'es')).toBe('/gallery?bookId=x');
+    expect(localePath('/artwork/foo', 'es')).toBe('/artwork/foo');
+    expect(localePath('/author/paracelsus', 'es')).toBe('/author/paracelsus');
+  });
+
+  it('passes through absolute URLs, anchors and already-prefixed paths', () => {
+    expect(localePath('https://example.org/book/x', 'es')).toBe('https://example.org/book/x');
+    expect(localePath('#pages', 'es')).toBe('#pages');
+    expect(localePath('/es/book/foo', 'es')).toBe('/es/book/foo');
+    expect(localePath('', 'es')).toBe('');
+  });
+
+  it('keeps the query string when it prefixes', () => {
+    expect(localePath('/book/foo?v=2', 'es')).toBe('/es/book/foo?v=2');
   });
 });


### PR DESCRIPTION
Closes the book-page half of #4082.

## Why

After phase 1 a Spanish reader clicking a book from `/es/collections/en-espanol`
got a **second, hand-written page** describing the same book: title, byline,
summary, contents, one button. The English page has editions, bibliography,
illustrations, an index, a timeline, related books. Two pages describing one
book drift apart with every change to the English one, and the Spanish reader
permanently has the lesser record. Derek, on seeing it: *"the book pages under
/es should be the same as the English ones, obviously."*

So there is now **one book page**. `src/app/book/[id]/page.tsx` takes
`lang: Locale`; `src/app/es/book/[id]/page.tsx` is a re-export that passes
`'es'`. They cannot diverge.

## What changed

**A link primitive, and a registry fix.** `localePath(href, lang)` (server) and
`useLocalePath()` (client) keep an internal link on its locale. Both are
guarded by the twin registry, so a path with **no** twin comes back untouched
rather than pointed at a 404. That forced a real fix: the registry held a bare
`/book` **prefix**, which claims a Spanish twin for `/book/x/overview`,
`/book/x/guide`, `/book/x/search` — none of which exist. It lists route
**shapes** now. A missing pattern costs an English page; a wrong one costs a
404, so the list is deliberately exact and sits next to a "keep in sync with
`src/app/es/**`" note.

**A module split.** `src/lib/i18n.ts` imports `usePathname`, so importing it
from a server component is an error in Next 16 — which is what a shared page
must do. The pure primitives moved to `src/lib/locale-path.ts`; `i18n.ts`
re-exports them all and keeps the two hooks, so every existing import still
works.

**Chrome.** Into `BOOK_STRINGS` (`src/lib/book-i18n.ts`), en + es: the page's
own ~40 literals plus the chrome of `PagesGrid`, `BookIndex`, `BookTimeline`,
`AboutVariants`. Client children take **no `lang` prop** — they call
`useLocale()`, because the pathname already says which language they are in.
Server children take an explicit locale prop (`RelatedEditions`).

**Content.** Title via `localizedTitle`, summary via `localized.es.summary`,
chapter titles via `localized.es.chapters` — the one language-keyed map, all
three already generated for the 103 Spanish-edition books. Where a book has no
Spanish text the English shows and is **labelled**; nothing is machine
translated at render time (i18n.md rule 4). A book with no `localized` map at
all falls back to the **original** title, never the English gloss.

**A missing route.** `/es/book/[id]/page-number/[num]`. The Read CTA, every
chapter link and every index page-reference go through `page-number`; without
the twin they would 308 a Spanish reader back into the English reader. Handler
extracted and shared, so the two cannot drift.

**Metadata.** Spanish title + description, `/es` canonical, hreflang pair. The
Google Scholar `citation_*` block and the DTS ld+json stay on the English page
only — that is the citable edition, and emitting them twice would mint a second
scholarly record for one book.

## Verification (local dev against Atlas)

- `/es/book/dawn-rising-boehme`: 200. **54 of 56** `/book/` links carry the
  prefix. The two that don't are the header's EN toggle (correct) and
  `/overview` (no twin — correct).
- Spanish H1 (*Aurora naciente*), Spanish summary, Spanish chapter titles
  (*Capítulo 1: Sobre la investigación del ser divino…*), Spanish chrome
  throughout; zero English chrome strings from the localized set.
- Read CTA → `/es/book/…/page-number/9` → **308** → `/es/book/…/page/…`. The
  English route still 308s to the English reader.
- `/book/dawn-rising-boehme` (English): all 12 checked strings present, zero
  Spanish leakage, exactly one `/es/` link (the ES toggle).
- A book with no `localized` map under `/es`: original title, Spanish chrome,
  English summary carrying "Resumen disponible en inglés."
- `npx tsc --noEmit` clean; `npx vitest run tests/unit` 2789 passed. Six new
  `localePath` cases pin the no-twin behaviour, including
  `/book/foo/overview` → unchanged.

## Out of scope (deliberate, and listed in the code)

- **The reader's own chrome** under `/es` — header title, chapter dropdown,
  Image/OCR/Read/Edit/Cite/Notes/Info/Copy, "Like this page", search
  placeholder. Same rule and same dictionary; filed as phase 2b on #4082 with
  the component-by-component list.
- Bibliographic panel, reading-guide prose, processing log, cite/download/share
  menus, contributing-library section, sign-up CTA. Each stays English **and is
  named** at the foot of `src/lib/book-i18n.ts`.
- The embed / tenant return of `BookInfo` (#3916's second top-level return) is
  untouched — tenant reading rooms keep the proven layout.
- Not fixed, noticed: the pages grid mints `/book/<hex-id>/page/<id>` links
  because the page never passes `bookPath`, which is what that prop exists for
  (#2266). Pre-existing on English; changing it moves English URLs, so it wants
  its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWM6HTvZUpgT3RUMLREQPC
