### PR TITLE
feat(i18n): Spanish reader chrome (#4082 phase 2b)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -101,9 +101,24 @@ Mind the TWO top-level returns in `BookInfo` (#3916): the standard layout and
 the embed-only one. Only the standard layout is localized; tenant reading rooms
 keep the proven English/embed layout (tenant-lockdown.md).
 
-## Known gap (tracked)
+## The reader
 
-The **reader** (`/es/book/[id]/page/[pageId]`) re-exports the English reader
-verbatim, so its chrome is still English — header title, chapter dropdown,
-Image/OCR/Read/Edit/Cite/Notes/Info/Copy, "Like this page", the search
-placeholder. Same rule, same dictionary; tracked as phase 2b on **#4082**.
+Same shape (#4082 phase 2b). `READER_STRINGS` in `src/lib/book-i18n.ts` holds
+its chrome; `TranslationEditor`, `ChapterDropdown`, `BookSearchBar` and
+`TranslationFeedbackPrompt` are client components and read `useLocale()`, so
+nothing threads a prop. The header title comes from `localizedTitle`, the
+chapter list from `localized.<lang>.chapters`, and the `<title>`/description
+from the same map — which meant adding `localized: 1` to the reader's book
+projections (`BOOK_NAV_PROJECTION`, `page-data.ts`); leaving it out is why the
+Spanish reader wore a German title over Spanish text.
+
+**EDITOR tooling is deliberately NOT localized** — Run OCR, Edit Prompt,
+Translate, the settings dialogs, the whole edit mode. It is staff-only, English
+is its working language, and translating it would advertise a Spanish editing
+workflow we do not offer.
+
+One trap worth knowing: `tenantPrefix` in the reader is the URL prefix for every
+link the component writes, and it knew about tenants and embeds but not
+locales — so share links, the page-metadata link and in-book search silently
+dropped `/es`. If you add a prefix concept anywhere, check who else composes a
+URL from it.

--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -11,6 +11,9 @@ import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getTranscriptionsForPage } from '@/lib/music-transcriptions';
 import { jsonLdHtml } from '@/lib/json-ld';
 import { markPageForReader } from '@/lib/provenance';
+import { localePath, type Locale } from '@/lib/locale-path';
+import { READER_STRINGS } from '@/lib/book-i18n';
+import { localizedTitle } from '@/lib/localized';
 
 // Schema.org structured data for a translated page, so it surfaces as a
 // citable scholarly work in web search (#2822). Only emitted for indexable
@@ -60,11 +63,15 @@ interface PageProps {
 // Book projection: only fields needed by the reader
 const BOOK_NAV_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1,
+  // The one language-keyed map: the reader header shows `localized.<lang>.title`
+  // and the chapter dropdown `localized.<lang>.chapters`. Leaving it out of this
+  // projection is why the Spanish reader showed a German title over Spanish text.
+  localized: 1,
   author: 1, published: 1, language: 1, doi: 1, chapters: 1,
   cdli_witnesses: 1, etcsl_id: 1, visible: 1,
 };
 
-export default async function PageEditorPage({ params, allowHidden = false }: PageProps & { allowHidden?: boolean }) {
+export default async function PageEditorPage({ params, allowHidden = false, lang = 'en' }: PageProps & { allowHidden?: boolean; lang?: Locale }) {
   const { id, pageId } = await params;
   const ctx = await getTenantContext();
   const db = await getReadDb();
@@ -151,15 +158,16 @@ export default async function PageEditorPage({ params, allowHidden = false }: Pa
           when client-component SSR changes (#2266). Sits below the h-screen
           reader; the in-reader controls remain the primary navigation. */}
       {!(ctx?.isEmbedded) && (() => {
+        const rs = READER_STRINGS[lang];
         const idx = serializedNavPages.findIndex(p => p.id === pageId);
         const prev = idx > 0 ? serializedNavPages[idx - 1] : null;
         const next = idx >= 0 && idx < serializedNavPages.length - 1 ? serializedNavPages[idx + 1] : null;
         return (
-          <nav aria-label="Page navigation" className="max-w-[1500px] mx-auto px-4 sm:px-6 py-4 text-sm text-stone-500 flex flex-wrap items-center gap-x-5 gap-y-1">
-            {prev && <a href={`/book/${bookPath}/page/${prev.id}`} className="hover:text-stone-700">← Page {prev.page_number}</a>}
-            <a href={`/book/${bookPath}`} className="hover:text-stone-700">{book.display_title || book.title}</a>
-            <a href={`/book/${bookPath}/overview`} className="hover:text-stone-700">All {serializedNavPages.length} pages</a>
-            {next && <a href={`/book/${bookPath}/page/${next.id}`} className="hover:text-stone-700">Page {next.page_number} →</a>}
+          <nav aria-label={rs.pageNavigation} className="max-w-[1500px] mx-auto px-4 sm:px-6 py-4 text-sm text-stone-500 flex flex-wrap items-center gap-x-5 gap-y-1">
+            {prev && <a href={localePath(`/book/${bookPath}/page/${prev.id}`, lang)} className="hover:text-stone-700">{rs.prevPageLink(prev.page_number)}</a>}
+            <a href={localePath(`/book/${bookPath}`, lang)} className="hover:text-stone-700">{localizedTitle(book, lang)}</a>
+            <a href={`/book/${bookPath}/overview`} className="hover:text-stone-700">{rs.allPagesLink(serializedNavPages.length)}</a>
+            {next && <a href={localePath(`/book/${bookPath}/page/${next.id}`, lang)} className="hover:text-stone-700">{rs.nextPageLink(next.page_number)}</a>}
           </nav>
         );
       })()}

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -6,6 +6,9 @@ import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 // (reader) group layout's visibility gate all read it, so one round trip
 // serves the whole request.
 import { getPageData } from './page-data';
+import { type Locale } from '@/lib/locale-path';
+import { READER_STRINGS } from '@/lib/book-i18n';
+import { localizedTitle } from '@/lib/localized';
 
 export const preferredRegion = 'fra1';
 
@@ -14,8 +17,9 @@ interface LayoutProps {
   params: Promise<{ id: string; pageId: string }>;
 }
 
-export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+export async function generateMetadata({ params, lang = 'en' }: LayoutProps & { lang?: Locale }): Promise<Metadata> {
   const { id, pageId } = await params;
+  const rs = READER_STRINGS[lang];
   const ctx = await getTenantContext();
   const { book, page } = await getPageData(id, pageId, ctx?.id ?? undefined);
 
@@ -29,10 +33,10 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
     };
   }
 
-  const bookTitle = book.display_title || book.title;
+  const bookTitle = localizedTitle(book as Parameters<typeof localizedTitle>[0], lang);
   const pageNum = page.page_number;
   const ogBookTitle = book.published ? `${bookTitle} (${book.published})` : bookTitle;
-  const title = `${ogBookTitle} - Page ${pageNum}`;
+  const title = rs.metaTitle(ogBookTitle, pageNum);
 
   // Use translation excerpt if available, otherwise OCR excerpt. Strip editorial
   // wrapper blocks first so <meta>/<summary>/… prose never lands in the OG
@@ -42,8 +46,10 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
     ? textContent.substring(0, 197) + '...'
     : textContent;
 
+  // The excerpt is the page's own text in the reader's language; the sentence
+  // around it follows the locale. An untranslated book keeps its English frame.
   const description = excerpt
-    ? `Page ${pageNum} of "${bookTitle}" by ${book.author}. ${excerpt}`
+    ? `${rs.metaPageOf(pageNum, bookTitle)} — ${book.author}. ${excerpt}`
     : `Page ${pageNum} of "${bookTitle}" by ${book.author}${book.published ? ` (${book.published})` : ''}. Digitized from the original ${book.language || 'manuscript'}.`;
 
   // Always use slug for canonical URL, even if accessed via hex ObjectId

--- a/src/app/book/[id]/page/[pageId]/page-data.ts
+++ b/src/app/book/[id]/page/[pageId]/page-data.ts
@@ -15,7 +15,7 @@ import { Book, Page } from '@/lib/types';
 // Only the fields the shells need — metadata, existence, visibility. Skip
 // index, reading_summary, etc.
 export const BOOK_META_PROJECTION = {
-  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1, language: 1,
+  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, localized: 1, author: 1, published: 1, language: 1,
   // `visible` powers the (reader) group's hidden-book gate (isHiddenBook).
   visible: 1,
 };

--- a/src/app/es/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/es/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -1,8 +1,19 @@
-// Spanish twin of the reader page (#4082). Identical server render; the client
-// (PageEditorClient) reads the /es prefix to open the Spanish edition and to
-// keep /es on every page flip. See .claude/docs/i18n.md rule 5.
-export { default } from '@/app/book/[id]/page/[pageId]/(reader)/page';
+import BasePage from '@/app/book/[id]/page/[pageId]/(reader)/page';
+
+/**
+ * Spanish twin of the reader page (#4082). Identical server render with
+ * `lang='es'`: the crawler nav below the reader keeps the `/es` prefix and
+ * names the book by its Spanish title. The reader itself is a client
+ * component and takes its language from the pathname (`useLocale()`), which is
+ * also how every page flip keeps `/es`. See .claude/docs/i18n.md rule 5.
+ */
 
 // Segment config must be a static literal (Next parses it at build time) —
 // keep in step with the English reader page (ISR, 24h).
 export const revalidate = 86400;
+
+type Props = { params: Promise<{ id: string; pageId: string }> };
+
+export default async function EsReaderPage(props: Props) {
+  return BasePage({ ...props, lang: 'es' });
+}

--- a/src/app/es/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/es/book/[id]/page/[pageId]/layout.tsx
@@ -15,7 +15,7 @@ interface LayoutProps {
 }
 
 export async function generateMetadata(props: LayoutProps): Promise<Metadata> {
-  const base = await baseMetadata(props);
+  const base = await baseMetadata({ ...props, lang: 'es' });
   const { id, pageId } = await props.params;
   const path = `/book/${id}/page/${pageId}`;
   return {

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
+import { useLocale } from '@/lib/i18n';
+import { READER_STRINGS } from '@/lib/book-i18n';
 import { useParams, usePathname } from 'next/navigation';
 import TranslationEditor from '@/components/pipeline/TranslationEditor';
 import VersionBanner from '@/components/ui/VersionBanner';
@@ -83,6 +85,7 @@ export default function PageEditorClient({
   // On the Spanish twin (/es/book/…) every URL this component writes keeps the
   // /es prefix, so page flips never drop the reader out of the Spanish site (#4082).
   const isOnEsRoute = pathname === '/es' || (pathname?.startsWith('/es/') ?? false);
+  const rs = READER_STRINGS[useLocale()];
   const tenantPrefix = isOnTenantSubdomain ? '' : isOnEsRoute ? '/es' : (params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '');
   // Every reader URL this component writes uses the book's slug — the same
   // human-readable segment the book page uses (/book/a-sacred-repository-…),
@@ -423,8 +426,8 @@ export default function PageEditorClient({
       )}
 
       {hasSpanish && !pinnedVersion && (
-        <div className="flex items-center justify-center gap-2 py-2 text-sm" role="group" aria-label="Reading language">
-          <span className="text-neutral-500">Read in:</span>
+        <div className="flex items-center justify-center gap-2 py-2 text-sm" role="group" aria-label={rs.readingLanguage}>
+          <span className="text-neutral-500">{rs.readIn}</span>
           <div className="inline-flex overflow-hidden rounded-full border border-neutral-300">
             <button
               type="button"

--- a/src/components/feedback/TranslationFeedbackPrompt.tsx
+++ b/src/components/feedback/TranslationFeedbackPrompt.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { useLocale } from '@/lib/i18n';
+import { READER_STRINGS } from '@/lib/book-i18n';
 
 /**
  * Contextual feedback prompt shown at the bottom of translated text.
@@ -17,6 +19,7 @@ export default function TranslationFeedbackPrompt({
   pageNumber: number;
   pageId: string;
 }) {
+  const rs = READER_STRINGS[useLocale()];
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
@@ -25,7 +28,7 @@ export default function TranslationFeedbackPrompt({
     return (
       <div className="mt-6 pt-4 text-center" style={{ borderTop: '1px solid var(--border-light, #e8e5e0)' }}>
         <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
-          Thank you &mdash; your feedback helps improve this translation.
+          {rs.feedbackThanks}
         </p>
       </div>
     );
@@ -39,7 +42,7 @@ export default function TranslationFeedbackPrompt({
           className="text-sm transition-colors hover:underline"
           style={{ color: 'var(--text-faint, #c4c0b8)' }}
         >
-          Notice a translation issue? Let us know.
+          {rs.translationIssue}
         </button>
       </div>
     );
@@ -64,12 +67,12 @@ export default function TranslationFeedbackPrompt({
   return (
     <div className="mt-6 pt-4" style={{ borderTop: '1px solid var(--border-light, #e8e5e0)' }}>
       <p className="text-sm mb-2" style={{ color: 'var(--text-muted)' }}>
-        What did you notice?
+        {rs.feedbackWhat}
       </p>
       <textarea
         value={message}
         onChange={(e) => setMessage(e.target.value)}
-        placeholder="Wrong word, awkward phrasing, missing context..."
+        placeholder={rs.feedbackPlaceholder}
         rows={2}
         className="w-full px-3 py-2 rounded-lg text-sm resize-none focus:outline-none"
         style={{
@@ -85,7 +88,7 @@ export default function TranslationFeedbackPrompt({
           className="text-xs transition-colors"
           style={{ color: 'var(--text-faint)' }}
         >
-          Cancel
+          {rs.cancel}
         </button>
         <button
           onClick={submit}
@@ -93,7 +96,7 @@ export default function TranslationFeedbackPrompt({
           className="px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-all hover:opacity-90 disabled:opacity-50"
           style={{ background: 'var(--text-primary, #2c2824)' }}
         >
-          {status === 'sending' ? 'Sending...' : 'Send'}
+          {status === 'sending' ? rs.sending : rs.send}
         </button>
       </div>
     </div>

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -11,6 +11,7 @@ import RecentlyRead from '@/components/home/RecentlyRead';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { type HomeData, SPANISH_COLLECTION_SLUG } from '@/lib/home-data';
 import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
+import { localePath } from '@/lib/locale-path';
 
 // Shared homepage body. The English `/` route renders it with lang="en"; the
 // Spanish `/es` route with lang="es". Keeping a single component means the two
@@ -18,6 +19,10 @@ import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
 
 export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLang }) {
   const t = HOME_STRINGS[lang];
+  // Every link on this page that HAS a twin keeps the locale; the rest (gallery,
+  // catalog, browse, podcast, blog…) are returned untouched by localePath and go
+  // to their English page rather than a 404. See .claude/docs/i18n.md rule 5.
+  const lp = (href: string) => localePath(href, lang);
   const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
 
@@ -41,7 +46,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 {t.spanishHeading}
               </h2>
               <Link
-                href={`${lang === 'es' ? '/es' : ''}/collections/${SPANISH_COLLECTION_SLUG}`}
+                href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)}
                 className="text-sm text-muted hover:text-accent-rust transition-colors whitespace-nowrap hidden sm:inline-flex"
               >
                 {t.spanishViewAll} &rarr;
@@ -52,7 +57,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
             </p>
             <BookSlider books={spanishBooks as unknown as MiniBook[]} lang={lang} />
             <div className="mt-6 sm:hidden">
-              <Link href={`${lang === 'es' ? '/es' : ''}/collections/${SPANISH_COLLECTION_SLUG}`} className="text-sm text-accent-rust hover:underline">
+              <Link href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)} className="text-sm text-accent-rust hover:underline">
                 {t.spanishViewAll} &rarr;
               </Link>
             </div>
@@ -105,7 +110,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                       {featuredPodcast.sources.map((s) => (
                         <li key={s.bookId}>
                           <Link
-                            href={`/book/${s.slug || s.bookId}`}
+                            href={lp(`/book/${s.slug || s.bookId}`)}
                             className="text-[15px] hover:underline"
                             style={{ color: '#e8e2d8' }}
                           >
@@ -177,7 +182,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
             {collections.slice(0, 11).map((col, i) => (
               <Link
                 key={col.slug}
-                href={`/collections/${col.slug}`}
+                href={lp(`/collections/${col.slug}`)}
                 className="group relative rounded-xl overflow-hidden aspect-square hover:shadow-lg transition-all hover:-translate-y-0.5"
               >
                 {col.hero_image ? (
@@ -206,7 +211,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
             ))}
             {collections.length > 11 && (
               <Link
-                href="/collections"
+                href={lp('/collections')}
                 className="group relative rounded-xl overflow-hidden aspect-square bg-[#2a2520] flex items-center justify-center hover:shadow-lg transition-all hover:-translate-y-0.5"
               >
                 <div className="text-center px-4">
@@ -229,7 +234,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
               <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
             </Link>
             <Link
-              href="/collections"
+              href={lp('/collections')}
               className="text-sm text-muted hover:text-accent-rust transition-colors"
             >
               {t.allCollections} &rarr;
@@ -280,6 +285,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
         <EditorialSpread
           collection={featuredItems[0].collection}
           books={featuredItems[0].books}
+          lang={lang}
         />
       )}
 
@@ -394,14 +400,14 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
                 <Link
-                  href="/support"
+                  href={lp('/support')}
                   className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-full text-sm font-medium transition-all hover:brightness-110"
                   style={{ background: 'var(--accent-rust)', color: '#fff' }}
                 >
                   {t.howToSupport}
                 </Link>
                 <Link
-                  href="/auth/signin"
+                  href={lp('/auth/signin')}
                   className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-full text-sm font-medium transition-all hover:brightness-110"
                   style={{ background: 'rgba(255,255,255,0.08)', color: '#a09a90' }}
                 >

--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -11,7 +11,7 @@ import { clearConsent } from '@/lib/consent';
 import { trackEvent } from '@/lib/track-event';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import { visibleFooterNavColumns } from '@/lib/footer-nav';
-import { useLocale, FOOTER_STRINGS } from '@/lib/i18n';
+import { useLocale, useLocalePath, FOOTER_STRINGS } from '@/lib/i18n';
 
 type Partner = {
   name: string;
@@ -33,6 +33,10 @@ const PARTNERS: Partner[] = [
 export default function GlobalFooter() {
   const pathname = usePathname();
   const t = FOOTER_STRINGS[useLocale()];
+  // Footer labels were localized before the pages were; now that `/collections`,
+  // `/support` and `/auth/signin` have twins, the LINKS follow too. localePath
+  // is registry-guarded, so everything else still points at its English page.
+  const localePath = useLocalePath();
   const [hasFavorites, setHasFavorites] = useState(false);
   // Global-only surfaces 404 on partner subdomains (the list and its rationale
   // live in src/lib/tenant-global-paths.ts — #3364, #3370). SiteHeader has
@@ -104,7 +108,7 @@ export default function GlobalFooter() {
                   <li key={link.href}>
                     {link.key === 'support' ? (
                       <Link
-                        href={link.href}
+                        href={localePath(link.href)}
                         // Instrumented alongside the header pill so the two paths
                         // are comparable. Before the pill existed this footer link
                         // was the ONLY route to giving, and it drew 60 of 330,698
@@ -128,7 +132,7 @@ export default function GlobalFooter() {
                       </button>
                     ) : (
                       <Link
-                        href={link.href}
+                        href={localePath(link.href)}
                         className="text-sm text-white/50 hover:text-white transition-colors"
                       >
                         {t[link.key]}

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useLocalePath } from '@/lib/i18n';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
 import { isInAppBrowser } from '@/lib/in-app-browser';
@@ -20,6 +21,8 @@ import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
  * librarian invitation lives in its own section below (AskTheSourceBand).
  */
 function HeroSignUp({ t }: { t: HomeStrings }) {
+  // The sign-in page has a Spanish twin; keep the visitor on their locale.
+  const localePath = useLocalePath();
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -130,7 +133,7 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
         </button>
         <span className="text-white/30">|</span>
         <Link
-          href="/auth/signin"
+          href={localePath('/auth/signin')}
           className="text-sm text-white/60 hover:text-white/90 transition-colors"
         >
           {t.haveAccount}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -42,6 +42,9 @@ import PageMetadataPanel from '@/components/reader/PageMetadataPanel';
 import HighlightedText from '@/components/search/HighlightedText';
 import HighlightSelection from '@/components/annotations/HighlightSelection';
 import ChapterDropdown from '@/components/reader/ChapterDropdown';
+import { useLocale, useLocalePath } from '@/lib/i18n';
+import { READER_STRINGS } from '@/lib/book-i18n';
+import { localizedTitle } from '@/lib/localized';
 import ShareButton from '@/components/ui/ShareButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
@@ -73,6 +76,7 @@ function hasNonLatinScript(language?: string): boolean {
 
 // Inline book search bar for the page reader footer
 function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?: string }) {
+  const rs = READER_STRINGS[useLocale()];
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Array<{ pageId: string; pageNumber: number; matches: Array<{ field: string; snippet: string }> }>>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -128,13 +132,13 @@ function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?
               window.location.href = `${tenantPrefix || ''}/book/${bookId}/search?q=${encodeURIComponent(query.trim())}`;
             }
           }}
-          placeholder="Search this book..."
-          aria-label="Search within this book"
+          placeholder={rs.searchThisBook}
+          aria-label={rs.searchWithinBook}
           className="bg-transparent outline-none text-xs w-full"
           style={{ color: 'var(--text-primary)' }}
         />
         {query && (
-          <button onClick={() => { setQuery(''); setResults([]); setShowResults(false); }} aria-label="Clear search">
+          <button onClick={() => { setQuery(''); setResults([]); setShowResults(false); }} aria-label={rs.clearSearch}>
             <X className="w-3 h-3" style={{ color: 'var(--text-muted)' }} aria-hidden="true" />
           </button>
         )}
@@ -456,8 +460,19 @@ export default function TranslationEditor({
   // so links should use /book/... not /bph/book/...
   const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
   const isOnEmbedRoute = pathname?.startsWith('/embed/');
-  const tenantPrefix = isOnTenantSubdomain ? '' : (params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '');
+  const locale = useLocale();
+  const rs = READER_STRINGS[locale];
+  const isOnLocaleRoute = locale !== 'en';
+  const tenantPrefix = isOnTenantSubdomain
+    ? ''
+    : isOnLocaleRoute
+      ? `/${locale}`
+      : (params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '');
   const bookSlugOrId = book.slug || book.id;
+  // Chapter titles in the reader's language, aligned by index with book.chapters.
+  const localizedChapterTitles = locale === 'en'
+    ? undefined
+    : (book as unknown as { localized?: Record<string, { chapters?: string[] }> }).localized?.[locale]?.chapters;
   const bookMetadata = book as Book & { metadata?: { scriptType?: string } };
   const hasRashiScript = !!bookMetadata.metadata?.scriptType?.toLowerCase().includes('rashi');
   const [ocrText, setOcrText] = useState(page.ocr?.data || '');
@@ -1201,7 +1216,7 @@ export default function TranslationEditor({
               {!isEmbedded && <span className="text-sm shrink-0" style={{ color: 'var(--text-muted)' }} aria-hidden="true">/</span>}
               <a href={`${tenantPrefix}/book/${bookSlugOrId}`} className="min-w-0 hover:opacity-70 transition-opacity">
                 <h1 className="text-sm sm:text-base font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                  {book.display_title || book.title}
+                  {localizedTitle(book, locale)}
                 </h1>
                 {(book.author || book.published) && (
                   <p className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
@@ -1215,6 +1230,7 @@ export default function TranslationEditor({
             {book.chapters && book.chapters.length > 0 && (
               <ChapterDropdown
                 chapters={book.chapters}
+                localizedTitles={localizedChapterTitles}
                 currentChapterIndex={
                   book.chapters.reduce((best, ch, i) =>
                     ch.pageNumber <= page.page_number ? i : best, -1)
@@ -1234,7 +1250,7 @@ export default function TranslationEditor({
                   onClick={(e) => { e.preventDefault(); onNavigate(previousPage.id); }}
                   className="p-1.5 sm:p-2 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
                   style={{ color: 'var(--text-secondary)' }}
-                  aria-label="Previous page"
+                  aria-label={rs.previousPage}
                 >
                   <ChevronLeft className="w-4 h-4" aria-hidden="true" />
                 </a>
@@ -1265,7 +1281,7 @@ export default function TranslationEditor({
                       onKeyDown={(e) => { if (e.key === 'Escape') setIsEditingPage(false); }}
                       className="w-12 text-sm font-medium text-center bg-transparent border-b focus:outline-none"
                       style={{ color: 'var(--text-primary)', borderColor: 'var(--accent-rust)' }}
-                      aria-label={`Jump to page (1 to ${pages.length})`}
+                      aria-label={rs.jumpToPageAria(pages.length)}
                     />
                     <span className="text-sm font-medium" style={{ color: 'var(--text-muted)' }}>/{pages.length}</span>
                   </form>
@@ -1275,8 +1291,8 @@ export default function TranslationEditor({
                     onClick={() => { setPageInputValue(String(currentIndex + 1)); setIsEditingPage(true); }}
                     className="text-sm font-medium rounded px-1 hover:bg-black/5 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none transition-colors"
                     style={{ color: 'var(--text-muted)' }}
-                    aria-label={`Page ${currentIndex + 1} of ${pages.length}. Click to jump to a page`}
-                    title="Jump to page"
+                    aria-label={rs.pageOfAria(currentIndex + 1, pages.length)}
+                    title={rs.jumpToPage}
                   >
                     {currentIndex + 1}/{pages.length}
                   </button>
@@ -1288,7 +1304,7 @@ export default function TranslationEditor({
                   onClick={(e) => { e.preventDefault(); onNavigate(nextPage.id); }}
                   className="p-1.5 sm:p-2 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
                   style={{ color: 'var(--text-secondary)' }}
-                  aria-label="Next page"
+                  aria-label={rs.nextPage}
                 >
                   <ChevronRight className="w-4 h-4" aria-hidden="true" />
                 </a>
@@ -1307,7 +1323,7 @@ export default function TranslationEditor({
           {/* Row 2: Panel toggles ... Mode toggle + Like */}
           <div className="flex items-center justify-between mt-2 sm:mt-3">
             {/* Panel visibility toggles */}
-            <div className={`flex items-center gap-1 p-1 rounded-lg `} role="toolbar" aria-label="Panel visibility">
+            <div className={`flex items-center gap-1 p-1 rounded-lg `} role="toolbar" aria-label={rs.panelVisibility}>
               <button
                 onClick={() => setShowImagePanel(!showImagePanel)}
                 className={`flex items-center justify-center gap-1.5 px-2 sm:px-2.5 py-1.5 rounded-md text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none ${showImagePanel ? 'text-white' : ''}`}
@@ -1315,11 +1331,11 @@ export default function TranslationEditor({
                   background: showImagePanel ? 'var(--accent-rust)' : 'transparent',
                   color: showImagePanel ? '#fff' : 'var(--text-muted)',
                 }}
-                aria-label={`${showImagePanel ? 'Hide' : 'Show'} source image`}
+                aria-label={rs.toggle(showImagePanel, rs.panelSourceImage)}
                 aria-pressed={showImagePanel}
               >
                 <ImageIcon className="w-4 h-4" aria-hidden="true" />
-                <span className="hidden sm:inline">Image</span>
+                <span className="hidden sm:inline">{rs.image}</span>
               </button>
               <button
                 onClick={() => setShowOcrPanel(!showOcrPanel)}
@@ -1328,11 +1344,11 @@ export default function TranslationEditor({
                   background: showOcrPanel ? 'var(--accent-rust)' : 'transparent',
                   color: showOcrPanel ? '#fff' : 'var(--text-muted)',
                 }}
-                aria-label={`${showOcrPanel ? 'Hide' : 'Show'} original text`}
+                aria-label={rs.toggle(showOcrPanel, rs.panelOriginalText)}
                 aria-pressed={showOcrPanel}
               >
                 <FileText className="w-4 h-4" aria-hidden="true" />
-                <span className="hidden sm:inline">OCR</span>
+                <span className="hidden sm:inline">{rs.ocr}</span>
               </button>
               {hasTransliteration && (
                 <button
@@ -1342,11 +1358,11 @@ export default function TranslationEditor({
                     background: showTransliterationPanel ? 'var(--accent-rust)' : 'transparent',
                     color: showTransliterationPanel ? '#fff' : 'var(--text-muted)',
                   }}
-                  aria-label={`${showTransliterationPanel ? 'Hide' : 'Show'} romanized text`}
+                  aria-label={rs.toggle(showTransliterationPanel, rs.panelRomanized)}
                   aria-pressed={showTransliterationPanel}
                 >
                   <Type className="w-4 h-4" aria-hidden="true" />
-                  <span className="hidden sm:inline">Romanized</span>
+                  <span className="hidden sm:inline">{rs.romanized}</span>
                 </button>
               )}
               {hasGermanSource && (
@@ -1357,11 +1373,11 @@ export default function TranslationEditor({
                     background: showGermanSourcePanel ? 'var(--accent-rust)' : 'transparent',
                     color: showGermanSourcePanel ? '#fff' : 'var(--text-muted)',
                   }}
-                  aria-label={`${showGermanSourcePanel ? 'Hide' : 'Show'} German scholarly translation`}
+                  aria-label={rs.toggle(showGermanSourcePanel, rs.panelGerman)}
                   aria-pressed={showGermanSourcePanel}
                 >
                   <BookOpen className="w-4 h-4" aria-hidden="true" />
-                  <span className="hidden sm:inline">Deutsch</span>
+                  <span className="hidden sm:inline">{rs.german}</span>
                 </button>
               )}
               {!englishOcrIsReadingView && (
@@ -1372,7 +1388,7 @@ export default function TranslationEditor({
                     background: showTranslationPanel ? 'var(--accent-rust)' : 'transparent',
                     color: showTranslationPanel ? '#fff' : 'var(--text-muted)',
                   }}
-                  aria-label={`${showTranslationPanel ? 'Hide' : 'Show'} translation`}
+                  aria-label={rs.toggle(showTranslationPanel, rs.panelTranslation)}
                   aria-pressed={showTranslationPanel}
                 >
                   <Languages className="w-4 h-4" aria-hidden="true" />
@@ -1390,21 +1406,21 @@ export default function TranslationEditor({
                     onClick={() => setShowFontControls(prev => !prev)}
                     className={`flex items-center gap-0.5 p-1.5 rounded-md text-xs font-medium transition-all hover:bg-stone-100 ${showFontControls ? 'bg-stone-200' : ''}`}
                     style={{ color: showFontControls ? 'var(--text-primary)' : 'var(--text-muted)' }}
-                    aria-label="Reading settings"
-                    title="Reading settings"
+                    aria-label={rs.readingSettings}
+                    title={rs.readingSettings}
                   >
                     <span className="text-xs">A</span><span className="text-base font-semibold leading-none">A</span>
                   </button>
                   {showFontControls && (
                     <div className="absolute right-0 top-full mt-2 z-50 bg-white rounded-xl shadow-lg border p-4" style={{ borderColor: 'var(--border-light)', minWidth: '220px' }}>
-                      <div className="text-[10px] uppercase tracking-widest text-center mb-3" style={{ color: 'var(--text-muted)' }}>Font Size</div>
+                      <div className="text-[10px] uppercase tracking-widest text-center mb-3" style={{ color: 'var(--text-muted)' }}>{rs.fontSize}</div>
                       <div className="flex items-center justify-between gap-4">
                         <button
                           onClick={decreaseFontSize}
                           disabled={isMinSize}
                           className="w-10 h-10 flex items-center justify-center rounded-lg text-base transition-colors bg-stone-100 hover:bg-stone-200 active:bg-stone-300 disabled:opacity-25 disabled:hover:bg-stone-100 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
                           style={{ color: 'var(--text-primary)' }}
-                          title="Smaller (Cmd+-)"
+                          title={rs.smaller}
                         >
                           A
                         </button>
@@ -1413,7 +1429,7 @@ export default function TranslationEditor({
                           disabled={isDefaultSize}
                           className={`text-base tabular-nums font-semibold transition-colors ${isDefaultSize ? '' : 'hover:text-accent-rust cursor-pointer'}`}
                           style={{ color: 'var(--text-primary)' }}
-                          title="Reset to default (Cmd+0)"
+                          title={rs.resetSize}
                         >
                           {fontSize}
                         </button>
@@ -1422,17 +1438,17 @@ export default function TranslationEditor({
                           disabled={isMaxSize}
                           className="w-10 h-10 flex items-center justify-center rounded-lg text-xl font-semibold transition-colors bg-stone-100 hover:bg-stone-200 active:bg-stone-300 disabled:opacity-25 disabled:hover:bg-stone-100 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
                           style={{ color: 'var(--text-primary)' }}
-                          title="Larger (Cmd+=)"
+                          title={rs.larger}
                         >
                           A
                         </button>
                       </div>
-                      <div className="text-[10px] uppercase tracking-widest text-center mt-4 mb-3" style={{ color: 'var(--text-muted)' }}>Theme</div>
+                      <div className="text-[10px] uppercase tracking-widest text-center mt-4 mb-3" style={{ color: 'var(--text-muted)' }}>{rs.theme}</div>
                       <div className="flex items-center justify-between gap-2">
                         {([
-                          ['paper', 'Paper', '#fdfcf9', '#1a1612'],
-                          ['sepia', 'Sepia', '#f6eeda', '#1a1612'],
-                          ['night', 'Night', '#1a1612', '#ece7df'],
+                          ['paper', rs.themePaper, '#fdfcf9', '#1a1612'],
+                          ['sepia', rs.themeSepia, '#f6eeda', '#1a1612'],
+                          ['night', rs.themeNight, '#1a1612', '#ece7df'],
                         ] as [ReaderTheme, string, string, string][]).map(([key, label, bg, fg]) => (
                           <button
                             key={key}
@@ -1612,7 +1628,7 @@ export default function TranslationEditor({
                 <div data-reader-section="image" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1 relative`} style={{ background: 'var(--bg-warm)', borderRight: '1px solid var(--border-light)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                      {!pageDisplayUrl && hasWitnessPhotos ? 'Tablet Photo' : 'Source Image'}
+                      {!pageDisplayUrl && hasWitnessPhotos ? rs.tabletPhoto : rs.sourceImage}
                     </span>
                     {!pageDisplayUrl && hasWitnessPhotos && currentWitness && (
                       <a
@@ -1640,7 +1656,7 @@ export default function TranslationEditor({
                         />
                       ) : (
                         <div className="w-full h-48 flex items-center justify-center" style={{ color: 'var(--text-muted)' }}>
-                          No image available
+                          {rs.noImage}
                         </div>
                       )}
                       {page.deepzoom && (
@@ -1663,7 +1679,7 @@ export default function TranslationEditor({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="hover:underline"
-                                  title={`View at ${book.image_source.provider_name}`}
+                                  title={rs.viewAt(book.image_source.provider_name)}
                                   onClick={(e) => e.stopPropagation()}
                                 >
                                   {book.image_source.provider_name}
@@ -1680,13 +1696,13 @@ export default function TranslationEditor({
                             download={`${book.slug || book.id}-page-${page.page_number}.jpg`}
                             className="inline-flex items-center gap-1 hover:underline"
                             style={{ color: 'var(--text-muted)' }}
-                            title="Download full resolution"
+                            title={rs.downloadFullRes}
                             onClick={(e) => e.stopPropagation()}
                           >
                             <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                               <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                             </svg>
-                            Download
+                            {rs.download}
                           </a>
                         )}
                       </div>
@@ -1734,7 +1750,7 @@ export default function TranslationEditor({
                       href={pageHref(previousPage)}
                       onClick={(e) => { e.preventDefault(); onNavigate(previousPage.id); }}
                       className="absolute left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/30 hover:bg-black/50 text-white/80 hover:text-white transition-all backdrop-blur-sm"
-                      aria-label="Previous page"
+                      aria-label={rs.previousPage}
                     >
                       <ChevronLeft className="w-5 h-5" />
                     </a>
@@ -1744,7 +1760,7 @@ export default function TranslationEditor({
                       href={pageHref(nextPage)}
                       onClick={(e) => { e.preventDefault(); onNavigate(nextPage.id); }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/30 hover:bg-black/50 text-white/80 hover:text-white transition-all backdrop-blur-sm"
-                      aria-label="Next page"
+                      aria-label={rs.nextPage}
                     >
                       <ChevronRight className="w-5 h-5" />
                     </a>
@@ -2026,10 +2042,10 @@ export default function TranslationEditor({
                             ? 'bg-accent-gold/15 text-accent-gold-dark hover:bg-accent-gold/25'
                             : 'bg-stone-100 text-stone-400 hover:bg-stone-200'
                             }`}
-                          title={showNotes ? "Hide notes and metadata" : "Show notes and metadata"}
+                          title={showNotes ? rs.hideNotes : rs.showNotes}
                         >
                           <MessageSquare className="w-3 h-3" />
-                          {showNotes ? 'Notes' : 'Notes Off'}
+                          {showNotes ? rs.notes : rs.notesOff}
                         </button>
                         <button
                           onClick={(e) => {
@@ -2038,10 +2054,10 @@ export default function TranslationEditor({
                           }}
                           className="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors bg-stone-100 hover:bg-stone-200"
                           style={{ color: 'var(--text-muted)' }}
-                          title="View page metadata (models, timestamps, etc.)"
+                          title={rs.viewPageMetadata}
                         >
                           <FileText className="w-3 h-3" />
-                          Info
+                          {rs.info}
                         </button>
                         <button
                           onClick={() => copyToClipboard(modernizedMode && modernizedText ? modernizedText : translationText)}
@@ -2049,7 +2065,7 @@ export default function TranslationEditor({
                           style={{ color: 'var(--text-muted)' }}
                         >
                           {copiedTranslation ? <Check className="w-3 h-3" style={{ color: 'var(--accent-sage)' }} /> : <Copy className="w-3 h-3" />}
-                          {copiedTranslation ? 'Copied' : 'Copy'}
+                          {copiedTranslation ? rs.copied : rs.copy}
                         </button>
                       </div>
                     )}
@@ -2256,7 +2272,7 @@ export default function TranslationEditor({
               {/* Empty state when no panels visible */}
               {visibleCount === 0 && (
                 <div className="flex-1 flex items-center justify-center" style={{ background: 'var(--bg-cream)' }}>
-                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>Select a panel to view</p>
+                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>{rs.selectAPanel}</p>
                 </div>
               )}
             </div>
@@ -2273,13 +2289,13 @@ export default function TranslationEditor({
               bookId={book.id}
               size="sm"
               showCount={true}
-              label="Like this page"
+              label={rs.likeThisPage}
             />
           </div>
           {showNavHint && (
             <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">
-              <span className="hidden lg:inline">Use ← → arrow keys to navigate</span>
-              <span className="lg:hidden">Swipe left/right to navigate</span>
+              <span className="hidden lg:inline">{rs.arrowKeysHint}</span>
+              <span className="lg:hidden">{rs.swipeHint}</span>
             </div>
           )}
           <div className="px-4 py-1.5" style={{ borderTop: '1px solid var(--border-light)' }}>
@@ -2491,7 +2507,7 @@ export default function TranslationEditor({
           <div className="w-full min-h-[50vh] lg:min-h-0 lg:flex-1 flex flex-col shrink-0 lg:shrink relative" style={{ background: 'var(--bg-cream)', borderRight: '1px solid var(--border-light)' }}>
             <div className="px-3 sm:px-4 py-2 sm:py-3 flex items-center justify-between" style={{ borderBottom: '1px solid var(--border-light)' }}>
               <div className="flex items-center gap-2">
-                <span className="label">Source</span>
+                <span className="label">{rs.source}</span>
                 <span className="px-2 py-0.5 rounded text-xs font-medium" style={{ background: 'rgba(124, 93, 181, 0.1)', color: 'var(--accent-violet)' }}>
                   {book.language || 'Latin'}
                 </span>
@@ -2500,10 +2516,10 @@ export default function TranslationEditor({
                 onClick={() => setShowPageMetadata(true)}
                 className="flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors hover:bg-stone-200"
                 style={{ color: 'var(--text-muted)' }}
-                title="View page metadata"
+                title={rs.viewPageMetadata}
               >
                 <Info className="w-3.5 h-3.5" />
-                <span className="hidden sm:inline">Info</span>
+                <span className="hidden sm:inline">{rs.info}</span>
               </button>
             </div>
             <div className="flex-1 overflow-auto p-4" data-reader-panel>

--- a/src/components/prototype/EditorialSpread.tsx
+++ b/src/components/prototype/EditorialSpread.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, ArrowRight } from 'lucide-react';
 import { bookUrl } from '@/lib/slugify';
+import { localePath, type Locale } from '@/lib/locale-path';
 import { getBookThumbnailUrl } from '@/lib/utils';
 
 interface FeaturedBook {
@@ -25,6 +26,8 @@ interface EditorialSpreadProps {
     hero_image: string | null;
   };
   books: FeaturedBook[];
+  /** Locale of the page mounting this — its links keep the URL prefix. */
+  lang?: Locale;
 }
 
 function bookTitle(book: { display_title?: string; title: string }): string {
@@ -32,7 +35,8 @@ function bookTitle(book: { display_title?: string; title: string }): string {
   return dt && dt !== 'None' ? dt : book.title;
 }
 
-export default function EditorialSpread({ collection, books }: EditorialSpreadProps) {
+export default function EditorialSpread({ collection, books, lang = 'en' }: EditorialSpreadProps) {
+  const lp = (href: string) => localePath(href, lang);
   return (
     <section className="relative overflow-hidden">
       {/* Background image */}
@@ -71,7 +75,7 @@ export default function EditorialSpread({ collection, books }: EditorialSpreadPr
             </p>
           )}
           <Link
-            href={`/collections/${collection.slug}`}
+            href={lp(`/collections/${collection.slug}`)}
             className="inline-flex items-center gap-2 bg-accent-gold/90 hover:bg-accent-gold text-white px-6 py-3 rounded-lg text-sm font-medium transition-colors"
           >
             Explore {collection.book_count} books
@@ -91,7 +95,7 @@ export default function EditorialSpread({ collection, books }: EditorialSpreadPr
                 // for the 120px slot — a 150px source upscales and looks soft.
                 const thumb = getBookThumbnailUrl(book, 'display') || book.thumbnail_blob || book.thumbnail;
                 return (
-                  <Link key={book.id} href={bookUrl(book)} className="group flex-shrink-0">
+                  <Link key={book.id} href={lp(bookUrl(book))} className="group flex-shrink-0">
                     <div className="w-[100px] md:w-[120px] aspect-[3/4] relative rounded-lg overflow-hidden bg-white/5 border border-white/10 group-hover:border-accent-gold/50 transition-all">
                       {thumb ? (
                         <Image

--- a/src/components/reader/ChapterDropdown.tsx
+++ b/src/components/reader/ChapterDropdown.tsx
@@ -3,19 +3,26 @@
 import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, X, List } from 'lucide-react';
 import type { Chapter } from '@/lib/types';
+import { useLocale } from '@/lib/i18n';
+import { READER_STRINGS } from '@/lib/book-i18n';
 
 interface ChapterDropdownProps {
   chapters: Chapter[];
   currentChapterIndex: number;
   onChapterSelect: (chapter: Chapter) => void;
+  /** Chapter titles in the reader's language, aligned by index with `chapters`
+   *  (books.localized.<lang>.chapters). Absent for English and for books that
+   *  have no translation of their contents yet. */
+  localizedTitles?: string[];
 }
 
-// Display title: prefer English, fall back to original
-function displayTitle(chapter: Chapter): string {
-  return chapter.titleEn || chapter.title;
+// Display title: the reader's language, else English, else the original.
+function displayTitle(chapter: Chapter, localized?: string): string {
+  return localized || chapter.titleEn || chapter.title;
 }
 
-export default function ChapterDropdown({ chapters, currentChapterIndex, onChapterSelect }: ChapterDropdownProps) {
+export default function ChapterDropdown({ chapters, currentChapterIndex, onChapterSelect, localizedTitles }: ChapterDropdownProps) {
+  const rs = READER_STRINGS[useLocale()];
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -65,8 +72,9 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
   // Detect mobile via media query
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
 
-  // Whether any chapter has an English translation
-  const hasEnglishTitles = chapters.some(ch => ch.titleEn);
+  // Is the title we show a GLOSS (translated), so the original belongs under it?
+  const isGloss = (chapter: Chapter, i: number) =>
+    displayTitle(chapter, localizedTitles?.[i]) !== chapter.title;
 
   return (
     <>
@@ -78,14 +86,14 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
         style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
-        aria-label={currentChapter ? `Chapter: ${displayTitle(currentChapter)}` : 'Table of contents'}
+        aria-label={currentChapter ? rs.chapterAria(displayTitle(currentChapter, localizedTitles?.[currentChapterIndex])) : rs.tableOfContents}
       >
         <List className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
         <span className="truncate hidden sm:inline">
-          {currentChapter ? displayTitle(currentChapter) : 'Contents'}
+          {currentChapter ? displayTitle(currentChapter, localizedTitles?.[currentChapterIndex]) : rs.contents}
         </span>
         <span className="sm:hidden">
-          {currentChapter ? `Ch. ${currentChapterIndex + 1}` : 'ToC'}
+          {currentChapter ? rs.chapterShort(currentChapterIndex + 1) : rs.toc}
         </span>
         <ChevronDown className={`w-3 h-3 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>
@@ -97,15 +105,15 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
           className="absolute top-full right-0 mt-1 z-50 w-[34rem] max-h-[60vh] overflow-y-auto rounded-lg shadow-xl"
           style={{ background: 'var(--bg-white, #fff)', border: '1px solid var(--border-light)' }}
           role="listbox"
-          aria-label="Table of contents"
+          aria-label={rs.tableOfContents}
         >
           <div className="sticky top-0 px-3 py-2 border-b" style={{ background: 'var(--bg-white, #fff)', borderColor: 'var(--border-light)' }}>
             <div className="flex items-center justify-between">
               <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-                Contents
+                {rs.contents}
               </span>
               <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
-                {chapters.length} chapters
+                {rs.chapterCount(chapters.length)}
               </span>
             </div>
           </div>
@@ -123,20 +131,20 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
               }}
               role="option"
               aria-selected={i === currentChapterIndex}
-              title={hasEnglishTitles && chapter.titleEn ? chapter.title : undefined}
+              title={isGloss(chapter, i) ? chapter.title : undefined}
             >
               <span className="min-w-0">
                 <span className="block truncate" style={{ fontSize: chapter.level === 1 ? '0.9375rem' : '0.875rem' }}>
-                  {displayTitle(chapter)}
+                  {displayTitle(chapter, localizedTitles?.[i])}
                 </span>
-                {hasEnglishTitles && chapter.titleEn && (
+                {isGloss(chapter, i) && (
                   <span className="block truncate text-xs italic" style={{ color: 'var(--text-muted)', marginTop: '2px' }}>
                     {chapter.title}
                   </span>
                 )}
               </span>
               <span className="text-xs shrink-0 tabular-nums" style={{ color: 'var(--text-muted)' }}>
-                p.{'\u00A0'}{chapter.pageNumber}
+                {rs.pageAbbrev(chapter.pageNumber)}
               </span>
             </button>
           ))}
@@ -158,7 +166,7 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
             className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl shadow-2xl"
             style={{ background: 'var(--bg-white, #fff)', maxHeight: '70vh' }}
             role="listbox"
-            aria-label="Table of contents"
+            aria-label={rs.tableOfContents}
           >
             {/* Drag handle */}
             <div className="flex justify-center pt-3 pb-1">
@@ -167,13 +175,13 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
             {/* Header */}
             <div className="flex items-center justify-between px-4 py-2 border-b" style={{ borderColor: 'var(--border-light)' }}>
               <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-                Contents
+                {rs.contents}
               </span>
               <button
                 onClick={() => setIsOpen(false)}
                 className="p-1 rounded-md"
                 style={{ color: 'var(--text-muted)' }}
-                aria-label="Close"
+                aria-label={rs.close}
               >
                 <X className="w-4 h-4" />
               </button>
@@ -199,16 +207,16 @@ export default function ChapterDropdown({ chapters, currentChapterIndex, onChapt
                 >
                   <span className="min-w-0">
                     <span className="block truncate" style={{ fontSize: chapter.level === 1 ? '0.9375rem' : '0.875rem' }}>
-                      {displayTitle(chapter)}
+                      {displayTitle(chapter, localizedTitles?.[i])}
                     </span>
-                    {hasEnglishTitles && chapter.titleEn && (
+                    {isGloss(chapter, i) && (
                       <span className="block truncate text-xs italic" style={{ color: 'var(--text-muted)', marginTop: '2px' }}>
                         {chapter.title}
                       </span>
                     )}
                   </span>
                   <span className="text-xs shrink-0 tabular-nums" style={{ color: 'var(--text-muted)' }}>
-                    p.{'\u00A0'}{chapter.pageNumber}
+                    {rs.pageAbbrev(chapter.pageNumber)}
                   </span>
                 </button>
               ))}

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -274,14 +274,270 @@ export const BOOK_STRINGS: Record<Locale, BookStrings> = {
 };
 
 /**
- * Not localized yet (stays English under `/es`, deliberately — #4082 phase 2):
+ * Reader chrome (`/es/book/<id>/page/<pageId>`, #4082 phase 2b).
+ *
+ * Kept separate from BOOK_STRINGS because it is a different screen with a
+ * different job — the words around a page of text, not the words around a
+ * record. The reader is a CLIENT component, so it reads its locale from the
+ * pathname (`useLocale()`) rather than taking a prop.
+ *
+ * EDITOR tooling (Run OCR, Edit Prompt, Translate, the settings dialogs, the
+ * edit-mode panes) is deliberately NOT here: it is staff-only, English is its
+ * working language, and translating it would imply a Spanish editing workflow
+ * we do not offer.
+ */
+export interface ReaderStrings {
+  // page navigation
+  previousPage: string;
+  nextPage: string;
+  jumpToPage: string;
+  jumpToPageAria: (total: number) => string;
+  pageOfAria: (n: number, total: number) => string;
+  arrowKeysHint: string;
+  swipeHint: string;
+  // panel toggles
+  panelVisibility: string;
+  image: string;
+  ocr: string;
+  romanized: string;
+  german: string;
+  toggle: (shown: boolean, what: string) => string;
+  panelSourceImage: string;
+  panelOriginalText: string;
+  panelRomanized: string;
+  panelGerman: string;
+  panelTranslation: string;
+  selectAPanel: string;
+  // source-image panel
+  sourceImage: string;
+  tabletPhoto: string;
+  source: string;
+  noImage: string;
+  download: string;
+  downloadFullRes: string;
+  viewAt: (provider: string) => string;
+  // translation panel toolbar
+  notes: string;
+  notesOff: string;
+  hideNotes: string;
+  showNotes: string;
+  info: string;
+  viewPageMetadata: string;
+  copy: string;
+  copied: string;
+  // reading settings
+  readingSettings: string;
+  fontSize: string;
+  smaller: string;
+  resetSize: string;
+  larger: string;
+  theme: string;
+  themePaper: string;
+  themeSepia: string;
+  themeNight: string;
+  // footer + search
+  likeThisPage: string;
+  searchThisBook: string;
+  searchWithinBook: string;
+  clearSearch: string;
+  translationIssue: string;
+  feedbackThanks: string;
+  feedbackWhat: string;
+  feedbackPlaceholder: string;
+  cancel: string;
+  send: string;
+  sending: string;
+  // chapters
+  contents: string;
+  tableOfContents: string;
+  chapterCount: (n: number) => string;
+  chapterAria: (title: string) => string;
+  chapterShort: (n: number) => string;
+  toc: string;
+  close: string;
+  pageAbbrev: (n: number) => string;
+  // reading language
+  readIn: string;
+  readingLanguage: string;
+  pageNavigation: string;
+  metaPageOf: (n: number, title: string) => string;
+  metaTitle: (title: string, n: number) => string;
+  prevPageLink: (n: number) => string;
+  nextPageLink: (n: number) => string;
+  allPagesLink: (n: number) => string;
+}
+
+export const READER_STRINGS: Record<Locale, ReaderStrings> = {
+  en: {
+    previousPage: 'Previous page',
+    nextPage: 'Next page',
+    jumpToPage: 'Jump to page',
+    jumpToPageAria: (total) => `Jump to page (1 to ${total})`,
+    pageOfAria: (n, total) => `Page ${n} of ${total}. Click to jump to a page`,
+    arrowKeysHint: 'Use \u2190 \u2192 arrow keys to navigate',
+    swipeHint: 'Swipe left/right to navigate',
+
+    panelVisibility: 'Panel visibility',
+    image: 'Image',
+    ocr: 'OCR',
+    romanized: 'Romanized',
+    german: 'Deutsch',
+    toggle: (shown, what) => `${shown ? 'Hide' : 'Show'} ${what}`,
+    panelSourceImage: 'source image',
+    panelOriginalText: 'original text',
+    panelRomanized: 'romanized text',
+    panelGerman: 'German scholarly translation',
+    panelTranslation: 'translation',
+    selectAPanel: 'Select a panel to view',
+
+    sourceImage: 'Source Image',
+    tabletPhoto: 'Tablet Photo',
+    source: 'Source',
+    noImage: 'No image available',
+    download: 'Download',
+    downloadFullRes: 'Download full resolution',
+    viewAt: (provider) => `View at ${provider}`,
+
+    notes: 'Notes',
+    notesOff: 'Notes Off',
+    hideNotes: 'Hide notes and metadata',
+    showNotes: 'Show notes and metadata',
+    info: 'Info',
+    viewPageMetadata: 'View page metadata',
+    copy: 'Copy',
+    copied: 'Copied',
+
+    readingSettings: 'Reading settings',
+    fontSize: 'Font Size',
+    smaller: 'Smaller (Cmd+-)',
+    resetSize: 'Reset to default (Cmd+0)',
+    larger: 'Larger (Cmd+=)',
+    theme: 'Theme',
+    themePaper: 'Paper',
+    themeSepia: 'Sepia',
+    themeNight: 'Night',
+
+    likeThisPage: 'Like this page',
+    searchThisBook: 'Search this book...',
+    searchWithinBook: 'Search within this book',
+    clearSearch: 'Clear search',
+    translationIssue: 'Notice a translation issue? Let us know.',
+    feedbackThanks: 'Thank you — your feedback helps improve this translation.',
+    feedbackWhat: 'What did you notice?',
+    feedbackPlaceholder: 'Wrong word, awkward phrasing, missing context...',
+    cancel: 'Cancel',
+    send: 'Send',
+    sending: 'Sending...',
+
+    contents: 'Contents',
+    tableOfContents: 'Table of contents',
+    chapterCount: (n) => `${n} chapters`,
+    chapterAria: (title) => `Chapter: ${title}`,
+    chapterShort: (n) => `Ch. ${n}`,
+    toc: 'ToC',
+    close: 'Close',
+    pageAbbrev: (n) => `p.\u00A0${n}`,
+
+    readIn: 'Read in:',
+    readingLanguage: 'Reading language',
+    pageNavigation: 'Page navigation',
+    metaPageOf: (n, title) => `Page ${n} of "${title}"`,
+    metaTitle: (title, n) => `${title} - Page ${n}`,
+    prevPageLink: (n) => `\u2190 Page ${n}`,
+    nextPageLink: (n) => `Page ${n} \u2192`,
+    allPagesLink: (n) => `All ${n} pages`,
+  },
+  es: {
+    previousPage: 'Página anterior',
+    nextPage: 'Página siguiente',
+    jumpToPage: 'Ir a una página',
+    jumpToPageAria: (total) => `Ir a una página (1 a ${total})`,
+    pageOfAria: (n, total) => `Página ${n} de ${total}. Pulsa para ir a otra página`,
+    arrowKeysHint: 'Usa las flechas \u2190 \u2192 para pasar de página',
+    swipeHint: 'Desliza a izquierda o derecha para pasar de página',
+
+    panelVisibility: 'Paneles visibles',
+    image: 'Imagen',
+    ocr: 'OCR',
+    romanized: 'Romanizado',
+    german: 'Alemán',
+    toggle: (shown, what) => `${shown ? 'Ocultar' : 'Mostrar'} ${what}`,
+    panelSourceImage: 'la imagen original',
+    panelOriginalText: 'el texto original',
+    panelRomanized: 'el texto romanizado',
+    panelGerman: 'la traducción académica alemana',
+    panelTranslation: 'la traducción',
+    selectAPanel: 'Elige un panel para verlo',
+
+    sourceImage: 'Imagen original',
+    tabletPhoto: 'Foto de la tablilla',
+    source: 'Original',
+    noImage: 'No hay imagen disponible',
+    download: 'Descargar',
+    downloadFullRes: 'Descargar en alta resolución',
+    viewAt: (provider) => `Ver en ${provider}`,
+
+    notes: 'Notas',
+    notesOff: 'Notas ocultas',
+    hideNotes: 'Ocultar notas y metadatos',
+    showNotes: 'Mostrar notas y metadatos',
+    info: 'Info',
+    viewPageMetadata: 'Ver los metadatos de la página',
+    copy: 'Copiar',
+    copied: 'Copiado',
+
+    readingSettings: 'Ajustes de lectura',
+    fontSize: 'Tamaño de letra',
+    smaller: 'Más pequeña (Cmd+-)',
+    resetSize: 'Volver al tamaño normal (Cmd+0)',
+    larger: 'Más grande (Cmd+=)',
+    theme: 'Tema',
+    themePaper: 'Papel',
+    themeSepia: 'Sepia',
+    themeNight: 'Noche',
+
+    likeThisPage: 'Me gusta esta página',
+    searchThisBook: 'Buscar en este libro...',
+    searchWithinBook: 'Buscar dentro de este libro',
+    clearSearch: 'Borrar la búsqueda',
+    translationIssue: '¿Has visto un problema en la traducción? Cuéntanoslo.',
+    feedbackThanks: 'Gracias — tus comentarios ayudan a mejorar esta traducción.',
+    feedbackWhat: '¿Qué has visto?',
+    feedbackPlaceholder: 'Una palabra equivocada, una frase forzada, un contexto que falta...',
+    cancel: 'Cancelar',
+    send: 'Enviar',
+    sending: 'Enviando...',
+
+    contents: 'Contenido',
+    tableOfContents: 'Índice',
+    chapterCount: (n) => `${n} capítulos`,
+    chapterAria: (title) => `Capítulo: ${title}`,
+    chapterShort: (n) => `Cap. ${n}`,
+    toc: 'Índ.',
+    close: 'Cerrar',
+    pageAbbrev: (n) => `pág.\u00A0${n}`,
+
+    readIn: 'Leer en:',
+    readingLanguage: 'Idioma de lectura',
+    pageNavigation: 'Navegación por páginas',
+    metaPageOf: (n, title) => `Página ${n} de «${title}»`,
+    metaTitle: (title, n) => `${title} - Página ${n}`,
+    prevPageLink: (n) => `\u2190 Página ${n}`,
+    nextPageLink: (n) => `Página ${n} \u2192`,
+    allPagesLink: (n) => `Las ${n} páginas`,
+  },
+};
+
+/**
+ * Not localized yet (stays English under `/es`, deliberately — #4082):
  * the bibliographic panel (`BookBiblioPanel`, `TranslationCardPanel`,
  * `RelatedEditions`), the reading guide's own prose, the processing log
  * (`PublicBookHistory`), the citation / download / share menus, the
- * contributing-library section, the sign-up call to action, and the index
- * TERMS themselves (English entity labels). Each is a component with its own
- * strings; thread `lang` (or `useLocale()` for client components) and move its
- * words into the dictionary above when it is done.
+ * contributing-library section, the sign-up call to action, the index TERMS
+ * themselves (English entity labels), and the reader's EDITOR tooling (see
+ * READER_STRINGS below). Each is a component with its own strings; thread
+ * `lang` (or `useLocale()` for client components) and move its words into the
+ * dictionary above when it is done.
  */
 
 /** Spanish names for the `books.language` values a Spanish reader will meet most. */


### PR DESCRIPTION
Phase 2b of #4082, on top of #4102.

## Why

With the book page done, the reader was the last English screen in the Spanish
journey — and it's the one a reader actually spends time on. Spanish page text
framed by *Image / OCR / Read / Edit / Notes / Info / Copy / Like this page /
Search this book…*, a German title in the header, and an English chapter
dropdown for a book whose **Spanish chapter titles we already hold**.

## What changed

- **`READER_STRINGS`** (`src/lib/book-i18n.ts`), en + es: page navigation,
  panel toggles, reading settings, the source-image panel, the translation
  toolbar, the footer, the translation-feedback prompt. Kept separate from
  `BOOK_STRINGS` — different screen, different job.
- `TranslationEditor`, `ChapterDropdown`, `BookSearchBar` and
  `TranslationFeedbackPrompt` read `useLocale()`. Nothing threads a prop: the
  pathname already says which language the page is in.
- **Content**: header title via `localizedTitle`, chapter list via
  `localized.<lang>.chapters`, and the `<title>` / meta description from the
  same map. That meant adding `localized: 1` to **both** reader book
  projections (`BOOK_NAV_PROJECTION` and `page-data.ts`) — leaving it out is
  precisely why the Spanish reader wore a German title over Spanish text.
- `/es/book/[id]/page/[pageId]` becomes a wrapper passing `lang='es'`, so the
  server-rendered crawler nav beneath the reader keeps `/es` and names the book
  in Spanish. Its `/overview` link stays unprefixed — that route has no twin.

## Two defects found on the way, both the shape #4082 exists to fix

- **`tenantPrefix` in `TranslationEditor` is the URL prefix for every link that
  component writes**, and it knew about tenants and embeds but not locales.
  Share links, the page-metadata link and in-book search all silently dropped
  `/es`. `PageEditorClient` had already learned about locales; its sibling
  hadn't. If you add a prefix concept anywhere, check who else composes a URL
  from it.
- **`ChapterDropdown` decided whether to show a chapter's ORIGINAL title
  beneath the shown one by asking whether an ENGLISH gloss existed.** A book
  with Spanish chapter titles and no English ones hid its own originals. It now
  asks whether what it is showing *is* a gloss.

## Deliberately untranslated

Editor tooling: Run OCR, Edit Prompt, Translate, the settings dialogs, all of
edit mode. Staff-only, English is its working language, and translating it
would advertise a Spanish editing workflow we don't offer. Recorded at the head
of `READER_STRINGS` so the next person doesn't "finish" it by accident.

## Verification (local dev against Atlas)

`/es/book/dawn-rising-boehme/page/…`:
- `<title>` **Aurora naciente (1780) - Página 9 - Source Library**, H1 *Aurora
  naciente*, 35 Spanish chapter entries in the dropdown.
- Every checked chrome string Spanish — *Página anterior/siguiente, Ajustes de
  lectura, Imagen original, Notas, Copiar, Me gusta esta página, Buscar en este
  libro, Paneles visibles, Ver los metadatos, ¿Has visto un problema en la
  traducción?* — and **zero** of the 15 English strings I probed for.
- **8 of 9** book links carry `/es`; the ninth is `/overview`.

`/book/dawn-rising-boehme/page/…` (English, unchanged): all 12 checked strings
present, zero Spanish, zero `/es` links.

`npx tsc --noEmit` clean; `npx vitest run tests/unit` 2791 passed.

## Note

`localized: 1` in the reader projections ships the Spanish titles/chapters in
the English reader's RSC payload too (a few KB, and only for the 103 books that
have them). Worth revisiting if the map grows a language; not worth a
conditional projection today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWM6HTvZUpgT3RUMLREQPC

---

## Second commit: the Spanish homepage's own cards linked into English

Measured, not guessed — I walked `/es`, `/es/collections`,
`/es/collections/en-espanol`, `/es/book/…` and the reader, and listed every
link that leaves the Spanish surface. The homepage had **113**, and the ones
that mattered were its own content: 12 collection tiles, 12 book links (the
podcast episode's source list, the featured-collection filmstrip) and the hero
sign-in link. Spanish names, Spanish blurbs, English destinations — a reader
who clicked any card left Spanish on the first click.

Fixed in `HomeView`, `EditorialSpread` (new `lang` prop, server component),
`HeroSection`'s sign-up (client, so `useLocalePath()`) and `GlobalFooter`
(whose labels were already Spanish while its links weren't). The two
hand-rolled `${lang === 'es' ? '/es' : ''}` prefixes in HomeView are now
`localePath`.

**After: zero book and zero collection links leave `/es`.** What still does is
exactly the set with no Spanish route — 49 gallery links (the image masonry),
blog, browse, podcast, about, catalog. Whether those should exist under `/es`
at all is the prefix-everything question, not this PR.

Two commits, two concerns, deliberately shipped together: they are the same
goal (the Spanish journey never drops the reader into English) and splitting
them would leave the reader complete but reachable only by a link that isn't.
