### PR TITLE
feat(es): Spanish librarian — Pregunta a la fuente (/es/librarian)

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -88,7 +88,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { threadId, message, history = [], visibility, stream = false, collection = null } = parsed.data;
+  const { threadId, message, history = [], visibility, stream = false, collection = null, lang } = parsed.data;
   const db = await getDb();
 
   // Get user display name (anonymous visitors skip the lookup)
@@ -149,6 +149,7 @@ export async function POST(request: NextRequest) {
       creatorName: displayName,
       visibility: threadVisibility(userId, visibility === 'public'),
       aiEnabled: true,
+      lang,
       messageCount: 0,
       createdAt: now,
       lastMessageAt: now,
@@ -214,7 +215,7 @@ export async function POST(request: NextRequest) {
 
   if (!stream) {
     try {
-      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection })) {
+      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection, lang })) {
         if (step.type === 'text') {
           fullText += step.text || '';
         } else if (step.type === 'sources') {
@@ -298,7 +299,7 @@ export async function POST(request: NextRequest) {
     try {
       await send({ type: 'threadId', threadId: activeThreadId });
 
-      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection })) {
+      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection, lang })) {
         lastStepType = step.type;
         switch (step.type) {
           case 'thinking':

--- a/src/app/es/librarian/layout.tsx
+++ b/src/app/es/librarian/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+import { librarianMetadata } from '@/lib/librarian-i18n';
+
+export const metadata: Metadata = librarianMetadata('es');
+
+export default function EsLibrarianLayout({ children }: { children: React.ReactNode }) {
+  return <div lang="es">{children}</div>;
+}

--- a/src/app/es/librarian/page.tsx
+++ b/src/app/es/librarian/page.tsx
@@ -1,0 +1,17 @@
+import LibrarianPage from '@/app/librarian/page';
+
+/**
+ * Spanish Librarian — "Pregunta a la fuente". The SAME page as `/librarian`,
+ * rendered with `lang='es'` (#4116): Spanish chrome from
+ * `src/lib/librarian-i18n.ts`, `/es`-prefixed links, and `lang: 'es'` on every
+ * chat request so the tools quote `pages.translations.es` where we hold it and
+ * label the English where we don't (`.claude/docs/i18n.md` rule 4).
+ */
+
+// Segment config must be a static literal (Next parses it at build time) —
+// keep in step with src/app/librarian/page.tsx.
+export const revalidate = 86400;
+
+export default async function EsLibrarianPage() {
+  return LibrarianPage({ lang: 'es' });
+}

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -11,6 +11,8 @@ import { applyCitationFixes, applyImageRemovals } from '@/lib/embassy/citation-f
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
 import LibrarianMessageBody from './_components/MessageBody';
+import { LIBRARIAN_STRINGS, type LibrarianStrings } from '@/lib/librarian-i18n';
+import { localePath, type Locale } from '@/lib/locale-path';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -110,43 +112,38 @@ interface FeaturedPassage {
 
 interface LibrarianClientProps {
   featuredPassage: FeaturedPassage | null;
+  /**
+   * The page's locale: `/librarian` → 'en', `/es/librarian` → 'es'. Picks the
+   * chrome dictionary, prefixes every internal link, and travels to the chat
+   * API as `lang` so the Librarian quotes the Spanish edition (see
+   * src/lib/embassy/chat-request.ts). Same component for both routes, so
+   * they cannot drift.
+   */
+  lang?: Locale;
 }
 
-function timeAgo(dateStr: string): string {
+function timeAgo(dateStr: string, t: LibrarianStrings): string {
   const d = new Date(dateStr);
   const now = new Date();
   const diffMs = now.getTime() - d.getTime();
   const diffMins = Math.floor(diffMs / 60000);
-  if (diffMins < 1) return 'just now';
+  if (diffMins < 1) return t.justNow;
   if (diffMins < 60) return `${diffMins}m ago`;
   const diffHours = Math.floor(diffMins / 60);
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
   if (diffDays < 7) return `${diffDays}d ago`;
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(t.dateLocale, { month: 'short', day: 'numeric' });
 }
-
-const TOOL_LABELS: Record<string, string> = {
-  search: 'Searching the collection',
-  search_collection: 'Searching the collection',
-  search_semantic: 'Semantic search',
-  search_wikipedia: 'Checking Wikipedia',
-  search_images: 'Searching illustrations',
-  search_artworks: 'Searching artworks',
-  get_book_page: 'Reading a page',
-  read_nearby_pages: 'Reading nearby pages',
-  add_to_notebook: 'Saving to notebook',
-  present_choices: 'Thinking...',
-};
 
 // ── Source Card Component ─────────────────────────────────────────────
 
-function SourceCardRow({ sources, tenant }: { sources: SourceCard[]; tenant?: string }) {
+function SourceCardRow({ sources, tenant, lang, t }: { sources: SourceCard[]; tenant?: string; lang: Locale; t: LibrarianStrings }) {
   if (sources.length === 0) return null;
   return (
     <div className="mt-3 flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
       {sources.map((s, i) => {
-        const url = tenantBookUrl({ slug: s.bookSlug, id: s.bookId }, tenant) + (s.pageNumber ? `/page-number/${s.pageNumber}` : '');
+        const url = localePath(tenantBookUrl({ slug: s.bookSlug, id: s.bookId }, tenant) + (s.pageNumber ? `/page-number/${s.pageNumber}` : ''), lang);
         return (
           <Link
             key={`${s.bookId}-${s.pageNumber}-${i}`}
@@ -169,7 +166,7 @@ function SourceCardRow({ sources, tenant }: { sources: SourceCard[]; tenant?: st
               </p>
             )}
             {!s.inCollection && (
-              <p className="text-[9px] text-[#b0a89c] font-sans mt-1">Not yet in collection</p>
+              <p className="text-[9px] text-[#b0a89c] font-sans mt-1">{t.notYetInCollection}</p>
             )}
           </Link>
         );
@@ -180,7 +177,7 @@ function SourceCardRow({ sources, tenant }: { sources: SourceCard[]; tenant?: st
 
 // ── Search Steps Component ────────────────────────────────────────────
 
-function SearchSteps({ steps }: { steps: SearchStep[] }) {
+function SearchSteps({ steps, t }: { steps: SearchStep[]; t: LibrarianStrings }) {
   if (steps.length === 0) return null;
   const busy = steps.some(s => s.status === 'searching');
   return (
@@ -206,7 +203,7 @@ function SearchSteps({ steps }: { steps: SearchStep[] }) {
             )}
           </span>
           <span>
-            {TOOL_LABELS[step.name] || step.name}
+            {t.tools[step.name] || step.name}
             {step.query && <span className="text-[#b0a89c]"> &ldquo;{step.query.slice(0, 50)}{step.query.length > 50 ? '...' : ''}&rdquo;</span>}
             {step.status === 'done' && step.summary && (
               <span className="text-[#6b6560]"> &mdash; {step.summary}</span>
@@ -229,18 +226,20 @@ function NotebookPanel({
   topic,
   threadId,
   onClose,
+  t,
 }: {
   findings: NotebookFinding[];
   topic?: string;
   threadId: string | null;
   onClose: () => void;
+  t: LibrarianStrings;
 }) {
   return (
     <div className="border-t border-[#e8e4dc] bg-[#faf8f4]">
       <div className="flex items-center justify-between px-4 py-2.5">
         <div className="flex items-center gap-2 text-[13px] font-sans text-[#6b8f5e]">
           <span aria-hidden>&#x1F4D3;</span>
-          <span className="font-medium">Research notebook</span>
+          <span className="font-medium">{t.notebook}</span>
           <span className="text-[#8a8480]">
             {findings.length} finding{findings.length === 1 ? '' : 's'}{topic ? ` · ${topic}` : ''}
           </span>
@@ -252,7 +251,7 @@ function NotebookPanel({
               download
               className="text-[11px] text-[#6b8f5e] hover:text-[#4a6b40] font-sans"
             >
-              Export
+              {t.exportNotebook}
             </a>
           )}
           <button onClick={onClose} className="text-[11px] text-[#8a8480] hover:text-[#6b6560] font-sans">
@@ -289,68 +288,10 @@ function NotebookPanel({
 
 // ── Main Component ────────────────────────────────────────────────────
 
-const ALL_SUGGESTIONS = [
-  // Alchemy & Hermetica
-  'How did alchemists describe the philosopher\'s stone?',
-  'What did alchemists believe about gold?',
-  'Tell me about the Emerald Tablet',
-  'Who was Hermes Trismegistus?',
-  'What equipment did a working alchemist actually use?',
-  'How did Arabic alchemy reach medieval Europe?',
-  'What did alchemists mean by the marriage of the sun and moon?',
-  // Renaissance philosophy & magic
-  'Who was Marsilio Ficino?',
-  'What do these texts say about the world soul?',
-  'What did Agrippa write about planetary seals?',
-  'What is the relationship between music and magic?',
-  'What books explore resonance as magic?',
-  'How did Giordano Bruno imagine infinite worlds?',
-  'What was the art of memory?',
-  'Was there any conception of artificial intelligence?',
-  'Did anyone write about talking statues or artificial beings?',
-  // Kabbalah & religious mysticism
-  'What is the Kabbalah\'s tree of life?',
-  'What did Christian scholars make of the Zohar?',
-  'What did Jacob Boehme see in his visions?',
-  'How did mystics describe union with the divine?',
-  // Astrology & cosmology
-  'What instruments did astrologers use?',
-  'How did Renaissance scholars understand the cosmos?',
-  'How were comets interpreted before modern astronomy?',
-  'How did Kepler mix astrology with astronomy?',
-  'What did people believe about the music of the spheres?',
-  // Medicine & natural history
-  'What did Paracelsus teach about medicine?',
-  'How were dreams interpreted as medical symptoms?',
-  'What remedies did early herbals prescribe?',
-  'How did physicians explain the plague?',
-  'What did anatomists discover before the microscope?',
-  // Magic, witchcraft & demonology
-  'How were demons understood in early modern Europe?',
-  'What did witch-hunting manuals actually claim?',
-  'How did scholars defend accused witches?',
-  'What were angels thought to know?',
-  // Dreams, divination & prophecy
-  'Did any of these authors write about dreams?',
-  'How did people tell fortunes before tarot cards?',
-  'What prophecies circulated during the Reformation?',
-  // Rosicrucians & secret societies
-  'Who were the Rosicrucians?',
-  'What ciphers and secret alphabets appear in these books?',
-  'What did the Rosicrucian manifestos promise?',
-  // Eastern traditions
-  'What do Tibetan texts say about the nature of mind?',
-  'What does Ayurvedic medicine say about the elements?',
-  'How did Sanskrit astronomers calculate eclipses?',
-  // Art, images & books themselves
-  'What are the strangest illustrations in the collection?',
-  'How were emblem books meant to be read?',
-  'What did the first printed books look like?',
-  'Which books here were never translated until now?',
-];
+// Suggestion chips come from LIBRARIAN_STRINGS[lang].suggestions (src/lib/librarian-i18n.ts).
 
-function pickSuggestions(count: number, extras: string[] = []): string[] {
-  const pool = [...ALL_SUGGESTIONS].sort(() => Math.random() - 0.5);
+function pickSuggestions(pool0: readonly string[], count: number, extras: string[] = []): string[] {
+  const pool = [...pool0].sort(() => Math.random() - 0.5);
   const picks = [...extras, ...pool.filter(s => !extras.includes(s))].slice(0, count);
   // Second shuffle so real visitor questions don't always sit first.
   return picks.sort(() => Math.random() - 0.5);
@@ -369,7 +310,9 @@ function looksLikeGoodQuestion(q: string): boolean {
     && QUESTION_START_RE.test(t);
 }
 
-export default function LibrarianClient({ featuredPassage }: LibrarianClientProps) {
+export default function LibrarianClient({ featuredPassage, lang = 'en' }: LibrarianClientProps) {
+  const t = LIBRARIAN_STRINGS[lang];
+  const href = (path: string) => localePath(path, lang);
   const { data: session, status } = useSession();
   const params = useParams<{ tenant: string }>();
   const tenant = params?.tenant;
@@ -377,8 +320,8 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   // Seed deterministically so SSR and the first client render agree (a random
   // initial set caused a hydration mismatch — React #418). Shuffle for variety
   // only after mount, where a state update is safe.
-  const [suggestions, setSuggestions] = useState<string[]>(() => ALL_SUGGESTIONS.slice(0, 6));
-  useEffect(() => { setSuggestions(pickSuggestions(6)); }, []);
+  const [suggestions, setSuggestions] = useState<string[]>(() => t.suggestions.slice(0, 6));
+  useEffect(() => { setSuggestions(pickSuggestions(t.suggestions, 6)); }, [t]);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);
@@ -502,13 +445,16 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   // Blend up to two real visitor questions into the suggestion chips once
   // public threads arrive, so the chips reflect what people actually ask.
   useEffect(() => {
+    // Visitor questions in Recent are (almost all) English; only surface them
+    // as chips on the English page.
+    if (lang !== 'en') return;
     const real = Array.from(new Set(
-      threads.map(t => t.preview.question).filter(looksLikeGoodQuestion),
+      threads.map(th => th.preview.question).filter(looksLikeGoodQuestion),
     ));
     if (real.length === 0) return;
     const extras = real.sort(() => Math.random() - 0.5).slice(0, 2);
-    setSuggestions(pickSuggestions(6, extras));
-  }, [threads]);
+    setSuggestions(pickSuggestions(t.suggestions, 6, extras));
+  }, [threads, lang, t]);
 
   // Fetch the reader's own threads once the session resolves. While NextAuth is
   // still deciding (`status === 'loading'`) this list is NOT empty — it is
@@ -609,6 +555,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
           })),
           visibility,
           stream: true,
+          lang,
         }),
         signal: abort.signal,
       });
@@ -620,14 +567,14 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
           // to sign in (free) to continue.
           updateLastAssistant(m => ({
             ...m,
-            content: 'You\'ve used your free questions for now. [Sign in](/auth/signin?callbackUrl=/librarian&reason=limit) (free) to keep talking with the Librarian — create an account or sign in with Google.',
+            content: t.limitReached,
           }));
         } else {
           updateLastAssistant(m => ({
             ...m,
             error: true,
             retryQuestion: trimmed,
-            content: err.error || 'I’m sorry — something went wrong on my end. Try again?',
+            content: err.error || t.genericError,
           }));
         }
         setSending(false);
@@ -910,10 +857,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
   const handleShareThread = async (i: number) => {
     if (!threadId) return;
-    const url = `${window.location.origin}/librarian/thread/${threadId}`;
+    const url = `${window.location.origin}${href(`/librarian/thread/${threadId}`)}`;
     if (navigator.share) {
       try {
-        await navigator.share({ title: 'The Librarian — Source Library', url });
+        await navigator.share({ title: t.metaTitle, url });
         return;
       } catch { return; /* user cancelled */ }
     }
@@ -930,9 +877,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     setNotebookTopic(undefined);
     setNotebookOpen(false);
     // Fresh chips for a fresh conversation.
-    const real = threads.map(t => t.preview.question).filter(looksLikeGoodQuestion);
+    const real = lang === 'en' ? threads.map(th => th.preview.question).filter(looksLikeGoodQuestion) : [];
     const extras = real.sort(() => Math.random() - 0.5).slice(0, 2);
-    setSuggestions(pickSuggestions(6, extras));
+    setSuggestions(pickSuggestions(t.suggestions, 6, extras));
     window.history.replaceState(null, '', window.location.pathname);
     inputRef.current?.focus();
   };
@@ -958,11 +905,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
         <div className="relative max-w-[var(--container-wide)] mx-auto px-6 md:px-12 pt-10 sm:pt-12 pb-10 animate-fade-in-up">
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-display mb-3 drop-shadow-lg" style={{ fontWeight: 500 }}>
-            The Librarian
+            {t.title}
           </h1>
           <p className="text-white/80 text-base sm:text-lg font-body leading-relaxed max-w-[480px] drop-shadow-sm">
-            Your research agent for over 10,000 rare books. Ask a question, and the Librarian
-            will search the collection, cross-reference sources, and build up findings you can export.
+            {t.intro}
           </p>
         </div>
       </div>
@@ -985,11 +931,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     <div className="text-center py-8">
                       <img src="/brand/png/icon-only--black-on-transparent--96h.png" alt="" className="w-10 h-10 mx-auto mb-3 opacity-40" />
                       <p className="text-[#8a8480] text-sm font-body max-w-[400px] mx-auto leading-relaxed">
-                        The Librarian searches the collection, Wikipedia, and semantic search
-                        to find answers in over 10,000 rare books.
+                        {t.emptyLead}
                       </p>
                       <p className="text-[#8a8480]/50 text-xs font-body mt-1.5">
-                        Responses may contain errors &mdash; always verify against the source page.
+                        {t.emptyDisclaimer}
                       </p>
                       <div className="flex flex-wrap justify-center gap-2 mt-5">
                         {suggestions.map((suggestion) => (
@@ -1037,7 +982,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                                 aria-expanded={showThinking}
                                 className="text-[11px] text-[#b0a89c] hover:text-[#8a8480] font-sans transition-colors"
                               >
-                                {showThinking ? 'Hide reasoning' : 'Show reasoning'}
+                                {showThinking ? t.hideReasoning : t.showReasoning}
                               </button>
                               {showThinking && (
                                 <div className="mt-1 text-[13px] text-[#8a8480] font-body italic leading-relaxed bg-[#faf8f4] rounded px-3 py-2 border-l-2 border-[#e8e4dc]">
@@ -1048,7 +993,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                           )}
 
                           {/* Search steps */}
-                          <SearchSteps steps={assistant.steps} />
+                          <SearchSteps steps={assistant.steps} t={t} />
 
                           {/* Response text */}
                           {assistant.content && (
@@ -1100,7 +1045,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                           )}
 
                           {/* Source cards */}
-                          <SourceCardRow sources={assistant.sources} tenant={tenant} />
+                          <SourceCardRow sources={assistant.sources} tenant={tenant} lang={lang} t={t} />
 
                           {/* Copy / share actions (once the response has finished streaming) */}
                           {assistant.content && !assistant.error && !(sending && i === messages.length - 1) && (
@@ -1116,7 +1061,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                                   onClick={() => handleShareThread(i)}
                                   className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans"
                                 >
-                                  {copiedKey === `share-${i}` ? 'Link copied ✓' : 'Share'}
+                                  {copiedKey === `share-${i}` ? t.linkCopied : t.share}
                                 </button>
                               )}
                             </div>
@@ -1152,6 +1097,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     topic={notebookTopic}
                     threadId={threadId}
                     onClose={() => setNotebookOpen(false)}
+                    t={t}
                   />
                 )}
 
@@ -1163,7 +1109,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       value={input}
                       onChange={handleInputChange}
                       onKeyDown={handleKeyDown}
-                      placeholder="Ask the Librarian..."
+                      placeholder={t.placeholder}
                       rows={1}
                       className="flex-1 resize-none border border-[#e8e4dc] rounded-lg px-4 py-2.5 text-[15px] font-body text-[#1a1612] placeholder-[#8a8480] focus:outline-none focus:border-[#c9a86c] transition-colors bg-transparent disabled:opacity-50"
                     />
@@ -1171,9 +1117,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       <button
                         type="button"
                         onClick={toggleDictation}
-                        aria-label={listening ? 'Stop voice input' : 'Start voice input'}
+                        aria-label={listening ? t.stopVoice : t.startVoice}
                         aria-pressed={listening}
-                        title={listening ? 'Stop voice input' : 'Speak your question'}
+                        title={listening ? t.stopVoice : t.speakYourQuestion}
                         className={`flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-lg border transition-colors ${listening
                           ? 'border-[#9e4a3a] bg-[#9e4a3a] text-white animate-pulse'
                           : 'border-[#e8e4dc] text-[#8a8480] hover:text-[#1a1612] hover:border-[#c9a86c]'
@@ -1192,7 +1138,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                         onClick={handleStop}
                         className="flex-shrink-0 px-5 py-2.5 bg-[#9e4a3a] text-white rounded-lg text-sm font-sans hover:bg-[#8b3d30] transition-colors"
                       >
-                        Stop
+                        {t.stop}
                       </button>
                     ) : (
                       <button
@@ -1200,7 +1146,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                         disabled={!input.trim()}
                         className="flex-shrink-0 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] disabled:opacity-30 transition-colors"
                       >
-                        Send
+                        {t.send}
                       </button>
                     )}
                   </form>
@@ -1209,7 +1155,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     <div className="flex items-center gap-3">
                       {messages.length > 0 && (
                         <button onClick={startNewThread} className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans">
-                          New conversation
+                          {t.newConversation}
                         </button>
                       )}
                       {notebookFindings.length > 0 && (
@@ -1228,11 +1174,11 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                         onClick={() => setListed(visibility !== 'public')}
                         className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
                       >
-                        <span>{visibility === 'public' ? 'Listed' : 'Not listed'}</span>
+                        <span>{visibility === 'public' ? t.listed : t.notListed}</span>
                         <span className="text-[9px]">
                           {visibility === 'public'
-                            ? '(shown in Recent, never under your name)'
-                            : isSignedIn ? '(only you)' : '(not shown to anyone else)'}
+                            ? t.listedHint
+                            : isSignedIn ? t.onlyYou : t.notShownToOthers}
                         </span>
                       </button>
                       <span className="text-[9px] text-[#c0b8b0] font-mono">v5</span>
@@ -1241,10 +1187,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
                   {!isSignedIn && status !== 'loading' && (
                     <p className="mt-2 text-[12px] text-[#8a8480] font-sans">
-                      <Link href="/auth/signin?callbackUrl=/librarian" className="text-[#9e4a3a] hover:underline">
-                        Sign in
+                      <Link href={`${href('/auth/signin')}?callbackUrl=${encodeURIComponent(href('/librarian'))}`} className="text-[#9e4a3a] hover:underline">
+                        {t.signIn}
                       </Link>
-                      {' '}(free) to keep your conversations and come back to them later.
+                      {' '}{t.signInToKeep}
                     </p>
                   )}
                 </div>
@@ -1261,7 +1207,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     className={`text-[11px] tracking-[0.2em] uppercase font-sans transition-colors ${sidebarTab === 'recent' ? 'text-[#1a1612]' : 'text-[#b0a89c] hover:text-[#8a8480]'
                       }`}
                   >
-                    Recent
+                    {t.recent}
                   </button>
                   {isSignedIn && (
                     <button
@@ -1269,14 +1215,14 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       className={`text-[11px] tracking-[0.2em] uppercase font-sans transition-colors ${sidebarTab === 'mine' ? 'text-[#1a1612]' : 'text-[#b0a89c] hover:text-[#8a8480]'
                         }`}
                     >
-                      My Conversations
+                      {t.myConversations}
                     </button>
                   )}
                 </div>
 
                 {sidebarTab === 'recent' && (
                   <p className="text-[10px] text-[#b0a89c] font-sans mb-3 leading-relaxed">
-                    What other readers are asking, shown without their names.
+                    {t.recentHint}
                   </p>
                 )}
 
@@ -1320,9 +1266,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                   if (allThreads.length === 0) {
                     return (
                       <p className="text-[#8a8480] text-sm font-body">
-                        {isMine
-                          ? 'No conversations yet. Ask the Librarian something!'
-                          : 'No conversations yet. Be the first to ask the Librarian something.'}
+                        {isMine ? t.noConversationsMine : t.noConversationsRecent}
                       </p>
                     );
                   }
@@ -1333,7 +1277,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       {displayThreads.map((thread) => (
                         <Link
                           key={thread.id}
-                          href={`/librarian/thread/${thread.id}`}
+                          href={href(`/librarian/thread/${thread.id}`)}
                           className="block py-3 border-b border-[#e8e4dc] hover:bg-[#f5f0e8]/50 transition-colors -mx-2 px-2 rounded"
                         >
                           <p className="text-sm font-body text-[#1a1612] line-clamp-2 leading-snug mb-1">
@@ -1343,8 +1287,8 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                             {thread.preview.answer}
                           </p>
                           <p className="text-[10px] text-[#8a8480] font-sans">
-                            {thread.creatorName} &middot; {timeAgo(thread.lastMessageAt)}
-                            {thread.messageCount > 2 && <span> &middot; {thread.messageCount} messages</span>}
+                            {thread.creatorName} &middot; {timeAgo(thread.lastMessageAt, t)}
+                            {thread.messageCount > 2 && <span> &middot; {thread.messageCount} {t.messages}</span>}
                           </p>
                         </Link>
                       ))}
@@ -1353,7 +1297,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                           onClick={() => setVisibleThreads(v => v + 10)}
                           className="block w-full py-2 mt-1 text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans text-center"
                         >
-                          Show more ({allThreads.length - visibleThreads} remaining)
+                          {t.showMore} ({allThreads.length - visibleThreads})
                         </button>
                       )}
                     </div>
@@ -1363,9 +1307,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                 {featuredPassage && (
                   <div className="mt-8 pt-6 border-t border-[#e8e4dc]">
                     <p className="text-[11px] text-[#b0a89c] tracking-[0.15em] uppercase font-sans mb-2">
-                      The Librarian is reading
+                      {t.librarianIsReading}
                     </p>
-                    <Link href={featuredPassage.pageId ? `/book/${featuredPassage.bookSlug}/page/${featuredPassage.pageId}` : `/book/${featuredPassage.bookSlug}`} className="block group">
+                    <Link href={href(featuredPassage.pageId ? `/book/${featuredPassage.bookSlug}/page/${featuredPassage.pageId}` : `/book/${featuredPassage.bookSlug}`)} className="block group">
                       <blockquote className="text-[#6b6560] text-[14px] font-body leading-relaxed italic border-l-2 border-[#c9a86c]/50 pl-3">
                         &ldquo;{featuredPassage.text}&rdquo;
                       </blockquote>

--- a/src/app/librarian/layout.tsx
+++ b/src/app/librarian/layout.tsx
@@ -1,16 +1,7 @@
 import type { Metadata } from 'next';
+import { librarianMetadata } from '@/lib/librarian-i18n';
 
-export const metadata: Metadata = {
-  title: 'The Librarian — Source Library',
-  description: 'Ask the Librarian about any text in the collection. Alchemy, Hermetica, Kabbalah, astrology, natural philosophy — thousands of rare books, many translated into English for the first time.',
-  openGraph: {
-    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
-    title: 'The Librarian — Source Library',
-    description: 'Ask the Librarian about any text in the collection.',
-    siteName: 'Source Library',
-    type: 'website',
-  },
-};
+export const metadata: Metadata = librarianMetadata('en');
 
 export default function LibrarianLayout({ children }: { children: React.ReactNode }) {
   return children;

--- a/src/app/librarian/page.tsx
+++ b/src/app/librarian/page.tsx
@@ -1,5 +1,6 @@
 import { connectToDatabase } from '@/lib/mongodb';
 import LibrarianClient from './LibrarianClient';
+import type { Locale } from '@/lib/locale-path';
 
 export const revalidate = 86400; // 24h ISR
 
@@ -145,12 +146,17 @@ async function getFeaturedPassage() {
   }
 }
 
-export default async function LibrarianPage() {
+/**
+ * `lang` is set by the `/es/librarian` twin (src/app/es/librarian/page.tsx),
+ * which re-exports this component — one page, two locales, no drift.
+ */
+export default async function LibrarianPage({ lang = 'en' }: { lang?: Locale } = {}) {
   const featuredPassage = await getFeaturedPassage();
 
   return (
     <LibrarianClient
       featuredPassage={featuredPassage}
+      lang={lang}
     />
   );
 }

--- a/src/lib/embassy/chat-request.ts
+++ b/src/lib/embassy/chat-request.ts
@@ -37,6 +37,11 @@ export const chatRequestSchema = z.object({
   // "Ask the Librarian" entry point on a collection page; the Librarian biases
   // results toward this collection while still surfacing strong outside matches.
   collection: z.string().max(120).nullable().optional(),
+  // The conversation's language (the URL locale of the page that sent it:
+  // `/es/librarian` → 'es'). Selects the edition the tools quote from and the
+  // `/es` prefix on every link. The model would answer in Spanish anyway;
+  // this is what makes it quote OUR Spanish edition instead of improvising one.
+  lang: z.enum(['en', 'es']).default('en'),
 });
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>;

--- a/src/lib/embassy/citation-fixes.ts
+++ b/src/lib/embassy/citation-fixes.ts
@@ -38,8 +38,12 @@ function escapeRegex(s: string): string {
  * `sourcelibrary.org`, so an unanchored pattern reads a perfectly good CDN URL
  * (`images.sourcelibrary.org/artwork/foo.jpg`) as a link to the `/artwork/foo`
  * page and reports it dead.
+ *
+ * The optional `/es` is the locale prefix: a Spanish conversation cites
+ * `sourcelibrary.org/es/book/<slug>`, which is the same book and must be
+ * verified (and repaired) exactly like the English link.
  */
-export const SITE_HOST_PATTERN = '(?<![\\w.-])sourcelibrary\\.org';
+export const SITE_HOST_PATTERN = '(?<![\\w.-])sourcelibrary\\.org(?:\\/es)?';
 
 /** Book links in a response: `/book/<slug>` plus any page suffix. */
 export function findCitedBookLinks(text: string): Array<{ slug: string; page?: number }> {
@@ -81,12 +85,13 @@ export function applyCitationFixes(text: string, fixes: CitationFix[]): string {
   let out = text;
   for (const fix of fixes) {
     if (!fix?.fromSlug || !fix?.toSlug || fix.fromSlug === fix.toSlug) continue;
+    // `$1` keeps the `/es` locale prefix (if any) on the repaired link.
     const pattern = new RegExp(
-      `https://sourcelibrary\\.org/book/${escapeRegex(fix.fromSlug)}(?![a-z0-9-])` +
+      `https://sourcelibrary\\.org(/es)?/book/${escapeRegex(fix.fromSlug)}(?![a-z0-9-])` +
       `(?:\\?page=\\d+|/page-number/\\d+|/page/[A-Za-z0-9-]+)?`,
       'g',
     );
-    out = out.replace(pattern, `https://sourcelibrary.org/book/${fix.toSlug}`);
+    out = out.replace(pattern, (_m, prefix: string | undefined) => `https://sourcelibrary.org${prefix ?? ''}/book/${fix.toSlug}`);
   }
   return out;
 }

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -6,6 +6,7 @@ import {
   findEmbeddedImageUrls,
   type CitationFix,
 } from '@/lib/embassy/citation-fixes';
+import type { Locale } from '@/lib/locale-path';
 import { GoogleGenAI, Type, type FunctionDeclaration, type GenerateContentResponse } from '@google/genai';
 import { logAiUsage } from '@/lib/log-ai-usage';
 // Atlas keyword + Supabase semantic are now combined in @/lib/search/librarian-search.
@@ -308,6 +309,48 @@ function tenantVisibilityFilter() {
   };
 }
 
+// ── Language ──────────────────────────────────────────────────────────
+
+/**
+ * Book URLs the model is handed (and told to copy verbatim) carry the locale
+ * prefix, so a Spanish conversation cites `/es/book/…` and the reader stays in
+ * the Spanish chrome. Every `/book/*` shape the Librarian emits has an `/es`
+ * twin (see LOCALIZED_PATTERNS in src/lib/locale-path.ts).
+ */
+function siteBase(lang: Locale): string {
+  return lang === 'en' ? 'https://sourcelibrary.org' : `https://sourcelibrary.org/${lang}`;
+}
+
+/**
+ * The page text the Librarian quotes, in the reader's language when we hold
+ * it. Search and the page tools read `translation.data` (English); for another
+ * locale this looks up `pages.translations.<lang>.data` for the same pages and
+ * returns what exists. A page with no edition in that language is simply
+ * absent from the map — the caller keeps the English text and LABELS it, so
+ * the model quotes our Spanish edition where there is one and never
+ * re-translates the English on the fly (`.claude/docs/i18n.md` rule 4).
+ */
+async function loadLocalizedTexts(
+  lang: Locale,
+  keys: Array<{ book_id: string; page_number: number }>,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (lang === 'en' || keys.length === 0) return out;
+  const db = await getDb();
+  const field = `translations.${lang}.data`;
+  const rows = await db.collection('pages')
+    .find({ $or: keys.map(k => ({ book_id: k.book_id, page_number: k.page_number })), [field]: { $exists: true, $ne: '' } })
+    .project({ book_id: 1, page_number: 1, [field]: 1 })
+    .toArray();
+  for (const r of rows) {
+    const text = (r.translations as Record<string, { data?: string }> | undefined)?.[lang]?.data;
+    if (typeof text === 'string' && text.trim()) out.set(`${r.book_id}:${r.page_number}`, text);
+  }
+  return out;
+}
+
+const LANG_NAMES: Record<Locale, string> = { en: 'English', es: 'Spanish' };
+
 // ── Tool Execution ────────────────────────────────────────────────────
 
 // Hybrid search — combines Atlas keyword + book-then-page semantic + global-page
@@ -367,8 +410,8 @@ async function executeSearchWikipedia(query: string): Promise<{ title: string; s
   } catch { return null; }
 }
 
-async function executeGetBookPage(bookId: string, pageNumber: number): Promise<{
-  text: string; originalText?: string; bookTitle: string; bookAuthor: string; bookSlug?: string;
+async function executeGetBookPage(bookId: string, pageNumber: number, lang: Locale = 'en'): Promise<{
+  text: string; textLang: Locale; originalText?: string; bookTitle: string; bookAuthor: string; bookSlug?: string;
 } | null> {
   const db = await getDb();
   const page = await db.collection('pages').findOne(
@@ -377,14 +420,15 @@ async function executeGetBookPage(bookId: string, pageNumber: number): Promise<{
   );
   if (!page) return null;
   const book = await db.collection('books').findOne({ id: bookId }, { projection: { title: 1, display_title: 1, author: 1, slug: 1 } });
+  const localized = (await loadLocalizedTexts(lang, [{ book_id: bookId, page_number: pageNumber }])).get(`${bookId}:${pageNumber}`);
   return {
-    text: page.translation?.data || '', originalText: page.ocr?.data?.slice(0, 800),
+    text: localized ?? page.translation?.data ?? '', textLang: localized ? lang : 'en', originalText: page.ocr?.data?.slice(0, 800),
     bookTitle: book?.display_title || book?.title || 'Unknown', bookAuthor: book?.author || 'Unknown', bookSlug: book?.slug,
   };
 }
 
-async function executeReadNearbyPages(bookId: string, centerPage: number, range = 2): Promise<{
-  pages: Array<{ page_number: number; text: string }>; bookTitle: string; bookAuthor: string; bookSlug?: string;
+async function executeReadNearbyPages(bookId: string, centerPage: number, range = 2, lang: Locale = 'en'): Promise<{
+  pages: Array<{ page_number: number; text: string; textLang: Locale }>; bookTitle: string; bookAuthor: string; bookSlug?: string;
 }> {
   const db = await getDb();
   const r = Math.min(range, 3);
@@ -395,9 +439,13 @@ async function executeReadNearbyPages(bookId: string, centerPage: number, range 
     .toArray();
 
   const book = await db.collection('books').findOne({ id: bookId }, { projection: { title: 1, display_title: 1, author: 1, slug: 1 } });
+  const localized = await loadLocalizedTexts(lang, pages.map(p => ({ book_id: bookId, page_number: p.page_number })));
 
   return {
-    pages: pages.map(p => ({ page_number: p.page_number, text: (p.translation?.data || '').slice(0, 1000) })),
+    pages: pages.map(p => {
+      const local = localized.get(`${bookId}:${p.page_number}`);
+      return { page_number: p.page_number, text: (local ?? p.translation?.data ?? '').slice(0, 1000), textLang: (local ? lang : 'en') as Locale };
+    }),
     bookTitle: book?.display_title || book?.title || 'Unknown',
     bookAuthor: book?.author || 'Unknown',
     bookSlug: book?.slug,
@@ -555,7 +603,9 @@ async function executeTool(
   args: Record<string, unknown>,
   threadId?: string,
   collectionContext?: string | null,
+  lang: Locale = 'en',
 ): Promise<{ result: unknown; step: LibrarianStep; sources?: SourceCard[] }> {
+  const base = siteBase(lang);
   switch (name) {
     case 'search':
     // Aliases — accept old tool names for one release to avoid breakage if
@@ -570,6 +620,14 @@ async function executeTool(
       const collection = (args.collection as string | undefined) || collectionContext || null;
       const data = await executeSearch(query, collection);
       const totalFound = data.passages.length + data.books.length;
+      // Spanish conversation: swap in the Spanish edition for every passage
+      // that has one, and say which language each passage is in so the model
+      // can label an English-only quote instead of translating it itself.
+      const localized = await loadLocalizedTexts(lang, data.passages.map(p => ({ book_id: p.book_id, page_number: p.page_number })));
+      for (const p of data.passages) {
+        const t = localized.get(`${p.book_id}:${p.page_number}`);
+        if (t) p.text = t.slice(0, 1200);
+      }
 
       let context = '';
       if (data.books.length > 0) {
@@ -583,14 +641,19 @@ async function executeTool(
               ? `[${b.author}](https://sourcelibrary.org/author/${b.authorSlug})`
               : b.author)
             : 'Unknown';
-          context += `- "${b.title}" by ${authorPart}${b.year ? ` (${b.year})` : ''} — https://sourcelibrary.org/book/${b.slug || b.id}\n`;
+          context += `- "${b.title}" by ${authorPart}${b.year ? ` (${b.year})` : ''} — ${base}/book/${b.slug || b.id}\n`;
         }
       }
       if (data.passages.length > 0) {
         context += '\nPassages found:\n';
         for (const p of data.passages) {
-          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}/page-number/${p.page_number}`;
-          context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url}) ---\n${p.text}\n`;
+          const url = `${base}/book/${p.bookSlug || p.book_id}/page-number/${p.page_number}`;
+          const langTag = lang === 'en'
+            ? ''
+            : (localized.has(`${p.book_id}:${p.page_number}`)
+              ? ` [text: ${LANG_NAMES[lang]} edition]`
+              : ` [text: English only — no ${LANG_NAMES[lang]} edition of this page]`);
+          context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url})${langTag} ---\n${p.text}\n`;
         }
       }
       if (totalFound === 0) context = 'No results found for this query.';
@@ -621,9 +684,9 @@ async function executeTool(
     case 'get_book_page': {
       const bookId = args.book_id as string;
       const pageNumber = args.page_number as number;
-      const result = await executeGetBookPage(bookId, pageNumber);
+      const result = await executeGetBookPage(bookId, pageNumber, lang);
       return {
-        result: result ? { found: 1, text: result.text, originalText: result.originalText, bookTitle: result.bookTitle } : { found: 0, text: 'Page not found.' },
+        result: result ? { found: 1, text: result.text, textLanguage: LANG_NAMES[result.textLang], originalText: result.originalText, bookTitle: result.bookTitle } : { found: 0, text: 'Page not found.' },
         step: { type: 'tool_result', name: 'get_book_page', query: `p.${pageNumber}`, found: result ? 1 : 0,
           summary: result ? `Read page ${pageNumber} of ${result.bookTitle}` : 'Page not found' },
       };
@@ -633,10 +696,11 @@ async function executeTool(
       const bookId = args.book_id as string;
       const centerPage = args.center_page as number;
       const range = (args.range as number) || 2;
-      const result = await executeReadNearbyPages(bookId, centerPage, range);
+      const result = await executeReadNearbyPages(bookId, centerPage, range, lang);
       let context = `Pages from ${result.bookTitle}:\n`;
       for (const p of result.pages) {
-        context += `\n--- Page ${p.page_number} ---\n${p.text}\n`;
+        const langTag = lang === 'en' ? '' : ` [text: ${p.textLang === 'en' ? 'English only' : `${LANG_NAMES[lang]} edition`}]`;
+        context += `\n--- Page ${p.page_number}${langTag} ---\n${p.text}\n`;
       }
       return {
         result: { found: result.pages.length, context, bookTitle: result.bookTitle },
@@ -803,6 +867,7 @@ function buildSystemPrompt(
   notebookContext: string,
   messageIndex: number,
   collectionOpts?: { catalog?: string; collectionContext?: string | null },
+  lang: Locale = 'en',
 ): string {
   const catalog = collectionOpts?.catalog?.trim();
   const collectionContext = collectionOpts?.collectionContext;
@@ -821,10 +886,34 @@ ${catalog}
 `
     : '';
 
-  return buildSystemPromptBody(notebookContext, messageIndex, collectionSection);
+  return buildSystemPromptBody(notebookContext, messageIndex, collectionSection, lang);
 }
 
-function buildSystemPromptBody(notebookContext: string, messageIndex: number, collectionSection: string): string {
+/**
+ * The language block for a non-English conversation. The model already answers
+ * in whatever language it is addressed in; what it cannot know on its own is
+ * that we HOLD a Spanish edition of many pages and that quoting our edition
+ * beats improvising a translation of the English. The tool results carry a
+ * `[text: …]` tag per passage for exactly this.
+ */
+function languageSection(lang: Locale): string {
+  if (lang === 'en') return '';
+  const name = LANG_NAMES[lang];
+  const base = siteBase(lang);
+  return `## Language — this is a ${name} conversation
+
+The reader is using the ${name} edition of the library. Write your whole answer in ${name} (headers, captions, suggested next steps included), unless the reader switches language.
+
+Searching: the search index is English, so write your **search queries in English** (translate the reader's terms yourself — "piedra filosofal" → "philosopher's stone") even though you answer in ${name}.
+
+Quotations: each passage a tool returns is tagged \`[text: ${name} edition]\` or \`[text: English only …]\`. Quote the ${name} edition text verbatim when you have it. When a passage is English only, quote it in English inside the blockquote and say in ${name} that this page has not been translated into ${name} yet — do NOT translate the English yourself and present it as a quotation. Paraphrasing in ${name} outside the blockquote is fine. The "original language" rule below still applies: Latin, German, Hebrew etc. can sit alongside.
+
+Links: the tool results give URLs under \`${base}/book/…\` — copy them exactly as given (the \`/${lang}\` prefix keeps the reader in the ${name} site). Page links use the same prefix: [Página N](${base}/book/SLUG?page=N).
+
+`;
+}
+
+function buildSystemPromptBody(notebookContext: string, messageIndex: number, collectionSection: string, lang: Locale = 'en'): string {
   return `You are the Librarian of the Embassy of the Free Mind — a research agent for scholars exploring rare historical texts across the pre-modern intellectual tradition. Your knowledge spans alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, Indian philosophy, Sanskrit texts, Egyptian sources, early modern science, demonology, and the broader history of ideas from antiquity through the Enlightenment.
 
 You are warm, knowledgeable, and genuinely enthusiastic about these texts. You speak like a learned scholar who loves sharing discoveries.
@@ -889,7 +978,7 @@ After 2-3 rounds of searching (4-6 tool calls total), stop and synthesize what y
 - Don't run the same search with slightly different wording — if keyword search missed, try semantic (or vice versa), then move on.
 - read_nearby_pages is for deepening a promising find, not for fishing. Only use it after you've found something specific worth expanding.
 
-## The collection
+${languageSection(lang)}## The collection
 
 Source Library has over 10,000 rare books spanning antiquity through the 18th century, many translated into English for the first time. The collection covers alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, demonology, Indian philosophy, Sanskrit texts, Egyptian sources, early modern science, and related traditions across Western, Middle Eastern, and Asian intellectual history.
 
@@ -918,9 +1007,10 @@ export async function* streamAgenticResponse(
   userMessage: string,
   history: ConversationMessage[] = [],
   threadId?: string,
-  options?: { collection?: string | null },
+  options?: { collection?: string | null; lang?: Locale },
 ): AsyncGenerator<LibrarianStep> {
   const apiKey = process.env.GEMINI_API_KEY;
+  const lang: Locale = options?.lang ?? 'en';
   if (!apiKey) throw new Error('GEMINI_API_KEY not set');
 
   const _t0 = Date.now();
@@ -942,11 +1032,13 @@ export async function* streamAgenticResponse(
     formatCatalogForPrompt(),
     resolveCollectionSlug(options?.collection),
   ]);
-  const systemPrompt = buildSystemPrompt(notebookContext, messageIndex, { catalog, collectionContext });
+  const systemPrompt = buildSystemPrompt(notebookContext, messageIndex, { catalog, collectionContext }, lang);
 
   const contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> = [
     { role: 'user', parts: [{ text: systemPrompt }] },
-    { role: 'model', parts: [{ text: 'I understand. I\'m the Librarian — ready to help with research across the collection.' }] },
+    { role: 'model', parts: [{ text: lang === 'es'
+      ? 'Entendido. Soy el Bibliotecario: listo para investigar en la colección, en español.'
+      : 'I understand. I\'m the Librarian — ready to help with research across the collection.' }] },
     ...history.map(msg => ({
       role: msg.role === 'user' ? 'user' : 'model',
       parts: [{ text: msg.content }],
@@ -1094,7 +1186,7 @@ export async function* streamAgenticResponse(
       functionCalls.map(async part => {
         const fc = (part as { functionCall: { name: string; args: Record<string, unknown> } }).functionCall;
         try {
-          return await executeTool(fc.name, fc.args || {}, threadId, collectionContext);
+          return await executeTool(fc.name, fc.args || {}, threadId, collectionContext, lang);
         } catch (err) {
           console.error(`[Librarian] Tool ${fc.name} failed:`, err instanceof Error ? err.message : err);
           return {

--- a/src/lib/librarian-i18n.ts
+++ b/src/lib/librarian-i18n.ts
@@ -1,0 +1,290 @@
+// The Librarian's chrome, per locale. `/librarian` reads `en`, `/es/librarian`
+// reads `es`; both render the same LibrarianClient so the two pages cannot
+// drift (same shape as home-i18n.ts / book-i18n.ts).
+//
+// What this does NOT decide: the language the Librarian ANSWERS in. That rides
+// in the chat request as `lang` (src/lib/embassy/chat-request.ts) and selects
+// which edition the tools quote from. This file is only the room around the
+// conversation. Client-safe: no server imports, no hooks.
+
+import type { Metadata } from 'next';
+import type { Locale } from './locale-path';
+
+export interface LibrarianStrings {
+  /** <title> / og:title */
+  metaTitle: string;
+  metaDescription: string;
+  /** Hero */
+  title: string;
+  intro: string;
+  /** Empty chat state */
+  emptyLead: string;
+  emptyDisclaimer: string;
+  /** Composer */
+  placeholder: string;
+  send: string;
+  stop: string;
+  startVoice: string;
+  stopVoice: string;
+  speakYourQuestion: string;
+  newConversation: string;
+  listed: string;
+  notListed: string;
+  listedHint: string;
+  onlyYou: string;
+  notShownToOthers: string;
+  signIn: string;
+  signInToKeep: string;
+  /** Messages */
+  showReasoning: string;
+  hideReasoning: string;
+  tryAgain: string;
+  share: string;
+  linkCopied: string;
+  limitReached: string;
+  genericError: string;
+  /** Source cards */
+  notYetInCollection: string;
+  /** Sidebar */
+  recent: string;
+  myConversations: string;
+  recentHint: string;
+  noConversationsMine: string;
+  noConversationsRecent: string;
+  showMore: string;
+  justNow: string;
+  /** '4 messages' in the thread list */
+  messages: string;
+  librarianIsReading: string;
+  /** Research notebook */
+  notebook: string;
+  exportNotebook: string;
+  /** Tool step labels */
+  tools: Record<string, string>;
+  /** Suggestion chips — the pool, shuffled per visit */
+  suggestions: string[];
+  /** date-fns style locale tag for relative dates */
+  dateLocale: string;
+}
+
+export const LIBRARIAN_STRINGS: Record<Locale, LibrarianStrings> = {
+  en: {
+    metaTitle: 'The Librarian — Source Library',
+    metaDescription: 'Ask the Librarian about any text in the collection. Alchemy, Hermetica, Kabbalah, astrology, natural philosophy — thousands of rare books, many translated into English for the first time.',
+    title: 'The Librarian',
+    intro: 'Your research agent for over 10,000 rare books. Ask a question, and the Librarian will search the collection, cross-reference sources, and build up findings you can export.',
+    emptyLead: 'The Librarian searches the collection, Wikipedia, and semantic search to find answers in over 10,000 rare books.',
+    emptyDisclaimer: 'Responses may contain errors — always verify against the source page.',
+    placeholder: 'Ask the Librarian...',
+    send: 'Send',
+    stop: 'Stop',
+    startVoice: 'Start voice input',
+    stopVoice: 'Stop voice input',
+    speakYourQuestion: 'Speak your question',
+    newConversation: 'New conversation',
+    listed: 'Listed',
+    notListed: 'Not listed',
+    listedHint: '(shown in Recent, never under your name)',
+    onlyYou: '(only you)',
+    notShownToOthers: '(not shown to anyone else)',
+    signIn: 'Sign in',
+    signInToKeep: '(free) to keep your conversations and come back to them later.',
+    showReasoning: 'Show reasoning',
+    hideReasoning: 'Hide reasoning',
+    tryAgain: 'Try again',
+    share: 'Share',
+    linkCopied: 'Link copied ✓',
+    limitReached: 'You\'ve used your free questions for now. [Sign in](/auth/signin?callbackUrl=/librarian&reason=limit) (free) to keep talking with the Librarian — create an account or sign in with Google.',
+    genericError: 'I’m sorry — something went wrong on my end. Try again?',
+    notYetInCollection: 'Not yet in collection',
+    recent: 'Recent',
+    myConversations: 'My Conversations',
+    recentHint: 'What other readers are asking, shown without their names.',
+    noConversationsMine: 'No conversations yet. Ask the Librarian something!',
+    noConversationsRecent: 'No conversations yet. Be the first to ask the Librarian something.',
+    showMore: 'Show more',
+    justNow: 'just now',
+    messages: 'messages',
+    librarianIsReading: 'The Librarian is reading',
+    notebook: 'Research notebook',
+    exportNotebook: 'Export',
+    tools: {
+      search: 'Searching the collection',
+      search_collection: 'Searching the collection',
+      search_semantic: 'Semantic search',
+      search_wikipedia: 'Checking Wikipedia',
+      search_images: 'Searching illustrations',
+      search_artworks: 'Searching artworks',
+      get_book_page: 'Reading a page',
+      read_nearby_pages: 'Reading nearby pages',
+      add_to_notebook: 'Saving to notebook',
+      present_choices: 'Thinking...',
+    },
+    suggestions: [
+      // Alchemy & Hermetica
+      'How did alchemists describe the philosopher\'s stone?',
+      'What did alchemists believe about gold?',
+      'Tell me about the Emerald Tablet',
+      'Who was Hermes Trismegistus?',
+      'What equipment did a working alchemist actually use?',
+      'How did Arabic alchemy reach medieval Europe?',
+      'What did alchemists mean by the marriage of the sun and moon?',
+      // Renaissance philosophy & magic
+      'Who was Marsilio Ficino?',
+      'What do these texts say about the world soul?',
+      'What did Agrippa write about planetary seals?',
+      'What is the relationship between music and magic?',
+      'What books explore resonance as magic?',
+      'How did Giordano Bruno imagine infinite worlds?',
+      'What was the art of memory?',
+      'Was there any conception of artificial intelligence?',
+      'Did anyone write about talking statues or artificial beings?',
+      // Kabbalah & mysticism
+      'What is the Kabbalah\'s tree of life?',
+      'What did Christian scholars make of the Zohar?',
+      'What did Jacob Boehme see in his visions?',
+      'How did mystics describe union with the divine?',
+      // Astrology & cosmology
+      'What instruments did astrologers use?',
+      'How did Renaissance scholars understand the cosmos?',
+      'How were comets interpreted before modern astronomy?',
+      'How did Kepler mix astrology with astronomy?',
+      'What did people believe about the music of the spheres?',
+      // Medicine & natural philosophy
+      'What did Paracelsus teach about medicine?',
+      'How were dreams interpreted as medical symptoms?',
+      'What remedies did early herbals prescribe?',
+      'How did physicians explain the plague?',
+      'What did anatomists discover before the microscope?',
+      // Demonology & witchcraft
+      'How were demons understood in early modern Europe?',
+      'What did witch-hunting manuals actually claim?',
+      'How did scholars defend accused witches?',
+      'What were angels thought to know?',
+      // Divination & prophecy
+      'Did any of these authors write about dreams?',
+      'How did people tell fortunes before tarot cards?',
+      'What prophecies circulated during the Reformation?',
+      // Rosicrucians & secret societies
+      'Who were the Rosicrucians?',
+      'What ciphers and secret alphabets appear in these books?',
+      'What did the Rosicrucian manifestos promise?',
+      // Eastern traditions
+      'What do Tibetan texts say about the nature of mind?',
+      'What does Ayurvedic medicine say about the elements?',
+      'How did Sanskrit astronomers calculate eclipses?',
+      // Book history & curiosities
+      'What are the strangest illustrations in the collection?',
+      'How were emblem books meant to be read?',
+      'What did the first printed books look like?',
+      'Which books here were never translated until now?',
+    ],
+    dateLocale: 'en-US',
+  },
+  es: {
+    metaTitle: 'Pregunta a la fuente — El Bibliotecario | Source Library',
+    metaDescription: 'Pregunta al Bibliotecario sobre cualquier texto de la colección. Alquimia, Hermetismo, Cábala, astrología, filosofía natural: miles de libros raros, y una edición en español que crece.',
+    title: 'Pregunta a la fuente',
+    intro: 'El Bibliotecario es tu agente de investigación sobre más de 10.000 libros raros. Haz una pregunta y buscará en la colección, contrastará fuentes y citará la edición en español cuando exista.',
+    emptyLead: 'El Bibliotecario busca en la colección, en Wikipedia y por semejanza de sentido para encontrar respuestas en más de 10.000 libros raros.',
+    emptyDisclaimer: 'Las respuestas pueden contener errores: comprueba siempre la página de origen.',
+    placeholder: 'Pregunta al Bibliotecario...',
+    send: 'Enviar',
+    stop: 'Detener',
+    startVoice: 'Dictar la pregunta',
+    stopVoice: 'Detener el dictado',
+    speakYourQuestion: 'Di tu pregunta en voz alta',
+    newConversation: 'Nueva conversación',
+    listed: 'Visible',
+    notListed: 'No visible',
+    listedHint: '(aparece en Recientes, nunca con tu nombre)',
+    onlyYou: '(solo tú)',
+    notShownToOthers: '(nadie más la ve)',
+    signIn: 'Inicia sesión',
+    signInToKeep: '(gratis) para guardar tus conversaciones y volver a ellas.',
+    showReasoning: 'Ver el razonamiento',
+    hideReasoning: 'Ocultar el razonamiento',
+    tryAgain: 'Intentar de nuevo',
+    share: 'Compartir',
+    linkCopied: 'Enlace copiado ✓',
+    limitReached: 'Has agotado tus preguntas gratuitas por ahora. [Inicia sesión](/es/auth/signin?callbackUrl=/es/librarian&reason=limit) (gratis) para seguir conversando con el Bibliotecario: crea una cuenta o entra con Google.',
+    genericError: 'Lo siento, algo ha fallado de mi lado. ¿Lo intentamos de nuevo?',
+    notYetInCollection: 'Aún no está en la colección',
+    recent: 'Recientes',
+    myConversations: 'Mis conversaciones',
+    recentHint: 'Lo que preguntan otros lectores, sin sus nombres.',
+    noConversationsMine: 'Todavía no hay conversaciones. ¡Pregúntale algo al Bibliotecario!',
+    noConversationsRecent: 'Todavía no hay conversaciones. Sé quien pregunte primero.',
+    showMore: 'Ver más',
+    justNow: 'ahora mismo',
+    messages: 'mensajes',
+    librarianIsReading: 'El Bibliotecario está leyendo',
+    notebook: 'Cuaderno de investigación',
+    exportNotebook: 'Exportar',
+    tools: {
+      search: 'Buscando en la colección',
+      search_collection: 'Buscando en la colección',
+      search_semantic: 'Búsqueda semántica',
+      search_wikipedia: 'Consultando Wikipedia',
+      search_images: 'Buscando ilustraciones',
+      search_artworks: 'Buscando obras de arte',
+      get_book_page: 'Leyendo una página',
+      read_nearby_pages: 'Leyendo páginas cercanas',
+      add_to_notebook: 'Guardando en el cuaderno',
+      present_choices: 'Pensando...',
+    },
+    // Leans toward what the Spanish edition actually holds (Hermetica, Ficino,
+    // Kabbalah, alchemy — the en-espanol collection) so the first answers a
+    // Spanish reader gets can quote Spanish pages, not English ones.
+    suggestions: [
+      '¿Quién fue Hermes Trismegisto?',
+      '¿Qué dice el Pimander sobre el origen del mundo?',
+      '¿Cómo describían los alquimistas la piedra filosofal?',
+      'Háblame de la Tabla de Esmeralda',
+      '¿Qué significaba para los alquimistas la boda del sol y la luna?',
+      '¿Quién fue Marsilio Ficino?',
+      '¿Qué dicen estos textos sobre el alma del mundo?',
+      '¿Qué escribió Agripa sobre los sellos planetarios?',
+      '¿Qué relación hay entre la música y la magia?',
+      '¿Cómo imaginó Giordano Bruno los mundos infinitos?',
+      '¿Qué era el arte de la memoria?',
+      '¿Qué es el árbol de la vida de la Cábala?',
+      '¿Qué vieron los místicos en sus visiones de la unión con lo divino?',
+      '¿Cómo entendían el cosmos los sabios del Renacimiento?',
+      '¿Cómo se interpretaban los cometas antes de la astronomía moderna?',
+      '¿Qué enseñaba Paracelso sobre la medicina?',
+      '¿Cómo explicaban los médicos la peste?',
+      '¿Cómo se entendía a los demonios en la Europa moderna temprana?',
+      '¿Quiénes fueron los rosacruces?',
+      '¿Qué prometían los manifiestos rosacruces?',
+      '¿Qué cifrados y alfabetos secretos aparecen en estos libros?',
+      '¿Cuáles son las ilustraciones más extrañas de la colección?',
+      '¿Cómo había que leer un libro de emblemas?',
+      '¿Qué libros de la colección están traducidos al español?',
+    ],
+    dateLocale: 'es-ES',
+  },
+};
+
+/** Route metadata for `/librarian` and `/es/librarian`, with hreflang twins. */
+export function librarianMetadata(lang: Locale): Metadata {
+  const t = LIBRARIAN_STRINGS[lang];
+  const path = lang === 'en' ? '/librarian' : `/${lang}/librarian`;
+  return {
+    title: t.metaTitle,
+    description: t.metaDescription,
+    alternates: {
+      canonical: path,
+      languages: { en: '/librarian', es: '/es/librarian', 'x-default': '/librarian' },
+    },
+    openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
+      title: t.metaTitle,
+      description: t.metaDescription,
+      siteName: 'Source Library',
+      type: 'website',
+      locale: lang === 'es' ? 'es_ES' : 'en_US',
+      url: `https://sourcelibrary.org${path}`,
+    },
+  };
+}

--- a/src/lib/locale-path.ts
+++ b/src/lib/locale-path.ts
@@ -44,7 +44,7 @@ export function localeFromPathname(pathname: string | null | undefined): Locale 
 // but on a page with no twin the ES link falls back to the Spanish homepage
 // (`/es`) as a front door rather than dead-ending on a 404 — the thin-i18n
 // bargain (deep pages rely on the browser's own translate).
-export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin']);
+export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin', '/librarian']);
 
 // Path SHAPES with a Spanish twin. One pattern per `src/app/es/**` route —
 // deliberately exact, not a bare `/book` prefix: `/book/<id>` and

--- a/tests/unit/citation-fixes.test.ts
+++ b/tests/unit/citation-fixes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyCitationFixes } from '@/lib/embassy/citation-fixes';
+import { applyCitationFixes, findCitedBookLinks } from '@/lib/embassy/citation-fixes';
 
 describe('applyCitationFixes', () => {
   const fix = { fromSlug: 'oedipus-aegyptiacus-kircher', toSlug: 'oedipus-aegyptiacus-volume-i-1652-kircher' };
@@ -38,5 +38,27 @@ describe('applyCitationFixes', () => {
     expect(applyCitationFixes(text, [{ fromSlug: 'some-book', toSlug: 'some-book' }])).toBe(text);
     expect(applyCitationFixes(text, [{ fromSlug: '', toSlug: 'x' }])).toBe(text);
     expect(applyCitationFixes(text, [])).toBe(text);
+  });
+});
+
+// A Spanish conversation (#4116) cites `/es/book/…` — the same book, verified
+// and repaired like the English link, with the locale prefix preserved.
+describe('locale-prefixed book links', () => {
+  const fix = { fromSlug: 'oedipus-aegyptiacus-kircher', toSlug: 'oedipus-aegyptiacus-volume-i-1652-kircher' };
+
+  it('findCitedBookLinks reads /es/book links', () => {
+    const text = '[Página 3](https://sourcelibrary.org/es/book/pimander-ficino?page=3) y https://sourcelibrary.org/book/other';
+    expect(findCitedBookLinks(text)).toEqual([{ slug: 'pimander-ficino', page: 3 }, { slug: 'other' }]);
+  });
+
+  it('applyCitationFixes keeps the /es prefix on a repaired link', () => {
+    const text = '[Página 427](https://sourcelibrary.org/es/book/oedipus-aegyptiacus-kircher?page=427)';
+    expect(applyCitationFixes(text, [fix])).toBe(
+      '[Página 427](https://sourcelibrary.org/es/book/oedipus-aegyptiacus-volume-i-1652-kircher)',
+    );
+  });
+
+  it('still ignores the image CDN host', () => {
+    expect(findCitedBookLinks('![x](https://images.sourcelibrary.org/es/book/foo.jpg)')).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #4116.

## What
**A. Language in the request.** `POST /api/embassy/chat` takes `lang` ('en' | 'es', default en). For 'es':
- `search`, `get_book_page`, `read_nearby_pages` look up `pages.translations.es.data` for the pages they return and substitute it where present; each passage is tagged `[text: Spanish edition]` or `[text: English only — no Spanish edition of this page]`.
- Prompt gains a Language section: answer in Spanish, quote the Spanish edition verbatim, quote English-only passages in English and say so (never translate on the fly — i18n.md rule 4), write search queries in English because the index is English.
- Every book/page URL handed to the model is `https://sourcelibrary.org/es/book/…` (both `?page=N` and `/page-number/N` resolve on prod, verified). `SITE_HOST_PATTERN` accepts the `/es` prefix so citation verification and repair work unchanged; repairs keep the prefix.
- `embassy_threads` rows record `lang`.

**B. Chrome twin.** `src/lib/librarian-i18n.ts` (en + es strings, Spanish suggestion chips leaning on what the Spanish edition holds), `LibrarianClient` takes `lang`, `/es/librarian` re-exports the page with `lang='es'`, hreflang alternates on both layouts, `/librarian` added to `LOCALIZED_PATHS` so the header's existing **Bibliotecario** item stops dropping the prefix.

Title in Spanish: **Pregunta a la fuente** (the idiomatic 'ask the source').

## Out of scope
- Spanish findability (search lane, embeddings, MCP) — #4095. Until then the Spanish librarian searches the English index and quotes Spanish pages; a Spanish-language keyword query still misses.
- `/es/librarian/thread/[id]` twin — thread links stay unprefixed (no 404).
- Notebook export / voice room strings.

## Tests
`citation-fixes.test.ts`: /es links parsed, repaired with prefix kept, CDN host still ignored. 47 unit tests green; `tsc --noEmit` clean. ESLint errors in the touched files are all pre-existing (ref mutation, `any`, `prefer-const`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZ59KjPZ6Fyt8kzgcopknR