### PR TITLE
feat(reader): read De Aetna in its own type — Aldine fount pilot (#4083)

### DIFF
--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -14,6 +14,8 @@ import { markPageForReader } from '@/lib/provenance';
 import { localePath, type Locale } from '@/lib/locale-path';
 import { READER_STRINGS } from '@/lib/book-i18n';
 import { localizedTitle } from '@/lib/localized';
+import { aldineVariables } from '@/lib/fonts/aldine';
+import { isAldineFount } from '@/lib/fonts/aldine-fount';
 
 // Schema.org structured data for a translated page, so it surfaces as a
 // citable scholarly work in web search (#2822). Only emitted for indexable
@@ -149,11 +151,19 @@ export default async function PageEditorPage({ params, allowHidden = false, lang
         />
       )}
       <EmbedNavigationReporter book={book.slug || book.id} page={pageId} />
-      <PageEditorClient
-        initialBook={book}
-        initialPage={markedPage}
-        initialPageList={serializedNavPages}
-      />
+      {/* Books we hold a facsimile fount for are read in their own type (#4083).
+          `display: contents` so this wrapper carries the font variables and the
+          scoping class without adding a box to the reader's flex layout. */}
+      <div
+        className={isAldineFount(book.id) ? `aldine-fount ${aldineVariables}` : undefined}
+        style={isAldineFount(book.id) ? { display: 'contents' } : undefined}
+      >
+        <PageEditorClient
+          initialBook={book}
+          initialPage={markedPage}
+          initialPageList={serializedNavPages}
+        />
+      </div>
       {musicTranscriptions.length > 0 && (
         <HymnPlayer transcriptions={musicTranscriptions} />
       )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -240,6 +240,33 @@ h1, h2, h3, h4 {
   max-width: 70ch;
   margin-inline: auto;
 }
+/* ---------------------------------------------------------------------------
+   Reading a book in the type it was printed in (#4083, pilot)
+   The reader page adds `.aldine-fount` for books listed in
+   src/lib/fonts/aldine-fount.ts. Both text panels — the transcription and the
+   English translation — are then set in the facsimile traced from that book's
+   own pages, with Cardo behind it for scripts the fount never had.
+   Display only: the DOM text is untouched, so search, copy and citation are
+   unaffected.
+--------------------------------------------------------------------------- */
+.aldine-fount [data-reader-panel] .prose-manuscript,
+.aldine-fount [data-reader-panel] > .prose {
+  font-family: var(--font-aldine-aetna), var(--font-cardo), 'Newsreader', Georgia, serif;
+  /* liga: the ct/ſt/fi sorts. calt: rotate the three impressions of each common
+     letter so neighbours are never the same cast — hand-set, not typeset. */
+  font-feature-settings: "liga" 1, "calt" 1;
+  /* x-height 0.424 em against Newsreader's 0.441 — a 4% bump keeps the reading
+     size the user chose. Measured, not guessed. */
+  font-size: calc(var(--reader-font-size, 18px) * 1.04);
+}
+/* Both reading panels use .prose-manuscript, whose size comes from CSS. The
+   German-source and modernised views use a `.prose` div that sets font-size
+   inline (a React style prop beats a stylesheet rule whatever its specificity),
+   so that one — and only that one — needs !important. */
+.aldine-fount [data-reader-panel] > .prose {
+  font-size: calc(var(--reader-font-size, 15px) * 1.04) !important;
+}
+
 /* Nested NotesRenderer inside an already-capped wrapper: don't re-center */
 [data-reader-panel] .prose-manuscript .prose-manuscript {
   max-width: none;

--- a/src/lib/fonts/aldine-fount.ts
+++ b/src/lib/fonts/aldine-fount.ts
@@ -1,0 +1,39 @@
+/**
+ * Which books are read in the type they were printed in.
+ *
+ * A *fount* is the case of sorts a book was set from. Where we hold a facsimile
+ * of that fount — traced from our own scans, see `scripts/fonts/aldine-aetna/` —
+ * the reader can set the transcription and the English translation in it, so the
+ * page image and the live text are the same letterforms.
+ *
+ * This is a PILOT (issue #4083). One book is enabled: Bembo's *De Aetna*, the
+ * 1496 Aldine the type was traced from — the one case where facsimile and
+ * original are provably the same metal. Widen the list only after looking at
+ * real pages: the other books set in this fount are listed below, commented,
+ * ready to switch on.
+ *
+ * Display only. Nothing here changes stored text: no ſ is substituted, no
+ * orthography is normalised, and copying a passage yields exactly the
+ * characters in `pages.ocr.data`. The facsimile carries no Greek, Hebrew or
+ * Arabic, so Cardo (a revival of the same Griffo roman) sits behind it in the
+ * stack and those scripts render as they always did.
+ */
+
+/** Books whose reader text is set in Aldine Aetna. Keys are `books.id`. */
+export const ALDINE_FOUNT_BOOKS: Record<string, string> = {
+  // The pilot: the book the type was traced from (BNCF copy, IA ita-bnc-ald-00000673-001).
+  '6a06d1f39a48d51399960d08': 'De Aetna (Aldus Manutius, Venice 1496)',
+
+  // Same fount, verified by eye and used as glyph sources — enable after the pilot is judged:
+  // '69b220c6f79d8af0eab7fcef': 'De Aetna, second copy (ita-bnc-ald-00000039)',
+  // '69b220de56715b0e3247381a': 'Leoniceno, De morbo gallico (1497)',
+  // '69b220da56715b0e32473793': 'Maiolo, Epiphyllides (1497)',
+  // '69b220cff79d8af0eab7fe91': 'Maiolo, De gradibus medicinarum (1497)',
+  // '69b220ccf79d8af0eab7fd3a': 'Lascaris, Erotemata (1495) — Greek falls back to Cardo',
+  // '69b220f356715b0e32473bd0': 'Perotti, Cornucopiae (1499) — smaller roman, figures came from here',
+};
+
+/** True when this book should be read in its own fount. */
+export function isAldineFount(bookId: string | undefined | null): boolean {
+  return !!bookId && bookId in ALDINE_FOUNT_BOOKS;
+}

--- a/src/lib/fonts/aldine.ts
+++ b/src/lib/fonts/aldine.ts
@@ -22,6 +22,10 @@ export const aldineAetna = localFont({
   src: '../../../public/fonts/aldine-aetna/AldineAetna-Regular.woff2',
   variable: '--font-aldine-aetna',
   display: 'swap',
+  // The reader route imports this for every book, but only books in
+  // `aldine-fount.ts` actually reference the family. Without preload:false the
+  // browser would fetch 30 KB of 1496 letterforms on every page of every book.
+  preload: false,
   // Cardo supplies everything the facsimile is missing.
   fallback: ['Cardo', 'Georgia', 'serif'],
 });


### PR DESCRIPTION
Derek: "let the aldine books render english and OCR with this font... start with one as a pilot."

## What
On `/book/6a06d1f39a48d51399960d08/page/…` both reading panels — the Latin transcription **and** the English translation — are now set in Aldine Aetna, the facsimile traced from that very book's pages. The scan on the left and the live text on the right are the same letterforms.

- **`src/lib/fonts/aldine-fount.ts`** — book id → fount. **One book enabled** (the 1496 *De Aetna* the type was traced from: the one case where facsimile and original are provably the same metal). The other six books set in this fount are listed commented, ready to switch on once you've judged the pilot.
- **`globals.css`** — rules scoped to `.aldine-fount`, hooked on the reader's existing `data-reader-panel` / `.prose-manuscript` structure. No client-component changes, no prop drilling. `liga` + `calt` on, so the three impressions of each common letter rotate as you read.
- **Reader page** — adds the class through a `display: contents` wrapper, which carries the font variables without adding a box to the reader's flex layout.
- **Size** — bumped 4%. Measured, not guessed: Aldine's x-height is 0.424 em against Newsreader's 0.441, so the reading size the user chose is preserved.
- **`preload: false`** on the local font — the reader route imports it for every book, but only listed books reference the family, so nobody else pays 30 KB.

## Deliberately not done
- **No ſ substitution.** The stored OCR reads *est*, *saepe*; the font has a real ſ, and a `hist`-style rule could swap them on screen. But the same panels render English, where "ſo" would be nonsense — and silently changing letters in a citable transcription is a trap. If we want period orthography it belongs behind an explicit toggle, argued separately.
- Display only: no character is substituted anywhere, so search, copy, quotes and DOIs are untouched. Greek, Hebrew and Arabic fall through to Cardo as before.

## Judge it here (preview)
`/book/6a06d1f39a48d51399960d08/page/20` — the page the specimen header uses, so scan and text can be compared line for line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)