### PR TITLE
fix(home): move the podcast band down — the hero's neighbour belongs to the books

### DIFF
--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -65,82 +65,6 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
         </section>
       )}
 
-      {/* Featured podcast episode, in the page's own language.
-          Was /es-only; now on both homepages, and it is the podcast's primary
-          entry point since the header nav item was retired (see SiteHeader).
-          Renders nothing when that language has no published episode, which is
-          currently the state of several languages — an empty section is correct,
-          not a bug. */}
-      {featuredPodcast && (
-        <section className="py-14 md:py-20" style={{ background: 'var(--bg-dark)' }}>
-          <div className="px-6 md:px-12 max-w-[1100px] mx-auto">
-            <div className="grid md:grid-cols-[1fr_1.2fr] gap-8 md:gap-12 items-center">
-              {featuredPodcast.heroImageUrl && (
-                <Link href={`/podcast/${featuredPodcast.threadId}`} className="block rounded-xl overflow-hidden bg-black/30">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={`/api/image?url=${encodeURIComponent(featuredPodcast.heroImageUrl)}&w=720&q=85`}
-                    alt=""
-                    className="w-full max-h-[360px] object-contain"
-                    loading="lazy"
-                  />
-                </Link>
-              )}
-              <div>
-                <p className="text-sm uppercase tracking-[0.2em] mb-3" style={{ color: 'var(--accent-gold)' }}>
-                  {t.podcastEyebrow}
-                </p>
-                <h2 className="text-2xl md:text-3xl font-display mb-4 leading-snug" style={{ color: '#f5f0e8' }}>
-                  {featuredPodcast.title}
-                </h2>
-                <p className="text-base leading-relaxed mb-5" style={{ color: '#b8b2a8' }}>
-                  {featuredPodcast.topic}
-                </p>
-
-                <audio controls preload="none" src={featuredPodcast.audioUrl} className="w-full mb-5">
-                  <a href={featuredPodcast.audioUrl}>{t.podcastListen}</a>
-                </audio>
-
-                {featuredPodcast.sources.length > 0 && (
-                  <div className="mb-5">
-                    <p className="text-xs uppercase tracking-wider mb-2" style={{ color: '#8a8480' }}>
-                      {t.podcastSourcesLabel}
-                    </p>
-                    <ul className="space-y-1.5">
-                      {featuredPodcast.sources.map((s) => (
-                        <li key={s.bookId}>
-                          <Link
-                            href={lp(`/book/${s.slug || s.bookId}`)}
-                            className="text-[15px] hover:underline"
-                            style={{ color: '#e8e2d8' }}
-                          >
-                            <span className="font-serif">{s.title}</span>
-                            {(s.author || s.origin) && (
-                              <span style={{ color: '#8a8480' }}>
-                                {' — '}{[s.author, s.origin].filter(Boolean).join(' · ')}
-                              </span>
-                            )}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                <Link
-                  href={`/podcast/${featuredPodcast.threadId}`}
-                  className="inline-flex items-center gap-1.5 text-sm font-medium px-5 py-2.5 rounded-full transition-all hover:brightness-110"
-                  style={{ background: 'var(--accent-rust)', color: '#fff' }}
-                >
-                  {t.podcastFullEpisode}
-                  <span className="text-xs">&rarr;</span>
-                </Link>
-              </div>
-            </div>
-          </div>
-        </section>
-      )}
-
       {/* Collections Grid */}
       <section id="library" className="bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6] py-16 md:py-24">
         <div className="px-6 md:px-12 max-w-[1500px] mx-auto">
@@ -352,6 +276,84 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
           />
         </div>
       </section>
+
+      {/* Featured podcast episode, in the page's own language.
+          Sits down here with the writing, NOT in the second slot under the hero:
+          the podcast is still experimental and the homepage's prominent space
+          belongs to the books. It remains the podcast's main entry point (the
+          header nav item was retired — see SiteHeader) alongside the footer link.
+          Renders nothing when that language has no published episode, which is
+          currently the state of several languages — an empty section is correct,
+          not a bug. */}
+      {featuredPodcast && (
+        <section className="py-14 md:py-20" style={{ background: 'var(--bg-dark)' }}>
+          <div className="px-6 md:px-12 max-w-[1100px] mx-auto">
+            <div className="grid md:grid-cols-[1fr_1.2fr] gap-8 md:gap-12 items-center">
+              {featuredPodcast.heroImageUrl && (
+                <Link href={`/podcast/${featuredPodcast.threadId}`} className="block rounded-xl overflow-hidden bg-black/30">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={`/api/image?url=${encodeURIComponent(featuredPodcast.heroImageUrl)}&w=720&q=85`}
+                    alt=""
+                    className="w-full max-h-[360px] object-contain"
+                    loading="lazy"
+                  />
+                </Link>
+              )}
+              <div>
+                <p className="text-sm uppercase tracking-[0.2em] mb-3" style={{ color: 'var(--accent-gold)' }}>
+                  {t.podcastEyebrow}
+                </p>
+                <h2 className="text-2xl md:text-3xl font-display mb-4 leading-snug" style={{ color: '#f5f0e8' }}>
+                  {featuredPodcast.title}
+                </h2>
+                <p className="text-base leading-relaxed mb-5" style={{ color: '#b8b2a8' }}>
+                  {featuredPodcast.topic}
+                </p>
+
+                <audio controls preload="none" src={featuredPodcast.audioUrl} className="w-full mb-5">
+                  <a href={featuredPodcast.audioUrl}>{t.podcastListen}</a>
+                </audio>
+
+                {featuredPodcast.sources.length > 0 && (
+                  <div className="mb-5">
+                    <p className="text-xs uppercase tracking-wider mb-2" style={{ color: '#8a8480' }}>
+                      {t.podcastSourcesLabel}
+                    </p>
+                    <ul className="space-y-1.5">
+                      {featuredPodcast.sources.map((s) => (
+                        <li key={s.bookId}>
+                          <Link
+                            href={lp(`/book/${s.slug || s.bookId}`)}
+                            className="text-[15px] hover:underline"
+                            style={{ color: '#e8e2d8' }}
+                          >
+                            <span className="font-serif">{s.title}</span>
+                            {(s.author || s.origin) && (
+                              <span style={{ color: '#8a8480' }}>
+                                {' — '}{[s.author, s.origin].filter(Boolean).join(' · ')}
+                              </span>
+                            )}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <Link
+                  href={`/podcast/${featuredPodcast.threadId}`}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium px-5 py-2.5 rounded-full transition-all hover:brightness-110"
+                  style={{ background: 'var(--accent-rust)', color: '#fff' }}
+                >
+                  {t.podcastFullEpisode}
+                  <span className="text-xs">&rarr;</span>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* About Section */}
       <section id="about" className="bg-white py-16 md:py-24">


### PR DESCRIPTION
> "I don't think we want the podcast front and center, tbh. It is still very experimental." — Derek

The featured-episode band was the **second section** on both homepages —
full-bleed dark, hero image, audio player — sitting immediately under the video
hero (immediately under the "Leer en español" band on `/es`). That is the most
valuable space on the site, and it was pointing at the most experimental thing
we make.

Moved to sit with the writing, between the blog and About. Nothing else moves;
the section markup is unchanged.

It remains the podcast's main entry point — the header nav item was retired, so
its only other link is in the footer — and it still renders in the page's own
language, or renders nothing when that language has no published episode.

**Verified in the rendered HTML**, not just in the source order: the podcast's
`<audio>` element now appears at byte 212,415 on `/es` and 147,379 on `/`, in
both cases immediately before the About section. It used to sit a few thousand
bytes after the hero.

`npx tsc --noEmit` clean; `npx vitest run tests/unit` 2791 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWM6HTvZUpgT3RUMLREQPC
