### PR TITLE
fix(reader): EN/ES language links belong in the reader header, not a band above it

### DIFF
--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -400,6 +400,42 @@ export default function PageEditorClient({
     } as Page;
   }
 
+  // EN/ES as LINKS between `/book/…` and `/es/book/…`, not as a view toggle:
+  // the language a reader is in is always the URL they are on (#4112). It rides
+  // INSIDE the reader's own header (#4116) rather than in a band above it — a
+  // separate strip made the ~100 books with a Spanish edition look like they
+  // carried a site notice, and put the one control that changes what you are
+  // reading outside the bar holding every other reading control.
+  // Hidden inside a tenant reading room or an embed — those surfaces have no
+  // `/es` twin and must never link off-tenant — and hidden on a pinned citation
+  // URL, whose whole point is that it resolves to one fixed text.
+  const showLanguageSwitch =
+    hasSpanish && !pinnedVersion && !isOnTenantSubdomain && !isOnEmbedRoute && !params?.tenant;
+  const languageSwitch = showLanguageSwitch ? (
+    <div
+      className="inline-flex shrink-0 overflow-hidden rounded-lg text-xs font-medium"
+      style={{ background: 'var(--bg-warm)' }}
+      role="group"
+      aria-label={rs.readingLanguage}
+    >
+      {(['en', 'es'] as const).map((code) => (
+        <Link
+          key={code}
+          href={localeHref(code, readerPath)}
+          aria-current={lang === code ? 'page' : undefined}
+          className="px-2 sm:px-2.5 py-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+          style={{
+            background: lang === code ? 'var(--accent-rust)' : 'transparent',
+            color: lang === code ? '#fff' : 'var(--text-muted)',
+          }}
+        >
+          <span className="hidden sm:inline">{code === 'en' ? 'English' : 'Español'}</span>
+          <span className="sm:hidden">{code === 'en' ? 'EN' : 'ES'}</span>
+        </Link>
+      ))}
+    </div>
+  ) : null;
+
   return (
     <>
       <Suspense fallback={null}>
@@ -418,36 +454,9 @@ export default function PageEditorClient({
         />
       )}
 
-      {/* EN/ES as LINKS between `/book/…` and `/es/book/…`, not as a view
-          toggle: the language a reader is in is always the URL they are on
-          (#4112). Hidden inside a tenant reading room or an embed — those
-          surfaces have no `/es` twin and must never link off-tenant — and
-          hidden on a pinned citation URL, whose whole point is that it resolves
-          to one fixed text. */}
-      {hasSpanish && !pinnedVersion && !isOnTenantSubdomain && !isOnEmbedRoute && !params?.tenant && (
-        <div className="flex items-center justify-center gap-2 py-2 text-sm" aria-label={rs.readingLanguage}>
-          <span className="text-neutral-500">{rs.readIn}</span>
-          <div className="inline-flex overflow-hidden rounded-full border border-neutral-300">
-            <Link
-              href={localeHref('en', readerPath)}
-              aria-current={lang === 'en' ? 'page' : undefined}
-              className={`px-3 py-1 transition-colors ${lang === 'en' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
-            >
-              English
-            </Link>
-            <Link
-              href={localeHref('es', readerPath)}
-              aria-current={lang === 'es' ? 'page' : undefined}
-              className={`px-3 py-1 transition-colors ${lang === 'es' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
-            >
-              Español
-            </Link>
-          </div>
-        </div>
-      )}
-
       <TranslationEditor
         book={book}
+        languageSwitch={languageSwitch}
         page={displayPage}
         pages={pageList}
         currentIndex={currentIndex}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, type ReactNode } from 'react';
 import { useParams, usePathname } from 'next/navigation';
 import { useStableSession } from '@/hooks/useStableSession';
 import { resolveImprintPlace } from '@/lib/imprint';
@@ -189,6 +189,13 @@ interface TranslationEditorProps {
   onNavigate: (pageId: string, opts?: { toTop?: boolean }) => void;
   onSave: (data: { ocr?: string; translation?: string; summary?: string }) => Promise<void>;
   onRefresh?: () => Promise<void>;
+  /**
+   * EN/ES reading-language links, built by the caller (PageEditorClient) because
+   * the target URLs are locale paths, not editor state. Rendered inside the
+   * reader header rather than as a band above it (#4116); null when the book has
+   * no Spanish edition, or on a tenant/embed/pinned-version surface.
+   */
+  languageSwitch?: ReactNode;
 }
 
 interface SettingsModalProps {
@@ -443,6 +450,7 @@ export default function TranslationEditor({
   onNavigate,
   onSave,
   onRefresh,
+  languageSwitch,
 }: TranslationEditorProps) {
   const params = useParams<{ tenant: string }>();
   const pathname = usePathname();
@@ -1225,6 +1233,8 @@ export default function TranslationEditor({
                 )}
               </a>
             </div>
+
+            {languageSwitch}
 
             {/* Chapter Navigation */}
             {book.chapters && book.chapters.length > 0 && (
@@ -2349,6 +2359,8 @@ export default function TranslationEditor({
               )}
             </a>
           </div>
+
+          {languageSwitch}
 
           {/* Navigation */}
           <div className="flex items-center gap-1 rounded-lg p-1 shrink-0" style={{ background: 'var(--bg-warm)' }}>

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -357,7 +357,6 @@ export interface ReaderStrings {
   close: string;
   pageAbbrev: (n: number) => string;
   // reading language
-  readIn: string;
   readingLanguage: string;
   pageNavigation: string;
   metaPageOf: (n: number, title: string) => string;
@@ -438,7 +437,6 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     close: 'Close',
     pageAbbrev: (n) => `p.\u00A0${n}`,
 
-    readIn: 'Read in:',
     readingLanguage: 'Reading language',
     pageNavigation: 'Page navigation',
     metaPageOf: (n, title) => `Page ${n} of "${title}"`,
@@ -517,7 +515,6 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     close: 'Cerrar',
     pageAbbrev: (n) => `pág.\u00A0${n}`,
 
-    readIn: 'Leer en:',
     readingLanguage: 'Idioma de lectura',
     pageNavigation: 'Navegación por páginas',
     metaPageOf: (n, title) => `Página ${n} de «${title}»`,


### PR DESCRIPTION
## What

Moves the reading-language control from a standalone strip above the reader into the reader's own header row.

Before: a full-width bar across the top of the page holding one control, stacked above the `SOURCELIBRARY / title / chapters / page-nav` header. After: an `English | Español` pill inside that header, between the title block and the chapter dropdown, styled like its neighbours (warm ground, `--accent-rust` for the active locale).

## Why

Two problems with the band, both cosmetic-looking and neither cosmetic:

1. **It reads as a site notice.** A thin full-width bar at the top of a page, holding one control, is the shape of every "your session expired" banner. It renders only on the ~100 books that carry a Spanish edition — so the books we most want to feel finished are the ones that look like they're flagging something.
2. **It separated the language control from every other reading control.** Pages, chapters, panels, font size, cite and like all live in the header. The one control that changes *which text you are reading* sat outside it.

Reported by Derek from a live page (`/book/900-theses-1486-rome-edition-pico-della-mirandola/page/…`).

## What is NOT changed

- The links themselves: still `/book/…` ↔ `/es/book/…`, still built from `currentPageId` rather than `usePathname()` (page flips use `history.pushState`, which Next's router does not observe), still hidden on tenant reading rooms, embeds, and pinned-version citation URLs. #4112's invariant — reading language is the URL prefix and nothing else — is untouched, and `tests/unit/reading-language-url.test.ts` still passes.
- The reader stays chromeless (no `SiteHeader`). It is on the `KNOWN_MINIMAL` allowlist in `scripts/audit/headerless-pages.mjs` as an immersive reader, deliberately, since #3180 — this PR does not reopen that.

## Notes

- Placement lives in `TranslationEditor` (it owns the header); the hrefs stay in `PageEditorClient` (it knows the locale). Passed as a `languageSwitch?: ReactNode` prop.
- Rendered in **both** the read-mode and edit-mode headers so they cannot drift.
- Full labels at `sm` and up, `EN`/`ES` below, so it costs no width on a phone where the title is already truncated.
- Drops the now-unused `readIn` string from `BOOK_STRINGS` (en + es).

## Out of scope

The third panel-visibility tab is labelled with the target language name ("Español"), which sits awkwardly next to a real language switcher — it toggles the translation *panel*, it does not change language. Renaming it to "Translation" / "Traducción" is a separate copy decision.

## Checks

`npx tsc --noEmit` clean; `tests/unit/reading-language-url.test.ts` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjRSQoY7i6PndpRXWyQLBf