### PR TITLE
feat(i18n): an /es URL means the page IS Spanish — enforce it at the route

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -101,6 +101,38 @@ Mind the TWO top-level returns in `BookInfo` (#3916): the standard layout and
 the embed-only one. Only the standard layout is localized; tenant reading rooms
 keep the proven English/embed layout (tenant-lockdown.md).
 
+## The promise: an `/es` URL means the page IS Spanish
+
+Derek, 2026-08-20: *"if it isn't Spanish, it's not /es."* That is the rule, and
+it is enforced at the ROUTE, not at link sites:
+
+- `/es/book/<slug>` and `/es/book/<slug>/page/<id>` **307 to the English page**
+  unless the book has pages in that language (`hasLocalizedEdition`,
+  `src/lib/localized.ts`). Link sites point straight at `/book/…` for those
+  books to save the hop, but they are an optimization — the rule lives where no
+  card, slider or hand-written href can forget it.
+- **307, never 308.** The condition is temporary by construction: the day a book
+  is translated its `/es` URL must start working, and a 308 would sit poisoned
+  in browser caches.
+- **A title gloss is not an edition.** 103 books have Spanish pages; only those
+  get Spanish URLs. Glossing a title is chrome.
+- The gate for the READER lives in `page/[pageId]/layout.tsx`, not in its
+  `page.tsx`. That segment has a `loading.tsx`, so the page is wrapped in an
+  automatic `<Suspense>` and the 200 shell flushes before the page runs — a
+  `redirect()` down there degrades into a client-side meta-refresh (#4036),
+  which a crawler will index. Measured: the page-level version returned 200
+  with `NEXT_REDIRECT` in the body. Same reason `notFound()` lives up there.
+- `hasLocalizedEdition` returns **`boolean | null`**. `null` means the payload
+  could not answer — the counter is a Mongo field and the Supabase catalog
+  fast-path lacks it. Never read that as false: it would 307 a genuinely
+  Spanish book away. Where the counter WAS explicitly projected, resolve with
+  `?? false` — absence is then an answer. Both halves of this were gotten wrong
+  once each and caught by measurement, not by review.
+
+What this rule buys: the `/es` index contains only pages that are actually in
+Spanish, and a Spanish reader who clicks a book we haven't translated lands on
+an honest English page instead of Spanish chrome wrapped around English text.
+
 ## The reader
 
 Same shape (#4082 phase 2b). `READER_STRINGS` in `src/lib/book-i18n.ts` holds

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { bylineClaimsAuthorship } from '@/lib/corporate-bylines';
 import { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound, permanentRedirect } from 'next/navigation';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
@@ -82,7 +82,7 @@ import { getEffectiveByline } from '@/lib/byline';
 import AuthorName from '@/components/AuthorName';
 import { localePath, type Locale } from '@/lib/locale-path';
 import { BOOK_STRINGS, languageName } from '@/lib/book-i18n';
-import { localizedTitle, originalTitleIfDifferent } from '@/lib/localized';
+import { localizedTitle, originalTitleIfDifferent, hasLocalizedEdition } from '@/lib/localized';
 import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import CatalogueBreadcrumb from '@/components/book/CatalogueBreadcrumb';
@@ -2455,12 +2455,46 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   // partner subdomain's reader out of its embed shell breaks the tenant lockdown.
   // Editor preview routes (previewProposed/allowHidden) are excluded for the same
   // reason: /artwork has no preview twin, so a redirect would 404 the editor.
-  // The proxy canonicalises /book/<id> → /book/<slug>, but its matcher is
-  // English-only (`^/book/([^/]+)$`), so the localized twin does it here. Safe
-  // on a streamed page only because nothing has rendered yet — redirect() is a
-  // no-op after the first flush (#4036).
+  // A localized URL is a PROMISE that the page is in that language. A book with
+  // no Spanish edition has no Spanish page — send the reader to the English one
+  // rather than dressing an English record in a Spanish address and declaring it
+  // to Google as the Spanish version (which is what ~37.7K of these URLs did).
+  //
+  // Enforced HERE, at the route, so no card, slider or hand-written link can
+  // mint one by forgetting. Link sites still point straight at /book/… for
+  // these books, to save the hop — but they are an optimization, not the rule.
+  //
+  // 307, not 308: the condition is temporary by construction. The day the book
+  // is translated its /es URL must start working, and a 308 would sit poisoned
+  // in browser caches. The ISR entry self-heals within its revalidate window.
+  //
+  // `hasLocalizedEdition` returns null when the payload cannot answer — the
+  // counter is a Mongo field and the Supabase catalog fast-path lacks it. Ask
+  // Atlas then, and on a failed lookup do NOTHING: reading absence as "no
+  // Spanish edition" would redirect a genuinely Spanish book away.
   if (lang !== 'en') {
     const canonicalSlug = (earlyBook as { slug?: string }).slug;
+    let hasEdition = hasLocalizedEdition(earlyBook as unknown as Record<string, unknown>, lang);
+    if (hasEdition === null) {
+      const bookId = (earlyBook as { id?: string }).id ?? id;
+      const doc = await getReadDb()
+        .then((db) => db.collection('books').findOne(
+          { id: bookId },
+          { projection: { _id: 0, pages_translated_es: 1 }, maxTimeMS: 3000 },
+        ))
+        .catch(() => null);
+      // A doc we READ with the counter explicitly projected is authoritative:
+      // the field being absent there means the book has no Spanish pages, not
+      // that we could not tell. Only a failed lookup (doc === null) stays
+      // unknown. Getting this backwards makes the gate silently never fire.
+      hasEdition = doc ? (hasLocalizedEdition(doc as unknown as Record<string, unknown>, lang) ?? false) : null;
+    }
+    if (hasEdition === false) redirect(`/book/${canonicalSlug || id}`);
+
+    // The proxy canonicalises /book/<id> → /book/<slug>, but its matcher is
+    // English-only (`^/book/([^/]+)$`), so the localized twin does it here. Safe
+    // on a streamed page only because nothing has rendered yet — redirect() is a
+    // no-op after the first flush (#4036).
     if (canonicalSlug && id !== canonicalSlug) permanentRedirect(`/${lang}/book/${canonicalSlug}`);
   }
 

--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -67,6 +67,9 @@ const BOOK_NAV_PROJECTION = {
   // and the chapter dropdown `localized.<lang>.chapters`. Leaving it out of this
   // projection is why the Spanish reader showed a German title over Spanish text.
   localized: 1,
+  // Gates whether this book may have a localized reader URL at all — see the
+  // redirect below. Always read from Atlas here, so it can never be absent.
+  pages_translated_es: 1,
   author: 1, published: 1, language: 1, doi: 1, chapters: 1,
   cdli_witnesses: 1, etcsl_id: 1, visible: 1,
 };

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getTenantContext } from '@/lib/tenant-context';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 // `cache()`d in its own module: generateMetadata, the shell below, and the
@@ -8,7 +8,7 @@ import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getPageData } from './page-data';
 import { type Locale } from '@/lib/locale-path';
 import { READER_STRINGS } from '@/lib/book-i18n';
-import { localizedTitle } from '@/lib/localized';
+import { localizedTitle, hasLocalizedEdition } from '@/lib/localized';
 
 export const preferredRegion = 'fra1';
 
@@ -90,7 +90,7 @@ export async function generateMetadata({ params, lang = 'en' }: LayoutProps & { 
   };
 }
 
-export default async function PageLayout({ children, params }: LayoutProps) {
+export default async function PageLayout({ children, params, lang = 'en' }: LayoutProps & { lang?: Locale }) {
   // Resolve existence HERE, in the shell, rather than leaving it to page.tsx.
   //
   // This segment has a loading.tsx and deliberately keeps it — the reader is
@@ -116,6 +116,23 @@ export default async function PageLayout({ children, params }: LayoutProps) {
   const ctx = await getTenantContext();
   const { book, page } = await getPageData(id, pageId, ctx?.id ?? undefined);
   if (!book || !page) notFound();
+
+  // A localized URL is a promise the page is in that language, so a book with
+  // no edition in it has no localized reader URL — 307 to the English one.
+  //
+  // This MUST live in the layout, not in page.tsx. The (reader) segment has a
+  // loading.tsx, so the page is wrapped in an automatic <Suspense> and the 200
+  // shell flushes before the page's code runs: a redirect() down there degrades
+  // into a client-side meta-refresh (#4036), which a crawler will happily index.
+  // Measured — the page-level version returned 200 with NEXT_REDIRECT in the
+  // body. The layout sits above that boundary, so this is a real HTTP 307.
+  //
+  // 307, not 308: the day the book is translated the URL must start working.
+  // `?? false` because the projection always asks for the counter, so an absent
+  // field means the book has none rather than "could not tell".
+  if (lang !== 'en' && (hasLocalizedEdition(book as unknown as Record<string, unknown>, lang) ?? false) === false) {
+    redirect(`/book/${(book as unknown as { slug?: string }).slug || id}/page/${pageId}`);
+  }
 
   return children;
 }

--- a/src/app/book/[id]/page/[pageId]/page-data.ts
+++ b/src/app/book/[id]/page/[pageId]/page-data.ts
@@ -18,6 +18,9 @@ export const BOOK_META_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1, localized: 1, author: 1, published: 1, language: 1,
   // `visible` powers the (reader) group's hidden-book gate (isHiddenBook).
   visible: 1,
+  // Gates whether a LOCALIZED reader URL may exist for this book at all — see
+  // the redirect in layout.tsx. Always projected, so its absence is an answer.
+  pages_translated_es: 1,
 };
 export const PAGE_META_PROJECTION = {
   _id: 0, id: 1, book_id: 1, page_number: 1, photo: 1,

--- a/src/app/es/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/es/book/[id]/page/[pageId]/layout.tsx
@@ -29,4 +29,9 @@ export async function generateMetadata(props: LayoutProps): Promise<Metadata> {
   };
 }
 
-export default BaseLayout;
+export default async function EsReaderLayout(props: LayoutProps) {
+  // `lang='es'` is what makes the base layout enforce the localized-URL promise
+  // (a book with no Spanish edition 307s to the English reader) and name the
+  // book in Spanish in the shell's metadata.
+  return BaseLayout({ ...props, lang: 'es' });
+}

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -119,9 +119,11 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   const [useFallback, setUseFallback] = useState(false);
   const embedHref = useEmbedHref();
   const embed = useEmbed();
-  // A card rendered on a localized surface links to that surface's twin —
-  // /es/collections/… → /es/book/… — so the prefix never drops on a click.
-  // localePath is registry-guarded, so /artwork/… (no twin) is untouched.
+  // A card on a localized surface links to that surface's twin — /es/collections/…
+  // → /es/book/… — so the prefix never drops on a click. But only for a book
+  // that HAS an edition in that language: an /es URL is a promise the page is
+  // in Spanish, and a book without one has no Spanish page to point at.
+  // localePath is registry-guarded on top of that, so /artwork/… is untouched.
   const localePath = useLocalePath();
 
   const isArtwork = !!book.resource_type;
@@ -131,8 +133,10 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
   const slug = book.slug || book.id || book.bookId || '';
 
-  const bookHref = localePath(embedHref(`${bookUrlPrefix || ''}/book/${encodeURIComponent(slug)}`));
-  const artworkHref = localePath(embedHref(`${bookUrlPrefix || ''}/artwork/${encodeURIComponent(slug)}`));
+  const hasSpanishEdition = (book.pages_translated_es ?? 0) > 0;
+  const localized = (href: string) => (hasSpanishEdition ? localePath(href) : href);
+  const bookHref = localized(embedHref(`${bookUrlPrefix || ''}/book/${encodeURIComponent(slug)}`));
+  const artworkHref = embedHref(`${bookUrlPrefix || ''}/artwork/${encodeURIComponent(slug)}`);
 
   const ocrPct = pctOf(book.pages_ocr, pageCount);
   const translatedPct = pctOf(book.pages_translated, pageCount);

--- a/src/lib/es-collections.ts
+++ b/src/lib/es-collections.ts
@@ -199,10 +199,13 @@ export async function getEsCollection(slug: string): Promise<EsCollectionDetail 
     const { chapters: _ch, read_count: _rc, ...rest } = b;
     return {
       ...rest,
-      // Every book now has a Spanish page, whether or not it has Spanish TEXT —
-      // one without shows the record in Spanish chrome and the English reader,
-      // which beats dropping the reader out of /es on the click.
-      href: spanishReaderHref(b),
+      // An /es URL is a promise the page is in Spanish, so only a book with a
+      // Spanish EDITION gets one; the rest link straight to their English page.
+      // The route enforces the same rule with a 307, so a link that gets this
+      // wrong is slow, not broken — but it should not be wrong.
+      href: (b.pages_translated_es ?? 0) > 0
+        ? spanishReaderHref(b)
+        : `/book/${encodeURIComponent(b.slug || b.id)}`,
     };
   });
 

--- a/src/lib/localized.ts
+++ b/src/lib/localized.ts
@@ -64,6 +64,42 @@ export function originalTitleIfDifferent(book: BookLike, lang: Locale): string |
   return original && original !== shown ? original : null;
 }
 
+/**
+ * Per-language page-text counters on `books`. Declared in
+ * `scripts/lib/book-docs.mjs`; one field per language, written by
+ * `scripts/maintenance/sync-pages-translated-es.mjs`.
+ */
+const TRANSLATED_COUNTER: Record<Exclude<Locale, 'en'>, string> = {
+  es: 'pages_translated_es',
+};
+
+/**
+ * Does this book actually EXIST in `lang`?
+ *
+ * A localized URL is a promise that the page is in that language, so this is
+ * the gate on whether `/es/book/<slug>` may exist at all — not a display
+ * preference. English is always true (it is the root). For any other language
+ * it means the book's PAGES have been translated: a title gloss alone is
+ * chrome, not an edition.
+ *
+ * Returns `null` when the payload cannot answer — the counter is a Mongo field
+ * and the Supabase catalog fast-path does not carry it. Callers must treat
+ * `null` as "ask, or do nothing", NEVER as false: reading an absent field as
+ * "no Spanish edition" would 307 a genuinely Spanish book to English, which is
+ * the absence-is-not-failure trap this codebase keeps re-learning.
+ */
+export function hasLocalizedEdition(
+  book: Record<string, unknown>,
+  lang: Locale,
+): boolean | null {
+  if (lang === 'en') return true;
+  const field = TRANSLATED_COUNTER[lang];
+  if (!field) return false;
+  const value = book[field];
+  if (value === undefined) return null;
+  return typeof value === 'number' && value > 0;
+}
+
 type CollectionLike = {
   name?: string; subtitle?: string; description?: string;
   localized?: LocalizedCollectionMap | null;

--- a/tests/unit/localized-edition-promise.test.ts
+++ b/tests/unit/localized-edition-promise.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { hasLocalizedEdition } from '@/lib/localized';
+
+/**
+ * The rule: a localized URL is a PROMISE that the page is in that language.
+ * `/es/book/<slug>` exists only for a book with Spanish PAGES; everything else
+ * 307s to the English page. This helper is the gate, and its three-valued
+ * return is the whole point — see the null cases.
+ */
+describe('hasLocalizedEdition', () => {
+  it('is always true for English — the root is the English site', () => {
+    expect(hasLocalizedEdition({}, 'en')).toBe(true);
+    expect(hasLocalizedEdition({ pages_translated_es: 0 }, 'en')).toBe(true);
+  });
+
+  it('is true only when the book has PAGES in that language', () => {
+    expect(hasLocalizedEdition({ pages_translated_es: 445 }, 'es')).toBe(true);
+    expect(hasLocalizedEdition({ pages_translated_es: 1 }, 'es')).toBe(true);
+    expect(hasLocalizedEdition({ pages_translated_es: 0 }, 'es')).toBe(false);
+  });
+
+  it('a title gloss alone is NOT an edition', () => {
+    // 103 books have Spanish text; the gloss is chrome and must not open a URL.
+    const glossOnly = { localized: { es: { title: 'Aurora naciente' } } };
+    expect(hasLocalizedEdition(glossOnly, 'es')).toBe(null);
+  });
+
+  it('returns null — never false — when the payload cannot answer', () => {
+    // The counter is a Mongo field; the Supabase catalog fast-path lacks it.
+    // Reading that absence as "no Spanish edition" would 307 a genuinely
+    // Spanish book to English, and a caller that does `=== false` silently
+    // never fires. Both mistakes were made and caught by measurement.
+    expect(hasLocalizedEdition({ id: 'x', slug: 'y' }, 'es')).toBe(null);
+    expect(hasLocalizedEdition({ id: 'x', slug: 'y' }, 'es')).not.toBe(false);
+  });
+
+  it('a projected-but-absent field is an ANSWER at the call site', () => {
+    // Call sites that projected the counter explicitly resolve null with
+    // `?? false`; this pins the shape they rely on.
+    const projectedDoc: Record<string, unknown> = {}; // { _id: 0, pages_translated_es: 1 } over a book with none
+    expect(hasLocalizedEdition(projectedDoc, 'es') ?? false).toBe(false);
+  });
+
+  it('treats a non-numeric counter as no edition', () => {
+    expect(hasLocalizedEdition({ pages_translated_es: null }, 'es')).toBe(false);
+    expect(hasLocalizedEdition({ pages_translated_es: '445' }, 'es')).toBe(false);
+  });
+});


### PR DESCRIPTION
> "If it isn't Spanish, it's not /es." — Derek, 2026-08-20

## The problem, measured on production

```
GET https://sourcelibrary.org/es/book/illustrations-of-the-fungi-…  → 200
  <title>       Illustrations of the Fungi of Our Fields and Woods, Second Series
  canonical     https://sourcelibrary.org/es/book/illustrations-of-the-fungi-…
  hreflang="es" (itself)
  robots        (none)
```

An English page, declaring itself to Google as the Spanish version. **103 books
have Spanish pages; 37,821 are visible.** The other ~37,700 had a Spanish URL
because I gave them one in #4102, so that browsing `/es` wouldn't drop a reader
into English mid-click. Wrong fix — it bought navigation continuity by making
the prefix mean nothing.

## The rule

A localized URL is a **promise** that the page is in that language.

- `/es/book/<slug>` and `/es/book/<slug>/page/<id>` **307 to the English page**
  unless the book has pages in that language (`hasLocalizedEdition`).
- Enforced at the **route**, so no card, slider or hand-written href can mint
  one by forgetting. Link sites (`es-collections`, `CollectionBookCard`) point
  straight at `/book/…` for those books to save the hop — an optimization, not
  the rule.
- **307, not 308.** Temporary by construction: the day a book is translated its
  `/es` URL must start working, and a 308 would sit poisoned in browser caches.
- **A title gloss is not an edition.** Glossing a title is chrome; only pages
  count.

English stays at the root — every DOI, `/q/` shortlink, `citation_fulltext_html_url`
and crawler rule points at `/book/…`, so there is no `/en/`.

## Two things I got wrong first — both caught by measurement, both now pinned

**1. `null` is not `false`.** `hasLocalizedEdition` returns `boolean | null`;
`null` means the payload couldn't answer, because the counter is a Mongo field
and the Supabase catalog fast-path lacks it. Reading that as `false` would 307 a
genuinely Spanish book to English. My first call site did `=== false` on it — so
the gate silently never fired and the page still returned 200. Where the counter
*was* explicitly projected, absence IS an answer and the site resolves `?? false`.
The test pins both directions.

**2. The reader's gate cannot live in `page.tsx`.** That segment has a
`loading.tsx`, so the page sits inside an automatic `<Suspense>` and the 200
shell flushes before the page's code runs — `redirect()` there degraded into a
client-side **meta-refresh** (#4036): 200 with `NEXT_REDIRECT` in the body,
which a crawler will happily index. It lives in `layout.tsx` now, above the
boundary — exactly where `notFound()` already had to move, for the same reason,
in #3277/#3376. Curl showed 200 before and 307 after; nothing in review would
have caught it.

## Verification (local dev against Atlas)

| | |
|---|---|
| `/es/book/<no-spanish>` | **307** → `/book/<no-spanish>` |
| `/es/book/<no-spanish>/page/<id>` | **307** → English reader |
| `/es/book/dawn-rising-boehme` (445 Spanish pages) | **200** |
| `/es/book/dawn-rising-boehme/page/<id>` | **200** |
| `/book/<no-spanish>/page/<id>` (English) | **200**, untouched |

On `/es/collections/alchemy`: 14 of 120 cards link to `/es/book/…`, the other
106 straight to `/book/…` — no redirect hop, rule intact.

`npx tsc --noEmit` clean; `npx vitest run tests/unit` **2797 passed** (6 new).

## Note

The `/es` ISR entry caches the redirect for its revalidate window, so a
newly-translated book's `/es` URL opens within 24h (or immediately if the
revalidation call is extended to `/es/book/<slug>` — not done here, since the
Spanish worker is run by hand today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWM6HTvZUpgT3RUMLREQPC
