### PR TITLE
feat(es): make the Spanish text findable — page_texts store, semantic + lexical lanes (#4095)

### DIFF
--- a/.claude/docs/embeddings.md
+++ b/.claude/docs/embeddings.md
@@ -1,6 +1,6 @@
 # Embeddings
 
-Source Library has **five embedding stores** in Supabase, indexing different things at different granularities. All live in the `secondrenaissance` project (ID `ykhxaecbbxaaqlujuzde`). No embeddings live in Mongo Atlas — Atlas holds the source of truth for content; Supabase holds derived vectors.
+Source Library has **six embedding stores** in Supabase, indexing different things at different granularities. All live in the `secondrenaissance` project (ID `ykhxaecbbxaaqlujuzde`). No embeddings live in Mongo Atlas — Atlas holds the source of truth for content; Supabase holds derived vectors.
 
 ## The five stores
 
@@ -11,8 +11,59 @@ Source Library has **five embedding stores** in Supabase, indexing different thi
 | `artwork_embeddings` | **3072 (halfvec)** | `gemini-embedding-2-preview` | One row per artwork (title + author + summary + subjects + figures + symbols) | `scripts/migration/backfill-artwork-embeddings.mjs` + `scripts/workers/image-embeddings-cron.mjs` | `match_artworks_semantic` | `src/lib/semantic-search.ts` artwork retrieval |
 | `gallery_text_embeddings` | 768 (vector) | `gemini-embedding-2-preview` | One row per gallery image (museum description text) | `scripts/workers/image-embeddings-cron.mjs` | `match_gallery_text` | `src/lib/embeddings.ts`, `src/app/api/gallery/{route,similar/route}.ts` |
 | `clip_embeddings` | 512 (vector) | CLIP visual | One row per image (artwork covers, gallery extractions) | `scripts/backfill-clip-embeddings.mjs` + `scripts/workers/image-embeddings-cron.mjs` | `match_gallery_text` (CLIP text→image) | gallery similar-image queries |
+| `page_texts` | 768 (vector) | `gemini-embedding-2-preview` | One row per translated page **per language** (`page_id, lang`) | `scripts/workers/embed-page-texts.mjs --lang=<iso>` (bulk) + `es-translate-worker.mjs` (inline) | `match_page_texts`, `match_page_texts_in_books`, `search_page_texts` (lexical) | Spanish/localized page search: `/api/search?lang=es`, `/api/books/:id/search?lang=es` |
 
 Approximate current row counts (May 2026): pages ~3.9M, books 33,828, artworks 19,731, gallery_text 116,641, clip 151,957.
+
+## `page_texts` — the language-keyed store (#4095)
+
+`page_translations` holds ONE translation per page, and that translation is
+English. Every other language lives in `page_texts`, keyed `(page_id, lang)` —
+the vector-layer form of the rule in `.claude/docs/i18n.md`: **one
+language-keyed shape per layer, never per-language columns or tables.** The next
+language is a key, not a feature.
+
+- **Why a sibling table and not a `lang` column on `page_translations`.** That
+  table is 4.5M rows behind four read paths (`match_semantic`,
+  `match_pages_in_books`, the librarian, `/api/search`). Widening its primary
+  key means migrating all of it and rebuilding an HNSW index those paths depend
+  on, to gain 38K Spanish rows. The sibling costs the English path nothing; the
+  English rows can move in later as a separately-verified step.
+- **The vector index is PARTIAL, one per language** (`page_texts_embedding_es_idx`).
+  HNSW returns the globally nearest N and filters afterwards, so a shared index
+  plus `WHERE lang = 'es'` would strip results to zero whenever the true
+  neighbours are in another language — the same cross-lingual bug fixed in
+  `match_semantic` in May 2026. A partial index makes it structurally
+  impossible. **Adding a language means running
+  `scripts/migration/add-page-texts-table.mjs --lang=<iso>` again**; until you
+  do, that language is searched by sequential scan (correct, just slower).
+- **There is a lexical lane too**, which the English store does not have here:
+  a `tsv` column, a GIN index, and `search_page_texts`. English keyword search
+  is Atlas (`pages_search`, mapping `translation.data`/`ocr.data`,
+  `dynamic: false`); reaching `translations.es.data` would mean rebuilding that
+  index over 18.9M pages on shared search capacity for 38K rows. Postgres full
+  text over the copy we already hold is free and gives real per-language
+  stemming, which `lucene.standard` does not. Which stemmer a language gets is
+  decided once, in the SQL function `page_text_config`, called by BOTH the
+  write-side trigger and the read-side RPC — so index and query cannot disagree.
+- **No OCR fallback.** `pageEmbeddingInput` falls back to the original text so
+  an untranslated page still gets a vector. `pageTextForLang` does NOT: a row in
+  `lang = 'es'` is a promise that the text IS Spanish, and falling back would
+  put Latin into the Spanish lane, where it would be retrieved for Spanish
+  queries and quoted as the Spanish edition.
+- **Staleness is checked on every run, not behind a flag.** The Spanish
+  audit→repair loop (`scripts/audit/es-edition-quality.mjs` → the worker's
+  `--strict --pages=@report` mode) REWRITES pages, and the row carries the
+  snippet that gets quoted as well as the vector — so a stale row serves text
+  that is no longer in the book.
+- **Coverage:** `scripts/audit/page-texts-coverage.mjs --lang=es` compares the
+  counter, the readable pages and the embedded rows, and reports the writer's
+  age rather than only the row count (`measurement-instruments.md`).
+
+The row shape and the upsert live with the English ones in
+`scripts/lib/page-embedding-text.mjs`; the per-book writer is
+`scripts/lib/embed-book-page-texts.mjs`. Four writers, one composer — for the
+reason that module exists.
 
 ## Why three different dimensions
 

--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -17,6 +17,7 @@ translation is a different layer — `pages.translations.<lang>` — see
 | **chrome** | nav, headings, buttons, footer | string dictionaries keyed by `Locale`: `src/lib/i18n.ts` (shell), `src/lib/home-i18n.ts` (homepage), `CARD_LABELS` in `CollectionBookCard` | `useLocale()` / a `lang` prop |
 | **metadata** | book title glosses, collection name/subtitle/description | **one language-keyed map per record**: `books.localized = { es: { title } }`, `collections.localized = { es: { name, subtitle, description } }` | `src/lib/localized.ts` |
 | **text** | the pages themselves | `pages.translations.<lang>` (English on `pages.translation`) | `src/lib/page-translations.ts` |
+| **findability** | the vectors + lexical index that make that text searchable | Supabase `page_texts` (`page_id`, `lang`), English on `page_translations` | `match_page_texts` / `search_page_texts` via `src/lib/semantic-search.ts` |
 
 English is never written into `localized`: `display_title` *is* the English
 gloss and `collections.name/…` *is* the English copy. The original title
@@ -76,6 +77,15 @@ shown with the original beneath it (`originalTitleIfDifferent`).
 3. Translation worker for page text → `pages.translations.<iso>`; counter
    `books.pages_translated_<iso>` (declare it in `book-docs.mjs`) and a derived
    collection like `en-espanol` via `sync-es-collection.mjs` as the template.
+3b. **Make it findable, or it does not exist.** Run
+   `scripts/migration/add-page-texts-table.mjs --lang=<iso>` (creates that
+   language's partial HNSW index — see `.claude/docs/embeddings.md`), then
+   `scripts/workers/embed-page-texts.mjs --lang=<iso>`, then verify with
+   `scripts/audit/page-texts-coverage.mjs --lang=<iso>`. Search takes the code
+   as `?lang=<iso>`; `language` stays the EDITION filter. A translated page that
+   is not embedded is invisible to search *and indistinguishable from a page
+   that simply does not match* — which is how the English page vectors sat two
+   months dark over 45% of the corpus.
 4. `localize-metadata.mjs --lang=<iso> --books-with-editions`.
 5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts` and the reader toggle.
 

--- a/.claude/docs/invariants/search-filters-and-lanes.md
+++ b/.claude/docs/invariants/search-filters-and-lanes.md
@@ -21,6 +21,18 @@ filter renders as *on* while out-of-range results sit at the top.
   lexical), collections.
 - **`/api/search` (Books tab):** four lanes — Supabase trigram books, Atlas
   pages, `semanticBookSearch`, `semanticPageSearchGlobal`.
+- **`?lang=<iso>` swaps the TEXT store, not the filter.** With `lang=es` the
+  keyword page lane becomes Postgres full-text over Supabase `page_texts`
+  (`search_page_texts`) instead of Atlas, and the semantic page lane becomes
+  `match_page_texts` instead of `match_semantic` — because the Atlas
+  `pages_search` index maps `translation.data`/`ocr.data` and cannot see
+  `translations.es.data` (#4095). `language` / `languages` /
+  `exclude_languages` keep their meaning throughout: they filter the BOOK's
+  edition language. `?lang=es&language=Latin` is a coherent query.
+  **A localized request also narrows every lane to books that HAVE that
+  edition** (`pages_translated_<iso> > 0`) — its result cards link to
+  `/es/book/…`, and an `/es` URL for a book with no Spanish pages 307s back to
+  English, so an unfiltered hit is a result the reader cannot open.
 - **Vector lanes carry no metadata predicate** and their hits merge in as
   book/passage results. They must be post-filtered in JS or they leak past every
   filter. This is the one people miss.

--- a/scripts/audit/page-texts-coverage.mjs
+++ b/scripts/audit/page-texts-coverage.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Is the non-English text actually FINDABLE? (#4095, workstream 5)
+ *
+ * Compares three numbers that are easy to confuse and easy to let drift:
+ *
+ *   counter   books.pages_translated_<lang>   — what the /es band and the cards claim
+ *   mongo     pages with translations.<lang>  — what a reader can actually read
+ *   supabase  page_texts rows with a vector   — what search can actually find
+ *
+ * The third is the one nothing else would notice. An unembedded page and a page
+ * with no match return the same empty list, which is how the ENGLISH page
+ * vectors sat two months dark over 45% of the corpus in Aug 2026. So this
+ * script reports the gap per book, and it reports the WRITER, not only the row
+ * count: a store whose writer has stopped reads exactly like a healthy one
+ * (`measurement-instruments.md` — the dashboard snapshot that served its
+ * 2026-04-01 value for 138 days).
+ *
+ * Staleness is the second failure mode and is specific to this corpus: the
+ * Spanish audit→repair loop REWRITES pages, so a row can be present, embedded
+ * and wrong. `mongo_updated_at` vs the Mongo source catches it.
+ *
+ * Usage:
+ *   SUPABASE_DB_URL=… node --env-file=.env.production.local \
+ *     scripts/audit/page-texts-coverage.mjs --lang=es [--json] [--books]
+ *
+ * Exit codes: 0 clean, 1 gaps found, 2 could not measure (so a caller cannot
+ * mistake "I couldn't reach the DB" for "nothing is missing").
+ */
+import { MongoClient } from 'mongodb';
+import pg from 'pg';
+import { pageFilterForLang } from '../lib/embed-book-page-texts.mjs';
+
+const args = process.argv.slice(2);
+const arg = (n, d = null) => { const m = args.find(a => a.startsWith(`--${n}=`)); return m ? m.slice(n.length + 3) : d; };
+const LANG = arg('lang', 'es');
+const AS_JSON = args.includes('--json');
+const PER_BOOK = args.includes('--books');
+/** A run older than this means the writer has stopped, not that nothing changed. */
+const STALE_WRITER_DAYS = parseInt(arg('stale-days', '30'), 10);
+
+if (!/^[a-z]{2,3}$/.test(LANG)) { console.error(`Not an ISO code: ${LANG}`); process.exit(2); }
+if (!process.env.MONGODB_URI || !process.env.SUPABASE_DB_URL) {
+  console.error('Missing MONGODB_URI or SUPABASE_DB_URL — cannot measure (exit 2, NOT "clean")');
+  process.exit(2);
+}
+
+const COUNTER = `pages_translated_${LANG}`;
+
+async function main() {
+  const mc = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 4 });
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const client = new pg.Client({ connectionString: process.env.SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  await client.query('SET statement_timeout = 120000');
+
+  try {
+    const books = await db.collection('books')
+      .find({ [COUNTER]: { $gt: 0 } }, { projection: { id: 1, title: 1, display_title: 1, visible: 1, [COUNTER]: 1 } })
+      .toArray();
+    const byId = new Map(books.map(b => [b.id, b]));
+
+    // What a reader can read: pages actually carrying text in this language.
+    // Counted per book (the book_id index makes this cheap); a corpus-wide
+    // count on translations.<lang> is unindexed and would take minutes.
+    const mongoPages = new Map();
+    for (const b of books) {
+      mongoPages.set(b.id, await db.collection('pages').countDocuments({ book_id: b.id, ...pageFilterForLang(LANG) }));
+    }
+
+    const { rows: supaRows } = await client.query(
+      `SELECT book_id, count(*)::int AS rows, count(embedding)::int AS embedded, max(mongo_updated_at) AS newest
+       FROM page_texts WHERE lang = $1 GROUP BY book_id`, [LANG],
+    );
+    const supa = new Map(supaRows.map(r => [r.book_id, r]));
+
+    // Rows whose Mongo source has been rewritten since they were embedded.
+    // Checked per book against the pages collection, because the watermark
+    // alone cannot tell you what Mongo says now.
+    let staleRows = 0;
+    const staleBooks = [];
+    for (const r of supaRows) {
+      if (!r.newest) { staleRows += r.rows; staleBooks.push({ book_id: r.book_id, reason: 'no watermark' }); continue; }
+      const newer = await db.collection('pages').countDocuments({
+        book_id: r.book_id, ...pageFilterForLang(LANG),
+        $or: [
+          { [`translations.${LANG}.updated_at`]: { $gt: r.newest } },
+          ...(LANG === 'es' ? [{ 'translation_es.updated_at': { $gt: r.newest } }] : []),
+        ],
+      });
+      if (newer > 0) { staleRows += newer; staleBooks.push({ book_id: r.book_id, reason: `${newer} page(s) re-translated after embedding` }); }
+    }
+
+    const totals = {
+      lang: LANG,
+      books: books.length,
+      counter: books.reduce((a, b) => a + (b[COUNTER] || 0), 0),
+      mongo: [...mongoPages.values()].reduce((a, n) => a + n, 0),
+      supabase_rows: supaRows.reduce((a, r) => a + r.rows, 0),
+      supabase_embedded: supaRows.reduce((a, r) => a + r.embedded, 0),
+      books_with_no_rows: books.filter(b => !supa.has(b.id)).length,
+      stale_rows: staleRows,
+    };
+
+    // The writer check. A store with no writer reads as live.
+    const { rows: [{ newest_write }] } = await client.query(
+      'SELECT max(mongo_updated_at) AS newest_write FROM page_texts WHERE lang = $1', [LANG],
+    );
+    const writerAgeDays = newest_write ? (Date.now() - new Date(newest_write)) / 86400000 : null;
+    totals.newest_source_write = newest_write ? new Date(newest_write).toISOString() : null;
+    totals.writer_age_days = writerAgeDays === null ? null : Math.round(writerAgeDays * 10) / 10;
+
+    const gaps = books
+      .map(b => {
+        const s = supa.get(b.id);
+        const readable = mongoPages.get(b.id) || 0;
+        const findable = s?.embedded || 0;
+        return { id: b.id, title: (b.display_title || b.title || b.id).slice(0, 60), counter: b[COUNTER] || 0, readable, findable, gap: readable - findable };
+      })
+      .filter(r => r.gap !== 0)
+      .sort((a, b) => b.gap - a.gap);
+
+    if (AS_JSON) {
+      console.log(JSON.stringify({ totals, gaps, stale_books: staleBooks }, null, 2));
+    } else {
+      console.log(`\n${LANG.toUpperCase()} findability — ${totals.books} book(s)`);
+      console.log(`  counter (${COUNTER}):    ${totals.counter}`);
+      console.log(`  readable (Mongo pages):  ${totals.mongo}${totals.mongo !== totals.counter ? '   ← counter disagrees with the pages' : ''}`);
+      console.log(`  findable (page_texts):   ${totals.supabase_embedded} embedded of ${totals.supabase_rows} rows`);
+      console.log(`  books with NO rows:      ${totals.books_with_no_rows}`);
+      console.log(`  rows re-translated since embedding (stale snippet + vector): ${totals.stale_rows}`);
+      console.log(`  newest source write in the store: ${totals.newest_source_write || 'never'}` +
+        (writerAgeDays === null ? '  ← nothing has ever been written'
+          : writerAgeDays > STALE_WRITER_DAYS ? `  ← ${totals.writer_age_days}d old; check the writer, not just the count`
+            : `  (${totals.writer_age_days}d)`));
+      if (gaps.length && PER_BOOK) {
+        console.log('\n  per-book gaps (readable − findable):');
+        for (const g of gaps) console.log(`    ${String(g.gap).padStart(6)}  ${g.title}  [${g.id}]`);
+      } else if (gaps.length) {
+        console.log(`\n  ${gaps.length} book(s) with a gap — pass --books to list them.`);
+      }
+      if (staleBooks.length) {
+        console.log(`\n  ${staleBooks.length} book(s) with stale rows — re-run: scripts/workers/embed-page-texts.mjs --lang=${LANG}`);
+      }
+      console.log('');
+    }
+
+    const clean = gaps.length === 0 && staleRows === 0 && totals.books_with_no_rows === 0;
+    process.exitCode = clean ? 0 : 1;
+  } finally {
+    await client.end();
+    await mc.close();
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(2); });

--- a/scripts/lib/embed-book-page-texts.mjs
+++ b/scripts/lib/embed-book-page-texts.mjs
@@ -1,0 +1,142 @@
+/**
+ * Embed one book's pages in ONE language into Supabase `page_texts` (#4095).
+ *
+ * The language-keyed twin of `embed-book-pages.mjs`. Both compose their text
+ * and their row through `page-embedding-text.mjs`, which is the whole point:
+ * the English store has two writers (the enrich-worker inline and the bulk
+ * cron) and this store has two as well (the bulk `embed-page-texts.mjs` worker
+ * and, inline, `es-translate-worker.mjs`). Four writers, one composer.
+ *
+ * ## Staleness is checked by default, not on a flag
+ *
+ * Spanish pages are not written once. `scripts/audit/es-edition-quality.mjs`
+ * flags bad pages and the worker rewrites them in `--strict --pages=@report`
+ * mode, so a page's text can change after it was embedded. A vector left
+ * pointing at the pre-repair text does not merely rank badly — the row also
+ * carries the SNIPPET that gets shown and quoted, so a stale row serves text
+ * that is no longer in the book. Every run therefore compares the Mongo
+ * translation's `updated_at` against the stored `mongo_updated_at` watermark
+ * and re-embeds what drifted. `force` re-embeds everything regardless.
+ */
+
+import { MongoClient } from 'mongodb';
+import {
+  pageTextForLang,
+  buildPageTextRow,
+  pageTextUpsertValues,
+  PAGE_TEXT_UPSERT_SQL,
+  embedTexts,
+  EMBED_MODEL,
+} from './page-embedding-text.mjs';
+
+const EMBED_BATCH_SIZE = 50;   // Gemini batchEmbedContents caps at 100; 50 matches the English worker
+const UPSERT_BATCH_SIZE = 10;  // HNSW index updates are expensive — keep writes small
+
+/** Mongo projection for one language, plus the legacy `translation_es` field. */
+export function pageProjectionForLang(lang) {
+  return {
+    id: 1, book_id: 1, page_number: 1, updated_at: 1,
+    [`translations.${lang}.data`]: 1,
+    [`translations.${lang}.updated_at`]: 1,
+    ...(lang === 'es' ? { 'translation_es.data': 1, 'translation_es.updated_at': 1 } : {}),
+  };
+}
+
+/** Mongo filter selecting pages that HAVE text in `lang`. */
+export function pageFilterForLang(lang) {
+  const has = (p) => ({ [`${p}.data`]: { $type: 'string', $ne: '' } });
+  return lang === 'es'
+    ? { $or: [has('translations.es'), has('translation_es')] }
+    : has(`translations.${lang}`);
+}
+
+/**
+ * @param {object} opts
+ * @param {import('mongodb').Db} opts.db     open Mongo handle
+ * @param {object} opts.pg                   node-postgres client for Supabase
+ * @param {object} opts.book                 books doc (id, title, author, language, year)
+ * @param {string} opts.lang                 ISO code, e.g. 'es'
+ * @param {string} opts.apiKey               Gemini key — prefer paid Tier 3
+ * @param {boolean} [opts.force]             re-embed rows that already exist and are fresh
+ * @param {string[]} [opts.pageIds]          restrict to these page ids (repair mode)
+ * @returns {Promise<{embedded:number, restaled:number, missing:number, alreadyPresent:number}>}
+ */
+export async function embedBookPageTexts({ db, pg, book, lang, apiKey, force = false, pageIds }) {
+  if (!book?.id) throw new Error('embedBookPageTexts: book.id is required');
+  if (!lang) throw new Error('embedBookPageTexts: lang is required');
+  if (!apiKey) throw new Error('embedBookPageTexts: apiKey is required');
+
+  const filter = { book_id: book.id, ...pageFilterForLang(lang) };
+  if (pageIds?.length) filter.id = { $in: pageIds };
+
+  const pages = await db.collection('pages')
+    .find(filter, { projection: pageProjectionForLang(lang) })
+    .sort({ page_number: 1 })
+    .toArray();
+  if (pages.length === 0) return { embedded: 0, restaled: 0, missing: 0, alreadyPresent: 0 };
+
+  const present = new Map();
+  if (!force) {
+    const { rows } = await pg.query(
+      'SELECT page_id, mongo_updated_at FROM page_texts WHERE book_id = $1 AND lang = $2',
+      [book.id, lang],
+    );
+    for (const r of rows) present.set(r.page_id, r.mongo_updated_at);
+  }
+
+  const work = [];
+  let missing = 0, alreadyPresent = 0, restaled = 0;
+  for (const page of pages) {
+    const input = pageTextForLang(page, lang);
+    if (!input) { missing++; continue; }
+    if (present.has(page.id)) {
+      const stored = present.get(page.id);
+      const source = page.translations?.[lang]?.updated_at
+        ?? (lang === 'es' ? page.translation_es?.updated_at : null)
+        ?? page.updated_at;
+      // A row with NO watermark predates the watermark column; treat it as
+      // stale rather than trusting it — `null` is "unknown", not "current".
+      const isStale = !stored || (source && new Date(source) > new Date(stored));
+      if (!isStale) { alreadyPresent++; continue; }
+      restaled++;
+    }
+    work.push({ page, ...input });
+  }
+  if (work.length === 0) return { embedded: 0, restaled: 0, missing, alreadyPresent };
+
+  let embedded = 0;
+  for (let i = 0; i < work.length; i += EMBED_BATCH_SIZE) {
+    const batch = work.slice(i, i + EMBED_BATCH_SIZE);
+    const vectors = await embedTexts(batch.map((w) => w.text), apiKey);
+    const rows = batch.map((w, j) => buildPageTextRow({
+      page: w.page, book, lang, text: w.text, embedding: vectors[j],
+    }));
+    for (let k = 0; k < rows.length; k += UPSERT_BATCH_SIZE) {
+      for (const row of rows.slice(k, k + UPSERT_BATCH_SIZE)) {
+        await pg.query(PAGE_TEXT_UPSERT_SQL, pageTextUpsertValues(row));
+      }
+    }
+    embedded += rows.length;
+  }
+
+  return { embedded, restaled, missing, alreadyPresent };
+}
+
+export { EMBED_MODEL };
+
+/** Convenience for ad-hoc single-book runs outside the worker. */
+export async function embedBookPageTextsStandalone(bookId, { lang, mongoUri, pgClient, apiKey, force, pageIds } = {}) {
+  const mc = new MongoClient(mongoUri || process.env.MONGODB_URI);
+  await mc.connect();
+  try {
+    const db = mc.db('bookstore');
+    const book = await db.collection('books').findOne({ id: bookId });
+    if (!book) throw new Error(`No such book: ${bookId}`);
+    return await embedBookPageTexts({
+      db, pg: pgClient, book, lang, force, pageIds,
+      apiKey: apiKey || process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY,
+    });
+  } finally {
+    await mc.close();
+  }
+}

--- a/scripts/lib/page-embedding-text.mjs
+++ b/scripts/lib/page-embedding-text.mjs
@@ -108,6 +108,85 @@ export const PAGE_EMBEDDING_COLUMNS = [
   'updated_at', 'embedding_model', 'mongo_updated_at',
 ];
 
+// ── The language-keyed store: page_texts (#4095) ─────────────────────
+//
+// `page_translations` above holds ONE translation per page — English, on the
+// `translation` column. Every other language lives in `page_texts`, keyed
+// `(page_id, lang)`, mirroring Mongo's `pages.translations.<iso>`. The row
+// shape lives HERE, next to the English one, for the reason this whole module
+// exists: two writers that each re-type the shape will drift, silently.
+
+/**
+ * The text of one page in ONE language, cleaned, or null if that language has
+ * no translation for the page.
+ *
+ * Note there is NO OCR fallback, unlike `pageEmbeddingInput`. The English store
+ * falls back to the original text so an untranslated page still gets a vector;
+ * a language-keyed store must not, because a row in `lang = 'es'` is a promise
+ * that the text IS Spanish. Falling back would put German or Latin into the
+ * Spanish lane, where it would be retrieved for Spanish queries and quoted as
+ * the Spanish edition. Absence is the honest answer.
+ *
+ * The legacy `pages.translation_es` field is folded in for `es`, matching
+ * `src/lib/page-translations.ts` — the map wins when both are present.
+ */
+export function pageTextForLang(page, lang) {
+  const src = page?.translations?.[lang]?.data
+    ?? (lang === 'es' ? page?.translation_es?.data : null);
+  const text = cleanPageText(src);
+  return text ? { text } : null;
+}
+
+/** Build the `page_texts` row. Every column the table has, in one place. */
+export function buildPageTextRow({ page, book, lang, text, embedding }) {
+  const t = page?.translations?.[lang] ?? (lang === 'es' ? page?.translation_es : null);
+  const mongoTs = t?.updated_at || page.updated_at;
+  return {
+    page_id: page.id,
+    lang,
+    book_id: page.book_id,
+    page_number: page.page_number,
+    text: text.slice(0, 50000),
+    embedding: JSON.stringify(embedding),
+    book_title: book?.title ?? null,
+    book_author: book?.author ?? null,
+    book_language: book?.language ?? null,
+    book_year: book?.year ?? null,
+    updated_at: mongoTs || new Date(),
+    embedding_model: EMBED_MODEL,
+    mongo_updated_at: mongoTs || null,
+  };
+}
+
+/** Columns of `page_texts`, in the order the upsert statement uses. */
+export const PAGE_TEXT_COLUMNS = [
+  'page_id', 'lang', 'book_id', 'page_number', 'text', 'embedding',
+  'book_title', 'book_author', 'book_language', 'book_year',
+  'updated_at', 'embedding_model', 'mongo_updated_at',
+];
+
+/** The one upsert statement for `page_texts`. Positional args follow PAGE_TEXT_COLUMNS. */
+export const PAGE_TEXT_UPSERT_SQL = `
+  INSERT INTO page_texts (${PAGE_TEXT_COLUMNS.join(', ')})
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+  ON CONFLICT (page_id, lang) DO UPDATE SET
+    book_id = EXCLUDED.book_id,
+    page_number = EXCLUDED.page_number,
+    text = EXCLUDED.text,
+    embedding = EXCLUDED.embedding,
+    book_title = EXCLUDED.book_title,
+    book_author = EXCLUDED.book_author,
+    book_language = EXCLUDED.book_language,
+    book_year = EXCLUDED.book_year,
+    updated_at = EXCLUDED.updated_at,
+    embedding_model = EXCLUDED.embedding_model,
+    mongo_updated_at = EXCLUDED.mongo_updated_at`;
+
+/** The values array for PAGE_TEXT_UPSERT_SQL, from a row built above. */
+export function pageTextUpsertValues(row) {
+  return PAGE_TEXT_COLUMNS.map((c) => row[c]);
+}
+
 /**
  * Embed a batch of texts. Retries on 429 with a growing backoff, because the
  * caller is usually a long-running loop that should slow down rather than die.

--- a/scripts/migration/add-page-texts-table.mjs
+++ b/scripts/migration/add-page-texts-table.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Apply add-page-texts-table.sql and create the per-language partial HNSW
+ * index (#4095, workstream 1).
+ *
+ * `page_texts` is the language-keyed sibling of `page_translations` — see the
+ * header of the .sql for why a sibling and not a `lang` column on the hot
+ * table. This runner is idempotent: the DDL is CREATE IF NOT EXISTS / CREATE OR
+ * REPLACE, and the vector index is skipped when it already exists.
+ *
+ * A language's rows are searchable the moment they are embedded; the partial
+ * index only makes that search fast. Run with --lang for each language you
+ * embed, and re-run it after a large backfill if you built the index first (a
+ * partial HNSW built over an empty predicate is valid but has nothing in it —
+ * this script reports the row count so you can tell).
+ *
+ * Usage:
+ *   secret-lover run -- node scripts/migration/add-page-texts-table.mjs --lang=es
+ *   node --env-file=.env.production.local scripts/migration/add-page-texts-table.mjs --lang=es
+ *
+ * Env: SUPABASE_DB_URL (secret-lover; the direct-postgres URL, not the REST
+ * key — the service-role key cannot run DDL).
+ */
+import pg from 'pg';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const LANGS = args.filter((a) => a.startsWith('--lang=')).map((a) => a.slice(7));
+const DRY_RUN = args.includes('--dry-run');
+
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+if (!SUPABASE_DB_URL) {
+  console.error('Missing SUPABASE_DB_URL (secret-lover get SUPABASE_DB_URL). The service-role key cannot run DDL.');
+  process.exit(1);
+}
+
+/** ISO 639-1 only — the index name is interpolated into DDL, so validate hard. */
+function assertIsoCode(lang) {
+  if (!/^[a-z]{2,3}$/.test(lang)) throw new Error(`Not an ISO language code: ${JSON.stringify(lang)}`);
+  return lang;
+}
+
+async function main() {
+  const sql = fs.readFileSync(path.join(HERE, 'add-page-texts-table.sql'), 'utf8');
+  const client = new pg.Client({ connectionString: SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  try {
+    if (DRY_RUN) {
+      console.log('[dry-run] would apply add-page-texts-table.sql');
+    } else {
+      await client.query(sql);
+      console.log('Applied add-page-texts-table.sql (table + tsv trigger + match_page_texts / match_page_texts_in_books / search_page_texts)');
+      // Rows written before the tsv column existed, or before page_text_config
+      // learned a language, carry no lexical index entry. The trigger fires on
+      // UPDATE, so touching `text` rebuilds them.
+      const { rowCount } = await client.query('UPDATE page_texts SET text = text WHERE tsv IS NULL');
+      if (rowCount) console.log(`  built tsv for ${rowCount} row(s) that predated the column`);
+    }
+
+    for (const raw of LANGS) {
+      const lang = assertIsoCode(raw);
+      const idx = `page_texts_embedding_${lang}_idx`;
+      const { rows: existing } = await client.query(
+        'SELECT 1 FROM pg_indexes WHERE tablename = $1 AND indexname = $2', ['page_texts', idx],
+      );
+      const { rows: [{ n }] } = await client.query('SELECT count(*)::int AS n FROM page_texts WHERE lang = $1', [lang]);
+      if (existing.length) {
+        console.log(`  ${idx}: already present (${n} rows in '${lang}')`);
+        continue;
+      }
+      if (DRY_RUN) { console.log(`  [dry-run] would create ${idx} (${n} rows in '${lang}')`); continue; }
+      // Same HNSW parameters as idx_pt_embedding_hnsw on page_translations, so
+      // recall behaves the same way across the two stores.
+      await client.query(
+        `CREATE INDEX ${idx} ON page_texts USING hnsw (embedding vector_cosine_ops)
+         WITH (m = 16, ef_construction = 64)
+         WHERE lang = '${lang}' AND embedding IS NOT NULL`,
+      );
+      console.log(`  ${idx}: created over ${n} '${lang}' rows`);
+    }
+
+    const { rows } = await client.query(
+      `SELECT lang, count(*)::int AS rows, count(embedding)::int AS embedded
+       FROM page_texts GROUP BY lang ORDER BY lang`,
+    );
+    console.log(rows.length ? 'page_texts contents:' : 'page_texts is empty (nothing embedded yet).');
+    for (const r of rows) console.log(`  ${r.lang}: ${r.rows} rows, ${r.embedded} with a vector`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/migration/add-page-texts-table.sql
+++ b/scripts/migration/add-page-texts-table.sql
@@ -1,0 +1,269 @@
+-- page_texts — the language-keyed sibling of page_translations (#4095).
+--
+-- WHY A SIBLING TABLE AND NOT A `lang` COLUMN ON page_translations
+--
+-- `page_translations` holds ONE translation per page (4.5M rows) plus its
+-- vector, and it is the hot table behind every semantic lane: match_semantic,
+-- match_pages_in_books, the librarian, /api/search. Adding `lang` to its
+-- primary key means migrating 4.5M rows and rebuilding an HNSW index that four
+-- read paths depend on, to gain 38K Spanish rows. The sibling table costs
+-- nothing to the English path — `match_semantic` keeps working unchanged — and
+-- the English rows can move in later as a deliberate, separately-verified step.
+--
+-- THE SHAPE IS LANGUAGE-KEYED, NOT SPANISH-SHAPED
+--
+-- `.claude/docs/i18n.md` rule 1: one language-keyed map per layer, never
+-- per-language columns. This table is that rule at the vector layer — the next
+-- language is a KEY (`lang = 'fr'`), not a table, a column or an RPC. Mongo's
+-- side of the same rule is `pages.translations.<iso>`.
+--
+-- WHY THE VECTOR INDEX IS PARTIAL, ONE PER LANGUAGE
+--
+-- HNSW returns the globally nearest N vectors and a WHERE clause filters them
+-- AFTERWARDS, so a `lang = 'es'` predicate against one shared index would strip
+-- the result set to zero whenever the query's true neighbours are in another
+-- language. That is exactly the cross-lingual bug fixed in match_semantic in
+-- May 2026 (see add-match-semantic-rpc.sql), and a partial index per language
+-- makes it structurally impossible: `WHERE lang = 'es'` matches the index
+-- predicate, so the scan happens inside that language.
+--
+-- Adding a language therefore means running the runner again with --lang=<iso>;
+-- until you do, that language's rows are searched by sequential scan (correct,
+-- just slower). The runner prints which partial indexes exist.
+
+CREATE TABLE IF NOT EXISTS page_texts (
+  page_id         text NOT NULL,
+  lang            text NOT NULL,
+  book_id         text NOT NULL,
+  page_number     integer,
+  -- The translated page text, cleaned by scripts/lib/page-embedding-text.mjs
+  -- (editorial wrappers dropped content-and-all). This column is quoted from,
+  -- so it obeys quote-and-snippet-integrity.md the same way `translation` does.
+  text            text,
+  embedding       vector(768),
+  book_title      text,
+  book_author     text,
+  book_language   text,
+  book_year       integer,
+  updated_at      timestamptz,
+  embedding_model text,
+  -- Freshness watermark of the Mongo source at embed time, so a re-translation
+  -- that never got re-embedded is detectable. Same meaning as
+  -- page_translations.mongo_updated_at; NOT a write timestamp.
+  mongo_updated_at timestamptz,
+  PRIMARY KEY (page_id, lang)
+);
+
+CREATE INDEX IF NOT EXISTS page_texts_book_lang_idx ON page_texts (book_id, lang);
+CREATE INDEX IF NOT EXISTS page_texts_lang_idx      ON page_texts (lang);
+
+-- ── The keyword lane ────────────────────────────────────────────────
+--
+-- Semantic search alone is not a search box. A reader looking for «alquimia»
+-- or an exact phrase needs lexical matching, and on the English side that is
+-- Atlas Search over `translation.data` (src/lib/atlas-search.ts). The Spanish
+-- text is already HERE, 38K rows of it, so a Postgres full-text index gives the
+-- lexical lane for free — and with real Spanish stemming, which the English
+-- Atlas index (lucene.standard) does not have.
+--
+-- ONE function decides which stemmer a language gets, and both the write side
+-- (the trigger below) and the read side (search_page_texts) call it. A language
+-- Postgres has no dictionary for falls back to 'simple' — exact-token matching,
+-- which is honest, rather than stemming Nahuatl as if it were Spanish.
+CREATE OR REPLACE FUNCTION page_text_config(lang TEXT) RETURNS regconfig
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT CASE lang
+    WHEN 'es' THEN 'spanish'
+    WHEN 'fr' THEN 'french'
+    WHEN 'de' THEN 'german'
+    WHEN 'it' THEN 'italian'
+    WHEN 'pt' THEN 'portuguese'
+    WHEN 'nl' THEN 'dutch'
+    WHEN 'ru' THEN 'russian'
+    WHEN 'ar' THEN 'arabic'
+    WHEN 'en' THEN 'english'
+    ELSE 'simple'
+  END::regconfig;
+$$;
+
+ALTER TABLE page_texts ADD COLUMN IF NOT EXISTS tsv tsvector;
+
+-- A TRIGGER, not a GENERATED column. A generated column cannot be altered in
+-- place: teaching page_text_config a new language would mean dropping and
+-- recreating the column, which silently drops its index too (the trap in
+-- search-filters-and-lanes.md). With a trigger, a new language is a
+-- CREATE OR REPLACE plus a no-op UPDATE over that language's rows.
+CREATE OR REPLACE FUNCTION page_texts_tsv_trigger() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.tsv := to_tsvector(page_text_config(NEW.lang), COALESCE(NEW.text, ''));
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS page_texts_tsv_update ON page_texts;
+CREATE TRIGGER page_texts_tsv_update
+  BEFORE INSERT OR UPDATE OF text, lang ON page_texts
+  FOR EACH ROW EXECUTE FUNCTION page_texts_tsv_trigger();
+
+-- One GIN index for every language. Unlike HNSW, GIN returns ALL matching rows
+-- rather than the nearest N, so filtering by `lang` afterwards is exact — the
+-- partial-index-per-language discipline above is a vector-index requirement,
+-- not a general one.
+CREATE INDEX IF NOT EXISTS page_texts_tsv_idx ON page_texts USING gin (tsv);
+
+-- Lexical page search in ONE language. Same return shape as match_page_texts,
+-- so the two lanes merge without a second mapper.
+CREATE OR REPLACE FUNCTION search_page_texts(
+  query_text TEXT,
+  filter_lang TEXT,
+  match_count INT DEFAULT 25,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_book_ids TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cfg regconfig := page_text_config(filter_lang);
+  q tsquery := websearch_to_tsquery(cfg, query_text);
+BEGIN
+  IF q IS NULL OR numnode(q) = 0 THEN RETURN; END IF;
+  RETURN QUERY
+  SELECT
+    p.page_id, p.book_id, p.page_number, p.text,
+    p.book_title, p.book_author, p.book_language, p.book_year,
+    ts_rank_cd(p.tsv, q)::float AS similarity
+  FROM page_texts p
+  WHERE p.lang = filter_lang
+    AND p.tsv @@ q
+    AND (filter_book_ids IS NULL OR p.book_id = ANY(filter_book_ids))
+    AND (filter_language IS NULL OR p.book_language = filter_language)
+    AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+    AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    -- Hidden / deduped pages live at page_number <= 0, same as the Atlas lane.
+    AND p.page_number > 0
+  ORDER BY ts_rank_cd(p.tsv, q) DESC
+  LIMIT match_count;
+END;
+$$;
+
+-- Global page-level semantic search in ONE language.
+--
+-- Column names deliberately mirror match_semantic (including `translation` for
+-- the text) so src/lib/semantic-search.ts maps one row shape for both RPCs and
+-- the two paths cannot drift apart in their snippet handling.
+--
+-- `filter_lang` is the TEXT language (which edition of the page to read).
+-- `filter_language` / `filter_languages` / `filter_exclude_languages` are the
+-- BOOK's language — the edition filter, unchanged in meaning from every other
+-- search surface (search-filters-and-lanes.md). Two different things; the
+-- names are the ones each layer already uses.
+CREATE OR REPLACE FUNCTION match_page_texts(
+  query_embedding vector(768),
+  filter_lang TEXT,
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_languages TEXT[] DEFAULT NULL,
+  filter_exclude_languages TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.page_id,
+    p.book_id,
+    p.page_number,
+    p.text,
+    p.book_title,
+    p.book_author,
+    p.book_language,
+    p.book_year,
+    1 - (p.embedding <=> query_embedding) AS similarity
+  FROM page_texts p
+  WHERE p.lang = filter_lang
+    AND p.embedding IS NOT NULL
+    AND (filter_language IS NULL OR p.book_language = filter_language)
+    AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+         OR p.book_language = ANY(filter_languages))
+    AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+         OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+    AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+    AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    AND 1 - (p.embedding <=> query_embedding) > match_threshold
+  ORDER BY p.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+-- Scoped variant — pages of specific books, in one language. Companion to
+-- match_pages_in_books, used by in-book search on a localized surface.
+CREATE OR REPLACE FUNCTION match_page_texts_in_books(
+  query_embedding vector(768),
+  filter_lang TEXT,
+  book_ids TEXT[],
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 10
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.page_id, p.book_id, p.page_number, p.text,
+    p.book_title, p.book_author, p.book_language, p.book_year,
+    1 - (p.embedding <=> query_embedding) AS similarity
+  FROM page_texts p
+  WHERE p.lang = filter_lang
+    AND p.book_id = ANY(book_ids)
+    AND p.embedding IS NOT NULL
+    AND 1 - (p.embedding <=> query_embedding) > match_threshold
+  ORDER BY p.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+-- Read-only for the browser roles. `page_translations` carries the full ALL
+-- grant that Supabase's default privileges hand out; there is no reason for a
+-- new table to inherit it, and the writers here are the service role and the
+-- direct postgres connection. Narrow it explicitly.
+GRANT SELECT ON page_texts TO anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON page_texts FROM anon, authenticated;

--- a/scripts/workers/embed-page-texts.mjs
+++ b/scripts/workers/embed-page-texts.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Bulk-embed non-English page text into Supabase `page_texts` (#4095).
+ *
+ * The language-keyed counterpart of `embed-gemini.mjs`. That worker is tuned
+ * for the 4.5M-row English table — `--full`, `--incremental`, `--missing-only`,
+ * `--restale`, worker sharding, a spend guard — and every one of those modes is
+ * written against `page_translations`' single-translation shape. Bolting a
+ * `--lang` onto it would mean a second code path through all of them for a
+ * store three orders of magnitude smaller. This worker walks books instead,
+ * which is the right granularity when a language covers ~100 of them, and
+ * shares the composer and the row shape via `page-embedding-text.mjs`.
+ *
+ * Selection: every book whose `pages_translated_<lang>` counter is above zero.
+ * Staleness is always checked (see embed-book-page-texts.mjs); `--force`
+ * re-embeds regardless.
+ *
+ * Usage:
+ *   secret-lover run -- node --env-file=.env.production.local \
+ *     scripts/workers/embed-page-texts.mjs --lang=es
+ *   … --lang=es --book=<id>          one book
+ *   … --lang=es --limit=10           first N books (fewest pages first)
+ *   … --lang=es --dry-run            count the work, embed nothing
+ *   … --lang=es --force              re-embed rows that already exist
+ *
+ * Env: MONGODB_URI, SUPABASE_DB_URL, GEMINI_API_KEY_TIER3 (or GEMINI_API_KEY).
+ *
+ * Cost: the embedding model is free-tier; a full 38.6K-page Spanish backfill
+ * costs $0 and runs in roughly an hour at ~13 texts/sec.
+ */
+
+import { MongoClient } from 'mongodb';
+import pg from 'pg';
+import { embedBookPageTexts } from '../lib/embed-book-page-texts.mjs';
+
+const args = process.argv.slice(2);
+const arg = (name, dflt = null) => {
+  const eq = args.find((a) => a.startsWith(`--${name}=`));
+  if (eq) return eq.slice(name.length + 3);
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : dflt;
+};
+
+const LANG = arg('lang');
+const BOOK = arg('book');
+const LIMIT = parseInt(arg('limit', '0'), 10) || 0;
+const DRY_RUN = args.includes('--dry-run');
+const FORCE = args.includes('--force');
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+const GEMINI_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
+
+if (!LANG || !/^[a-z]{2,3}$/.test(LANG)) {
+  console.error('Usage: embed-page-texts.mjs --lang=<iso> [--book=ID] [--limit=N] [--dry-run] [--force]');
+  process.exit(1);
+}
+if (!MONGODB_URI || !SUPABASE_DB_URL || (!GEMINI_KEY && !DRY_RUN)) {
+  console.error('Missing env: MONGODB_URI, SUPABASE_DB_URL, or GEMINI_API_KEY[_TIER3]');
+  process.exit(1);
+}
+
+const COUNTER = `pages_translated_${LANG}`;
+
+async function main() {
+  const mc = new MongoClient(MONGODB_URI, { maxPoolSize: 4 });
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const client = new pg.Client({ connectionString: SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  await client.query('SET statement_timeout = 60000'); // PgBouncer rejects startup params — SET after connect
+
+  try {
+    const match = BOOK ? { id: { $in: BOOK.split(',') } } : { [COUNTER]: { $gt: 0 } };
+    // Select first, order second — sorting before the limit once picked the
+    // shortest books in the library rather than the intended set (2026-08-20).
+    let books = await db.collection('books')
+      .find(match, { projection: { id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, [COUNTER]: 1 } })
+      .toArray();
+    books.sort((a, b) => (a[COUNTER] || 0) - (b[COUNTER] || 0));
+    if (LIMIT) books = books.slice(0, LIMIT);
+
+    const expected = books.reduce((a, b) => a + (b[COUNTER] || 0), 0);
+    console.log(`[${LANG}] ${books.length} book(s), ${expected} pages by the ${COUNTER} counter${DRY_RUN ? ' — DRY RUN' : ''}`);
+
+    const totals = { embedded: 0, restaled: 0, missing: 0, alreadyPresent: 0 };
+    let done = 0;
+    const t0 = Date.now();
+
+    for (const book of books) {
+      const label = (book.display_title || book.title || book.id).slice(0, 48);
+      if (DRY_RUN) {
+        const { rows: [{ n }] } = await client.query(
+          'SELECT count(*)::int AS n FROM page_texts WHERE book_id = $1 AND lang = $2', [book.id, LANG],
+        );
+        console.log(`[${LANG}] ${label} — counter ${book[COUNTER] || 0}, already in page_texts: ${n}`);
+        continue;
+      }
+      let r;
+      try {
+        r = await embedBookPageTexts({ db, pg: client, book, lang: LANG, apiKey: GEMINI_KEY, force: FORCE });
+      } catch (e) {
+        // One book's failure must be visible, not swallowed into a clean-looking
+        // total — absence is not failure, but a recorded skip is not absence.
+        console.error(`[${LANG}] ${label} — FAILED: ${e.message}`);
+        continue;
+      }
+      for (const k of Object.keys(totals)) totals[k] += r[k];
+      done++;
+      console.log(
+        `[${LANG}] ${label} — +${r.embedded} embedded` +
+        `${r.restaled ? ` (${r.restaled} re-embedded stale)` : ''}` +
+        `${r.alreadyPresent ? `, ${r.alreadyPresent} fresh` : ''}` +
+        `${r.missing ? `, ${r.missing} without ${LANG} text` : ''}` +
+        ` [${done}/${books.length}, ${((Date.now() - t0) / 60000).toFixed(1)} min]`,
+      );
+    }
+
+    if (!DRY_RUN) {
+      const { rows } = await client.query(
+        'SELECT count(*)::int AS rows, count(embedding)::int AS embedded FROM page_texts WHERE lang = $1', [LANG],
+      );
+      console.log(
+        `[${LANG}] done — ${totals.embedded} embedded this run ` +
+        `(${totals.restaled} stale re-embedded, ${totals.alreadyPresent} already fresh, ${totals.missing} pages had no ${LANG} text). ` +
+        `page_texts now holds ${rows[0].rows} '${LANG}' rows, ${rows[0].embedded} with a vector; the counter expects ${expected}.`,
+      );
+    }
+  } finally {
+    await client.end();
+    await mc.close();
+  }
+}
+
+main().catch((e) => { console.error(`[${LANG}] fatal`, e); process.exit(1); });

--- a/scripts/workers/es-translate-worker.mjs
+++ b/scripts/workers/es-translate-worker.mjs
@@ -24,12 +24,21 @@
  *
  * Cost ≈ $0.0007/page (flash-lite). Respects the processing_control pause flag.
  *
+ * After each book it also embeds the new Spanish text into Supabase
+ * `page_texts` (#4095), which is what makes the pages FINDABLE — a Spanish page
+ * that exists but is not embedded is invisible to Spanish search, and, as the
+ * English page vectors proved in Aug 2026, an unembedded book and a book with
+ * no match return the same empty list. Keeping the writer inside the worker is
+ * the fix for that class: `--no-embed` opts out (needs SUPABASE_DB_URL).
+ *
  *   node --env-file=.env.production.local scripts/workers/es-translate-worker.mjs \
- *        [--top=50] [--book=<id>[,<id>]] [--max-pages=20000] [--dry-run]
+ *        [--top=50] [--book=<id>[,<id>]] [--max-pages=20000] [--dry-run] [--no-embed]
  */
 import { MongoClient } from 'mongodb';
+import pg from 'pg';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
+import { embedBookPageTexts } from '../lib/embed-book-page-texts.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (n, d) => { const m = args.find(a => a.startsWith(`--${n}=`)); return m ? m.split('=')[1] : d; };
@@ -45,6 +54,7 @@ const PAGE_IDS = PAGES_ARG
 // --order=reads (default: most-read first) | pages (shortest first — more books visible sooner)
 const ORDER = getArg('order', 'reads') === 'pages' ? { pages_translated: 1, read_count: -1 } : { read_count: -1 };
 const DRY_RUN = args.includes('--dry-run');
+const NO_EMBED = args.includes('--no-embed');
 const CONC = 6;
 const MODEL = 'gemini-3.1-flash-lite';
 const PROMPT_VERSION = 'es-pivot-v2';
@@ -132,6 +142,30 @@ async function recount(db, bookId) {
   return n;
 }
 
+/**
+ * Open the Supabase connection used to embed each finished book, or null when
+ * embedding is off or unconfigured. Deliberately NOT fatal: a missing
+ * SUPABASE_DB_URL should not stop translation — but it must SAY so, because a
+ * silent skip here is precisely how the English page vectors went two months
+ * dark without anything downstream noticing.
+ */
+async function openEmbedClient() {
+  if (NO_EMBED || DRY_RUN) return null;
+  if (!process.env.SUPABASE_DB_URL) {
+    console.warn('[ES] SUPABASE_DB_URL missing — translating WITHOUT embedding; the new Spanish pages will not be findable until scripts/workers/embed-page-texts.mjs --lang=es is run.');
+    return null;
+  }
+  try {
+    const c = new pg.Client({ connectionString: process.env.SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+    await c.connect();
+    await c.query('SET statement_timeout = 60000');
+    return c;
+  } catch (e) {
+    console.warn(`[ES] Supabase unavailable (${e.message}) — translating WITHOUT embedding; run embed-page-texts.mjs --lang=es afterwards.`);
+    return null;
+  }
+}
+
 async function main() {
   const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 8 });
   await client.connect();
@@ -145,6 +179,9 @@ async function main() {
     console.log('[ES] processing_control paused — exiting (pass --ignore-pause to run the EN→ES pivot anyway)');
     await client.close(); return;
   }
+
+  const embedPg = await openEmbedClient();
+  const embedKey = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
 
   // Popular-first: the most-read books with an English translation, skipping
   // those whose Spanish counter already covers their translated pages.
@@ -203,10 +240,26 @@ async function main() {
     await Promise.all(Array.from({ length: CONC }, worker));
     const n = await recount(db, b.id);
     console.log(`[ES] ${label} — done: es=${n}/${b.pages_translated}`);
+
+    if (embedPg && bookDone > 0) {
+      try {
+        // Re-fetch the book: embedBookPageTexts denormalizes author/language/
+        // year onto every row and the projection above carries none of them.
+        const full = await db.collection('books').findOne(
+          { id: b.id }, { projection: { id: 1, title: 1, author: 1, language: 1, year: 1 } });
+        // Staleness is checked inside, so a re-translated page's vector and
+        // snippet are replaced rather than left pointing at the old text.
+        const r = await embedBookPageTexts({ db, pg: embedPg, book: full, lang: 'es', apiKey: embedKey });
+        console.log(`[ES] ${label} — embedded ${r.embedded} page(s)${r.restaled ? ` (${r.restaled} re-embedded after re-translation)` : ''}`);
+      } catch (e) {
+        console.error(`[ES] ${label} — EMBED FAILED: ${e.message} (pages are translated but not yet findable; re-run embed-page-texts.mjs --lang=es --book=${b.id})`);
+      }
+    }
   }
 
   const cost = usage.input / 1e6 * 0.25 + usage.output / 1e6 * 1.5;
   console.log(`[ES] done — ${pagesDone} pages translated, ${skipped} skipped; ${usage.calls} calls, ${usage.input} in / ${usage.output} out tokens ≈ $${cost.toFixed(2)} (list price)`);
+  await embedPg?.end().catch(() => {});
   await client.close();
 }
 

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search';
-import { semanticPageSearchScoped } from '@/lib/semantic-search';
+import { semanticPageSearchScoped, lexicalPageSearchLang } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBookReadable } from '@/lib/book-access';
@@ -99,6 +99,14 @@ export async function GET(
     const { id: bookId } = await params;
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
+    // Which EDITION of the page text to search and quote. `en` (the default)
+    // is Mongo's `translation.data` + `ocr.data` via Atlas; anything else is
+    // the language-keyed `page_texts` store (#4095). The reader's own search
+    // bar is already Spanish under `/es` — searching English text behind a
+    // Spanish input is the mismatch this closes.
+    const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+    const textLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
+    const isLocalized = textLang !== 'en';
     const tenantContext = getTenantContextFromRequest(request.headers);
 
     if (tenantContext.slug && !tenantContext.id) {
@@ -140,6 +148,47 @@ export async function GET(
     const [keywordResults, semanticResults] = await Promise.all([
       // --- Keyword search (Atlas Search with regex fallback) ---
       (async (): Promise<SearchResult[]> => {
+        // Localized keyword leg. Atlas's `pages_search` index maps
+        // `translation.data` / `ocr.data` only, so it cannot see
+        // `translations.es.data`; the Spanish text is already in Supabase with
+        // a Spanish-stemmed GIN index, which is a better lexical match for it
+        // than lucene.standard would have been anyway. Front-matter demotion
+        // still reads the ENGLISH OCR — front matter is a property of the
+        // physical page, not of the language it is read in.
+        if (isLocalized) {
+          try {
+            const hits = await lexicalPageSearchLang(matchQuery, textLang, CANDIDATE_POOL, { bookIds: [bookId] });
+            if (hits.length === 0) return [];
+            const meta = await db.collection('pages')
+              .find({ id: { $in: hits.map(h => h.page_id) } }, { projection: { id: 1, page_type: 1, 'ocr.data': 1 } })
+              .toArray();
+            const ocrById = new Map(meta.map(d => [d.id as string, (d.ocr as { data?: string } | undefined)?.data]));
+            const badIds = new Set(
+              meta.filter(d => (NON_CONTENT_PAGE_TYPES as readonly string[]).includes(d.page_type as string))
+                .map(d => d.id as string),
+            );
+            const out: SearchResult[] = [];
+            for (const h of hits) {
+              if (badIds.has(h.page_id)) continue;
+              const text = h.full_text || h.snippet;
+              const matches = generateSnippet(text, matchQuery).map(m => ({ ...m, field: 'translation' as const }));
+              if (matches.length === 0) continue;
+              out.push({ pageId: h.page_id, pageNumber: h.page_number, matches, ...frontMatterVerdict(ocrById.get(h.page_id)) });
+              // ts_rank_cd, normalised against this leg's own best hit below —
+              // the same treatment Atlas's BM25 gets, for the same reason: the
+              // two scales have no common unit.
+              rawKeywordScore.set(h.page_id, h.score);
+              scoreText.set(h.page_id, cleanText(text));
+            }
+            return out;
+          } catch (e) {
+            // Loud, not silent: an empty result here is indistinguishable from
+            // "the book says nothing about that" unless we say which happened.
+            console.warn(`[book-search] localized keyword leg failed (${textLang}):`, e instanceof Error ? e.message : String(e));
+            return [];
+          }
+        }
+
         let pages: Record<string, unknown>[];
         let usedAtlas = false;
 
@@ -278,7 +327,7 @@ export async function GET(
       // --- Semantic search (conceptual matches via page embeddings) ---
       (async (): Promise<SearchResult[]> => {
         try {
-          const pages = await semanticPageSearchScoped(trimmedQuery, [bookId], 10);
+          const pages = await semanticPageSearchScoped(trimmedQuery, [bookId], 10, { textLang });
           const filtered = pages.filter(p => p.snippet && p.snippet.length > 20);
           if (filtered.length === 0) return [];
           // Look up page_type to drop boilerplate (title-page, blank, illustration, etc.)
@@ -386,8 +435,12 @@ export async function GET(
     // for an absent passage, and checking unconditionally would put a Supabase
     // round-trip on every search that is already working. See
     // src/lib/semantic-coverage.ts for the measurement that motivated this.
+    // Coverage is measured against `page_translations`, the English store, so
+    // it can only speak for an English request. Reporting it for a Spanish one
+    // would answer a question nobody asked — and a "full" verdict there would
+    // be actively misleading about the Spanish index.
     let coverage: SemanticCoverage | undefined;
-    if (semanticResults.length === 0) {
+    if (semanticResults.length === 0 && !isLocalized) {
       coverage = await semanticCoverage(
         (gateBook?.id as string) || bookId,
         (gateBook?.pages_translated as number) || 0,
@@ -406,11 +459,14 @@ export async function GET(
     logSearchEvent({
       request, db, query: trimmedQuery, resultsCount: results.length, source: 'book_search',
       tenantId: tenantContext.id || null,
-      filters: { book_id: bookId },
+      filters: { book_id: bookId, lang: textLang },
     });
 
     return NextResponse.json({
       query: trimmedQuery,
+      // Which edition answered. Never leave this to be inferred: a caller that
+      // asked for `es` and silently got English text has no way to tell.
+      lang: textLang,
       // total is what MATCHED, not what is being returned — a caller that sees
       // 50 and assumes that is everything will stop looking too early.
       total: totalMatched,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -323,10 +323,30 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         // same code the English lane runs.
         if (isLocalizedSearch) {
           try {
+            // Every book-level filter is resolved to an ALLOW-LIST of book ids
+            // and pushed into the RPC, rather than re-expressed as RPC
+            // parameters. `page_texts` denormalizes only `book_language` and
+            // `book_year`, so a lane that filtered on those alone would leak
+            // past category, has_doi, library, first_translation and the
+            // languages/exclude_languages arrays — a filter is only as strong
+            // as its weakest lane (search-filters-and-lanes.md), and a vector
+            // or text lane with no metadata predicate is the one people miss.
+            let allowedBookIds: string[] | undefined;
+            if (bookId) {
+              allowedBookIds = [bookId];
+            } else if (hasBookLevelFilters || tenantId) {
+              const allowed = await db.collection('books')
+                .find(buildBookFilters()).project({ id: 1 }).toArray();
+              // An empty allow-list must return NOTHING, never fall open to the
+              // whole corpus (#2760). `[]` reaches the RPC as an empty array and
+              // `book_id = ANY('{}')` matches nothing, but bail here rather than
+              // depend on that.
+              if (allowed.length === 0) return [];
+              allowedBookIds = allowed.map(b => b.id as string);
+            }
             const rows = await lexicalPageSearchLang(query, textLang, (bookId || pagesOnly) ? limit : MAX_PAGE_RESULTS, {
-              language: language || undefined,
               yearMin, yearMax,
-              bookIds: bookId ? [bookId] : undefined,
+              bookIds: allowedBookIds,
             });
             return rows.map(r => ({
               id: r.page_id,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,7 +6,7 @@ import type { SearchResult, SearchResponse } from '@/lib/api-client/types/search
 import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search';
 import { CONTENT_LICENSE } from '@/lib/license-info';
 import { searchBookIds } from '@/lib/books-catalog';
-import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
+import { semanticBookSearch, semanticPageSearchGlobal, lexicalPageSearchLang } from '@/lib/semantic-search';
 import { rrfScores } from '@/lib/search/rrf';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { withApiAuth } from '@/lib/api-auth';
@@ -60,6 +60,21 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     const excludeLanguagesParam = searchParams.get('exclude_languages');
     const languages = expandLanguages(languagesParam ? languagesParam.split(',').map(l => l.trim()).filter(Boolean) : []);
     const excludeLanguages = expandLanguages(excludeLanguagesParam ? excludeLanguagesParam.split(',').map(l => l.trim()).filter(Boolean) : []);
+    // `lang` is the TEXT language of the answer — which edition of each page to
+    // search and to quote back. It is NOT `language`, which filters by the
+    // BOOK's edition language and keeps that meaning everywhere
+    // (search-filters-and-lanes.md). `?lang=es&language=Latin` is coherent: the
+    // Spanish rendering of Latin editions.
+    //
+    // Anything but `en` narrows the whole request to books that HAVE that
+    // edition. That is not a nicety — result cards on a localized surface link
+    // to `/es/book/…`, and an `/es` URL for a book with no Spanish pages 307s
+    // straight back to English (i18n.md, "an /es URL is a promise"). A result
+    // the reader cannot open in their language is worse than no result.
+    const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+    const textLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
+    const isLocalizedSearch = textLang !== 'en';
+    const editionCounter = `pages_translated_${textLang}`;
     const category = searchParams.get('category'); // Category filter
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
@@ -178,6 +193,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       if (hasTranslation === 'true') filters.pages_translated = { $gt: 0 };
       if (firstTranslation === 'true') filters.is_first_translation = true;
       if (library) filters.$or = [{ held_by: library }, { 'image_source.provider': library }];
+      if (isLocalizedSearch) filters[editionCounter] = { $gt: 0 };
       return filters;
     }
 
@@ -297,6 +313,37 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       timed(async () => {
         if (!searchContent && !pagesOnly) return [];
 
+        // Localized keyword lane. The Atlas `pages_search` index maps
+        // `translation.data` / `ocr.data` and nothing else, so it cannot see
+        // `translations.es.data`; the Spanish text lives in Supabase for the
+        // vector lane anyway, and a GIN index over it gives real Spanish
+        // stemming that the Atlas index (lucene.standard everywhere) does not.
+        // Shaped to look like a Mongo page doc so everything downstream — the
+        // books join, the hidden-book drop, RRF, snippet extraction — is the
+        // same code the English lane runs.
+        if (isLocalizedSearch) {
+          try {
+            const rows = await lexicalPageSearchLang(query, textLang, (bookId || pagesOnly) ? limit : MAX_PAGE_RESULTS, {
+              language: language || undefined,
+              yearMin, yearMax,
+              bookIds: bookId ? [bookId] : undefined,
+            });
+            return rows.map(r => ({
+              id: r.page_id,
+              book_id: r.book_id,
+              page_number: r.page_number,
+              // The stored text is already wrapper-stripped by the embedding
+              // composer; extractSnippet re-cleans it harmlessly.
+              translation: { data: r.full_text || r.snippet },
+              ocr: { data: '' },
+            }));
+          } catch (err) {
+            console.warn('[search] Localized page lane failed:', err instanceof Error ? err.message : String(err));
+            degradedLanes.push('page');
+            return [];
+          }
+        }
+
         const pageSearchPromise = (async () => {
           const pageFilter: Record<string, unknown> = {};
           if (bookId) {
@@ -397,7 +444,10 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       timed(async () => {
         if (bookId || !searchContent) return [];
         try {
-          const pages = await semanticPageSearchGlobal(matchQuery, 15, { tenantId: tenantId || undefined });
+          const pages = await semanticPageSearchGlobal(matchQuery, 15, {
+            tenantId: tenantId || undefined,
+            textLang,
+          });
           if (pages.length === 0) return pages;
           // Drop semantic matches on non-content pages (cover/blank/illustration/etc.).
           // The Supabase embedding table has these — they pollute conceptual queries.
@@ -562,6 +612,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           .find(
             {
               id: { $in: semanticBookIds }, visible: true, pages_count: { $gt: 0 },
+              ...(isLocalizedSearch ? { [editionCounter]: { $gt: 0 } } : {}),
               // Tenant scope: match_books_semantic is GLOBAL (book_embeddings has
               // no tenant_id column, so the RPC can't filter), so a tenant request
               // must re-apply the tenant filter here or global books leak into the
@@ -644,6 +695,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           .find(
             {
               id: { $in: pageBookIds }, visible: true, pages_count: { $gt: 0 },
+              ...(isLocalizedSearch ? { [editionCounter]: { $gt: 0 } } : {}),
               // match_semantic already filters by filter_tenant_id, so this is
               // defense-in-depth — but keep it consistent with the book lane so a
               // future RPC change can't silently leak cross-tenant pages.
@@ -896,7 +948,9 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       // unattributable even though the value was sitting in scope — the same
       // blind spot that made the pre-existing rows unsplittable.
       tenantId,
-      filters: { language, category, year, bookId, library, semantic_count: semanticDocs.length },
+      // `lang` is recorded so Spanish demand is measurable — without it a
+      // localized search is indistinguishable from an English one in the log.
+      filters: { language, category, year, bookId, library, semantic_count: semanticDocs.length, lang: textLang },
     });
 
     logSearchQuery({

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -76,7 +76,8 @@ function hasNonLatinScript(language?: string): boolean {
 
 // Inline book search bar for the page reader footer
 function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?: string }) {
-  const rs = READER_STRINGS[useLocale()];
+  const locale = useLocale();
+  const rs = READER_STRINGS[locale];
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Array<{ pageId: string; pageNumber: number; matches: Array<{ field: string; snippet: string }> }>>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -91,7 +92,10 @@ function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?
     debounceRef.current = setTimeout(async () => {
       setIsSearching(true);
       try {
-        const res = await fetch(`/api/books/${bookId}/search?q=${encodeURIComponent(query.trim())}`);
+        // Search the edition the reader is actually reading. Under `/es` the
+        // input, the placeholder and the page text are Spanish; without this
+        // the results came back from the English text (#4095).
+        const res = await fetch(`/api/books/${bookId}/search?q=${encodeURIComponent(query.trim())}&lang=${locale}`);
         if (res.ok) {
           const data = await res.json();
           setResults(data.results || []);
@@ -100,7 +104,7 @@ function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?
       finally { setIsSearching(false); }
     }, 300);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  }, [query, bookId]);
+  }, [query, bookId, locale]);
 
   // Close on click outside
   useEffect(() => {

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -260,6 +260,29 @@ export interface SemanticPageSearchOptions {
   language?: string;
   languages?: string[];
   excludeLanguages?: string[];
+  /**
+   * Which TEXT to search — an ISO code. `'en'` (the default) reads
+   * `page_translations`; anything else reads the language-keyed `page_texts`
+   * store via `match_page_texts` (#4095).
+   *
+   * Do not confuse this with `language` / `languages` / `excludeLanguages`,
+   * which filter by the BOOK's edition language and keep that meaning on every
+   * surface (`search-filters-and-lanes.md`). `textLang: 'es'` with
+   * `language: 'Latin'` is a coherent query: the Spanish translation of Latin
+   * editions.
+   */
+  textLang?: string;
+}
+
+/**
+ * The default text language. A store keyed by language needs a name for the
+ * unkeyed English one, and `page_translations` is it.
+ */
+export const DEFAULT_TEXT_LANG = 'en';
+
+/** True when this request should read the language-keyed store rather than English. */
+export function usesLangStore(textLang: string | undefined | null): boolean {
+  return !!textLang && textLang !== DEFAULT_TEXT_LANG;
 }
 
 /**
@@ -294,20 +317,38 @@ export async function semanticPageSearchGlobal(
   const expandedLanguages = (opts.languages?.length ?? 0) > 0 ? expandLanguages(opts.languages!) : null;
   const expandedExcludeLanguages = (opts.excludeLanguages?.length ?? 0) > 0 ? expandLanguages(opts.excludeLanguages!) : null;
 
-  const { data, error } = await supabase.rpc('match_semantic', {
-    query_embedding: JSON.stringify(queryEmbedding),
-    match_threshold: 0.3,
-    match_count: overRequest,
-    filter_tenant_id: opts.tenantId ?? null,
-    filter_language: opts.language ?? null,
-    filter_year_min: opts.yearMin ?? null,
-    filter_year_max: opts.yearMax ?? null,
-    filter_languages: expandedLanguages,
-    filter_exclude_languages: expandedExcludeLanguages,
-  });
+  // The language-keyed store lives in its own table with its own RPC; the two
+  // return identical column names on purpose, so only the call differs.
+  // `page_texts` carries no tenant column — neither does `page_translations`,
+  // whose RPC accepts filter_tenant_id and ignores it — so tenant scoping stays
+  // where it actually happens: the books join in the caller.
+  const rpc = usesLangStore(opts.textLang) ? 'match_page_texts' : 'match_semantic';
+  const { data, error } = usesLangStore(opts.textLang)
+    ? await supabase.rpc('match_page_texts', {
+      query_embedding: JSON.stringify(queryEmbedding),
+      filter_lang: opts.textLang!,
+      match_threshold: 0.3,
+      match_count: overRequest,
+      filter_language: opts.language ?? null,
+      filter_year_min: opts.yearMin ?? null,
+      filter_year_max: opts.yearMax ?? null,
+      filter_languages: expandedLanguages,
+      filter_exclude_languages: expandedExcludeLanguages,
+    })
+    : await supabase.rpc('match_semantic', {
+      query_embedding: JSON.stringify(queryEmbedding),
+      match_threshold: 0.3,
+      match_count: overRequest,
+      filter_tenant_id: opts.tenantId ?? null,
+      filter_language: opts.language ?? null,
+      filter_year_min: opts.yearMin ?? null,
+      filter_year_max: opts.yearMax ?? null,
+      filter_languages: expandedLanguages,
+      filter_exclude_languages: expandedExcludeLanguages,
+    });
 
   if (error) {
-    throw new SemanticSearchError('match_semantic', error.message);
+    throw new SemanticSearchError(rpc, error.message);
   }
 
   let rows = (data || []) as any[];
@@ -345,6 +386,14 @@ export interface SemanticPageResult {
   book_id: string;
   page_number: number;
   snippet: string;
+  /**
+   * The complete stored page text, when the lane has it (the lexical
+   * `page_texts` lane does). Callers that want to centre a snippet on the hit —
+   * the way the Atlas lane does with its highlights — use this instead of
+   * re-reading the page from Mongo. Absent on the vector lanes, whose snippet
+   * is already the answer.
+   */
+  full_text?: string;
   // 'translation' = verbatim source text (safe to quote)
   // 'summary'     = AI-written continuity preamble that we could not cleanly strip
   snippet_type?: 'translation' | 'summary';
@@ -366,21 +415,31 @@ export async function semanticPageSearchScoped(
   query: string,
   bookIds: string[],
   limit: number = 10,
+  opts?: { textLang?: string },
 ): Promise<SemanticPageResult[]> {
   if (bookIds.length === 0) return [];
 
   const queryEmbedding = await getQueryEmbedding(query);
   if (!queryEmbedding) return [];
 
-  const { data, error } = await supabase.rpc('match_pages_in_books', {
-    query_embedding: JSON.stringify(queryEmbedding),
-    book_ids: bookIds,
-    match_threshold: 0.3,
-    match_count: limit,
-  });
+  const rpc = usesLangStore(opts?.textLang) ? 'match_page_texts_in_books' : 'match_pages_in_books';
+  const { data, error } = usesLangStore(opts?.textLang)
+    ? await supabase.rpc('match_page_texts_in_books', {
+      query_embedding: JSON.stringify(queryEmbedding),
+      filter_lang: opts!.textLang!,
+      book_ids: bookIds,
+      match_threshold: 0.3,
+      match_count: limit,
+    })
+    : await supabase.rpc('match_pages_in_books', {
+      query_embedding: JSON.stringify(queryEmbedding),
+      book_ids: bookIds,
+      match_threshold: 0.3,
+      match_count: limit,
+    });
 
   if (error) {
-    throw new SemanticSearchError('match_pages_in_books', error.message);
+    throw new SemanticSearchError(rpc, error.message);
   }
 
   return (data || []).map((row: any) => {
@@ -396,6 +455,72 @@ export async function semanticPageSearchScoped(
       book_author: row.book_author,
       book_language: row.book_language,
       book_year: row.book_year,
+    };
+  });
+}
+
+// ── Lexical page search in a non-English language (#4095) ────────────
+
+/**
+ * Keyword search over `page_texts` — the language-keyed twin of the Atlas
+ * Search page lane.
+ *
+ * WHY THIS IS POSTGRES AND NOT ATLAS. English keyword search runs on the
+ * `pages_search` Atlas index (`src/lib/atlas-search.ts`), whose mapping is
+ * explicit — `translation.data` and `ocr.data`, `dynamic: false`. Reaching
+ * `translations.es.data` would mean editing that definition, and a definition
+ * change rebuilds the whole index over 18.9M pages, on shared search capacity,
+ * to gain 38K Spanish rows. The Spanish text is already in Supabase for the
+ * vector lane, so a GIN index over it costs nothing and buys something Atlas
+ * would not have given: real Spanish stemming («alquimia» matches «alquímico»),
+ * where `pages_search` uses `lucene.standard` for every language.
+ *
+ * Which stemmer a language gets is decided ONCE, in the SQL function
+ * `page_text_config` — the same function the write-side trigger calls — so the
+ * index and the query can never disagree about it. A language Postgres has no
+ * dictionary for falls back to exact-token matching rather than being stemmed
+ * as something it is not.
+ *
+ * Returns the same row shape as the semantic lanes, so callers merge the two
+ * without a second mapper.
+ */
+export async function lexicalPageSearchLang(
+  query: string,
+  textLang: string,
+  limit: number = 25,
+  opts?: { language?: string; yearMin?: number; yearMax?: number; bookIds?: string[] },
+): Promise<SemanticPageResult[]> {
+  if (!usesLangStore(textLang) || !query.trim()) return [];
+
+  const { data, error } = await supabase.rpc('search_page_texts', {
+    query_text: query,
+    filter_lang: textLang,
+    match_count: limit,
+    filter_language: opts?.language ?? null,
+    filter_year_min: opts?.yearMin ?? null,
+    filter_year_max: opts?.yearMax ?? null,
+    filter_book_ids: opts?.bookIds ?? null,
+  });
+
+  if (error) {
+    throw new SemanticSearchError('search_page_texts', error.message);
+  }
+
+  return (data || []).map((row: Record<string, unknown>) => {
+    const text = (row.translation as string) || '';
+    const { snippet, type } = stripContinuityPrefix(text);
+    return {
+      page_id: row.page_id as string,
+      book_id: row.book_id as string,
+      page_number: row.page_number as number,
+      snippet,
+      snippet_type: type,
+      score: Number(row.similarity) || 0,
+      book_title: row.book_title as string,
+      book_author: (row.book_author as string) ?? null,
+      book_language: (row.book_language as string) ?? null,
+      book_year: (row.book_year as number) ?? null,
+      full_text: text,
     };
   });
 }

--- a/tests/unit/page-text-lang-store.test.ts
+++ b/tests/unit/page-text-lang-store.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pageTextForLang,
+  buildPageTextRow,
+  pageTextUpsertValues,
+  PAGE_TEXT_COLUMNS,
+  PAGE_TEXT_UPSERT_SQL,
+  pageEmbeddingInput,
+} from '../../scripts/lib/page-embedding-text.mjs';
+import { usesLangStore, DEFAULT_TEXT_LANG } from '../../src/lib/semantic-search';
+
+// `page_texts` rows carry the SNIPPET that gets quoted, not only the vector, so
+// the two properties pinned here are content-integrity properties, not tidiness:
+//
+//   1. a row in `lang: 'es'` contains Spanish, or the row does not exist;
+//   2. the row's values line up with the columns of the upsert that writes it.
+//
+// Both fail silently in production. A fallback to the original text would be
+// retrieved for Spanish queries and quoted as the Spanish edition; a
+// column/value misalignment would write well-formed rows with the wrong data in
+// each field — the same shape as the `People: , , , ,` bug that motivated
+// having one composer at all.
+
+const book = { id: 'b1', title: 'Splendor Solis', author: 'Trismosin', language: 'German', year: 1582 };
+
+describe('pageTextForLang — a language-keyed row promises that language', () => {
+  it('returns null when the language is absent, even though OCR and English exist', () => {
+    const page = {
+      id: 'p1', book_id: 'b1', page_number: 4,
+      ocr: { data: 'Der Sonnenglanz' },
+      translation: { data: 'The Splendour of the Sun' },
+    };
+    // The English store deliberately falls back to OCR so an untranslated page
+    // still gets a vector...
+    expect(pageEmbeddingInput(page)).not.toBeNull();
+    // ...the language-keyed one must not, or German lands in the Spanish lane.
+    expect(pageTextForLang(page, 'es')).toBeNull();
+  });
+
+  it('reads translations.<lang> and strips editorial wrappers', () => {
+    const page = {
+      id: 'p1', book_id: 'b1', page_number: 4,
+      translations: { es: { data: '<meta>Una página sobre mercurio</meta>El esplendor del sol.' } },
+    };
+    const got = pageTextForLang(page, 'es');
+    expect(got?.text).toBe('El esplendor del sol.');
+  });
+
+  it('folds the legacy translation_es field in for es, and only for es', () => {
+    const page = { id: 'p1', book_id: 'b1', page_number: 4, translation_es: { data: 'El esplendor.' } };
+    expect(pageTextForLang(page, 'es')?.text).toBe('El esplendor.');
+    expect(pageTextForLang(page, 'fr')).toBeNull();
+  });
+
+  it('prefers the map over the legacy field when both are present', () => {
+    const page = {
+      id: 'p1', book_id: 'b1', page_number: 4,
+      translation_es: { data: 'vieja' },
+      translations: { es: { data: 'nueva' } },
+    };
+    expect(pageTextForLang(page, 'es')?.text).toBe('nueva');
+  });
+});
+
+describe('buildPageTextRow / the upsert', () => {
+  const page = {
+    id: 'p1', book_id: 'b1', page_number: 4,
+    translations: { es: { data: 'El esplendor del sol.', updated_at: new Date('2026-08-20T10:00:00Z') } },
+  };
+
+  it('keys the row by (page_id, lang)', () => {
+    const row = buildPageTextRow({ page, book, lang: 'es', text: 'El esplendor del sol.', embedding: [0.1, 0.2] });
+    expect(row.page_id).toBe('p1');
+    expect(row.lang).toBe('es');
+    expect(row.book_title).toBe('Splendor Solis');
+    // book_language is the EDITION's language and stays German — it is the
+    // filter every other search surface means by "language".
+    expect(row.book_language).toBe('German');
+  });
+
+  it('takes the watermark from the translation, not from the page', () => {
+    const row = buildPageTextRow({ page, book, lang: 'es', text: 'x', embedding: [] });
+    expect(row.mongo_updated_at).toEqual(new Date('2026-08-20T10:00:00Z'));
+  });
+
+  it('emits exactly as many values as the upsert has placeholders, in order', () => {
+    const row = buildPageTextRow({ page, book, lang: 'es', text: 'x', embedding: [0.1] });
+    const values = pageTextUpsertValues(row);
+    expect(values.length).toBe(PAGE_TEXT_COLUMNS.length);
+    const placeholders = new Set(PAGE_TEXT_UPSERT_SQL.match(/\$\d+/g));
+    expect(placeholders.size).toBe(PAGE_TEXT_COLUMNS.length);
+    // Positional order is what actually maps a value to a column.
+    expect(values[0]).toBe(row.page_id);
+    expect(values[1]).toBe('es');
+    expect(values[PAGE_TEXT_COLUMNS.indexOf('text')]).toBe('x');
+  });
+});
+
+describe('usesLangStore', () => {
+  it('treats English as the unkeyed store and everything else as page_texts', () => {
+    expect(DEFAULT_TEXT_LANG).toBe('en');
+    expect(usesLangStore('en')).toBe(false);
+    expect(usesLangStore(undefined)).toBe(false);
+    expect(usesLangStore('')).toBe(false);
+    expect(usesLangStore('es')).toBe(true);
+    expect(usesLangStore('fr')).toBe(true);
+  });
+});


### PR DESCRIPTION
Workstreams **1, 2 and 5** of #4095. 103 books carry a Spanish edition (38,576 pages) and none of it was searchable: search, embeddings and snippets all assumed one translation per page, in English.

## The store

`page_texts (page_id, lang, …)` in Supabase — the vector-layer form of the `i18n.md` rule that the next language is a **key**, not a feature.

A sibling table rather than a `lang` column on `page_translations`, because that table is 4.5M rows behind four read paths (`match_semantic`, `match_pages_in_books`, the librarian, `/api/search`) and widening its primary key to gain 38K Spanish rows means migrating all of it and rebuilding an HNSW index those paths depend on. English is untouched; its rows can move in later as a separate, verified step.

## Two lanes

**Semantic** — `match_page_texts`, on a **partial HNSW index per language**. HNSW returns the globally nearest N and filters afterwards, so one shared index plus `WHERE lang = 'es'` would strip results to zero whenever the query's true neighbours are in another language. That is the cross-lingual bug already fixed once in `match_semantic` (May 2026); a partial index makes it structurally impossible. Adding a language means re-running the migration with `--lang=<iso>`, which the doc and the "adding a language" checklist now say.

**Lexical** — `search_page_texts`, Postgres full text. English keyword search is Atlas `pages_search`, whose mapping is explicit (`translation.data` / `ocr.data`, `dynamic: false`) and cannot see `translations.es.data`; changing that definition rebuilds an index over 18.9M pages on shared search capacity to gain 38K rows. The Spanish text is already in Supabase for the vector lane, so a GIN index over it costs nothing — and gives real Spanish stemming, which `lucene.standard` never did. Measured: «alquimia» → `'alquimi'`, 241 matching pages, 2.4 ms, index scan.

Which stemmer a language gets is decided **once**, in the SQL function `page_text_config`, called by both the write-side trigger and the read-side RPC, so the index and the query cannot disagree about it. A `tsvector` trigger rather than a generated column, because a generated column cannot be altered in place and dropping it silently drops its index.

## Two properties worth reviewing carefully

**No OCR fallback.** `pageEmbeddingInput` (English) falls back to the original text so an untranslated page still gets a vector. `pageTextForLang` must **not**: a row in `lang: 'es'` is a promise that the text IS Spanish, and the row carries the snippet that gets quoted, so a fallback would put Latin into the Spanish lane and quote it as the Spanish edition. Pinned by a test.

**Staleness is checked on every run, not behind a flag.** The Spanish audit→repair loop (`es-edition-quality.mjs` → the worker's `--strict --pages=@report` mode) rewrites pages. A stale row does not merely rank badly — it serves text that is no longer in the book.

## Surfaces

- **`/api/search?lang=es`** — swaps the text store in both page lanes, and narrows every lane to books that HAVE the edition. That last part is not a nicety: result cards on a localized surface link to `/es/book/…`, and an `/es` URL for a book without Spanish pages 307s straight back to English, so an unfiltered hit is a result the reader cannot open. `language` / `languages` / `exclude_languages` keep their meaning throughout (the BOOK's edition language) — `?lang=es&language=Latin` is a coherent query.
- **`/api/books/:id/search?lang=es`**, and the reader's own search bar now passes its locale. That bar is already Spanish under `/es`; it was searching the English text behind a Spanish input. The response echoes `lang` so a caller can never be silently served the wrong edition.
- Both routes record `lang` in the search event log, so Spanish demand is measurable.

## Writers and measurement

Bulk: `scripts/workers/embed-page-texts.mjs --lang=<iso>`. Inline: after each book in `es-translate-worker.mjs` — a step outside the pipeline can be switched off without anything downstream noticing, which is exactly how the English page vectors sat two months dark over 45% of the corpus. Both compose their rows through `page-embedding-text.mjs`. Four writers, one composer.

`scripts/audit/page-texts-coverage.mjs --lang=es` compares three numbers that are easy to confuse — the counter, the readable pages, the embedded rows — and reports the **writer's** age rather than only the row count, because a store with no writer reads as live. It exits 2 when it cannot measure, so a caller cannot mistake "could not reach the DB" for "nothing missing".

## Applied and backfilled

The migration is applied to production Supabase and all 103 books / 38,576 pages are embedded. ~~Embedding runs on `gemini-embedding-2-preview` (free tier for this table, as the English backfill did).~~

**Corrected 2026-08-21: that was wrong — embedding is BILLED.** `gemini-embedding-2-preview` is $0.20/1M input tokens on the paid tier and every `GEMINI_API_KEY*` here is a paid key. This backfill cost ≈$5.83 per full pass and was run twice (the second to repair a truncation bug), ≈$11.65 in total, without asking first. The stale doc line that caused it, an up-front estimate and a budget gate are in #4160; details on #4095.

## Out of scope, deliberately

- **MCP `lang` and the exports** (workstreams 3 and 4) are their own PR — different blast radius, different reviewers' concern.
- **`/es/search`** is not created. The search page is 2,284 lines with English chrome throughout; a half-English `/es/search` would break the rule that an `/es` URL means the page IS Spanish. That belongs with the chrome backlog (#4119).
- **English rows do not move into `page_texts`.** They can, later; nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ

