### PR TITLE
fix(collections): sub-collection cards count what their page actually shows

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -101,6 +101,33 @@ function stripMarkdownLinks(text: string | null | undefined): string {
   return (text || '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
 }
 
+interface ChildCollection {
+  slug: string;
+  name: string;
+  subtitle?: string;
+  book_count?: number;
+  total_book_count?: number;
+  artwork_count?: number;
+  collection_type?: string;
+  featured_images?: ({ extracted_url?: string; image_url?: string; thumbnail_url?: string } | string)[];
+}
+
+/**
+ * What a sub-collection card should claim, judged by the child's OWN type.
+ *
+ * A `visual_art` collection renders artworks and nothing else (see `isArtCollection`
+ * in the loader), so its `book_count` / `total_book_count` describe texts the reader
+ * will never be shown. `school-of-athens` is the worst case: 518 tagged texts, 30
+ * artworks on the page. Nineteen art children were mislabelled this way — most in
+ * the other direction, e.g. `esoteric-engravers` advertising 0 while holding ~1,600
+ * artworks — because the card took the parent's noun and the parent's counter.
+ */
+function childCardCount(child: ChildCollection): { count: number; label: string } {
+  return child.collection_type === 'visual_art'
+    ? { count: child.artwork_count || 0, label: 'works' }
+    : { count: child.total_book_count ?? child.book_count ?? 0, label: 'books' };
+}
+
 interface BookItem {
   id: string;
   slug?: string;
@@ -682,12 +709,15 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     }
   }
 
-  // Fetch child collections if this is a parent collection
+  // Fetch child collections if this is a parent collection.
+  // `collection_type` + `artwork_count` are load-bearing here: a `visual_art` child
+  // renders ONLY artworks on its own page, so its book counters describe items the
+  // reader will never see. Project both so the card can label itself (see
+  // `childCardCount` below) instead of inheriting the parent's noun and counter.
   const childCollections = await withTimeout(
     db.collection('collections')
       .find({ parent: id, visible: true, ...(tenantId ? { tenantId } : {}) })
-      .sort({ book_count: -1 })
-      .project({ slug: 1, name: 1, subtitle: 1, book_count: 1, total_book_count: 1, featured_images: 1 })
+      .project({ slug: 1, name: 1, subtitle: 1, book_count: 1, total_book_count: 1, artwork_count: 1, collection_type: 1, featured_images: 1 })
       .toArray(),
     8000, [],
   );
@@ -807,7 +837,8 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     galleryTotalCount,
     exhibition: curationDraft?.curation ? JSON.parse(JSON.stringify(curationDraft.curation)) : null,
     exhibitionBooks,
-    childCollections: childCollections.map(({ _id, ...rest }) => rest) as { slug: string; name: string; subtitle?: string; book_count?: number; total_book_count?: number; featured_images?: ({ extracted_url?: string; image_url?: string; thumbnail_url?: string } | string)[] }[],
+    childCollections: (childCollections.map(({ _id, ...rest }) => rest) as ChildCollection[])
+      .sort((a, b) => childCardCount(b).count - childCardCount(a).count),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     artworks: artworks as any[],
   };
@@ -1114,6 +1145,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
             </h2>
             <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
               {childCollections.map((child) => {
+                const { count: childCount, label: childLabel } = childCardCount(child);
                 const fi = child.featured_images;
                 let heroUrl: string | undefined;
                 if (fi?.length) {
@@ -1144,9 +1176,9 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
                     )}
                     <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
                     <div className="absolute inset-0 flex flex-col justify-end p-3 sm:p-4">
-                      {(child.total_book_count ?? child.book_count) ? (
+                      {childCount ? (
                         <p className="text-white/50 text-xs mb-1 hidden sm:block">
-                          {(child.total_book_count ?? child.book_count)!.toLocaleString('en-US')} {itemLabel}
+                          {childCount.toLocaleString('en-US')} {childLabel}
                         </p>
                       ) : null}
                       <h3 className="font-serif text-sm sm:text-base lg:text-lg text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">

--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -26,6 +26,7 @@ interface SubCollection {
   book_count: number;
   total_book_count?: number;
   artwork_count?: number;
+  collection_type?: string;
   visible: boolean;
   type?: string;
   image?: string;
@@ -66,7 +67,7 @@ async function fetchWings(): Promise<Wing[]> {
     parent: { $exists: true },
     visible: { $ne: false },
   }).project({
-    slug: 1, tenantId: 1, name: 1, book_count: 1, total_book_count: 1, artwork_count: 1, parent: 1, visible: 1, type: 1,
+    slug: 1, tenantId: 1, name: 1, book_count: 1, total_book_count: 1, artwork_count: 1, collection_type: 1, parent: 1, visible: 1, type: 1,
     hero_image: 1, featured_images: { $slice: 1 }, _id: 0,
   }).toArray();
 
@@ -95,6 +96,7 @@ async function fetchWings(): Promise<Wing[]> {
         book_count: sub.book_count || 0,
         total_book_count: sub.total_book_count,
         artwork_count: sub.artwork_count || 0,
+        collection_type: sub.collection_type,
         visible: sub.visible !== false,
         type: sub.type,
         image: coverOverride(sub.slug) || sub.hero_image || pickImage(sub.featured_images),
@@ -102,9 +104,13 @@ async function fetchWings(): Promise<Wing[]> {
     }
   }
 
-  // Sort children by book count descending
+  // Sort children by the count their card actually shows — an art child's
+  // book_count is meaningless (see collectionCountLabel), so sorting on it buried
+  // 1,600-artwork collections below 20-text ones.
+  const displayCount = (c: SubCollection) =>
+    c.collection_type === 'visual_art' ? (c.artwork_count ?? 0) : (c.total_book_count ?? c.book_count);
   for (const kids of childMap.values()) {
-    kids.sort((a, b) => b.book_count - a.book_count);
+    kids.sort((a, b) => displayCount(b) - displayCount(a));
   }
 
   return wings.map(w => ({
@@ -141,7 +147,7 @@ function CollectionCard({ col }: { col: SubCollection }) {
       <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
       <div className="absolute inset-0 flex flex-col justify-end p-3">
         <p className="text-white/50 text-[10px] mb-0.5">
-          {collectionCountLabel(col.total_book_count ?? col.book_count, col.artwork_count) || 'Empty'}
+          {collectionCountLabel(col.total_book_count ?? col.book_count, col.artwork_count, col.collection_type) || 'Empty'}
         </p>
         <h3 className="font-serif text-xs sm:text-sm text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
           {col.name}

--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -118,9 +118,15 @@ export function bookTitle(book: { display_title?: string; title: string }): stri
 /**
  * Format a human-readable count label for a collection.
  * Shows "X texts · Y artworks", "X texts", "Y artworks", or empty string.
+ *
+ * `collectionType` matters: a `visual_art` collection's page renders artworks and
+ * nothing else, so its book counters describe texts the reader can never reach from
+ * it. Advertising them is a promise the page does not keep — `school-of-athens`
+ * claimed 518 texts over a page showing 30 works. Pass the type and the text half
+ * is dropped.
  */
-export function collectionCountLabel(bookCount?: number, artworkCount?: number): string {
-  const b = bookCount || 0;
+export function collectionCountLabel(bookCount?: number, artworkCount?: number, collectionType?: string): string {
+  const b = collectionType === 'visual_art' ? 0 : (bookCount || 0);
   const a = artworkCount || 0;
   if (b > 0 && a > 0) {
     return `${b.toLocaleString()} texts · ${a.toLocaleString()} artworks`;


### PR DESCRIPTION
## What Derek saw

Clicking into Collections → Classical Philosophy, the second card in the grid says **"518 books — The School of Athens."** Click it and the page says **"30 works"** and lists thirty Raphael paintings. No books at all.

## Root cause

`school-of-athens` is `collection_type: 'visual_art'`. The collection page honours that — `isArtCollection` makes it count and render artworks only. But the sub-collection card that links to it did two wrong things in the same block:

1. It showed `total_book_count ?? book_count` — text counters for a page that never lists texts.
2. It took its noun (`itemLabel`) from the **parent** collection, so an art child inherited "books".

And `.sort({ book_count: -1 })` ordered the grid by that same meaningless number, which is why the card landed second — the loudest number on the page was measuring content the reader can't reach.

## Scope of the defect

Audited all 284 child cards against what each child's page actually renders. **19 art children were mislabelled.** School of Athens is the only one that over-counts; every other one fails the opposite way and vanishes:

| collection | card said | page shows |
|---|---|---|
| esoteric-engravers | 0 | 1,653 artworks |
| portraits-tradition | 0 | 1,617 artworks |
| the-visionary | 2 | 1,403 artworks |
| medieval-illuminations | 2 | 904 artworks |
| visions-ecstasies | 0 | 824 artworks |
| **school-of-athens** | **518** | **30 artworks** |

## Changes

- **`/collections/[id]`** — new `childCardCount(child)` helper labels and sorts each card by the **child's own** `collection_type`. Projection now carries `collection_type` + `artwork_count`.
- **`collectionCountLabel`** — optional third `collectionType` arg; drops the text half for `visual_art`. Existing call sites are unaffected (the arg is optional and defaults to old behaviour).
- **`/collections/all`** — wires `collection_type` through and sorts children by the displayed count rather than `book_count`.

`/collections` and the homepage grids already exclude `visual_art` at the query level, so no other surface was affected.

## Verified

Simulated against production data. Classical Philosophy's grid, top 6:

```
BEFORE                          AFTER
627 books  Chinese Classics     627 books  Chinese Classics
518 books  The School of Athens 516 books  Neoplatonism
516 books  Neoplatonism         361 works  The Classical Mysteries
191 books  Islamic Philosophy   279 works  Before Ficino
152 books  Indian Philosophy    191 books  Islamic Philosophy
130 books  Aristotelian Trad.   152 books  Indian Philosophy
```

The School of Athens leaves the top row; Classical Mysteries and Before Ficino — previously advertising 13 and 0 books — surface honestly as 361 and 279 works.

`npx tsc --noEmit` clean.

## Out of scope (deliberate)

The 518 texts tagged `school-of-athens` are legitimate — Plato, Euclid, Ptolemy, Plotinus, the philosophers in the fresco. They're simply unreachable, because an art-typed page never lists texts. **Whether to untag them or retype the collection as mixed is a curation decision**, and it needs a human. This PR only stops the card from promising them.

A second, milder inconsistency is also left alone: ~98 text children show `total_book_count` (all holdings) on the card and `book_count` (translated only) on the page — e.g. Buddhism 211 vs 148. That's the intentional #3176 split, not a bug, though it reads as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019raPK8srcLYTA5G4qL4M1K