### PR TITLE
docs(invariants): language-fields.md — which language field answers which question

### DIFF
--- a/.claude/docs/invariants/language-fields.md
+++ b/.claude/docs/invariants/language-fields.md
@@ -1,0 +1,152 @@
+# Language fields — `language`, `original_language`, `languages[]`
+
+**Read this when:** writing or reading any language field on `books`; adding a
+language filter or facet; routing OCR/translation by language; writing a
+detector or sweep that "fixes" a language; or deciding what a bilingual edition
+is tagged. Companion to `edition-identity.md` and `work-identity.md` — this is
+the axis between them that nothing else documents.
+
+Measured 2026-08-21 against production `bookstore`, live = `visible: true &&
+pages_count > 0` = 22,068.
+
+---
+
+## The three questions, and the one field each
+
+| Question | Field | Example (Ficino's Latin *De mysteriis*) |
+|---|---|---|
+| What language is **this edition's text**? | `language` | Latin |
+| What language was the **work** composed in? | `original_language` | Greek |
+| Is this edition **substantially multilingual**? | `languages[]` + `language_multi` | `["Latin","Greek"]` for a facing-page edition |
+
+Conflating the first two is the most expensive mistake in this cluster, and it
+has been made repeatedly (#2184, #3261, #3957).
+
+## THE TRAP: `language` is the EDITION's language, not the source's
+
+For a `text_role: modern-translation` or `period-translation` book — an English
+translation we host — **`language: English` is correct**. The source lives in
+`original_language`.
+
+In June 2026 a "language-mislabel" detector (PR #2806) and a sweep bucket
+(PR #2796) both assumed `language: English` + non-English `original_language` =
+a mislabel, and proposed relabelling **547 books** to their source languages.
+The dry-run caught it: 523 were `modern-translation` and 16 `period-translation`
+— *The Works of Li Po*, *The Art of War*, a 1609 Boethius — English editions
+with English titles. Applying it would have corrupted ~540 records. Only the 8
+rows with `text_role: null` were even worth looking at. Nothing was applied.
+
+**Rule: never derive a language correction without gating on `text_role`.** And
+never use "readable + non-English `language`" as a proxy for first-translation
+eligibility — that filter excludes English translation editions, which is
+precisely what a "first English translation" is.
+
+## `languages[]` already exists. Do not add another array.
+
+Present on 45,675 books (17,857 live), alongside `language_multi`. Written by
+`scripts/maintenance/normalize-language-tags.mjs` (#2258, first run 2026-05-31).
+
+It is currently **degenerate and unread**:
+
+| | live |
+|---|---|
+| `languages` present | 17,857 |
+| …singleton arrays | 17,489 |
+| …**more than one language** | **245** |
+| …empty array | 123 |
+| `languages[0] !== language` | 892 |
+| missing `languages` entirely | 4,211 |
+
+Two things follow, and both have bitten:
+
+1. **Nothing in `src/` reads it**, and it is absent from `src/lib/types/book.ts`.
+   Search filters the scalar — `src/app/api/search/route.ts:172` — *including
+   its `languages=` query parameter*. `?languages=Latin` is a parameter named
+   `languages` that queries the field `language`. Do not assume the array is
+   live because the param exists.
+2. **The sweep parses; it cannot detect.** It splits the string already in
+   `language`, so `"Greek-Latin"` becomes `["Greek","Latin"]`, but a book tagged
+   `"Greek"` that is half Latin stays `["Greek"]`. On the Lascaris pair (#4089)
+   it ran and confirmed the wrong answer on both copies.
+
+96 of the 229 distinct live `language` values are list-shaped strings on 262
+live books (`"Hebrew and Aramaic"`, `"Sanskrit-English"`, `"Arabic, Ottoman
+Turkish, Persian, Latin, Ternate (a Papuan language), French and Dutch."`) —
+the workaround for the scalar schema is already in the data.
+
+## Evidence sources, ranked — and one that looks like evidence and isn't
+
+1. **The per-page `<language>` tag inside `pages.ocr.data`** — genuine per-page
+   detection by the OCR model, already paid for. The strongest signal we hold.
+   On two independently OCR'd copies of the same 1495 Aldine it returned Latin
+   178 / Greek 153 and Latin 175 / Greek 151 — near-identical, against two
+   different catalogue answers.
+2. **`ai_metadata.language` + `ai_metadata.secondary_languages`** — a *candidate
+   generator*, never a source of truth (see below). `language` and
+   `ai_metadata.language` disagree on 1,560 of the 13,310 live books with both.
+3. **`pages.ocr.language`** — **NOT detection.** It is the request parameter:
+   `null` or `"auto-detect"`. Anything reading it as an answer is measuring its
+   own input. This is a live trap; the name is the whole problem.
+
+## `secondary_languages` means "traces present", not "bilingual"
+
+Its prompt asks for "any other languages present, e.g. Greek quotes in a Latin
+text" — which is true of nearly every early modern Latin book. Measured against
+the page tags on 40 live books, using "second language on ≥10% of pages" as the
+bilingual bar: **11 hit / 26 miss / 3 unevaluable**. Most misses are the field
+being correct about its own, weaker question; about 6 are wrong at any threshold
+(`Latin + [Greek]` on 100% Latin pages; `Arabic + [German]` with no German).
+Recall is also poor — 4 of 33 books *without* the field have a real ≥10% second
+language.
+
+Hygiene: 257 books list `Latin` as a secondary of `Latin`, 204 the same for
+Greek; 231 distinct uncontrolled values in which "Ancient Greek" and "Greek" are
+different languages.
+
+**Use it to generate candidates. Never copy it into `languages[]`.**
+
+## Four vocabularies, none authoritative
+
+- `src/lib/language-utils.ts` — `CODE_TO_NAME` / `CODE3_TO_NAME` / `expandLanguages` (read path)
+- `scripts/maintenance/normalize-language-tags.mjs` — `CODE` / `SYNONYM` / `EXTRA` (write path)
+- `scripts/iiif-discovery/sources/*.mjs` — per-source import maps
+- the OCR `<language>` tag — **no vocabulary at all** (`Ancient Greek`, bare `de`,
+  `early new high german`, `sanskrit (transliterated)`, `None`/`none`/`N/A`)
+
+Before adding a fifth, extend `language-utils.ts` and give it an `.mjs` twin
+with a parity test, in the shape of `identity-fields.ts` /
+`scripts/lib/identity-fields.mjs`. #3893 covers only the Supabase catalog rows.
+
+When splitting a free-text language string, split on `,` `;` and `" and "` —
+**not on `/`**, which turns `N/A` into two languages named `n` and `a`.
+
+## The field count is itself the warning
+
+`books` carries **18 live language fields** (5 more already retired), of 423 in
+`scripts/lib/books-known-fields.json`: `language`, `languages`, `language_multi`,
+`language_raw`, `language_unparsed`, `language_review`, `language_review_detail`,
+`language_review_resolved`, `language_source`, `language_detected`,
+`language_corrected`, `language_confidence`, `language_relabel`,
+`language_verified_content`, `ai_detected_language`, `original_language`,
+`source_language_screen`, `_language_backfill`.
+
+This is `field-sprawl.md`'s pattern several times over. **A language sweep
+records a ROW, not a new column.** If you need somewhere to put a finding, the
+answer is a sweep-log row or an existing flag — not `language_<yourthing>`.
+
+## Rules
+
+1. Never "fix" `language` toward `original_language` without gating on `text_role`.
+2. Never read `pages.ocr.language` as a detected language.
+3. Never copy `ai_metadata.secondary_languages` into a public or canonical field.
+4. `languages[0]` must equal `language`. Order the rest by measured page share.
+5. OCR/translation routing reads the **per-page** tag, never `languages[0]` —
+   a bilingual page set must not inherit one model choice from a book-level field.
+6. New language field ⇒ demote something or use a row. Check the 18 above first.
+
+## Open issues
+
+#4089 (read path + ordering rule) · #4117 (detector from page tags) ·
+#3893 (one vocabulary) · #3958 (1,519 live books in `language_review` with no
+consumer) · #2184 (translations catalogued as the original's language) ·
+#3957 / #3261 (`text_role` misclassification, the adjacent axis)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - `books.author`, `author_id`, the `authors` thesaurus, `/author/[slug]` → `author-identity.md`
 - `books.work_id`, translation gaps, "do we hold the original?", acquisition at scale → `work-identity.md`
 - `books.edition_key`, "same edition?", duplicate queues, other-scans rails, USTC/VD16/ESTC ids → `edition-identity.md`
+- `books.language` / `original_language` / `languages[]`, language filters, "fix this book's language", OCR routing by language → `language-fields.md` (**`language` is the EDITION's language, not the source's** — a sweep that forgot nearly relabelled 547 translation editions)
 - **Any write to `bph_works`** — migrations, sweeps, the catalogue editor → `../bph-catalogue-disaster-recovery.md` (a bulk UPDATE with no revision rows pages a human at 04:30; 2,012 records legitimately have no UBN)
 - Bekker/Stephanus references, `locus_anchors`, `/api/locus`, "which page is 1094a?" → `canonical-loci.md`
 - `entities.books[]`, book-index generation, page citations from the index → `entity-page-attribution.md`


### PR DESCRIPTION
## Why

`books` carries **18 live language fields** (5 more retired) and **four separate
normalization vocabularies**, and no document said which field answers which question.
`edition-identity.md` and `work-identity.md` cover the layers either side of this axis;
the axis itself was undocumented.

The load-bearing fact lived only in a private per-machine memory note: **`language` is
the EDITION's text language, `original_language` is the source, and "correcting" the
former to the latter corrupts every translation edition.** In June 2026 two sweeps
(PRs #2796, #2806) proposed relabelling 547 books on exactly that mistake; the dry-run
caught it because 523 were `modern-translation`. That belongs in the repo, not on one
laptop.

## What's in it

Measured 2026-08-21 against production, and recorded so the next session doesn't
re-derive it:

- **`languages[]` already exists** — 45,675 books, 17,857 live — and is degenerate
  (17,489 singletons, 245 with >1 language, 892 with `languages[0] !== language`) and
  read by nothing in `src/`. Written by `normalize-language-tags.mjs` (#2258), which
  parses the existing string and structurally cannot detect anything.
- **`?languages=Latin` is a trap**: the search param named `languages` filters the
  scalar field `language` (`src/app/api/search/route.ts:172`).
- **`pages.ocr.language` is not detection** — it's the request parameter (`null` /
  `auto-detect`). The `<language>` tag *inside* `pages.ocr.data` is real per-page
  detection, and it reconstructed the facing-page structure of two independently OCR'd
  copies of the same 1495 Aldine near-identically (Latin 178/Greek 153 and Latin
  175/Greek 151) against two different catalogue answers.
- **`ai_metadata.secondary_languages` means "traces present", not "bilingual"** —
  11 hit / 26 miss / 3 unevaluable against page tags on 40 live books, with ~6 wrong at
  any threshold. Candidate generator only; never copy it into a canonical field.
- Six numbered rules, and the reminder that a language sweep records a ROW
  (`field-sprawl.md`), which is how 18 columns happened.

## Scope

Docs only. One line added to CLAUDE.md's conditional-invariants index — the file stays
at 232 lines, within its ~250 budget, and the new material is in the tier-two doc where
it belongs.

**Out of scope, deliberately:** every defect the measurements surfaced. Those are
#4089 (read path + ordering rule), #4117 (detector from the page tags), #3893 (one
vocabulary), #3958, #2184. This PR only writes down what is true today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqVg3Ya2b5Q5WQgtVeEeBT