### PR TITLE
fix(i18n): Spanish lives at /es — retire the cross-URL reading-language store

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2508,10 +2508,10 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
 
   return (
     <div className={isEmbedded ? "" : "min-h-screen bg-cream"} lang={lang === 'en' ? undefined : lang}>
-      {/* Arriving on a localized book URL is itself a statement about which
-          language you read, so the reader opens in it — and keeps it after the
-          reader's own toggle overrides this. See src/lib/reading-language.ts. */}
-      {lang !== 'en' && <ReadingLanguagePreference lang={lang} />}
+      {/* Migrates a legacy `?lang=es` link to the `/es` twin and sweeps the
+          retired reading-language localStorage key. The language of a page is
+          its URL prefix; nothing is recorded. See src/lib/reading-language.ts. */}
+      {lang === 'en' && <ReadingLanguagePreference />}
       {!isEmbedded && <ConditionalSiteHeader variant="dark" />}
 
       {/* Tenant reading rooms (EFM/BPH iframe + subdomains) get a breadcrumb

--- a/src/app/es/collections/[id]/page.tsx
+++ b/src/app/es/collections/[id]/page.tsx
@@ -5,7 +5,6 @@ import { ArrowLeft } from 'lucide-react';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import CollectionCardImage from '@/components/collections/CollectionCardImage';
 import CollectionBookCard, { type CollectionBook } from '@/components/CollectionBookCard';
-import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
 import { getEsCollection } from '@/lib/es-collections';
 import collectionRedirects from '@/lib/collection-redirects.json';
 
@@ -54,7 +53,6 @@ export default async function EsCollectionPage({ params }: Props) {
 
   return (
     <div className="min-h-screen bg-cream" lang="es">
-      <ReadingLanguagePreference lang="es" />
       <ConditionalSiteHeader variant="light" />
 
       {/* Hero */}

--- a/src/app/es/collections/page.tsx
+++ b/src/app/es/collections/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import CollectionCardImage from '@/components/collections/CollectionCardImage';
-import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
 import { getEsCollectionList, type EsCollectionSummary } from '@/lib/es-collections';
 
 // Spanish edition of /collections. Real, indexable route; the header and footer
@@ -68,7 +67,6 @@ export default async function EsCollectionsPage() {
 
   return (
     <div className="min-h-screen bg-cream" lang="es">
-      <ReadingLanguagePreference lang="es" />
       <ConditionalSiteHeader variant="light" />
 
       <div className="max-w-[1500px] mx-auto px-6 pt-10 pb-6">

--- a/src/app/es/page.tsx
+++ b/src/app/es/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { getHomeData } from '@/lib/home-data';
 import HomeView from '@/components/home/HomeView';
-import ReadingLanguagePreference from '@/components/ReadingLanguagePreference';
 import { FEED_TYPES } from '@/lib/feed-links';
 
 // Spanish-language edition of the homepage — a real, server-rendered, indexable
@@ -41,7 +40,6 @@ export default async function HomePageEs() {
       {/* Arriving via the Spanish front door means "I read Spanish": books
           opened afterwards start in their Spanish edition where one exists.
           Client-side localStorage only — this page stays ISR and cache-safe. */}
-      <ReadingLanguagePreference lang="es" />
       <HomeView data={data} lang="es" />
     </>
   );

--- a/src/components/ReadingLanguagePreference.tsx
+++ b/src/components/ReadingLanguagePreference.tsx
@@ -1,22 +1,35 @@
 'use client';
 
 import { useEffect } from 'react';
-import { type ReadingLanguage, resolveReadingLanguage, setStoredReadingLanguage } from '@/lib/reading-language';
+import { useRouter } from 'next/navigation';
+import { clearLegacyReadingLanguage, legacyLangRedirect } from '@/lib/reading-language';
+import { hasLocalizedTwin } from '@/lib/locale-path';
 
 /**
- * Renders nothing; records a reading-language preference on mount.
+ * Renders nothing. Cleans up after the retired reading-language preference
+ * store (#4112), in two ways:
  *
- * - With `lang` (the `/es` homepage passes 'es'): visiting that front door
- *   means "I read Spanish", so books opened afterwards start in Spanish where a
- *   Spanish edition exists. The reader's own toggle can override it at any time
- *   and is remembered the same way.
- * - Without `lang` (the ISR book page): picks up a `?lang=es` link parameter
- *   and stores it, so the static page can pass the choice on to the reader.
+ * 1. A legacy `?lang=es` link — minted before `/es/…` existed — is migrated to
+ *    the `/es` twin of the same page, so old shared links still open in Spanish
+ *    and the address bar tells the truth about it. `replace`, not `push`, so
+ *    Back doesn't bounce between the two.
+ * 2. The stale `sl:reading-language` localStorage key is removed. It is read by
+ *    nothing now; clearing it means a reader stuck in Spanish by the old
+ *    behaviour is fixed by their next page load rather than by finding a toggle.
+ *
+ * Mounted on the ISR book page, which cannot read `searchParams` server-side.
+ * Both jobs are idempotent, so this is safe anywhere.
  */
-export default function ReadingLanguagePreference({ lang }: { lang?: ReadingLanguage }) {
+export default function ReadingLanguagePreference() {
+  const router = useRouter();
   useEffect(() => {
-    if (lang) setStoredReadingLanguage(lang);
-    else resolveReadingLanguage();
-  }, [lang]);
+    clearLegacyReadingLanguage();
+    const target = legacyLangRedirect(
+      window.location.pathname,
+      window.location.search,
+      hasLocalizedTwin,
+    );
+    if (target) router.replace(target);
+  }, [router]);
   return null;
 }

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -11,12 +11,10 @@ import { useSearchHighlight } from '@/hooks/useSearchHighlight';
 import type { Book, Page } from '@/lib/types';
 import { getTranslation } from '@/lib/page-translations';
 import { pages as pagesApi, readingHistory } from '@/lib/api-client';
-import {
-  type ReadingLanguage,
-  READING_LANGUAGE_PARAM,
-  resolveReadingLanguage,
-  setStoredReadingLanguage,
-} from '@/lib/reading-language';
+import Link from 'next/link';
+import { localeHref, type Locale } from '@/lib/locale-path';
+
+type ReadingLanguage = Locale;
 
 interface PageEditorClientProps {
   initialBook: Book;
@@ -65,27 +63,20 @@ export default function PageEditorClient({
   const [pageList] = useState<Page[]>(initialPageList);
   const [currentPageId, setCurrentPageId] = useState<string>(initialPage.id);
   const [currentPage, setCurrentPage] = useState<Page>(initialPage);
-  // Reading language: 'en' or 'es' (Spanish edition, when available). Starts as
-  // English for the server render, then resolves on mount from `?lang=` or the
-  // stored preference (set by the /es front door, a `?lang=es` link, or this
-  // toggle) — see src/lib/reading-language.ts. Toggling persists the choice, so
-  // a Spanish reader is not asked to find the switch on every book.
-  const [lang, setLangState] = useState<ReadingLanguage>('en');
-  useEffect(() => {
-    setLangState(resolveReadingLanguage());
-  }, []);
-  const setLang = useCallback((next: ReadingLanguage) => {
-    setLangState(next);
-    setStoredReadingLanguage(next);
-  }, []);
   const params = useParams<{ tenant: string }>();
   const pathname = usePathname();
+  // Reading language IS the URL (#4112): /book/… is English, /es/book/… is
+  // Spanish. No stored preference, no client state — the same value the rest of
+  // the page's chrome is rendered from, so the address bar can never disagree
+  // with what the reader is looking at. The EN/ES control below is a LINK
+  // between the two URLs, not a view toggle.
+  const lang: ReadingLanguage = useLocale();
   const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
   const isOnEmbedRoute = pathname?.startsWith('/embed/');
   // On the Spanish twin (/es/book/…) every URL this component writes keeps the
   // /es prefix, so page flips never drop the reader out of the Spanish site (#4082).
   const isOnEsRoute = pathname === '/es' || (pathname?.startsWith('/es/') ?? false);
-  const rs = READER_STRINGS[useLocale()];
+  const rs = READER_STRINGS[lang];
   const tenantPrefix = isOnTenantSubdomain ? '' : isOnEsRoute ? '/es' : (params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '');
   // Every reader URL this component writes uses the book's slug — the same
   // human-readable segment the book page uses (/book/a-sacred-repository-…),
@@ -93,6 +84,12 @@ export default function PageEditorClient({
   // the canonical <link> was already slug-based, but the address bar is what
   // readers copy and share, so it has to be the readable one.
   const bookPath = book.slug || book.id;
+
+  // Canonical (English, unprefixed) path of the page currently on screen. Built
+  // from currentPageId rather than usePathname() because page flips use
+  // history.pushState, which Next's router does not observe — usePathname would
+  // still name the page the reader landed on. localeHref() adds the /es prefix.
+  const readerPath = `/book/${bookPath}/page/${currentPageId}`;
 
   // Version pinning: detect ?v= param for citation-pinned reading
   const [pinnedVersion, setPinnedVersion] = useState<string | null>(null);
@@ -325,12 +322,8 @@ export default function PageEditorClient({
     // Build URL with supported query params (version pinning)
     const newParams = new URLSearchParams();
     if (pinnedVersion) newParams.set('v', pinnedVersion);
-    // Keep an explicit ?lang=es on the URL across page flips so the address bar
-    // stays shareable as a Spanish-edition link (the stored preference already
-    // carries it for this reader).
-    if (lang === 'es' && new URLSearchParams(window.location.search).get(READING_LANGUAGE_PARAM) === 'es') {
-      newParams.set(READING_LANGUAGE_PARAM, 'es');
-    }
+    // No language param: on the Spanish twin the /es prefix rides on
+    // tenantPrefix, so every flipped-to URL is already a Spanish URL (#4112).
     const suffix = newParams.toString() ? `?${newParams.toString()}` : '';
     window.history.pushState(null, '', `${tenantPrefix}/book/${bookPath}/page/${newPageId}${suffix}`);
 
@@ -425,26 +418,30 @@ export default function PageEditorClient({
         />
       )}
 
-      {hasSpanish && !pinnedVersion && (
-        <div className="flex items-center justify-center gap-2 py-2 text-sm" role="group" aria-label={rs.readingLanguage}>
+      {/* EN/ES as LINKS between `/book/…` and `/es/book/…`, not as a view
+          toggle: the language a reader is in is always the URL they are on
+          (#4112). Hidden inside a tenant reading room or an embed — those
+          surfaces have no `/es` twin and must never link off-tenant — and
+          hidden on a pinned citation URL, whose whole point is that it resolves
+          to one fixed text. */}
+      {hasSpanish && !pinnedVersion && !isOnTenantSubdomain && !isOnEmbedRoute && !params?.tenant && (
+        <div className="flex items-center justify-center gap-2 py-2 text-sm" aria-label={rs.readingLanguage}>
           <span className="text-neutral-500">{rs.readIn}</span>
           <div className="inline-flex overflow-hidden rounded-full border border-neutral-300">
-            <button
-              type="button"
-              onClick={() => setLang('en')}
-              aria-pressed={lang === 'en'}
+            <Link
+              href={localeHref('en', readerPath)}
+              aria-current={lang === 'en' ? 'page' : undefined}
               className={`px-3 py-1 transition-colors ${lang === 'en' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
             >
               English
-            </button>
-            <button
-              type="button"
-              onClick={() => setLang('es')}
-              aria-pressed={lang === 'es'}
+            </Link>
+            <Link
+              href={localeHref('es', readerPath)}
+              aria-current={lang === 'es' ? 'page' : undefined}
               className={`px-3 py-1 transition-colors ${lang === 'es' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
             >
               Español
-            </button>
+            </Link>
           </div>
         </div>
       )}

--- a/src/lib/es-collections.ts
+++ b/src/lib/es-collections.ts
@@ -2,7 +2,6 @@ import { getReadDb } from '@/lib/mongodb';
 import { sortCollections, sanitizeThumbnail, coverOverride } from '@/lib/collections-utils';
 import { toGalleryCardUrl } from '@/lib/utils';
 import { ES_COLLECTION_NAMES } from '@/lib/home-i18n';
-import { READING_LANGUAGE_PARAM } from '@/lib/reading-language';
 import { localizedCollection, type LocalizedBookMap, type LocalizedCollectionMap } from '@/lib/localized';
 
 /**
@@ -121,8 +120,6 @@ function spanishCopy(doc: Record<string, unknown>) {
 export function spanishReaderHref(book: { slug?: string; id: string; pages_count?: number; chapters?: { pageNumber?: number }[] }): string {
   return `/es/book/${encodeURIComponent(book.slug || book.id)}`;
 }
-// READING_LANGUAGE_PARAM stays exported for the legacy ?lang=es links still in the wild.
-export { READING_LANGUAGE_PARAM };
 
 const PUBLIC_COLLECTION = { visible: true, collection_type: { $ne: 'visual_art' } };
 

--- a/src/lib/reading-language.ts
+++ b/src/lib/reading-language.ts
@@ -1,68 +1,61 @@
 /**
- * Reading-language preference (#2770 follow-up).
+ * Reading language = the URL prefix. Nothing else. (#4112)
  *
- * The reader can show a book in English (the pivot translation) or, where a
- * page carries one, in Spanish (`translations.es` / legacy `translation_es`).
- * The preference lives in localStorage so it follows the READER, not the URL:
- * a Spanish speaker who arrives via `/es` or via a `?lang=es` link opens every
- * subsequent book in Spanish without hunting for the toggle, and switching back
- * to English in the reader is remembered the same way.
+ * Spanish lives at `/es/…`, English at the root. A `/book/…` URL is an English
+ * page and renders English; `/es/book/…` renders Spanish. The reader's EN/ES
+ * control is a LINK between those two URLs, not a view toggle, so the address
+ * bar always says which language you are reading and every reading URL is
+ * shareable, indexable and edge-cacheable as itself.
  *
- * URL wins over storage for a single visit (`?lang=es` on a shared link), and a
- * `?lang=` value is also persisted, so the book page — which is ISR and cannot
- * read searchParams server-side — can hand the preference on to the reader by
- * the client picking it up on mount.
+ * This module used to keep a `localStorage` preference that followed the reader
+ * across URLs. It was written on mere ARRIVAL at any `/es/…` page, and read on
+ * mount by every book page including English ones — so one visit to the Spanish
+ * site silently switched the English site to Spanish, permanently, with nothing
+ * in the URL to explain it. That also contradicted the rule the rest of the i18n
+ * layer is built on (`src/lib/locale-path.ts`: "locale is derived from the URL
+ * prefix rather than a cookie or Accept-Language header, so it never branches
+ * edge-cached HTML"). The store is gone; `clearLegacyReadingLanguage` below
+ * exists only to sweep the stale key out of browsers that still carry it.
+ *
+ * To resolve the locale of the current page, use `useLocale()`
+ * (`src/lib/i18n.ts`) or `localeFromPathname()` (`src/lib/locale-path.ts`).
  */
-export type ReadingLanguage = 'en' | 'es';
 
-export const READING_LANGUAGE_KEY = 'sl:reading-language';
+/** Legacy `?lang=es` links minted before `/es` existed still point at English URLs. */
 export const READING_LANGUAGE_PARAM = 'lang';
 
-function isReadingLanguage(v: unknown): v is ReadingLanguage {
-  return v === 'en' || v === 'es';
-}
+/** The key the retired preference store used. Read by nothing; only cleared. */
+const LEGACY_STORAGE_KEY = 'sl:reading-language';
 
-/** Stored preference, or null when unset / not in a browser. */
-export function getStoredReadingLanguage(): ReadingLanguage | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const v = window.localStorage.getItem(READING_LANGUAGE_KEY);
-    return isReadingLanguage(v) ? v : null;
-  } catch {
-    return null;
-  }
-}
-
-export function setStoredReadingLanguage(lang: ReadingLanguage): void {
+/**
+ * Drop the retired preference key. Readers who visited `/es` while the store was
+ * live still carry `es` in localStorage; it no longer does anything, but leaving
+ * it behind would let any future reintroduction silently resurrect the bug.
+ */
+export function clearLegacyReadingLanguage(): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(READING_LANGUAGE_KEY, lang);
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY);
   } catch {
-    /* private mode / quota — the preference is a convenience, never required */
+    /* private mode / quota — nothing depends on this succeeding */
   }
-}
-
-/** `?lang=` from the current URL, if it names a supported reading language. */
-export function readingLanguageFromUrl(): ReadingLanguage | null {
-  if (typeof window === 'undefined') return null;
-  const v = new URLSearchParams(window.location.search).get(READING_LANGUAGE_PARAM);
-  return isReadingLanguage(v) ? v : null;
 }
 
 /**
- * Resolve the reading language on mount: URL first (and remember it), then the
- * stored preference, else English. Client-only — call from an effect.
+ * The `/es` twin of a legacy `?lang=es` URL, or null when there is nothing to
+ * migrate. Returns null for paths that are already localized, so this is safe to
+ * call unconditionally.
  */
-export function resolveReadingLanguage(): ReadingLanguage {
-  const fromUrl = readingLanguageFromUrl();
-  if (fromUrl) {
-    setStoredReadingLanguage(fromUrl);
-    return fromUrl;
-  }
-  // On a Spanish twin route (/es/book/…) the URL IS the preference (#4082).
-  if (typeof window !== 'undefined' && /^\/es(\/|$)/.test(window.location.pathname)) {
-    setStoredReadingLanguage('es');
-    return 'es';
-  }
-  return getStoredReadingLanguage() ?? 'en';
+export function legacyLangRedirect(
+  pathname: string,
+  search: string,
+  hasTwin: (path: string) => boolean,
+): string | null {
+  const params = new URLSearchParams(search);
+  if (params.get(READING_LANGUAGE_PARAM) !== 'es') return null;
+  if (pathname === '/es' || pathname.startsWith('/es/')) return null;
+  if (!hasTwin(pathname)) return null;
+  params.delete(READING_LANGUAGE_PARAM);
+  const rest = params.toString();
+  return `/es${pathname}${rest ? `?${rest}` : ''}`;
 }

--- a/tests/unit/reading-language-url.test.ts
+++ b/tests/unit/reading-language-url.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { legacyLangRedirect, READING_LANGUAGE_PARAM } from '@/lib/reading-language';
+import { hasLocalizedTwin } from '@/lib/locale-path';
+
+/**
+ * Reading language is the URL prefix (#4112). The module that used to hold a
+ * cross-URL localStorage preference now does exactly one thing: migrate the
+ * legacy `?lang=es` links minted before `/es/…` existed.
+ *
+ * The guard these cover is the one the old bug needed and did not have — that
+ * an English URL stays English. A test that only asserts "/es renders Spanish"
+ * would have passed throughout the entire life of the bug.
+ */
+describe('legacyLangRedirect', () => {
+  it('sends a legacy ?lang=es book link to its /es twin', () => {
+    expect(legacyLangRedirect('/book/x/page/y', '?lang=es', hasLocalizedTwin))
+      .toBe('/es/book/x/page/y');
+    expect(legacyLangRedirect('/book/x', '?lang=es', hasLocalizedTwin))
+      .toBe('/es/book/x');
+  });
+
+  it('preserves other query params across the migration, dropping only lang', () => {
+    expect(legacyLangRedirect('/book/x/page/y', '?lang=es&v=1.2', hasLocalizedTwin))
+      .toBe('/es/book/x/page/y?v=1.2');
+  });
+
+  it('leaves a plain English URL alone — this is the bug that was fixed', () => {
+    expect(legacyLangRedirect('/book/x/page/y', '', hasLocalizedTwin)).toBeNull();
+    expect(legacyLangRedirect('/book/x/page/y', '?v=1.2', hasLocalizedTwin)).toBeNull();
+  });
+
+  it('does not redirect a page with no Spanish twin', () => {
+    // `/book/<id>/overview` has no /es route; sending a reader there is a 404.
+    expect(legacyLangRedirect('/book/x/overview', '?lang=es', hasLocalizedTwin)).toBeNull();
+    expect(legacyLangRedirect('/search', '?lang=es', hasLocalizedTwin)).toBeNull();
+  });
+
+  it('is a no-op on an already-Spanish URL, so it cannot loop', () => {
+    expect(legacyLangRedirect('/es/book/x/page/y', '?lang=es', hasLocalizedTwin)).toBeNull();
+    expect(legacyLangRedirect('/es', '?lang=es', hasLocalizedTwin)).toBeNull();
+  });
+
+  it('ignores a lang value that is not a supported prefixed locale', () => {
+    expect(legacyLangRedirect('/book/x', '?lang=fr', hasLocalizedTwin)).toBeNull();
+    expect(legacyLangRedirect('/book/x', '?lang=en', hasLocalizedTwin)).toBeNull();
+  });
+
+  it('keeps the param name the legacy links actually used', () => {
+    expect(READING_LANGUAGE_PARAM).toBe('lang');
+  });
+});


### PR DESCRIPTION
Closes #4112.

## The bug

Following a link from `/encyclopedia/Active Intellect` to an English book page rendered the **Spanish** translation — on a plain `/book/…` URL, no `?lang=` in the address bar, nothing to explain it.

`resolveReadingLanguage()` wrote `sl:reading-language = 'es'` to localStorage on mere **arrival** at any `/es/…` page, and `PageEditorClient` read that key on mount for **every** book page, English ones included. So a single visit to the Spanish site — reviewing the `/es` work, say — converted the English site to Spanish permanently, until the reader found the toggle.

It was also invisible to any server-side check: the HTML ships `lang="en"` with English in the meta description, and the swap happens after hydration.

## Why it's the wrong model

`src/lib/locale-path.ts` already states the rule the rest of the i18n layer follows:

> Locale is derived from the URL prefix (`/es`, `/es/...`) rather than a cookie or Accept-Language header, so it never branches edge-cached HTML and every localized route is its own indexable page.

`reading-language.ts` was the one piece contradicting it. A store keyed on nothing in the URL can't distinguish *"I read Spanish"* from *"I looked at the Spanish site once"* — and edge-cached HTML that renders differently per browser is exactly the branch that rule exists to prevent.

## What changes

- **`PageEditorClient`** takes `lang` from `useLocale()` (the pathname) instead of client state seeded from storage. The EN/ES control becomes a pair of **links** between `/book/…` and `/es/book/…` rather than a view toggle, so the address bar always names the language on screen and every reading URL stays shareable and indexable as itself.
  - The link target is built from `currentPageId`, **not** `usePathname()` — page flips use `history.pushState`, which Next's router doesn't observe, so `usePathname()` would still name the page the reader landed on.
  - Hidden inside tenant reading rooms and embeds: those surfaces have no `/es` twin and must never link off-tenant (`tenant-lockdown.md`).
- **`reading-language.ts`** loses the storage helpers. What's left migrates legacy `?lang=es` links to the `/es` twin, and clears the stale key — so readers already stuck in Spanish are fixed by their next page load rather than by finding a toggle or a console.
- **`/es` pages** stop recording anything on arrival; the prefix already says it.
- **Page flips** stop carrying `?lang=es` — on the twin the `/es` prefix already rides on `tenantPrefix`.

## Tests

`tests/unit/reading-language-url.test.ts` covers legacy-link migration, param preservation, no-twin and already-Spanish no-ops — and, centrally, that **an English URL stays English**. That's the assertion the old code needed and never had: a test checking only "/es renders Spanish" would have passed throughout the entire life of the bug.

`npx tsc --noEmit` clean; 20 locale tests pass.

## Out of scope

Anything about *which* pages have Spanish twins (`LOCALIZED_PATTERNS` is untouched) and the `/es` findability work in #4095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tKgEkDtGGD8kemc4WSkmy