### PR TITLE
feat(audit): detect a book's real language mix from the per-page OCR tag (#4117)

### DIFF
--- a/.claude/docs/invariants/language-fields.md
+++ b/.claude/docs/invariants/language-fields.md
@@ -105,6 +105,52 @@ different languages.
 
 **Use it to generate candidates. Never copy it into `languages[]`.**
 
+## Compare by FAMILY, not by name — or the artifact eats the finding
+
+A language name and a language *identity* are not the same thing, and the gap
+between them is where language detectors go wrong. Two measured examples from
+the first full run of the detector (#4117, 2026-08-21), both of which produced
+confident, wrong headline numbers before they were caught:
+
+1. **Compound catalogue values.** 96 of the 229 distinct live `books.language`
+   values are list-shaped strings. Normalising the catalogue value with a
+   single-token function makes every one of them match nothing, so they all land
+   in "contradicts the catalogue". Comenius's *Orbis Sensualium Pictus*
+   (catalogued `Latin/English`, measured English 93% / Latin 91%) is catalogued
+   **correctly** and was reported as a mislabel. All five apparent mislabels in
+   the first 200-book slice were this artifact. **Parse the catalogue value as a
+   list before comparing it to anything.**
+2. **Historical stages of one language.** The first full run reported 6,230
+   bilingual books; **2,387 of them — 38% — were "Chinese + Classical Chinese"**,
+   the OCR model emitting two labels for a single text, page to page. The Korean
+   *hanmun* corpus has the same shape and supplied 196 of the 1,053 apparent
+   mislabels: Joseon scholarly works catalogued Korean whose pages are Classical
+   Chinese, which is what that literature *is*.
+
+`languageFamily()` / `sameLanguageFamily()` in `language-normalize` exist for
+case 2. Historical stages stay **distinct as catalogue values** — a reader
+looking for Old English does not want modern English — and count as **one
+language** when asking whether a book is bilingual. Families today: Chinese
+(+ Classical, Literary), English (+ Old, Middle), French (+ Old, Middle),
+German (+ Middle High, Old High, Early New High), Hebrew (+ Biblical,
+Samaritan), Church Slavonic (+ Old).
+
+**The general rule, worth more than either instance:** when a detector fires and
+the output looks like a data problem, suspect the detector's own vocabulary
+first. Both of the above read as corpus defects and were defects in the
+comparison. Before reporting a rate, take the largest single cluster in your
+findings and look at it by hand — an artifact is almost always the *biggest*
+group, because it is systematic and the real thing is not.
+
+## The Korean/hanmun class must never be auto-flipped
+
+A book catalogued `Korean` whose pages are Classical Chinese is not mislabelled.
+Provenance, tradition and readership are Korean; the script on the page is
+literary Chinese. The same holds for Sanskrit in Tibetan works and for Latin in
+early modern vernacular scholarship. These belong in `languages[]` as an
+addition, never as a replacement of `language`, and they are the standing reason
+the detector's `contradict` bucket is a review queue and not a patch.
+
 ## Four vocabularies, none authoritative
 
 - `src/lib/language-utils.ts` — `CODE_TO_NAME` / `CODE3_TO_NAME` / `expandLanguages` (read path)
@@ -143,6 +189,10 @@ answer is a sweep-log row or an existing flag — not `language_<yourthing>`.
 5. OCR/translation routing reads the **per-page** tag, never `languages[0]` —
    a bilingual page set must not inherit one model choice from a book-level field.
 6. New language field ⇒ demote something or use a row. Check the 18 above first.
+7. Parse the catalogue value as a **list** and compare by **family** before
+   claiming any book disagrees with its own record.
+8. Before quoting a rate from a language detector, hand-check its largest
+   cluster. Twice now that cluster has been the instrument, not the corpus.
 
 ## Open issues
 

--- a/scripts/audit/detect-book-languages.mjs
+++ b/scripts/audit/detect-book-languages.mjs
@@ -47,7 +47,7 @@
 import { MongoClient } from 'mongodb';
 import fs from 'node:fs';
 import path from 'node:path';
-import { normalizeLanguageToken, parseLanguageField } from '../lib/language-normalize.mjs';
+import { normalizeLanguageToken, parseLanguageField, languageFamily } from '../lib/language-normalize.mjs';
 
 const arg = (name, dflt) => {
   const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
@@ -126,13 +126,34 @@ function verdict(book, prof) {
 
   const top = prof.shares[0];
   const above = prof.shares.filter((s) => s.share >= THRESHOLD);
-  const aboveSet = new Set(above.map((s) => s.lang));
+
+  // Compare by FAMILY, not by name. "Chinese" and "Classical Chinese" are
+  // distinct catalogue values and the same language for this question; without
+  // this, 2,387 of 6,230 apparently-bilingual books were one text tagged two
+  // ways by the OCR model (measured on the first full run, 2026-08-21).
+  const famOf = (l) => languageFamily(l);
+  const cataloguedFams = new Set(catalogued.map(famOf));
+  const aboveFams = new Set(above.map((s) => famOf(s.lang)));
   /** Catalogue languages the pages actually support. */
-  const supported = catalogued.filter((l) => aboveSet.has(l));
+  const supported = catalogued.filter((l) => aboveFams.has(famOf(l)));
   /** Catalogue languages the pages do NOT support at this threshold. */
-  const unsupported = catalogued.filter((l) => !aboveSet.has(l));
-  /** Measured languages the catalogue never mentions. */
-  const extra = above.filter((s) => !cataloguedSet.has(s.lang)).map((s) => s.lang);
+  const unsupported = catalogued.filter((l) => !aboveFams.has(famOf(l)));
+  /**
+   * Measured languages the catalogue never mentions — one per family, highest
+   * share first, so a book is not credited with "Chinese AND Classical Chinese".
+   */
+  const seenFams = new Set(cataloguedFams);
+  const extra = [];
+  for (const s of above) {
+    const f = famOf(s.lang);
+    if (seenFams.has(f)) continue;
+    seenFams.add(f);
+    extra.push(s.lang);
+  }
+  /** Variant spellings of a catalogued language, reported but never counted as a second language. */
+  const variants = above
+    .filter((s) => cataloguedFams.has(famOf(s.lang)) && !cataloguedSet.has(s.lang))
+    .map((s) => s.lang);
 
   // Order: supported catalogue languages first, in catalogue order, so the
   // `languages[0] === language` invariant survives for scalar values; then the
@@ -157,8 +178,9 @@ function verdict(book, prof) {
     changed,
     // Catalogued language is present but is NOT the dominant one — pinning it at
     // languages[0] puts a minority language first (both Lascaris copies do this).
-    primary_shifted: supported.length > 0 && !cataloguedSet.has(top.lang),
+    primary_shifted: supported.length > 0 && !cataloguedFams.has(languageFamily(top.lang)),
     unsupported: unsupported.length ? unsupported : null,
+    variants: variants.length ? variants : null,
   };
 }
 

--- a/scripts/audit/detect-book-languages.mjs
+++ b/scripts/audit/detect-book-languages.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Detect each book's real language mix from the per-page OCR `<language>` tag.
+ *
+ * WHY THIS EXISTS (#4117, split out of #4089)
+ * -------------------------------------------
+ * `books.languages[]` already exists on 45,675 books, but it is written by
+ * `scripts/maintenance/normalize-language-tags.mjs`, which only PARSES the
+ * string already in `books.language`. It can turn "Greek-Latin" into two
+ * entries; it can never learn that a book catalogued "Greek" is half Latin.
+ * On our two copies of the 1495 Aldine Lascaris it ran and confirmed the wrong
+ * answer on both.
+ *
+ * The `<language>` tag the OCR model writes into `pages.ocr.data` IS real
+ * per-page detection, and it is already paid for. On those same two copies,
+ * independently OCR'd, it returned Latin 178 / Greek 153 and Latin 175 / Greek
+ * 151 — near-identical, against two different catalogue answers.
+ *
+ * DO NOT use `pages.ocr.language` (the FIELD). That is the request parameter
+ * (`null`, `"auto-detect"`); reading it as an answer measures your own input.
+ *
+ * THIS SCRIPT NEVER WRITES. It is the dry-run report #4117 asks for, and the
+ * instrument for tuning the "is it really bilingual" threshold before anyone
+ * writes anything. There is deliberately no --apply.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/detect-book-languages.mjs --limit=500
+ *   node scripts/audit/detect-book-languages.mjs --resume          # long run
+ *   node scripts/audit/detect-book-languages.mjs --book-id=69b220ccf79d8af0eab7fd3a
+ *
+ * Flags:
+ *   --out=FILE         JSONL output (default scripts/output/book-languages.jsonl)
+ *   --limit=N          stop after N books
+ *   --book-id=ID       one book (implies --limit=1, prints detail)
+ *   --resume           continue from <out>.checkpoint instead of starting over
+ *   --concurrency=N    parallel per-book aggregations (default 6)
+ *   --threshold=F      share at which a second language is "real" (default 0.10)
+ *   --min-pages=N      fewest tagged pages for a verdict (default 10)
+ *   --all              include hidden/unpublished books (default: live only)
+ *
+ * Checkpointing is not optional here and not a nicety: this is a corpus walk
+ * over ~57K books, and three long jobs died mid-walk in one day in July 2026
+ * because they streamed a cursor across slow work. Each batch is re-queried by
+ * `_id` range; the checkpoint is flushed with every batch.
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+import { normalizeLanguageToken, parseLanguageField } from '../lib/language-normalize.mjs';
+
+const arg = (name, dflt) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : dflt;
+};
+const flag = (name) => process.argv.includes(`--${name}`);
+
+const OUT = arg('out', 'scripts/output/book-languages.jsonl');
+const CHECKPOINT = `${OUT}.checkpoint`;
+const LIMIT = Number(arg('limit', '0')) || 0;
+const BOOK_ID = arg('book-id', '');
+const RESUME = flag('resume');
+const CONCURRENCY = Math.max(1, Number(arg('concurrency', '6')));
+const THRESHOLD = Number(arg('threshold', '0.10'));
+const MIN_PAGES = Number(arg('min-pages', '10'));
+const ALL = flag('all');
+const BATCH = 200;
+/** Extra thresholds reported so the real one can be chosen from evidence. */
+const SENSITIVITY = [0.05, 0.10, 0.15, 0.20, 0.25];
+
+if (process.argv.includes('--apply')) {
+  console.error('This script never writes. Removing --apply and continuing would be a lie; refusing instead.');
+  console.error('Writing languages[] is gated on a tuned threshold + a reviewed sample — see #4117.');
+  process.exit(2);
+}
+
+/** Pull the `<language>` tag out of the head of each page and count pages per raw tag. */
+async function tagCounts(pages, bookId) {
+  return pages.aggregate([
+    { $match: { book_id: bookId, 'ocr.data': { $type: 'string' } } },
+    // The tag sits in the first 40 chars on ~95% of pages and at 0 on ~61%
+    // (sampled 2026-08-21). Capping the input keeps this off the full text.
+    { $project: { head: { $substrCP: ['$ocr.data', 0, 300] } } },
+    { $project: { tag: { $regexFind: { input: '$head', regex: '<language>([^<]{0,60})</language>' } } } },
+    { $group: { _id: { $arrayElemAt: ['$tag.captures', 0] }, n: { $sum: 1 } } },
+  ], { maxTimeMS: 60000, allowDiskUse: false }).toArray();
+}
+
+/**
+ * Turn raw tag counts into normalized per-language page counts.
+ * A page tagged "Latin, Greek" counts toward BOTH, so shares can sum above 1.
+ * That is deliberate: the alternative (splitting the page's weight) would
+ * under-report facing-page editions, which are the whole point of this run.
+ */
+function profile(rows) {
+  const byLang = new Map();
+  let tagged = 0, untagged = 0, unparsed = 0;
+  for (const r of rows) {
+    const raw = r._id;
+    if (raw == null) { untagged += r.n; continue; }
+    const langs = parseLanguageField(raw);
+    if (!langs.length) { unparsed += r.n; continue; }
+    tagged += r.n;
+    for (const l of langs) byLang.set(l, (byLang.get(l) || 0) + r.n);
+  }
+  const shares = [...byLang.entries()]
+    .map(([lang, n]) => ({ lang, pages: n, share: tagged ? n / tagged : 0 }))
+    .sort((a, b) => b.share - a.share || a.lang.localeCompare(b.lang));
+  return { tagged, untagged, unparsed, shares };
+}
+
+function verdict(book, prof) {
+  // The catalogue value may itself be a LIST: 96 of the 229 distinct live
+  // `books.language` values are compound strings ("Latin/English",
+  // "Hebrew and Aramaic") on 262 live books. Parsing with the single-token
+  // normaliser made every one of them look like a mislabel — Comenius's
+  // *Orbis Sensualium Pictus* (catalogued "Latin/English", measured English 93%
+  // / Latin 91%) is catalogued CORRECTLY and was being reported as contradicted.
+  const catalogued = parseLanguageField(book.language);
+  const cataloguedSet = new Set(catalogued);
+  const current = Array.isArray(book.languages) ? book.languages : null;
+  if (!prof.shares.length) {
+    return { bucket: prof.tagged || prof.unparsed ? 'unparsed' : 'no_tag', proposed: null, catalogued };
+  }
+  if (prof.tagged < MIN_PAGES) return { bucket: 'thin', proposed: null, catalogued };
+
+  const top = prof.shares[0];
+  const above = prof.shares.filter((s) => s.share >= THRESHOLD);
+  const aboveSet = new Set(above.map((s) => s.lang));
+  /** Catalogue languages the pages actually support. */
+  const supported = catalogued.filter((l) => aboveSet.has(l));
+  /** Catalogue languages the pages do NOT support at this threshold. */
+  const unsupported = catalogued.filter((l) => !aboveSet.has(l));
+  /** Measured languages the catalogue never mentions. */
+  const extra = above.filter((s) => !cataloguedSet.has(s.lang)).map((s) => s.lang);
+
+  // Order: supported catalogue languages first, in catalogue order, so the
+  // `languages[0] === language` invariant survives for scalar values; then the
+  // rest by measured share.
+  const proposed = supported.length ? [...supported, ...extra] : above.map((s) => s.lang);
+
+  let bucket;
+  if (!catalogued.length) bucket = 'no_catalogue_value';
+  else if (!supported.length) bucket = 'contradict';   // #2184 class — gate on text_role
+  else if (extra.length) bucket = 'add_second';        // bilingual candidate
+  else if (unsupported.length) bucket = 'unsupported_claim'; // catalogue claims a language the pages don't show
+  else bucket = 'agree';
+
+  const changed = !current
+    || current.length !== proposed.length
+    || current.some((v, i) => v !== proposed[i]);
+
+  return {
+    bucket,
+    proposed,
+    catalogued,
+    changed,
+    // Catalogued language is present but is NOT the dominant one — pinning it at
+    // languages[0] puts a minority language first (both Lascaris copies do this).
+    primary_shifted: supported.length > 0 && !cataloguedSet.has(top.lang),
+    unsupported: unsupported.length ? unsupported : null,
+  };
+}
+
+/** How many languages would clear each candidate threshold? Feeds the tuning decision. */
+function sensitivity(prof) {
+  const out = {};
+  for (const t of SENSITIVITY) out[t] = prof.shares.filter((s) => s.share >= t).length;
+  return out;
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI not set (set -a; source .env.production.local; set +a).');
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+
+  let after = null;
+  if (RESUME && fs.existsSync(CHECKPOINT)) {
+    after = fs.readFileSync(CHECKPOINT, 'utf8').trim() || null;
+    console.error(`resuming after _id ${after}`);
+  } else if (!BOOK_ID) {
+    fs.writeFileSync(OUT, '');
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+  const sink = fs.createWriteStream(OUT, { flags: RESUME ? 'a' : 'w' });
+
+  const query = BOOK_ID
+    ? { id: BOOK_ID }
+    : { pages_ocr: { $gt: 0 }, ...(ALL ? {} : { visible: true }) };
+  const projection = { id: 1, title: 1, language: 1, languages: 1, language_multi: 1, pages_ocr: 1, text_role: 1, visible: 1 };
+
+  const totals = { seen: 0, written: 0 };
+  const buckets = {};
+  const sensTotals = Object.fromEntries(SENSITIVITY.map((t) => [t, 0]));
+  const started = process.hrtime.bigint();
+
+  for (;;) {
+    const q = after ? { ...query, _id: { $gt: after } } : query;
+    const batch = await books.find(q, { projection }).sort({ _id: 1 }).limit(BATCH).maxTimeMS(60000).toArray();
+    if (!batch.length) break;
+
+    // Bounded concurrency: Atlas serves the request path from the same cluster.
+    for (let i = 0; i < batch.length; i += CONCURRENCY) {
+      const slice = batch.slice(i, i + CONCURRENCY);
+      const results = await Promise.all(slice.map(async (book) => {
+        try {
+          const prof = profile(await tagCounts(pages, book.id));
+          return { book, prof, error: null };
+        } catch (e) {
+          return { book, prof: null, error: String(e && e.message || e) };
+        }
+      }));
+      for (const { book, prof, error } of results) {
+        totals.seen++;
+        // An error is recorded as a ROW, never skipped silently — an absent
+        // book in the output must mean "not reached", not "failed quietly".
+        if (error) {
+          sink.write(JSON.stringify({ id: book.id, bucket: 'error', error }) + '\n');
+          buckets.error = (buckets.error || 0) + 1;
+          continue;
+        }
+        const v = verdict(book, prof);
+        const sens = sensitivity(prof);
+        for (const t of SENSITIVITY) if (sens[t] > 1) sensTotals[t]++;
+        buckets[v.bucket] = (buckets[v.bucket] || 0) + 1;
+        sink.write(JSON.stringify({
+          id: book.id,
+          title: book.title,
+          language: book.language,
+          catalogued: v.catalogued,
+          languages_current: book.languages ?? null,
+          language_multi_current: book.language_multi ?? null,
+          text_role: book.text_role ?? null,
+          pages_ocr: book.pages_ocr ?? null,
+          tagged: prof.tagged,
+          untagged: prof.untagged,
+          unparsed: prof.unparsed,
+          shares: prof.shares.map((s) => [s.lang, Number(s.share.toFixed(4)), s.pages]),
+          bucket: v.bucket,
+          proposed_languages: v.proposed,
+          changed: v.changed ?? null,
+          primary_shifted: v.primary_shifted ?? null,
+          unsupported: v.unsupported ?? null,
+          multi_at: sens,
+        }) + '\n');
+        totals.written++;
+      }
+    }
+
+    after = batch[batch.length - 1]._id;
+    fs.writeFileSync(CHECKPOINT, String(after));
+    const secs = Number(process.hrtime.bigint() - started) / 1e9;
+    console.error(`${totals.seen} books · ${(totals.seen / secs).toFixed(1)}/s · ${JSON.stringify(buckets)}`);
+    if (BOOK_ID || (LIMIT && totals.seen >= LIMIT)) break;
+  }
+
+  await new Promise((r) => sink.end(r));
+  await client.close();
+
+  console.error('\n--- summary (DRY RUN — nothing written to the database) ---');
+  console.error(`books examined: ${totals.seen}, rows written: ${totals.written} -> ${OUT}`);
+  console.error(`buckets: ${JSON.stringify(buckets, null, 1)}`);
+  console.error(`\nthreshold sensitivity — books that would be MULTI-language at each cut:`);
+  for (const t of SENSITIVITY) {
+    console.error(`  >= ${(t * 100).toFixed(0)}%: ${sensTotals[t]} of ${totals.seen}`);
+  }
+  console.error(`\nActive threshold this run: ${(THRESHOLD * 100).toFixed(0)}% (min ${MIN_PAGES} tagged pages).`);
+  console.error('Pick the real one from a hand-labelled sample before ANY write (#4117).');
+  console.error('`contradict` rows are #2184 candidates and must gate on text_role — `language`');
+  console.error('is the EDITION language, and a sweep that forgot nearly relabelled 547 books.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/audit/detect-book-languages.mjs
+++ b/scripts/audit/detect-book-languages.mjs
@@ -270,6 +270,10 @@ async function main() {
           changed: v.changed ?? null,
           primary_shifted: v.primary_shifted ?? null,
           unsupported: v.unsupported ?? null,
+          // Same-family variant spellings on this book's pages ("Chinese" AND
+          // "Classical Chinese"). Never counted as a second language; recorded
+          // because an inconsistent tag vocabulary is itself a finding (#3893).
+          variants: v.variants ?? null,
           multi_at: sens,
         }) + '\n');
         totals.written++;

--- a/scripts/lib/language-normalize.mjs
+++ b/scripts/lib/language-normalize.mjs
@@ -1,0 +1,131 @@
+/**
+ * Pinned plain-node twin of `src/lib/language-normalize.ts`.
+ *
+ * Held identical by `tests/unit/language-normalize-parity.test.ts`. Change both
+ * sides or neither — a normaliser that disagrees with itself depending on which
+ * door the data came through is the exact disease this file exists to end
+ * (cf. `identity-fields.mjs`, `r2-key.mjs`).
+ *
+ * See `.claude/docs/invariants/language-fields.md`.
+ */
+
+/** ISO-639-1 -> canonical English name. */
+const CODE2 = {
+  ar: 'Arabic', bn: 'Bengali', cs: 'Czech', da: 'Danish', de: 'German', el: 'Greek',
+  en: 'English', es: 'Spanish', fa: 'Persian', fr: 'French', gu: 'Gujarati',
+  he: 'Hebrew', hi: 'Hindi', hu: 'Hungarian', it: 'Italian', ja: 'Japanese',
+  kn: 'Kannada', ko: 'Korean', la: 'Latin', ml: 'Malayalam', mr: 'Marathi',
+  nl: 'Dutch', no: 'Norwegian', pa: 'Punjabi', pl: 'Polish', pt: 'Portuguese',
+  ru: 'Russian', sa: 'Sanskrit', sv: 'Swedish', ta: 'Tamil', te: 'Telugu',
+  tr: 'Turkish', ur: 'Urdu', vi: 'Vietnamese', zh: 'Chinese',
+};
+
+/** ISO-639-2/3 and MARC -> canonical English name. */
+const CODE3 = {
+  ara: 'Arabic', arm: 'Armenian', ben: 'Bengali', ces: 'Czech', chi: 'Chinese',
+  chu: 'Church Slavonic', cze: 'Czech', dan: 'Danish', deu: 'German', dut: 'Dutch',
+  egy: 'Egyptian', ell: 'Greek', eng: 'English', enm: 'Middle English',
+  fas: 'Persian', fra: 'French', fre: 'French', frm: 'Middle French',
+  fro: 'Old French', geo: 'Georgian', ger: 'German', gmh: 'Middle High German',
+  grc: 'Greek', gre: 'Greek', heb: 'Hebrew', hin: 'Hindi', hun: 'Hungarian',
+  ice: 'Icelandic', ita: 'Italian', jpn: 'Japanese', kor: 'Korean', lat: 'Latin',
+  mar: 'Marathi', nah: 'Nahuatl', nld: 'Dutch', nor: 'Norwegian', ota: 'Ottoman Turkish',
+  per: 'Persian', pol: 'Polish', por: 'Portuguese', rus: 'Russian', san: 'Sanskrit',
+  spa: 'Spanish', swe: 'Swedish', syr: 'Syriac', tam: 'Tamil', tel: 'Telugu',
+  tur: 'Turkish', urd: 'Urdu', zho: 'Chinese',
+};
+
+/** Variant spellings -> canonical. Curly-apostrophe forms included on purpose. */
+const SYNONYM = {
+  geez: "Ge'ez", "ge'ez": "Ge'ez", 'ge’ez': "Ge'ez", ethiopic: "Ge'ez",
+  'quiche maya': "K'iche' Maya", 'quiché maya': "K'iche' Maya",
+  castilian: 'Spanish', flemish: 'Dutch',
+  hellenistic: 'Greek', attic: 'Greek', koine: 'Greek',
+  'high german': 'German', 'low german': 'German',
+};
+
+/**
+ * Tokens meaning "no usable signal". Checked BEFORE any delimiter split, which
+ * is what keeps "N/A" from being read as two languages named "n" and "a".
+ */
+const PLACEHOLDER = new Set([
+  '', '-', '--', 'n/a', 'na', 'none', 'null', 'nil', 'unknown', 'und',
+  'undetermined', 'unidentified', 'illegible', 'blank', 'multiple', 'mul',
+  'mixed', 'various', 'zxx', 'auto-detect', 'auto', 'visual', 'no text',
+  'not applicable', 'unclear', 'indeterminate',
+]);
+
+/** Real languages whose canonical name contains a hyphen or a period word. */
+const DISTINCT_VARIANTS = new Set([
+  'old english', 'middle english', 'old french', 'middle french',
+  'middle high german', 'old high german', 'early new high german',
+  'old church slavonic', 'church slavonic', 'old norse', 'old irish',
+  'classical chinese', 'literary chinese', 'ottoman turkish', 'biblical hebrew',
+  'samaritan hebrew', 'judeo-arabic', 'judeo-italian', 'judeo-greek',
+  'judeo-persian', 'judeo-occitan', 'anglo-norman', 'scottish gaelic',
+  'egyptian hieroglyphs',
+]);
+
+/** Prefixes that are period markers, not separate languages. */
+const VARIANT_PREFIX = /^(ancient|modern|classical|koine|medieval|mediaeval|late|early|vulgar|new)\s+/;
+
+/** Title-case a word, including across hyphens: "judeo-arabic" -> "Judeo-Arabic". */
+const TITLE = (s) =>
+  s.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('-');
+
+/**
+ * Normalise ONE token (a code or a free-text name) to a canonical language
+ * name, or null when the token carries no language signal.
+ */
+export function normalizeLanguageToken(raw) {
+  if (raw == null) return null;
+  let s = String(raw).toLowerCase().trim();
+  s = s.replace(/\([^)]*\)/g, ' ');
+  s = s.replace(/\s+in\s+[\w'’-]+\s+script\b/g, ' ');
+  s = s.replace(/[.\s]+$/, '').replace(/^[.\s]+/, '').replace(/\s+/g, ' ').trim();
+  if (PLACEHOLDER.has(s)) return null;
+  if (!s) return null;
+  if (SYNONYM[s]) return SYNONYM[s];
+  if (CODE2[s]) return CODE2[s];
+  if (CODE3[s]) return CODE3[s];
+  if (DISTINCT_VARIANTS.has(s)) return s.split(' ').map(TITLE).join(' ');
+  const stripped = s.replace(VARIANT_PREFIX, '').trim();
+  if (stripped && stripped !== s) {
+    if (PLACEHOLDER.has(stripped)) return null;
+    if (SYNONYM[stripped]) return SYNONYM[stripped];
+    if (CODE2[stripped]) return CODE2[stripped];
+    if (CODE3[stripped]) return CODE3[stripped];
+    return stripped.split(' ').map(TITLE).join(' ');
+  }
+  return s.split(' ').map(TITLE).join(' ');
+}
+
+/**
+ * Parse a possibly-compound language string into an ordered, de-duplicated list
+ * of canonical names.
+ */
+export function parseLanguageField(raw) {
+  if (raw == null) return [];
+  const cleaned = String(raw).toLowerCase().trim();
+  if (PLACEHOLDER.has(cleaned)) return [];
+  const whole = normalizeLanguageToken(raw);
+  if (whole && (DISTINCT_VARIANTS.has(cleaned) || !/[,;/]|\sand\s|\s&\s|-/.test(cleaned))) {
+    return [whole];
+  }
+  const out = [];
+  const push = (v) => { if (v && !out.includes(v)) out.push(v); };
+  for (const frag of String(raw).split(/\s*[,;/]\s*|\s+and\s+|\s+&\s+/i)) {
+    const f = frag.trim();
+    if (!f) continue;
+    const bare = f.toLowerCase().replace(/\([^)]*\)/g, ' ').replace(/\s+/g, ' ').trim();
+    const direct = normalizeLanguageToken(f);
+    if (direct && DISTINCT_VARIANTS.has(bare)) { push(direct); continue; }
+    if (f.includes('-')) {
+      const halves = f.split(/\s*-\s*/);
+      const parts = halves.map(normalizeLanguageToken).filter(Boolean);
+      if (parts.length > 1 && parts.length === halves.length) { parts.forEach(push); continue; }
+    }
+    push(direct);
+  }
+  return out;
+}

--- a/scripts/lib/language-normalize.mjs
+++ b/scripts/lib/language-normalize.mjs
@@ -69,6 +69,37 @@ const DISTINCT_VARIANTS = new Set([
 /** Prefixes that are period markers, not separate languages. */
 const VARIANT_PREFIX = /^(ancient|modern|classical|koine|medieval|mediaeval|late|early|vulgar|new)\s+/;
 
+/**
+ * Historical stages that are distinct languages for CATALOGUING but the same
+ * language for "is this book bilingual?".
+ *
+ * Measured artifact this fixes: on the first full corpus run,
+ * "Chinese + Classical Chinese" was 2,387 of 6,230 apparently-bilingual books —
+ * the OCR model emitting two labels for one text, not a facing-page edition.
+ */
+const FAMILY = {
+  'Classical Chinese': 'Chinese', 'Literary Chinese': 'Chinese',
+  'Old English': 'English', 'Middle English': 'English',
+  'Old French': 'French', 'Middle French': 'French',
+  'Middle High German': 'German', 'Old High German': 'German',
+  'Early New High German': 'German',
+  'Biblical Hebrew': 'Hebrew', 'Samaritan Hebrew': 'Hebrew',
+  'Old Church Slavonic': 'Church Slavonic',
+};
+
+/** The family a canonical language name belongs to, for equivalence tests. */
+export function languageFamily(name) {
+  if (!name) return null;
+  return FAMILY[name] || name;
+}
+
+/** True when two canonical names are the same language for bilingual purposes. */
+export function sameLanguageFamily(a, b) {
+  const fa = languageFamily(a);
+  const fb = languageFamily(b);
+  return !!fa && !!fb && fa === fb;
+}
+
 /** Title-case a word, including across hyphens: "judeo-arabic" -> "Judeo-Arabic". */
 const TITLE = (s) =>
   s.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('-');

--- a/src/lib/language-normalize.ts
+++ b/src/lib/language-normalize.ts
@@ -1,0 +1,154 @@
+/**
+ * Canonical language-token normalisation.
+ *
+ * Source Library had FOUR uncontrolled language vocabularies when this was
+ * written (2026-08-21, #4117): `language-utils.ts` on the read path,
+ * `scripts/maintenance/normalize-language-tags.mjs` on the write path, the
+ * per-source maps under `scripts/iiif-discovery/sources/`, and the free-text
+ * `<language>` tag the OCR model writes into `pages.ocr.data`, which had none
+ * at all. This file is the merge of the first two, extended to survive the
+ * fourth. See `.claude/docs/invariants/language-fields.md`.
+ *
+ * Twin convention: `scripts/lib/language-normalize.mjs` is a pinned copy for
+ * plain-node workers, held identical by
+ * `tests/unit/language-normalize-parity.test.ts`. Change both sides or neither.
+ *
+ * DELIBERATE DIFFERENCE from `displayLanguage()` in `language-utils.ts`: that
+ * function strips every period prefix, so "Old English" becomes "English" and
+ * "Middle High German" becomes "High German" — distinct languages merged into
+ * their modern descendants. Here, variant prefixes collapse ("Ancient Greek" →
+ * "Greek", which is what the OCR tag needs) EXCEPT for the forms in
+ * DISTINCT_VARIANTS, which are real separate languages and survive intact.
+ * The read path is NOT rewired to use this yet — that belongs to #4089/#3893,
+ * because changing `expandLanguages()` changes what search returns.
+ */
+
+/** ISO-639-1 -> canonical English name. */
+const CODE2: Record<string, string> = {
+  ar: 'Arabic', bn: 'Bengali', cs: 'Czech', da: 'Danish', de: 'German', el: 'Greek',
+  en: 'English', es: 'Spanish', fa: 'Persian', fr: 'French', gu: 'Gujarati',
+  he: 'Hebrew', hi: 'Hindi', hu: 'Hungarian', it: 'Italian', ja: 'Japanese',
+  kn: 'Kannada', ko: 'Korean', la: 'Latin', ml: 'Malayalam', mr: 'Marathi',
+  nl: 'Dutch', no: 'Norwegian', pa: 'Punjabi', pl: 'Polish', pt: 'Portuguese',
+  ru: 'Russian', sa: 'Sanskrit', sv: 'Swedish', ta: 'Tamil', te: 'Telugu',
+  tr: 'Turkish', ur: 'Urdu', vi: 'Vietnamese', zh: 'Chinese',
+};
+
+/** ISO-639-2/3 and MARC -> canonical English name. */
+const CODE3: Record<string, string> = {
+  ara: 'Arabic', arm: 'Armenian', ben: 'Bengali', ces: 'Czech', chi: 'Chinese',
+  chu: 'Church Slavonic', cze: 'Czech', dan: 'Danish', deu: 'German', dut: 'Dutch',
+  egy: 'Egyptian', ell: 'Greek', eng: 'English', enm: 'Middle English',
+  fas: 'Persian', fra: 'French', fre: 'French', frm: 'Middle French',
+  fro: 'Old French', geo: 'Georgian', ger: 'German', gmh: 'Middle High German',
+  grc: 'Greek', gre: 'Greek', heb: 'Hebrew', hin: 'Hindi', hun: 'Hungarian',
+  ice: 'Icelandic', ita: 'Italian', jpn: 'Japanese', kor: 'Korean', lat: 'Latin',
+  mar: 'Marathi', nah: 'Nahuatl', nld: 'Dutch', nor: 'Norwegian', ota: 'Ottoman Turkish',
+  per: 'Persian', pol: 'Polish', por: 'Portuguese', rus: 'Russian', san: 'Sanskrit',
+  spa: 'Spanish', swe: 'Swedish', syr: 'Syriac', tam: 'Tamil', tel: 'Telugu',
+  tur: 'Turkish', urd: 'Urdu', zho: 'Chinese',
+};
+
+/** Variant spellings -> canonical. Curly-apostrophe forms included on purpose. */
+const SYNONYM: Record<string, string> = {
+  geez: "Ge'ez", "ge'ez": "Ge'ez", 'ge’ez': "Ge'ez", ethiopic: "Ge'ez",
+  'quiche maya': "K'iche' Maya", 'quiché maya': "K'iche' Maya",
+  castilian: 'Spanish', flemish: 'Dutch',
+  hellenistic: 'Greek', attic: 'Greek', koine: 'Greek',
+  'high german': 'German', 'low german': 'German',
+};
+
+/**
+ * Tokens meaning "no usable signal". Checked BEFORE any delimiter split, which
+ * is what keeps "N/A" from being read as two languages named "n" and "a" — a
+ * real bug in a throwaway probe that briefly reported 1-2% "n" across the corpus.
+ */
+const PLACEHOLDER = new Set([
+  '', '-', '--', 'n/a', 'na', 'none', 'null', 'nil', 'unknown', 'und',
+  'undetermined', 'unidentified', 'illegible', 'blank', 'multiple', 'mul',
+  'mixed', 'various', 'zxx', 'auto-detect', 'auto', 'visual', 'no text',
+  'not applicable', 'unclear', 'indeterminate',
+]);
+
+/** Real languages whose canonical name contains a hyphen or a period word. */
+const DISTINCT_VARIANTS = new Set([
+  'old english', 'middle english', 'old french', 'middle french',
+  'middle high german', 'old high german', 'early new high german',
+  'old church slavonic', 'church slavonic', 'old norse', 'old irish',
+  'classical chinese', 'literary chinese', 'ottoman turkish', 'biblical hebrew',
+  'samaritan hebrew', 'judeo-arabic', 'judeo-italian', 'judeo-greek',
+  'judeo-persian', 'judeo-occitan', 'anglo-norman', 'scottish gaelic',
+  'egyptian hieroglyphs',
+]);
+
+/** Prefixes that are period markers, not separate languages. */
+const VARIANT_PREFIX = /^(ancient|modern|classical|koine|medieval|mediaeval|late|early|vulgar|new)\s+/;
+
+/** Title-case a word, including across hyphens: "judeo-arabic" -> "Judeo-Arabic". */
+const TITLE = (s: string) =>
+  s.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('-');
+
+/**
+ * Normalise ONE token (a code or a free-text name) to a canonical language
+ * name, or null when the token carries no language signal.
+ */
+export function normalizeLanguageToken(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  let s = String(raw).toLowerCase().trim();
+  // "Sanskrit (transliterated)", "undetermined (Voynich script)"
+  s = s.replace(/\([^)]*\)/g, ' ');
+  // "Italian in Italian script"
+  s = s.replace(/\s+in\s+[\w'’-]+\s+script\b/g, ' ');
+  s = s.replace(/[.\s]+$/, '').replace(/^[.\s]+/, '').replace(/\s+/g, ' ').trim();
+  if (PLACEHOLDER.has(s)) return null;
+  if (!s) return null;
+  if (SYNONYM[s]) return SYNONYM[s];
+  if (CODE2[s]) return CODE2[s];
+  if (CODE3[s]) return CODE3[s];
+  if (DISTINCT_VARIANTS.has(s)) return s.split(' ').map(TITLE).join(' ');
+  const stripped = s.replace(VARIANT_PREFIX, '').trim();
+  if (stripped && stripped !== s) {
+    if (PLACEHOLDER.has(stripped)) return null;
+    if (SYNONYM[stripped]) return SYNONYM[stripped];
+    if (CODE2[stripped]) return CODE2[stripped];
+    if (CODE3[stripped]) return CODE3[stripped];
+    return stripped.split(' ').map(TITLE).join(' ');
+  }
+  return s.split(' ').map(TITLE).join(' ');
+}
+
+/**
+ * Parse a possibly-compound language string into an ordered, de-duplicated list
+ * of canonical names. Handles "Greek-Latin", "Hebrew and Aramaic",
+ * "Cakchiquel / English", "Arabic, Ottoman Turkish, Persian".
+ *
+ * Order is preserved from the source string; callers that want order by
+ * measured page share must sort it themselves.
+ */
+export function parseLanguageField(raw: string | null | undefined): string[] {
+  if (raw == null) return [];
+  const cleaned = String(raw).toLowerCase().trim();
+  if (PLACEHOLDER.has(cleaned)) return [];
+  const whole = normalizeLanguageToken(raw);
+  // A whole-string match wins: "Judeo-Arabic" must not split on its hyphen.
+  if (whole && (DISTINCT_VARIANTS.has(cleaned) || !/[,;/]|\sand\s|\s&\s|-/.test(cleaned))) {
+    return [whole];
+  }
+  const out: string[] = [];
+  const push = (v: string | null) => { if (v && !out.includes(v)) out.push(v); };
+  for (const frag of String(raw).split(/\s*[,;/]\s*|\s+and\s+|\s+&\s+/i)) {
+    const f = frag.trim();
+    if (!f) continue;
+    const bare = f.toLowerCase().replace(/\([^)]*\)/g, ' ').replace(/\s+/g, ' ').trim();
+    const direct = normalizeLanguageToken(f);
+    if (direct && DISTINCT_VARIANTS.has(bare)) { push(direct); continue; }
+    if (f.includes('-')) {
+      const halves = f.split(/\s*-\s*/);
+      const parts = halves.map(normalizeLanguageToken).filter(Boolean) as string[];
+      // Only treat the hyphen as a delimiter when EVERY side is a real language.
+      if (parts.length > 1 && parts.length === halves.length) { parts.forEach(push); continue; }
+    }
+    push(direct);
+  }
+  return out;
+}

--- a/src/lib/language-normalize.ts
+++ b/src/lib/language-normalize.ts
@@ -84,6 +84,45 @@ const DISTINCT_VARIANTS = new Set([
 /** Prefixes that are period markers, not separate languages. */
 const VARIANT_PREFIX = /^(ancient|modern|classical|koine|medieval|mediaeval|late|early|vulgar|new)\s+/;
 
+/**
+ * Historical stages that are distinct languages for CATALOGUING but the same
+ * language for "is this book bilingual?".
+ *
+ * This exists because of a measured artifact: on the first full corpus run,
+ * "Chinese + Classical Chinese" was 2,387 of 6,230 apparently-bilingual books —
+ * 38% of the finding — and every one was the OCR model emitting two labels for
+ * one text, not a facing-page edition. Same trap for the Korean hanmun corpus,
+ * where pages alternate between "Chinese" and "Classical Chinese" tags.
+ *
+ * Keep the names distinct (a reader looking for Old English does not want
+ * modern English) but compare by family before claiming a second language.
+ */
+const FAMILY: Record<string, string> = {
+  'Classical Chinese': 'Chinese', 'Literary Chinese': 'Chinese',
+  'Old English': 'English', 'Middle English': 'English',
+  'Old French': 'French', 'Middle French': 'French',
+  'Middle High German': 'German', 'Old High German': 'German',
+  'Early New High German': 'German',
+  'Biblical Hebrew': 'Hebrew', 'Samaritan Hebrew': 'Hebrew',
+  'Old Church Slavonic': 'Church Slavonic',
+};
+
+/**
+ * The family a canonical language name belongs to, for equivalence tests.
+ * Returns the name itself when it heads its own family.
+ */
+export function languageFamily(name: string | null | undefined): string | null {
+  if (!name) return null;
+  return FAMILY[name] || name;
+}
+
+/** True when two canonical names are the same language for bilingual purposes. */
+export function sameLanguageFamily(a: string | null | undefined, b: string | null | undefined): boolean {
+  const fa = languageFamily(a);
+  const fb = languageFamily(b);
+  return !!fa && !!fb && fa === fb;
+}
+
 /** Title-case a word, including across hyphens: "judeo-arabic" -> "Judeo-Arabic". */
 const TITLE = (s: string) =>
   s.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('-');

--- a/tests/unit/language-normalize-parity.test.ts
+++ b/tests/unit/language-normalize-parity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeLanguageToken, parseLanguageField } from '@/lib/language-normalize';
+import { normalizeLanguageToken, parseLanguageField, languageFamily, sameLanguageFamily } from '@/lib/language-normalize';
 import * as twin from '../../scripts/lib/language-normalize.mjs';
 
 /**
@@ -69,6 +69,43 @@ describe('language-normalize TS/mjs parity', () => {
       expect(twin.parseLanguageField(f), `field: ${JSON.stringify(f)}`)
         .toEqual(parseLanguageField(f));
     }
+  });
+
+  it('languageFamily agrees on every fixture', () => {
+    for (const t of TOKENS) {
+      const canon = normalizeLanguageToken(t);
+      expect(twin.languageFamily(canon), `family: ${JSON.stringify(canon)}`)
+        .toEqual(languageFamily(canon));
+    }
+  });
+});
+
+describe('language families', () => {
+  /**
+   * The artifact this guards: on the first full corpus run,
+   * "Chinese + Classical Chinese" was 2,387 of 6,230 apparently-bilingual books
+   * — 38% of the headline finding — and every one was the OCR model emitting
+   * two labels for a single text. Same trap on the Korean hanmun corpus.
+   */
+  it('treats historical stages as one language for bilingual purposes', () => {
+    expect(sameLanguageFamily('Chinese', 'Classical Chinese')).toBe(true);
+    expect(sameLanguageFamily('English', 'Old English')).toBe(true);
+    expect(sameLanguageFamily('German', 'Middle High German')).toBe(true);
+    expect(sameLanguageFamily('Hebrew', 'Biblical Hebrew')).toBe(true);
+  });
+
+  it('still keeps the names distinct for cataloguing', () => {
+    expect(normalizeLanguageToken('Classical Chinese')).toBe('Classical Chinese');
+    expect(normalizeLanguageToken('Old English')).toBe('Old English');
+    expect(languageFamily('Classical Chinese')).toBe('Chinese');
+    expect(languageFamily('Latin')).toBe('Latin');
+  });
+
+  it('does not merge genuinely different languages', () => {
+    expect(sameLanguageFamily('Latin', 'Greek')).toBe(false);
+    expect(sameLanguageFamily('Chinese', 'Korean')).toBe(false);
+    expect(sameLanguageFamily('German', 'Dutch')).toBe(false);
+    expect(sameLanguageFamily('Hebrew', 'Aramaic')).toBe(false);
   });
 });
 

--- a/tests/unit/language-normalize-parity.test.ts
+++ b/tests/unit/language-normalize-parity.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLanguageToken, parseLanguageField } from '@/lib/language-normalize';
+import * as twin from '../../scripts/lib/language-normalize.mjs';
+
+/**
+ * The language detector (#4117) runs the .mjs twin under plain node; API routes
+ * and future read paths run the TS side. If they disagree, the same book gets a
+ * different language depending on which door it came through — which is how the
+ * corpus ended up with four vocabularies in the first place.
+ * (Twin convention: cf. identity-fields-parity.test.ts, r2-key.test.ts.)
+ *
+ * Fixtures are drawn from values actually observed in production on 2026-08-21:
+ * `books.language`, `ai_metadata.secondary_languages`, and the free-text
+ * `<language>` tag inside `pages.ocr.data`.
+ */
+
+const TOKENS = [
+  // straightforward
+  'Latin', 'Greek', 'German', 'english', 'FRENCH',
+  // codes: ISO-1, ISO-2/3, MARC (the #3893 population)
+  'la', 'de', 'grc', 'lat', 'ger', 'gre', 'rus', 'nld', 'ota', 'chu',
+  // period variants that must COLLAPSE onto the base language
+  'Ancient Greek', 'Modern Greek', 'Classical Latin', 'Koine Greek', 'New Latin',
+  // period variants that are DISTINCT languages and must survive
+  'Old English', 'Middle High German', 'Early New High German', 'Old French',
+  'Church Slavonic', 'Classical Chinese', 'Ottoman Turkish', 'Judeo-Arabic',
+  // placeholders — every one of these must be null
+  'None', 'none', 'N/A', 'NA', 'und', 'zxx', 'mul', 'unknown', 'auto-detect',
+  'Visual', 'undetermined', '', '-', 'Multiple', 'various',
+  // the parenthetical / script noise the OCR tag emits
+  'Sanskrit (transliterated)', 'undetermined (Voynich script)',
+  'Russian (pre-reform)', 'Italian in Italian script', 'Hebrew in Hebrew script',
+  // synonyms
+  'Geez', "Ge'ez", 'Ethiopic', 'Anglo-Norman', 'Flemish', 'Castilian',
+  // unmapped but real — must pass through title-cased, not vanish
+  'Tamil', 'Nahuatl', 'Syriac', 'Aramaic', 'Ladino', 'Coptic',
+  null, undefined,
+];
+
+const FIELDS = [
+  // real compound values from books.language (96 of 229 distinct live values)
+  'Greek-Latin', 'Hebrew and Aramaic', 'Sanskrit-English', 'German-Latin',
+  'Cakchiquel / English', 'English, Greek, Hebrew, Latin', 'French, Latin',
+  'Church Slavonic, Greek', 'Arabic and Samaritan Hebrew',
+  'Hebrew, Judeo-Arabic and Ladino in Hebrew script',
+  'Italian in Italian script, Hebrew in Hebrew script',
+  'Arabic, Ottoman Turkish, Persian, Latin, Ternate (a Papuan language), French and Dutch.',
+  'Hebrew, Aramaic, and Judeo-Arabic',
+  // hyphenated SINGLE languages — must NOT split
+  'Judeo-Arabic', 'Anglo-Norman', 'Scottish Gaelic', 'Judeo-Persian',
+  // the N/A trap: contains "/" but is a placeholder, not two languages
+  'N/A', 'n/a',
+  // comma-joined forms the OCR tag emits
+  'Latin, Greek', 'Greek, Latin',
+  // plain singles and nulls
+  'Latin', 'lat', 'None', '', null, undefined,
+];
+
+describe('language-normalize TS/mjs parity', () => {
+  it('normalizeLanguageToken agrees on every fixture', () => {
+    for (const t of TOKENS) {
+      expect(twin.normalizeLanguageToken(t), `token: ${JSON.stringify(t)}`)
+        .toEqual(normalizeLanguageToken(t));
+    }
+  });
+
+  it('parseLanguageField agrees on every fixture', () => {
+    for (const f of FIELDS) {
+      expect(twin.parseLanguageField(f), `field: ${JSON.stringify(f)}`)
+        .toEqual(parseLanguageField(f));
+    }
+  });
+});
+
+describe('language-normalize behaviour', () => {
+  it('collapses period variants onto the base language', () => {
+    expect(normalizeLanguageToken('Ancient Greek')).toBe('Greek');
+    expect(normalizeLanguageToken('Koine Greek')).toBe('Greek');
+    expect(normalizeLanguageToken('Classical Latin')).toBe('Latin');
+  });
+
+  it('keeps genuinely distinct period languages apart', () => {
+    expect(normalizeLanguageToken('Old English')).toBe('Old English');
+    expect(normalizeLanguageToken('Middle High German')).toBe('Middle High German');
+    expect(normalizeLanguageToken('Old French')).toBe('Old French');
+  });
+
+  it('folds codes, including the MARC set behind #3893', () => {
+    for (const [code, name] of [['lat', 'Latin'], ['ger', 'German'], ['gre', 'Greek'], ['grc', 'Greek'], ['de', 'German']]) {
+      expect(normalizeLanguageToken(code)).toBe(name);
+    }
+  });
+
+  it('returns null for every placeholder, so callers can tell "no signal" from a value', () => {
+    for (const p of ['None', 'n/a', 'und', 'zxx', 'mul', 'auto-detect', 'Visual', 'undetermined', '']) {
+      expect(normalizeLanguageToken(p), `placeholder: ${p}`).toBeNull();
+    }
+  });
+
+  it('does NOT split N/A into languages named "n" and "a"', () => {
+    // The bug this guards: splitting on "/" before the placeholder check made
+    // "N/A" look like two languages, which then showed up at 1-2% share across
+    // the corpus and read as real signal.
+    expect(parseLanguageField('N/A')).toEqual([]);
+    expect(parseLanguageField('n/a')).toEqual([]);
+  });
+
+  it('splits real compounds but never a hyphenated single language', () => {
+    expect(parseLanguageField('Greek-Latin')).toEqual(['Greek', 'Latin']);
+    expect(parseLanguageField('Hebrew and Aramaic')).toEqual(['Hebrew', 'Aramaic']);
+    expect(parseLanguageField('Cakchiquel / English')).toEqual(['Cakchiquel', 'English']);
+    expect(parseLanguageField('Judeo-Arabic')).toEqual(['Judeo-Arabic']);
+    expect(parseLanguageField('Anglo-Norman')).toEqual(['Anglo-Norman']);
+  });
+
+  it('de-duplicates, which is what kills the "Latin + Latin" rows', () => {
+    // 257 books list Latin as a secondary language of Latin; 204 the same for Greek.
+    expect(parseLanguageField('Latin, Latin')).toEqual(['Latin']);
+    expect(parseLanguageField('Greek and Ancient Greek')).toEqual(['Greek']);
+  });
+
+  it('strips the parenthetical and script noise the OCR tag emits', () => {
+    expect(normalizeLanguageToken('Sanskrit (transliterated)')).toBe('Sanskrit');
+    expect(normalizeLanguageToken('Russian (pre-reform)')).toBe('Russian');
+    expect(normalizeLanguageToken('undetermined (Voynich script)')).toBeNull();
+    expect(normalizeLanguageToken('Italian in Italian script')).toBe('Italian');
+  });
+});


### PR DESCRIPTION
Closes the evidence half of #4117 — the detector, and the shared vocabulary it needs.

## Why this and not the obvious thing

#4089 asked for a `languages[]` field. It already exists: 45,675 books, 17,857 live.
Its only writer, `scripts/maintenance/normalize-language-tags.mjs` (#2258), **parses the
string already in `books.language`** — it can split `"Greek-Latin"` into two entries, but
it can never learn that a book catalogued `"Greek"` is half Latin. On our two copies of
the 1495 Aldine Lascaris it ran and confirmed the wrong answer on both.

The `<language>` tag the OCR model writes into `pages.ocr.data` is genuine per-page
detection, and we have already paid for it. On those two independently OCR'd copies:

| | copy `69b220cc…` (340pp) | copy `6a085748…` (336pp) |
|---|---|---|
| Latin | 53% (178pp) | 54% (178pp) |
| Greek | 46% (153pp) | 47% (154pp) |
| catalogued as | **Greek** | **Latin** |

Same edition, same measured mix from two separate scans and two separate OCR runs, two
different catalogue answers. That is the argument for the detector in one table.

**`pages.ocr.language` — the FIELD — is not this.** It holds the request parameter
(`null`, `"auto-detect"`). Anything reading it as an answer measures its own input. The
script documents that at the top so the next person doesn't reach for the obvious name.

## What's here

**`src/lib/language-normalize.ts` + `scripts/lib/language-normalize.mjs`** — one
vocabulary, merged from the read-path map (`language-utils.ts`) and the write-path map
(`normalize-language-tags.mjs`), held identical by a parity test. Twin convention follows
`identity-fields` / `r2-key`: change both sides or neither.

- folds ISO-639-1/2/3 **and** the MARC codes behind #3893 (`lat`, `ger`, `gre`, `und`)
- collapses period variants that aren't separate languages (`Ancient Greek` → `Greek`)
  while keeping the ones that are (`Old English`, `Middle High German`, `Judeo-Arabic`)
- treats placeholders as null **before** splitting on delimiters — which is what stops
  `N/A` being read as two languages named `n` and `a`. My own throwaway probe had that
  bug and briefly reported `n` at 1–2% across the corpus, so the test pins it.
- de-duplicates, which is what kills the 257 `Latin + Latin` and 204 `Greek + Greek` rows

**`scripts/audit/detect-book-languages.mjs`** — checkpointed corpus walk with bounded
concurrency, bucketing each book:

| bucket | meaning |
|---|---|
| `agree` | pages support exactly what the catalogue says |
| `add_second` | catalogue is right but incomplete — bilingual candidate |
| `contradict` | **no** catalogued language appears on the pages — #2184 class |
| `unsupported_claim` | catalogue names a language the pages don't show |
| `thin` / `no_tag` / `unparsed` | not enough signal for a verdict |

It reports threshold sensitivity at 5/10/15/20/25% so the "is it really bilingual" cut
gets chosen from evidence rather than from the 10% I guessed in the issue.

## It never writes

`--apply` exits 2 with a message. Writing `languages[]` is gated on a tuned threshold and
a reviewed sample, and `contradict` rows must gate on `text_role` before anyone touches
them — `language` is the **edition's** language, and the sweep that forgot that nearly
relabelled 547 translation editions in June 2026.

## A bug the first run caught

The initial bucketing normalised the catalogue value with the single-token function, so
every compound string (`"Latin/English"`, `"Hebrew and Aramaic"` — 96 of the 229 distinct
live values, on 262 books) matched nothing and landed in `contradict`. Comenius's *Orbis
Sensualium Pictus*, catalogued `Latin/English` and measured English 93% / Latin 91%, is
catalogued **correctly** and was being reported as a mislabel. Fixed before this commit:
the catalogue value is parsed as a list, and the bucket asks whether *any* catalogued
language is supported. Five of five `contradict` rows in that first 200-book slice were
this artifact.

Shares can sum above 100% on purpose: a page tagged `"Latin, Greek"` counts toward both,
because splitting its weight would under-report facing-page editions, which are the whole
point.

## Scope

**In:** the normaliser, its twin, the parity test, the detector, a full dry-run.
**Out:** rewiring the read path to the new normaliser — that changes what search returns,
and belongs to #4089/#3893. Any write to `books`. The `?languages=` param trap
(a parameter named for the array that filters the scalar) is documented in #4089, not
fixed here.

Acceptance item 1 of #4117 ("one normalisation function, shared by read path, write path
and detector") is therefore **partially** done: the function and the parity test exist and
the detector uses them; the two existing call sites are untouched.

Refs #4117, #4089, #2184, #3958, #3893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqVg3Ya2b5Q5WQgtVeEeBT
