### PR TITLE
feat(es): a book WRITTEN in Spanish is a Spanish edition (/es sees 67 more)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2480,7 +2480,11 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
       const doc = await getReadDb()
         .then((db) => db.collection('books').findOne(
           { id: bookId },
-          { projection: { _id: 0, pages_translated_es: 1 }, maxTimeMS: 3000 },
+          // BOTH inputs, always: a book can be in Spanish by translation
+          // (the counter) or by having been written in it (`language`).
+          // Projecting only the counter reads every Spanish original as
+          // "no Spanish edition" and 307s it away.
+          { projection: { _id: 0, pages_translated_es: 1, language: 1 }, maxTimeMS: 3000 },
         ))
         .catch(() => null);
       // A doc we READ with the counter explicitly projected is authoritative:

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -128,8 +128,11 @@ export default async function PageLayout({ children, params, lang = 'en' }: Layo
   // body. The layout sits above that boundary, so this is a real HTTP 307.
   //
   // 307, not 308: the day the book is translated the URL must start working.
-  // `?? false` because the projection always asks for the counter, so an absent
-  // field means the book has none rather than "could not tell".
+  // `?? false` because PAGE_META_PROJECTION asks for BOTH inputs — the
+  // `pages_translated_es` counter and `language` — so an absent value means the
+  // book has no edition in the language rather than "could not tell". If that
+  // projection ever drops `language`, every natively-Spanish book starts
+  // redirecting away from its own /es reader.
   if (lang !== 'en' && (hasLocalizedEdition(book as unknown as Record<string, unknown>, lang) ?? false) === false) {
     redirect(`/book/${(book as unknown as { slug?: string }).slug || id}/page/${pageId}`);
   }

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -44,7 +44,7 @@ import HighlightSelection from '@/components/annotations/HighlightSelection';
 import ChapterDropdown from '@/components/reader/ChapterDropdown';
 import { useLocale, useLocalePath } from '@/lib/i18n';
 import { READER_STRINGS } from '@/lib/book-i18n';
-import { localizedTitle } from '@/lib/localized';
+import { isNativeEdition, localizedTitle } from '@/lib/localized';
 import ShareButton from '@/components/ui/ShareButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
@@ -594,12 +594,25 @@ export default function TranslationEditor({
   const bookYear = parseInt(String(book.published ?? ''), 10);
   const englishOcrIsReadingView = isEnglishBook && !(bookYear < 1820);
 
+  // The same idea one locale over. A book WRITTEN in the reading language has
+  // no translation into it and never will — `pages.translations.es` is empty
+  // for Cogolludo — so the transcription IS the Spanish text. Without this the
+  // Spanish reader renders an empty translation panel over a book that is
+  // entirely in Spanish. Deliberately narrow: only the current locale, only a
+  // native edition (`NATIVE_EDITION_LANGUAGE`, which excludes half-Spanish
+  // bilinguals), and it does not touch the English behaviour above.
+  const nativeOcrIsReadingView = locale !== 'en'
+    && isNativeEdition(book as unknown as Record<string, unknown>, locale);
+
+  // Either route to "the transcription is the reading text".
+  const sourceOcrIsReadingView = englishOcrIsReadingView || nativeOcrIsReadingView;
+
   // Panel visibility toggles for read mode (default: image + translation visible, OCR hidden;
   // for modern-print English books, image + OCR visible, translation hidden)
   const [showImagePanel, setShowImagePanel] = useState(true);
   const [showNotes, setShowNotes] = useState(true); // Toggle for inline notes visibility
-  const [showOcrPanel, setShowOcrPanel] = useState(englishOcrIsReadingView);
-  const [showTranslationPanel, setShowTranslationPanel] = useState(!englishOcrIsReadingView);
+  const [showOcrPanel, setShowOcrPanel] = useState(sourceOcrIsReadingView);
+  const [showTranslationPanel, setShowTranslationPanel] = useState(!sourceOcrIsReadingView);
   const [showTransliterationPanel, setShowTransliterationPanel] = useState(false);
   const [showGermanSourcePanel, setShowGermanSourcePanel] = useState(false);
   const [transliterationText, setTransliterationText] = useState('');
@@ -1380,7 +1393,7 @@ export default function TranslationEditor({
                   <span className="hidden sm:inline">{rs.german}</span>
                 </button>
               )}
-              {!englishOcrIsReadingView && (
+              {!sourceOcrIsReadingView && (
                 <button
                   onClick={() => setShowTranslationPanel(!showTranslationPanel)}
                   className={`flex items-center justify-center gap-1.5 px-2 sm:px-2.5 py-1.5 rounded-md text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none ${showTranslationPanel ? 'text-white' : ''}`}
@@ -1956,8 +1969,8 @@ export default function TranslationEditor({
                 </div>
               )}
 
-              {/* Translation Panel — suppressed for modern-print English books (OCR is the reading view) */}
-              {showTranslationPanel && !englishOcrIsReadingView && (
+              {/* Translation Panel — suppressed when the transcription IS the reading text: modern-print English, or a book written in the reading language */}
+              {showTranslationPanel && !sourceOcrIsReadingView && (
                 <div id={showOcrPanel ? undefined : 'reader-text'} data-reader-section="translation" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">

--- a/src/lib/es-collections.ts
+++ b/src/lib/es-collections.ts
@@ -3,7 +3,7 @@ import { sortCollections, sanitizeThumbnail, coverOverride } from '@/lib/collect
 import { toGalleryCardUrl } from '@/lib/utils';
 import { ES_COLLECTION_NAMES } from '@/lib/home-i18n';
 import { READING_LANGUAGE_PARAM } from '@/lib/reading-language';
-import { localizedCollection, type LocalizedBookMap, type LocalizedCollectionMap } from '@/lib/localized';
+import { isNativeEdition, localizedCollection, localizedEditionFilter, type LocalizedBookMap, type LocalizedCollectionMap } from '@/lib/localized';
 
 /**
  * Data for the Spanish collection routes (`/es/collections`, `/es/collections/[id]`).
@@ -75,6 +75,18 @@ export interface EsCollectionDetail {
 /** Books shown on a Spanish collection page; the English page lists the rest. */
 export const ES_COLLECTION_BOOK_CAP = 120;
 
+/**
+ * Is this book readable in Spanish — translated into it, or written in it?
+ *
+ * The JS twin of `localizedEditionFilter('es')`, which selects the same set in
+ * Mongo. Both delegate to `NATIVE_EDITION_LANGUAGE` so the card, the count and
+ * the query can never disagree about which books are Spanish; the route gate
+ * (`hasLocalizedEdition`) is the third reader of that same rule.
+ */
+function hasEsEdition(b: { pages_translated_es?: number; language?: string }): boolean {
+  return (b.pages_translated_es ?? 0) > 0 || isNativeEdition(b as unknown as Record<string, unknown>, 'es');
+}
+
 type FeaturedImage = { thumbnail_url?: string; extracted_url?: string; image_url?: string } | string;
 
 function imageCandidates(images: FeaturedImage[] | undefined, slug: string, heroImage?: string): string[] {
@@ -141,7 +153,7 @@ export async function getEsCollectionList(): Promise<EsCollectionSummary[]> {
     // Which collections hold Spanish editions — indexed by the small set of
     // books that have them, never by scanning collections × books.
     db.collection('books').aggregate<{ _id: string; count: number }>([
-      { $match: { pages_translated_es: { $gt: 0 }, visible: true } },
+      { $match: { ...localizedEditionFilter('es'), visible: true } },
       { $unwind: '$collections' },
       { $group: { _id: '$collections', count: { $sum: 1 } } },
     ], { maxTimeMS: 8000 }).toArray(),
@@ -203,9 +215,11 @@ export async function getEsCollection(slug: string): Promise<EsCollectionDetail 
       // Spanish EDITION gets one; the rest link straight to their English page.
       // The route enforces the same rule with a 307, so a link that gets this
       // wrong is slow, not broken — but it should not be wrong.
-      href: (b.pages_translated_es ?? 0) > 0
-        ? spanishReaderHref(b)
-        : `/book/${encodeURIComponent(b.slug || b.id)}`,
+      //
+      // "Edition" covers both ways a book can be in Spanish: TRANSLATED into it
+      // (the counter) or WRITTEN in it (`language`). Cogolludo needs no pivot to
+      // be Spanish, and testing the counter alone sent him to an English page.
+      href: hasEsEdition(b) ? spanishReaderHref(b) : `/book/${encodeURIComponent(b.slug || b.id)}`,
     };
   });
 
@@ -218,7 +232,7 @@ export async function getEsCollection(slug: string): Promise<EsCollectionDetail 
     description,
     descriptionIsEnglish: copy.descriptionIsEnglish || (!copy.description && !!description),
     bookCount: (doc.total_book_count ?? doc.book_count ?? 0) as number,
-    spanishBookCount: books.filter((b) => (b.pages_translated_es ?? 0) > 0).length,
+    spanishBookCount: books.filter(hasEsEdition).length,
     books,
     truncated,
     parent: parentDoc ? { slug: parentDoc.slug as string, name: spanishCopy(parentDoc).name } : null,

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -7,7 +7,7 @@ import { browseBooks, type CatalogBook } from '@/lib/books-catalog';
 import { toGalleryCardUrl } from '@/lib/utils';
 import { type Plate } from '@/components/GalleryMasonry';
 import { type HomeLang } from '@/lib/home-i18n';
-import { type LocalizedBookMap } from '@/lib/localized';
+import { isNativeEdition, localizedEditionFilter, type LocalizedBookMap } from '@/lib/localized';
 import { spanishReaderHref } from '@/lib/es-collections';
 
 // Shared data layer for the homepage. Both the English `/` route and the
@@ -750,10 +750,21 @@ export interface SpanishBook {
 // are most likely to be looking for. `pages_translated_es` is the book-level
 // counter kept by scripts/maintenance/sync-pages-translated-es.mjs — the per-
 // page fields are not indexed and must never be scanned on a request path.
+//
+// The band selects through localizedEditionFilter('es'), so it holds books that
+// are in Spanish EITHER WAY: translated into it, or written in it. A Spanish
+// original has no counter and never will, and selecting on the counter alone
+// hid 67 live books — Cogolludo, Landa, Aguilar — from the Spanish homepage.
+// Books with a counter still sort first; a native edition has none, so within a
+// read_count tie it follows, which is the right order for a band whose subject
+// is our Spanish editions.
 async function getSpanishBooks(): Promise<SpanishBook[]> {
   const db = await getReadDb();
   const books = await db.collection('books').find(
-    { pages_translated_es: { $gt: 0 }, visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' } },
+    {
+      ...localizedEditionFilter('es'),
+      visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' },
+    },
     {
       projection: {
         _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1,

--- a/src/lib/localized.ts
+++ b/src/lib/localized.ts
@@ -74,19 +74,69 @@ const TRANSLATED_COUNTER: Record<Exclude<Locale, 'en'>, string> = {
 };
 
 /**
+ * `books.language` values whose ORIGINAL text is already in a locale.
+ *
+ * A book WRITTEN in Spanish has no `pages_translated_es` and never will — you
+ * do not pivot Spanish into Spanish — so a counter-only test scores it zero and
+ * hides the most Spanish thing we own from every /es surface. 67 live books
+ * were in exactly that position when this was added.
+ *
+ * ANCHORED on purpose. The stored values it must REFUSE are real ones:
+ * "Spanish / Latin", "Spanish / French", "Nahuatl-Spanish", "Old Spanish", and
+ * "Spanish in Hebrew characters" — Judeo-Spanish in Hebrew script, which a
+ * Spanish reader cannot read at all and which a substring match would happily
+ * claim. A half-Spanish page is a weaker promise than `/es` makes, and a
+ * bilingual edition is its own question (the Ximénez Popol Vuh carries K'iche'
+ * and Spanish in parallel columns and is catalogued under K'iche'). Widen this
+ * only with a decision about what a bilingual page owes a Spanish reader.
+ *
+ * ONE pattern, exported, because the same set has to be selected in Mongo
+ * (`{ language: NATIVE_EDITION_LANGUAGE.es }`) and tested in JS. Two copies of
+ * this rule would drift the moment a spelling is added to one of them.
+ */
+export const NATIVE_EDITION_LANGUAGE: Record<Exclude<Locale, 'en'>, RegExp> = {
+  es: /^\s*(spanish|espa(?:ñ|n)ol|castellano|castilian)\s*$/i,
+};
+
+/** Is the book's own text already in `lang` (no translation involved)? */
+export function isNativeEdition(book: Record<string, unknown>, lang: Locale): boolean {
+  if (lang === 'en') return false; // English is the root; hasLocalizedEdition short-circuits it
+  const pattern = NATIVE_EDITION_LANGUAGE[lang];
+  const language = book?.language;
+  return !!pattern && typeof language === 'string' && pattern.test(language);
+}
+
+/**
+ * Mongo fragment for "this book exists in `lang`" — native original OR
+ * translated pages. Use this wherever a surface selects books for a localized
+ * page, so the query and `hasLocalizedEdition` below can never disagree.
+ */
+export function localizedEditionFilter(lang: Exclude<Locale, 'en'>): Record<string, unknown> {
+  return {
+    $or: [
+      { [TRANSLATED_COUNTER[lang]]: { $gt: 0 } },
+      { language: NATIVE_EDITION_LANGUAGE[lang] },
+    ],
+  };
+}
+
+/**
  * Does this book actually EXIST in `lang`?
  *
  * A localized URL is a promise that the page is in that language, so this is
  * the gate on whether `/es/book/<slug>` may exist at all — not a display
  * preference. English is always true (it is the root). For any other language
- * it means the book's PAGES have been translated: a title gloss alone is
- * chrome, not an edition.
+ * it means the book's PAGES are in it, which happens two ways: they were
+ * TRANSLATED into it (`pages_translated_<iso> > 0`), or they were WRITTEN in it
+ * (`NATIVE_EDITION_LANGUAGE`). Either way the promise `/es` makes is kept. A
+ * title gloss alone is still chrome, not an edition.
  *
- * Returns `null` when the payload cannot answer — the counter is a Mongo field
- * and the Supabase catalog fast-path does not carry it. Callers must treat
- * `null` as "ask, or do nothing", NEVER as false: reading an absent field as
- * "no Spanish edition" would 307 a genuinely Spanish book to English, which is
- * the absence-is-not-failure trap this codebase keeps re-learning.
+ * Returns `null` when the payload cannot answer — both inputs are Mongo fields
+ * and the Supabase catalog fast-path carries neither. Callers must treat `null`
+ * as "ask, or do nothing", NEVER as false: reading an absent field as "no
+ * Spanish edition" would 307 a genuinely Spanish book to English, which is the
+ * absence-is-not-failure trap this codebase keeps re-learning. Note both fields
+ * must be PROJECTED for a false to mean anything — see the tail of the body.
  */
 export function hasLocalizedEdition(
   book: Record<string, unknown>,
@@ -95,9 +145,17 @@ export function hasLocalizedEdition(
   if (lang === 'en') return true;
   const field = TRANSLATED_COUNTER[lang];
   if (!field) return false;
+  // Written in the language: the pages already ARE it, no counter involved.
+  if (isNativeEdition(book, lang)) return true;
   const value = book[field];
   if (value === undefined) return null;
-  return typeof value === 'number' && value > 0;
+  if (typeof value === 'number' && value > 0) return true;
+  // The counter says no. That only settles it if we could also SEE that the
+  // book is not a native edition — with `language` unprojected we cannot, and
+  // answering false here would 307 a genuinely Spanish book to English, the
+  // exact failure the paragraph above warns about. Say "cannot answer" instead;
+  // callers re-ask Atlas with both fields projected.
+  return book.language === undefined ? null : false;
 }
 
 type CollectionLike = {

--- a/tests/unit/localized-edition-promise.test.ts
+++ b/tests/unit/localized-edition-promise.test.ts
@@ -16,7 +16,28 @@ describe('hasLocalizedEdition', () => {
   it('is true only when the book has PAGES in that language', () => {
     expect(hasLocalizedEdition({ pages_translated_es: 445 }, 'es')).toBe(true);
     expect(hasLocalizedEdition({ pages_translated_es: 1 }, 'es')).toBe(true);
-    expect(hasLocalizedEdition({ pages_translated_es: 0 }, 'es')).toBe(false);
+    // Counter zero AND the book is known not to be a Spanish original.
+    expect(hasLocalizedEdition({ pages_translated_es: 0, language: 'Latin' }, 'es')).toBe(false);
+  });
+
+  // A book WRITTEN in Spanish has no pages_translated_es and never will — you do
+  // not pivot Spanish into Spanish. Testing the counter alone hid 67 live books
+  // (Cogolludo, Landa, Aguilar) from every /es surface while they sat there
+  // fully readable. "Has pages in Spanish" is the promise; being written in it
+  // keeps that promise as completely as being translated into it.
+  it('counts a book WRITTEN in the language as an edition', () => {
+    expect(hasLocalizedEdition({ language: 'Spanish' }, 'es')).toBe(true);
+    expect(hasLocalizedEdition({ language: 'spanish', pages_translated_es: 0 }, 'es')).toBe(true);
+  });
+
+  // These are real stored `books.language` values, read off production, not
+  // invented for the assertion. A substring match would claim every one of them.
+  it('refuses partly-Spanish editions — the /es promise is the whole page', () => {
+    for (const language of ['Spanish / Latin', 'Spanish / French', 'Nahuatl-Spanish', 'Old Spanish']) {
+      expect(hasLocalizedEdition({ language, pages_translated_es: 0 }, 'es')).toBe(false);
+    }
+    // Judeo-Spanish in Hebrew script: Spanish words a Spanish reader cannot read.
+    expect(hasLocalizedEdition({ language: 'Spanish in Hebrew characters', pages_translated_es: 0 }, 'es')).toBe(false);
   });
 
   it('a title gloss alone is NOT an edition', () => {
@@ -35,14 +56,26 @@ describe('hasLocalizedEdition', () => {
   });
 
   it('a projected-but-absent field is an ANSWER at the call site', () => {
-    // Call sites that projected the counter explicitly resolve null with
+    // Call sites that projected BOTH inputs explicitly resolve null with
     // `?? false`; this pins the shape they rely on.
-    const projectedDoc: Record<string, unknown> = {}; // { _id: 0, pages_translated_es: 1 } over a book with none
+    const projectedDoc: Record<string, unknown> = {}; // both fields asked for, book has neither
     expect(hasLocalizedEdition(projectedDoc, 'es') ?? false).toBe(false);
   });
 
-  it('treats a non-numeric counter as no edition', () => {
-    expect(hasLocalizedEdition({ pages_translated_es: null }, 'es')).toBe(false);
-    expect(hasLocalizedEdition({ pages_translated_es: '445' }, 'es')).toBe(false);
+  // CONTRACT CHANGE, deliberate: a zero counter alone no longer settles it.
+  // Once "written in Spanish" counts as an edition, a doc with the counter
+  // projected but `language` absent cannot distinguish "not translated" from
+  // "Spanish original we cannot see" — and answering false there would 307 a
+  // genuinely Spanish book to English, the failure this whole helper exists to
+  // prevent. So it says "cannot answer" and the caller re-asks with both fields.
+  // Both current call sites project both, so neither is affected.
+  it('a zero counter with language unknown is null, not false', () => {
+    expect(hasLocalizedEdition({ pages_translated_es: 0 }, 'es')).toBe(null);
+    expect(hasLocalizedEdition({ pages_translated_es: null }, 'es')).toBe(null);
+  });
+
+  it('treats a non-numeric counter as no edition when the language is known', () => {
+    expect(hasLocalizedEdition({ pages_translated_es: null, language: 'Latin' }, 'es')).toBe(false);
+    expect(hasLocalizedEdition({ pages_translated_es: '445', language: 'Latin' }, 'es')).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug

Every /es surface asked one question — `pages_translated_es > 0` — and that counter counts **EN→ES pivot pages**. A book *written* in Spanish has no pivot pages and never will, because you don't translate Spanish into Spanish. So it scored zero and was invisible: absent from the /es home band, uncounted on every collection, and **307'd off its own `/es/book/<slug>` URL** by the route gate.

**67 live books were in that position.** All have OCR. All are readable right now. Among them Cogolludo's *Historia de Yucatán* (both volumes), Landa's *Relación*, and Aguilar's *Informe contra idolorum cultores* — sitting in the `maya` collection, in Spanish, unreachable from the Spanish site.

**/es goes from 103 books to 170.** Measured, not estimated.

## This keeps the rule, it doesn't bend it

`.claude/docs/i18n.md` records the rule as *"if it isn't Spanish, it's not /es."* A Spanish original satisfies that completely — the pages genuinely **are** Spanish. What was wrong was the *definition of edition*, which said "translated into it" when it meant "in it". Now it means: in it, by translation **or** by authorship.

## One rule, four readers

`NATIVE_EDITION_LANGUAGE` in `localized.ts` is a single exported pattern read by the Mongo query (`localizedEditionFilter`), the collection card, the Spanish count, and the route gate (`hasLocalizedEdition`). Two copies of this rule would drift the first time a spelling was added to one of them.

It is **anchored on purpose**, and the values it refuses are real ones read off production, not hypotheticals:

| stored `books.language` | claimed? |
|---|---|
| `Spanish` | yes |
| `Spanish / Latin` | no |
| `Spanish / French` | no |
| `Nahuatl-Spanish` | no |
| `Old Spanish` | no |
| `Spanish in Hebrew characters` | no |

That last one is the reason a substring match would have been a bug: Judeo-Spanish printed in Hebrew script is Spanish words a Spanish reader cannot read. A bilingual edition is its own question — the Ximénez Popol Vuh carries K'iche' and Spanish in parallel columns and is catalogued under K'iche' — and is deliberately left for a decision about what a half-Spanish page owes a Spanish reader.

## Contract change, deliberate

`hasLocalizedEdition` now returns **`null` rather than `false`** when the counter is zero *and* `language` was not projected. It genuinely cannot distinguish "not translated" from "Spanish original we can't see", and answering `false` there would 307 a genuinely Spanish book to English — the exact failure the helper exists to prevent.

Both call sites project both fields. The book-page fallback lookup was projecting only the counter and is fixed here; the reader layout's `PAGE_META_PROJECTION` already carried both.

## The reader

`englishOcrIsReadingView` is generalised. A book written in the reading language has no translation *into* it, so the transcription **is** the text — without this the Spanish reader paints an empty translation panel over an all-Spanish book. The English pre/post-1820 behaviour is untouched.

## Verification

- `npx tsc --noEmit` clean; **2,800 tests across 205 files pass**
- The spec file changed because the spec changed, with the reasoning inline. New cases use language values read off production rather than invented ones.
- **Negative control run** (`tests-that-are-not-guards.md`): breaking `isNativeEdition` turns the native-edition test red; restoring it turns it green. A test I haven't watched fail isn't a guard.

## No request-path regression — measured

The query this replaces was *already* a scan: `pages_translated_es` is not indexed, so it examined the whole visible set. Before and after, from `explain('executionStats')`:

| | returned | docs examined | ms |
|---|---|---|---|
| baseline (counter only) | 103 | 37,821 | 1158 |
| new (`$or` with the pattern) | 170 | 37,821 | 839 |

Identical work, 67 more books. **Out of scope but worth an issue:** that scan is on an ISR request path and neither branch is indexed — it predates this PR and I haven't touched it.

## Out of scope

- Bilingual editions (the Ximénez Popol Vuh) — needs a product decision first.
- Paid EN→ES pivots for the Yucatec and English Maya books.
- Indexing the band query.

Part of #4095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC54GMgv8cdmbVojFrwhGq