### PR TITLE
feat(es): say how much of the library is in Spanish, and lead with where it is

### DIFF
--- a/src/app/es/collections/page.tsx
+++ b/src/app/es/collections/page.tsx
@@ -57,7 +57,14 @@ function Card({ col, priority }: { col: EsCollectionSummary; priority?: boolean 
 export default async function EsCollectionsPage() {
   const collections = await getEsCollectionList();
   const spanish = collections.find((c) => c.slug === 'en-espanol');
+  // Spanish-bearing collections first, richest first — then the rest, labelled.
+  // A reader should be able to see at a glance where Spanish reading is
+  // possible, instead of opening collections until one has something.
   const rest = collections.filter((c) => c.slug !== 'en-espanol');
+  const withSpanish = rest
+    .filter((c) => c.spanishBookCount > 0)
+    .sort((a, b) => b.spanishBookCount - a.spanishBookCount);
+  const englishOnly = rest.filter((c) => c.spanishBookCount === 0);
 
   return (
     <div className="min-h-screen bg-cream" lang="es">
@@ -67,8 +74,9 @@ export default async function EsCollectionsPage() {
       <div className="max-w-[1500px] mx-auto px-6 pt-10 pb-6">
         <h1 className="text-4xl sm:text-5xl font-display text-primary mb-3">Colecciones</h1>
         <p className="text-muted max-w-2xl leading-relaxed">
-          La biblioteca, ordenada por tradiciones. Los títulos y las introducciones de cada colección están en inglés
-          salvo donde se indica; los libros con edición en español se abren directamente en español.
+          La biblioteca, ordenada por tradiciones. Primero las colecciones que ya contienen libros con edición en
+          español; debajo, el resto de la biblioteca, en su lengua original y con traducción al inglés en muchos casos.
+          Los títulos y las introducciones de cada colección están en inglés salvo donde se indica.
         </p>
       </div>
 
@@ -93,9 +101,29 @@ export default async function EsCollectionsPage() {
         </section>
       )}
 
+      {withSpanish.length > 0 && (
+        <section className="max-w-[1500px] mx-auto px-6 pb-14">
+          <div className="flex items-baseline justify-between gap-4 mb-4">
+            <h2 className="text-2xl sm:text-3xl font-display text-primary">Colecciones con libros en español</h2>
+            <span className="text-sm text-muted whitespace-nowrap">{nf(withSpanish.length)}</span>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
+            {withSpanish.map((col, i) => <Card key={col.slug} col={col} priority={i < 4} />)}
+          </div>
+        </section>
+      )}
+
       <section className="max-w-[1500px] mx-auto px-6 pb-20">
+        <div className="flex items-baseline justify-between gap-4 mb-2">
+          <h2 className="text-2xl sm:text-3xl font-display text-primary">El resto de la biblioteca</h2>
+          <span className="text-sm text-muted whitespace-nowrap">{nf(englishOnly.length)}</span>
+        </div>
+        <p className="text-sm text-muted mb-4 max-w-2xl">
+          Estas colecciones todavía no tienen ninguna edición en español. Sus libros están en su lengua original —
+          latín, griego, alemán, francés… — con traducción al inglés en muchos casos.
+        </p>
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
-          {rest.map((col, i) => <Card key={col.slug} col={col} priority={i < 4} />)}
+          {englishOnly.map((col) => <Card key={col.slug} col={col} />)}
         </div>
         <p className="mt-10 text-sm text-muted">
           ¿Buscas las exposiciones y la galería? Están en la{' '}

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -23,7 +23,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
   // catalog, browse, podcast, blog…) are returned untouched by localePath and go
   // to their English page rather than a 404. See .claude/docs/i18n.md rule 5.
   const lp = (href: string) => localePath(href, lang);
-  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks } = data;
+  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
 
   return (
@@ -52,9 +52,16 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 {t.spanishViewAll} &rarr;
               </Link>
             </div>
-            <p className="text-muted mb-6 max-w-2xl">
+            <p className="text-muted mb-2 max-w-2xl">
               {t.spanishSubtitle}
             </p>
+            {/* Say the size. Fifteen covers and no number implies a Spanish
+                library; the reader would otherwise find out by clicking. */}
+            {spanishCounts && (
+              <p className="text-sm text-muted/80 mb-6 max-w-2xl">
+                {t.spanishScale(nf(spanishCounts.books), nf(spanishCounts.pages), nf(counts.totalBooks))}
+              </p>
+            )}
             <BookSlider books={spanishBooks as unknown as MiniBook[]} lang={lang} />
             <div className="mt-6 sm:hidden">
               <Link href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)} className="text-sm text-accent-rust hover:underline">

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -692,6 +692,27 @@ async function getFeaturedPodcast(language: HomeLang): Promise<FeaturedPodcast |
   };
 }
 
+/**
+ * How much of the library a Spanish reader can actually read.
+ *
+ * Stated on the page because the honest answer is "a small, growing corner":
+ * 103 books of 37,821. A Spanish front door that shows fifteen covers and says
+ * nothing about scale implies a Spanish library, and the reader finds out by
+ * clicking. Counted live rather than hard-coded — the number grows every time
+ * the worker runs.
+ */
+export interface SpanishCounts { books: number; pages: number }
+
+async function getSpanishCounts(): Promise<SpanishCounts | null> {
+  const db = await getReadDb();
+  const [row] = await db.collection('books').aggregate<{ books: number; pages: number }>([
+    { $match: { pages_translated_es: { $gt: 0 }, visible: true, pages_count: { $gt: 0 } } },
+    { $group: { _id: null, books: { $sum: 1 }, pages: { $sum: '$pages_translated_es' } } },
+    { $project: { _id: 0, books: 1, pages: 1 } },
+  ], { maxTimeMS: 8000 }).toArray();
+  return row ?? null;
+}
+
 // ---------- Aggregate ----------
 
 // ---------- Books with a Spanish edition (the /es "Leer en español" band) ----------
@@ -767,6 +788,8 @@ export interface HomeData {
   featuredPodcast: FeaturedPodcast | null;
   /** Books with a Spanish edition, most-read first. Empty on the English homepage. */
   spanishBooks: SpanishBook[];
+  /** Size of the Spanish corpus, for the honest scale line. Null off /es. */
+  spanishCounts: SpanishCounts | null;
 }
 
 // `lang` selects the podcast episode's language and the Spanish-edition band,
@@ -774,7 +797,7 @@ export interface HomeData {
 // keeps the two homepages structurally identical (see the note at the top of
 // this file).
 export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
-  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks] = await Promise.all([
+  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getRecentlyTranslated(), 20000, [] as CatalogBook[]),
@@ -783,7 +806,8 @@ export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
     withTimeout(getRemainingCollections(), 20000, SORTED_FALLBACK_COLLECTIONS),
     withTimeout(getFeaturedPodcast(lang), 8000, null),
     lang === 'es' ? withTimeout(getSpanishBooks(), 8000, [] as SpanishBook[]) : Promise.resolve([] as SpanishBook[]),
+    lang === 'es' ? withTimeout(getSpanishCounts(), 8000, null) : Promise.resolve(null),
   ]);
 
-  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks };
+  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -70,6 +70,8 @@ export interface HomeStrings {
   // so the two editions keep one shape.
   spanishHeading: string;
   spanishSubtitle: string;
+  /** The honest scale line. Counts arrive already locale-formatted by nf(). */
+  spanishScale: (books: string, pages: string, total: string) => string;
   spanishViewAll: string;
 
   // Gallery masonry (homepage)
@@ -182,6 +184,8 @@ const en: HomeStrings = {
   recentlyTranslatedSubtitle: 'The latest works Source Library has brought into a modern, readable translation.',
   spanishHeading: 'Read in Spanish',
   spanishSubtitle: 'The most-read works in the library, with a Spanish edition you can open page by page beside the original.',
+  spanishScale: (books, pages, total) =>
+    `${books} of the library's ${total} books can be read in full in Spanish — ${pages} translated pages beside the original. The rest are in their own language, with an English translation in many cases.`,
   spanishViewAll: 'All books in Spanish',
   galleryHeading: 'Gallery',
   gallerySubtitle: 'Plates, figures, and engravings from rare books across the library.',
@@ -294,6 +298,8 @@ const es: HomeStrings = {
   recentlyTranslatedSubtitle: 'Las obras más recientes que Source Library ha traducido a una versión moderna y legible.',
   spanishHeading: 'Leer en español',
   spanishSubtitle: 'Las obras más leídas de la biblioteca, con una edición en español que puedes abrir página a página junto al original.',
+  spanishScale: (books, pages, total) =>
+    `${books} de los ${total} libros de la biblioteca se pueden leer completos en español — ${pages} páginas traducidas junto al original. Los demás están en su lengua original, con traducción al inglés en muchos casos.`,
   spanishViewAll: 'Todos los libros en español',
   galleryHeading: 'Galería',
   gallerySubtitle: 'Láminas, figuras y grabados de libros raros de toda la biblioteca.',


### PR DESCRIPTION
> "say how many books are in spanish, so people know that most books are in english. Maybe we need some spanish collections... and then can have the english collections below" — Derek

The `/es` front door showed fifteen covers and named no number, which reads as a
Spanish library. It is **103 books of 22,068** — a real corner, not the whole
thing — and a reader was left to discover that by clicking.

## 1. The scale line

Under the "Leer en español" band, counted live:

> 103 de los 22.068 libros de la biblioteca se pueden leer completos en español
> — 38.576 páginas traducidas junto al original. Los demás están en su lengua
> original, con traducción al inglés en muchos casos.

The denominator is the homepage's **own** book count
(`homepage_stats.totalBooks` = `visible: true, pages_count > 0`), and
`getSpanishCounts` now uses that same filter — so "103 of 22,068" is a subset
claim **by construction**, not by coincidence. Checked before writing the
sentence: all 103 fall inside that set. My first draft used a different total
(37,821 `visible: true`, which includes zero-page artwork shells) and would have
printed a number contradicting the stat line six lines above it on the same page.

## 2. `/es/collections` leads with where Spanish reading is possible

The 19 collections that hold Spanish editions come first, richest first —
Filosofía renacentista 31, Hermética 28, Magia y artes ocultas 27, Misticismo
25, Teología 23, … down to three with a single Spanish book — then the other 11
under **"El resto de la biblioteca"** with a line saying plainly that they have
no Spanish edition yet and their books are in their original languages.

(An earlier draft of this description listed `shwep 45` at the head of that
list. Wrong: that number came from a raw aggregation over books' `collections`
arrays, which ignores collection visibility. **SHWEP is `visible: false`** — a
private reading room, not a public collection — and does not render here.
Confirmed against the page: 30 collections render, 19 + 11, none of them SHWEP.)

Each card already printed "N en español" — nothing changes there but the order
and the two headings.

## Verification

Rendered HTML on `/es`: the scale line reads 103 / 22.068 / 38.576, and 22.068
is the same figure the stat line above it prints. `/es/collections` splits
19 / 11 under the two headings.

Both strings live in the `en` + `es` dictionaries, so the English homepage gets
the same sentence if that band is ever shown there.

`npx tsc --noEmit` clean; `npx vitest run tests/unit` 2797 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWM6HTvZUpgT3RUMLREQPC
