### PR TITLE
fix(reader): the translation tab names the panel, not the language

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -496,6 +496,14 @@ export default function TranslationEditor({
   const translationLangLabel = (translationLang.startsWith('es') || translationLang.includes('span'))
     ? 'Español'
     : isEnglishBook ? 'Modernized' : 'English';
+  // The panel TOGGLE names the panel; the panel's own header names the language
+  // it holds (translationLangLabel, above). Labelling the toggle with the target
+  // language put a control reading "Español" a few pixels from the EN/ES
+  // reading-language links (#4116) — two language-shaped controls side by side,
+  // only one of which changes the language. On an English-language book the
+  // panel is not a translation at all (the OCR panel holds the diplomatic
+  // transcription, this one the modernization), so it keeps its own name.
+  const translationTabLabel = isEnglishBook ? rs.modernizedTab : rs.translationTab;
   const [summaryText, setSummaryText] = useState(page.summary?.data || '');
   // Save state for the inline page editor. The previous design auto-saved on
   // blur with no UI feedback — editors (Paul Dijstelberge, May 2026) reported
@@ -1415,7 +1423,7 @@ export default function TranslationEditor({
                   aria-pressed={showTranslationPanel}
                 >
                   <Languages className="w-4 h-4" aria-hidden="true" />
-                  <span className="hidden sm:inline">{translationLangLabel}</span>
+                  <span className="hidden sm:inline">{translationTabLabel}</span>
                 </button>
               )}
             </div>
@@ -2468,7 +2476,7 @@ export default function TranslationEditor({
               title="Toggle translation panel"
             >
               <Languages className="w-4 h-4" />
-              <span className="hidden sm:inline">{translationLangLabel}</span>
+              <span className="hidden sm:inline">{translationTabLabel}</span>
             </button>
           </div>
 

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -301,6 +301,8 @@ export interface ReaderStrings {
   ocr: string;
   romanized: string;
   german: string;
+  translationTab: string;
+  modernizedTab: string;
   toggle: (shown: boolean, what: string) => string;
   panelSourceImage: string;
   panelOriginalText: string;
@@ -381,6 +383,8 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     ocr: 'OCR',
     romanized: 'Romanized',
     german: 'Deutsch',
+    translationTab: 'Translation',
+    modernizedTab: 'Modernized',
     toggle: (shown, what) => `${shown ? 'Hide' : 'Show'} ${what}`,
     panelSourceImage: 'source image',
     panelOriginalText: 'original text',
@@ -459,6 +463,8 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     ocr: 'OCR',
     romanized: 'Romanizado',
     german: 'Alemán',
+    translationTab: 'Traducción',
+    modernizedTab: 'Modernizado',
     toggle: (shown, what) => `${shown ? 'Ocultar' : 'Mostrar'} ${what}`,
     panelSourceImage: 'la imagen original',
     panelOriginalText: 'el texto original',


### PR DESCRIPTION
## What

The reader's third panel toggle was labelled with the **target language** — "Español" on a book that has a Spanish edition. It now reads **"Translation" / "Traducción"**. The panel's own header keeps the language name ("ESPAÑOL").

## Why

That tab does not change the language — it shows and hides the translation panel. After #4116 moved the EN/ES reading-language links into the same header row, the two sat a few pixels apart: two language-shaped controls, only one of which switches language. Derek flagged it from the live page.

The division that fixes it: **the toggle says what the panel IS; the panel says what it holds.** Same shape as its neighbours (Image, OCR, Romanized).

## English-language books keep "Modernized"

There the panel genuinely isn't a translation — the OCR panel holds the diplomatic transcription (long ſ and all) and this one the modernization. Collapsing that into "Translation" would be wrong, so `isEnglishBook` keeps its own label. It is now localized too (`Modernizado`), where before it was a hardcoded English string.

## Notes

- Both labels go through `BOOK_STRINGS` (en + es), so a Spanish reader no longer gets an English word over Spanish text.
- Applied to the read-mode and edit-mode headers alike so they cannot drift.
- `translationLangLabel` still exists and is unchanged — it is the panel header's label, and the paired-edition case (`English · Berthelot`) still routes through it.

## Checks

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjRSQoY7i6PndpRXWyQLBf