### PR TITLE
docs(i18n): rule 6 described the reading-language store retired in #4114

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -61,10 +61,27 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    importing IT from a server component is an error in Next 16, because it pulls
    in `usePathname`. Server code imports `@/lib/locale-path`; client code can use
    either.
-6. **Reading language follows the reader off the prefix.** `src/lib/reading-language.ts`
-   (localStorage): a `/es` visit or `?lang=es` stores it; the reader toggle
-   persists it. This is what lets the cache-shared `/book/*` pages stay
-   language-agnostic until they have their own twin.
+6. **Reading language is the prefix too — nothing follows the reader.** Rule 5
+   has no exception. `/book/…` renders English, `/es/book/…` renders Spanish,
+   and the reader's EN/ES control is a LINK between those two URLs (built with
+   `localeHref`), not a view toggle.
+
+   This rule used to read the opposite way: `src/lib/reading-language.ts` kept a
+   `localStorage` preference that "follows the reader off the prefix." It was
+   written on mere ARRIVAL at any `/es/…` page and read on mount by every book
+   page, English ones included — so one visit to the Spanish site silently
+   switched the English site to Spanish, permanently, with nothing in the URL to
+   explain it (#4112, reported by a reader who followed an `/encyclopedia` link
+   and landed in Spanish). Being client-side it was also invisible to every
+   server-side check: the HTML ships `lang="en"` with English metadata and the
+   swap happens after hydration.
+
+   A store keyed on nothing in the URL cannot tell *"I read Spanish"* from *"I
+   looked at the Spanish site once"* — and it is the same edge-cache branch rule
+   5 exists to forbid, just spelled in localStorage instead of a cookie. What is
+   left of that module migrates legacy `?lang=es` links to their twin and clears
+   the stale key. **Do not reintroduce a cross-URL language preference in any
+   form.**
 
 ## Adding a language (checklist)
 
@@ -77,7 +94,9 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    `books.pages_translated_<iso>` (declare it in `book-docs.mjs`) and a derived
    collection like `en-espanol` via `sync-es-collection.mjs` as the template.
 4. `localize-metadata.mjs --lang=<iso> --books-with-editions`.
-5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts` and the reader toggle.
+5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts`, and the reader's language
+   links in `PageEditorClient` (a third locale makes that pair a list — keep it
+   built from `localeHref`, one link per prefixed locale).
 
 ## The book page: ONE page, two URLs
 


### PR DESCRIPTION
Follow-up to #4114 / #4112 — the downward half of the CLAUDE.md loop ("is anything here now stale?").

`.claude/docs/i18n.md` rule 5 says *"the locale is the URL prefix, and it stays."* Rule 6 said the reading language **doesn't** — it documented the `localStorage` store as the design, with the cache-sharing rationale that made it sound deliberate.

That gap between rules 5 and 6 is exactly where the bug lived: a `/es` **visit** wrote the preference and every English book page read it on mount, so one look at the Spanish site switched the English site to Spanish permanently.

Rule 6 now states the real rule (no exception to rule 5), records why a cross-URL language preference is wrong so it isn't rebuilt, and the add-a-language checklist names the reader's language **links** instead of a toggle.

Docs only — no code, no deploy owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tKgEkDtGGD8kemc4WSkmy