### PR TITLE
fix(i18n): a locale prefix is not a tenant slug — /es pages call /api/es/*

### DIFF
--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
+import { PREFIXED_LOCALES } from '@/lib/locale-path';
 
 // Global routes that are not tenant slugs; keep in sync with proxy routing rules.
 const NON_TENANT_SEGMENTS = new Set([
@@ -17,6 +18,16 @@ const NON_TENANT_SEGMENTS = new Set([
 
 export function getTenantSlugFromPathname(pathname: string): string | null {
   const segments = pathname.split('/').filter(Boolean);
+  // A locale prefix is NOT a tenant. `/es/book/x` is the Spanish rendering of a
+  // GLOBAL route, so every client call it fires must go to `/api/books/...`,
+  // not `/api/es/books/...` — a tenant-scoped URL whose slug resolves to
+  // nothing, which the API answers with a flat 404 ("Book not found" in the
+  // cover picker, "Tenant not found" in analytics). Strip the prefix and let
+  // the rest of the resolution run unchanged; a real tenant page under a
+  // locale (`/es/bph/...`) still resolves to `bph`.
+  if (segments[0] && (PREFIXED_LOCALES as string[]).includes(segments[0])) {
+    segments.shift();
+  }
   // Handle /embed/{tenant}/... paths (tenant subdomains rewrite to /embed/bph/...)
   if (segments[0] === 'embed' && segments[1]) {
     const embedTenant = segments[1];

--- a/tests/unit/locale-prefix-not-tenant.test.ts
+++ b/tests/unit/locale-prefix-not-tenant.test.ts
@@ -1,0 +1,42 @@
+/**
+ * A locale prefix is not a tenant slug.
+ *
+ * `/es/book/<id>` is the Spanish rendering of a GLOBAL route, but the
+ * client-side tenant resolver read its first path segment and returned `es`,
+ * so every api-client call fired from a Spanish page went to `/api/es/...`.
+ * No tenant has that slug, so the route answered 404 — which surfaced to a
+ * reader as "Book not found" inside the cover picker on /es/book/…, and as
+ * "Tenant not found" on the loading-analytics endpoint.
+ *
+ * The resolver must strip a locale prefix before looking for a tenant, while
+ * still resolving a real tenant that happens to sit under one.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getTenantSlugFromPathname } from '@/lib/api-client/client';
+import { PREFIXED_LOCALES } from '@/lib/locale-path';
+
+describe('getTenantSlugFromPathname', () => {
+  it('returns null for global routes under a locale prefix', () => {
+    for (const locale of PREFIXED_LOCALES) {
+      expect(getTenantSlugFromPathname(`/${locale}`)).toBeNull();
+      expect(getTenantSlugFromPathname(`/${locale}/`)).toBeNull();
+      expect(getTenantSlugFromPathname(`/${locale}/book/celestial-hierarchy`)).toBeNull();
+      expect(getTenantSlugFromPathname(`/${locale}/collections/alchemy`)).toBeNull();
+    }
+  });
+
+  it('still resolves a tenant that sits under a locale prefix', () => {
+    for (const locale of PREFIXED_LOCALES) {
+      expect(getTenantSlugFromPathname(`/${locale}/bph/book/x`)).toBe('bph');
+      expect(getTenantSlugFromPathname(`/${locale}/embed/bph/book/x`)).toBe('bph');
+    }
+  });
+
+  it('leaves unprefixed routes alone', () => {
+    expect(getTenantSlugFromPathname('/book/celestial-hierarchy')).toBeNull();
+    expect(getTenantSlugFromPathname('/gallery')).toBeNull();
+    expect(getTenantSlugFromPathname('/bph/book/x')).toBe('bph');
+    expect(getTenantSlugFromPathname('/embed/bph/book/x')).toBe('bph');
+  });
+});


### PR DESCRIPTION
## What happened

Opening the cover picker on `https://sourcelibrary.org/es/book/celestial-hierarchy-divine-names…` and choosing a page fails with **"Book not found."** The book exists; the request never reached it.

`getTenantSlugFromPathname` (src/lib/api-client/client.ts) treats the first path segment as a tenant slug unless it's on an exclusion list. `es` isn't on that list, so on any `/es/...` page every api-client call is built tenant-scoped:

| call from an `/es` page | result |
|---|---|
| `PATCH /api/es/books/<id>` (cover save) | 404 `{"error":"Book not found"}` |
| `GET /api/es/likes?...` | 400 |
| `POST /api/es/analytics/loading` | 400 `{"error":"Tenant not found"}` |

Verified against production, not inferred — all three measured today.

The cover picker's page grid is server-rendered, so nothing looks wrong until save time, which is why this reads as a missing book rather than a routing bug.

## Fix

Strip a `PREFIXED_LOCALES` prefix before tenant resolution. A real tenant under a locale (`/es/bph/...`, `/es/embed/bph/...`) still resolves; unprefixed behaviour is unchanged. `src/lib/locale-path.ts` already carried the rule ("Keep the prefixes disjoint from tenant slugs") — the client-side resolver was the half that never got it.

Adding a new prefixed locale is now covered automatically: the test iterates `PREFIXED_LOCALES`.

## Scope

In: the client tenant resolver + a regression test. Out: the server-side proxy resolver, which resolves tenants against the database and so has never mistaken `es` for one.

`npx tsc --noEmit` clean; new unit test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuWqyiLFfftfiKfXyawPgc