### PR TITLE
docs: an output that cannot vary with its input is reporting nothing

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -1,6 +1,6 @@
 # A metric is a claim about an instrument before it is a claim about readers
 
-**Read this when:** Quoting any usage number, building an analytics read path, adding an alarm or health probe, adding a search/analytics write path, or answering "how many readers…".
+**Read this when:** Quoting any usage number, building an analytics read path, adding an alarm or health probe, adding a search/analytics write path, answering "how many readers…", or building any RANKED or RELATED list a reader will read as meaningful (connections, recommendations, "see also").
 
 *Split out of `CLAUDE.md` on 2026-08-04. The text is unchanged apart from cross-references repointed to their new files. See `.claude/docs/knowledge-layer.md` for why this tier exists.*
 
@@ -132,6 +132,32 @@ what was new is that a *safety control* embodied it.
   in the store production writes to, and cross-check the vendor's own meter (Cloud Monitoring
   hourly buckets — day-aligned queries anchor to the query END time and silently become
   rolling-24h windows). Verified 2026-08-09 for ~$0.05.
+
+## An output that cannot vary with its input is reporting nothing — and a plausible list hides it best
+
+The `/encyclopedia/[name]` **Connections** panel showed "other entities that appear in
+the same books as X". It found entities sharing a book with the subject, sorted them by
+their **global** `book_count`, took the top 20 — and only THEN computed the shared-book
+overlap. The corpus's most frequent entities (Rome 6,242 books, Egypt 6,103, Aristotle
+4,834, Plato 4,464 …) share a book with essentially every subject, so the limit always
+ate the same twenty. Measured 2026-08-21: Active Intellect (248 books), Philosopher's
+Stone (89), Kabbalah (496), Rosicrucian (14) and Mercury (825) returned an **identical
+list, in identical order**. The panel had shipped long enough to be indexed, and was
+caught by a reader asking "are these legit?" (#4109 removed it; #4111 rebuilds it).
+
+- **The failure is upstream of the numbers.** A sort + limit that runs before the
+  subject-specific measure doesn't merely rank badly — it makes the output stop
+  depending on the input at all. Compute the per-subject measure BEFORE the limit.
+- **Rank by association, not frequency.** Lift or PMI — shared books over what chance
+  predicts from each item's own base rate — with a support floor. Raw co-occurrence in a
+  corpus with a heavy head is a popularity readout wearing a relevance label.
+- **It fails in the most expensive direction: plausible.** An empty panel gets reported
+  in a day; twenty famous, on-topic-looking names read as insight. Same family as *an
+  activity count is not a quality metric* and *an empty set is not disagreement* below —
+  a signal that cannot move is not a weak signal, it is not a signal.
+- **No single-subject check can see it.** The guard is a test that two different inputs
+  produce different outputs. One that asserts only "the panel renders for X" passes for
+  the entire life of the bug — see `tests-that-are-not-guards.md`.
 
 ## An activity count is not a quality metric, and "carrying" is not "depending"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - A localized route (`/es/…`), a title/name/intro in another language, a field holding translated metadata, adding a language → `../i18n.md` (**one `localized` map per record, never `title_<lang>` columns**; the locale is the URL prefix and stays)
 
 **Measuring anything**
-- Quoting a usage number, analytics read/write paths, alarms, health probes, **a scheduled detector that files its findings as issues**, or using a model as a judge/screen → `measurement-instruments.md`
+- Quoting a usage number, analytics read/write paths, alarms, health probes, **a scheduled detector that files its findings as issues**, using a model as a judge/screen, or **any ranked/related list a reader reads as meaningful** (connections, recommendations, "see also") → `measurement-instruments.md`
 - Writing a test that pins behaviour, or a fixture for one → `tests-that-are-not-guards.md`
 - Normalising, folding, comparing or validating TEXT (names, quotes, dedup keys, detectors) → `non-latin-text-operations.md`
 


### PR DESCRIPTION
The up-half of the `/gnite` ratchet for #4109 / #4111.

## The incident

The `/encyclopedia/[name]` **Connections** panel ranked co-occurring entities by their **global** `book_count` and cut to the top 20 **before** computing the shared-book overlap. The corpus's most frequent entities (Rome 6,242 books, Egypt 6,103, Aristotle 4,834 …) share a book with essentially every subject, so the limit always ate the same twenty. Measured: Active Intellect (248 books), Philosopher's Stone (89), Kabbalah (496), Rosicrucian (14) and Mercury (825) returned an **identical list in identical order**.

It shipped, was indexed, and was caught by a reader asking "are these legit?" — not by any check.

## Where it goes

`measurement-instruments.md`, beside *"an activity count is not a quality metric"* and *"an empty set is not disagreement"*. Same family: a signal that cannot move is not a weak signal, it is not a signal.

What's new beyond the family:

- **The failure direction.** An empty panel gets reported in a day; twenty famous, on-topic-looking names read as insight. Plausible output hides this better than broken output does.
- **The guard.** Assert that two different inputs produce different outputs. A check asserting only "the panel renders for X" passes for the entire life of the bug.
- **The fix shape.** Compute the per-subject measure before the limit, and rank by association (lift/PMI) rather than raw frequency — co-occurrence in a heavy-headed corpus is a popularity readout wearing a relevance label.

## Routing

Also widens that doc's "Read this when" line, and the `CLAUDE.md` routing entry, to name **ranked/related lists** (connections, recommendations, "see also"). Nobody building a connections panel would have thought to look under "measurement instruments" — which is exactly why the family was already documented and the instance still shipped.

`CLAUDE.md` 231 → 232 lines, within the ~250 budget; no demotion owed.

Docs only — no deploy owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tKgEkDtGGD8kemc4WSkmy