### PR TITLE
fix(librarian): drop the sidebar link list

### DIFF
--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -1377,23 +1377,6 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     </Link>
                   </div>
                 )}
-
-                <div className="mt-8 pt-6 border-t border-[#e8e4dc]">
-                  <div className="space-y-2">
-                    <Link href="/librarian/voice" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                      Voice conversation
-                    </Link>
-                    <Link href="/podcast" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                      Deep Dives podcast
-                    </Link>
-                    <Link href="/ficino-society" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                      The Ficino Society
-                    </Link>
-                    <Link href="/collections" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                      Browse the Collection
-                    </Link>
-                  </div>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Removes the four-link list (Voice conversation / Deep Dives podcast / The Ficino Society / Browse the Collection) under the featured passage in the Librarian sidebar. All four are reachable from the header or footer already.

Out of scope: the Spanish librarian (tracked in a separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZ59KjPZ6Fyt8kzgcopknR