### PR TITLE
fix(access): the image gate read year_published, a field no book has

### DIFF
--- a/scripts/maintenance/kloss-hidden-reason-backfill.mjs
+++ b/scripts/maintenance/kloss-hidden-reason-backfill.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Kloss takedown enumeration repair — issue #4132.
+ *
+ * The takedown discipline keys on `hidden_reason`: that is how a sweep tells a
+ * takedown apart from a merely-unprocessed hidden book. But only 813 of the
+ * 1,517 `cmc_kloss` books carry a Kloss reason; the other 704 are `visible:
+ * false` with a different or absent one. A sweep selecting `hidden_reason:
+ * /kloss/i` therefore sees 54% of the set and reports success.
+ *
+ * Nothing is exposed today — all 1,517 are `visible: false` and the read gate
+ * holds. This repairs the ENUMERATION, which is the half that failed in #4056.
+ *
+ * Only ever ADDS the reason to an already-hidden Kloss book. It never unhides
+ * anything and never overwrites a reason that already names Kloss.
+ *
+ *   node --env-file=.env.production.local scripts/maintenance/kloss-hidden-reason-backfill.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const REASON = 'kloss_manuscripts_removed_2026-07-08';
+const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+await client.connect();
+const books = client.db('bookstore').collection('books');
+
+const KLOSS = { 'image_source.provider': 'cmc_kloss' };
+const total = await books.countDocuments(KLOSS);
+const hidden = await books.countDocuments({ ...KLOSS, visible: false });
+const withReason = await books.countDocuments({ ...KLOSS, hidden_reason: /kloss/i });
+
+console.log(`cmc_kloss books        : ${total}`);
+console.log(`  visible: false       : ${hidden}`);
+console.log(`  Kloss hidden_reason  : ${withReason}`);
+console.log(`  MISSING the reason   : ${total - withReason}`);
+
+// Refuse to touch anything that is not already hidden. If a Kloss book were
+// visible, stamping a takedown reason on it would look like a takedown while
+// leaving it public — worse than the gap being repaired.
+const visibleKloss = await books.countDocuments({ ...KLOSS, visible: { $ne: false } });
+if (visibleKloss > 0) {
+  console.error(`\nREFUSING: ${visibleKloss} cmc_kloss book(s) are not visible:false. Hide them first, then re-run.`);
+  await client.close();
+  process.exit(1);
+}
+
+const targets = { ...KLOSS, visible: false, hidden_reason: { $not: /kloss/i } };
+const sample = await books.find(targets, { projection: { slug: 1, hidden_reason: 1 } }).limit(5).toArray();
+console.log('\nsample of what would change:');
+for (const s of sample) console.log(`  ${String(s.slug).slice(0, 52).padEnd(54)} reason=${JSON.stringify(s.hidden_reason ?? null)}`);
+
+if (!APPLY) {
+  console.log(`\nDRY RUN — would set hidden_reason on ${await books.countDocuments(targets)} book(s). Pass --apply to write.`);
+  await client.close();
+  process.exit(0);
+}
+
+// Preserve what was there. The reasons being replaced are not merely unhelpful,
+// they are FALSE — all 704 carry `pages_count > 0` and real page documents while
+// claiming `no-pages-catalog-stub` (532) or `unprocessed` (172). They were
+// presumably stamped before the pages landed and never revisited. Keeping the
+// prior value means this sweep is reversible and auditable rather than a
+// destructive overwrite of provenance.
+const res = await books.updateMany(targets, [
+  {
+    $set: {
+      hidden_reason_prior: { $ifNull: ['$hidden_reason', null] },
+      hidden_reason: REASON,
+      hidden_reason_backfilled_at: '$$NOW',
+      updated_at: '$$NOW',
+    },
+  },
+]);
+console.log(`\nmatched=${res.matchedCount} modified=${res.modifiedCount}`);
+
+// The invariant this exists to establish, asserted rather than assumed.
+const remaining = await books.countDocuments({ ...KLOSS, hidden_reason: { $not: /kloss/i } });
+console.log(`VERIFY cmc_kloss without a Kloss reason: ${remaining} ${remaining === 0 ? '(OK)' : '(STILL BROKEN)'}`);
+await client.close();
+process.exit(remaining === 0 ? 0 : 1);

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -893,7 +893,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
   //  - 'blocked': modern + unknown license + non-BPH → withheld entirely
   const imgLicense = (book as any).image_source?.license || 'unknown';
   const imgProvider = (book as any).image_source?.provider;
-  const yearPublished = (book as unknown as { year_published?: number }).year_published;
+  // `year`, NOT `year_published` (#4131). Every read in this file named a field
+  // that ZERO of 104,690 books have, so all of them silently evaluated to
+  // undefined: the pre-1930 image release below never fired once, and the
+  // DublinCoreMeta `year=` prop — the date library crawlers harvest — was empty
+  // on every book page, in both of this component's returns. `books.published`
+  // is the free-text twin and must not be parsed here (#3718); `year` is the
+  // numeric field, present on 49,959 books.
+  const yearPublished = (book as unknown as { year?: number }).year;
   const isNcLicense = typeof imgLicense === 'string' && /\bnc\b/i.test(imgLicense);
   const imageAccess: 'open' | 'nc-free' | 'blocked' =
     imgProvider === 'bph' || (typeof yearPublished === 'number' && yearPublished < 1930)
@@ -1042,7 +1049,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // location × time-period lead, a shared collection is only a minor nudge
     // (it used to dominate). See src/lib/related-books.ts.
     const relatedYear = Number(String(book.published ?? '').match(/\d{3,4}/)?.[0])
-      || (book as unknown as { year_published?: number }).year_published
+      || (book as unknown as { year?: number }).year
       || null;
     const tagRelated: CatalogBook[] = embedPolicy.showBookRelatedBooks
       ? await getRelatedBooks({
@@ -1495,7 +1502,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           displayTitle={book.display_title}
           author={book.author}
           language={book.language}
-          year={(book as unknown as { year_published?: number }).year_published}
+          year={yearPublished}
           description={book.ai_metadata?.description as string | undefined}
           categories={book.categories}
           keywords={(book as unknown as { subject_keywords?: string[] }).subject_keywords}
@@ -1817,7 +1824,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         displayTitle={book.display_title}
         author={book.author}
         language={book.language}
-        year={(book as unknown as { year_published?: number }).year_published}
+        year={yearPublished}
         description={book.ai_metadata?.description as string | undefined}
         categories={book.categories}
         keywords={(book as unknown as { subject_keywords?: string[] }).subject_keywords}

--- a/src/lib/purchases.ts
+++ b/src/lib/purchases.ts
@@ -31,12 +31,17 @@ export async function classifyImageAccess(bookId: string): Promise<ImageAccess> 
   const db = await getDb();
   const book = await db.collection('books').findOne(
     { $or: [{ id: bookId }, { _id: bookId as any }] },
-    { projection: { 'image_source.license': 1, 'image_source.provider': 1, year_published: 1 } },
+    { projection: { 'image_source.license': 1, 'image_source.provider': 1, year: 1 } },
   );
   if (!book) return 'blocked';
   const license = book.image_source?.license;
   const provider = book.image_source?.provider;
-  const year = (book as { year_published?: number }).year_published;
+  // `year` — NOT `year_published`, which no book has ever had (#4131). This
+  // projected and read a nonexistent field, so the pre-1930 release below never
+  // fired once and 4,840 public-domain library scans stayed blocked on an
+  // `unknown` license. `books.published` is the free-text twin and must never be
+  // parsed for this (#3718); `year` is the numeric one, on 49,959 books.
+  const year = (book as { year?: number }).year;
   if (provider === 'bph') return 'open';
   if (typeof year === 'number' && year < 1930) return 'open';
   if (license && NC_LICENSE_PATTERNS.some(p => p.test(license))) return 'nc-free';

--- a/tests/unit/image-access-year-field.test.ts
+++ b/tests/unit/image-access-year-field.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * #4131 — the image-download gate released pre-1930 books by reading
+ * `year_published`, a field ZERO of 104,690 books have. It never fired, and
+ * 4,840 public-domain library scans stayed blocked on an `unknown` license.
+ *
+ * This is an ABSENCE invariant, which is the one case where a source-shape
+ * assertion earns its keep (see .claude/docs/invariants/tests-that-are-not-guards.md):
+ * the failure mode is re-introducing the dead field name, and re-adding it is
+ * exactly what the test catches. It cannot be satisfied by a comment, because
+ * comments are stripped before matching.
+ */
+const repoRoot = join(__dirname, '..', '..');
+const stripComments = (src: string) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const GUARDED = [
+  'src/lib/purchases.ts',
+  'src/app/book/[id]/page.tsx',
+];
+
+describe('image-access gate reads a field that exists', () => {
+  for (const rel of GUARDED) {
+    it(`${rel} does not read year_published`, () => {
+      const code = stripComments(readFileSync(join(repoRoot, rel), 'utf8'));
+      expect(code).not.toMatch(/year_published/);
+    });
+  }
+
+  it('purchases.ts still gates on a numeric year below 1930', () => {
+    const code = stripComments(readFileSync(join(repoRoot, 'src/lib/purchases.ts'), 'utf8'));
+    // The rule itself must survive — deleting it would also make the above pass.
+    expect(code).toMatch(/year\s*<\s*1930/);
+    expect(code).toMatch(/projection:\s*\{[^}]*\byear:\s*1/);
+  });
+});


### PR DESCRIPTION
Closes #4131. Closes #4132.

## The defect

Both copies of the image-access classifier release pre-1930 books by reading **`year_published`**:

- `src/lib/purchases.ts` — `classifyImageAccess`, which also *projected* the field
- `src/app/book/[id]/page.tsx` — the inline mirror

**Zero of 104,690 books have `year_published`.** They carry `year` (49,959 numeric). `published` is the free-text twin and must never be parsed for this (#3718). So the pre-1930 rule has never fired once, in either copy, and the decision fell entirely to `image_source.license`.

## What it cost

**4,840 public-domain library scans** blocked on an `unknown` license:

| provider | books |
|---|---|
| British Library | 1,439 |
| generic IIIF | 1,021 |
| e-rara | 765 |
| Harvard | 727 |
| Allard Pierson | 437 |
| Manchester | 145 |
| Laurenziana | 125 |
| NDL Japan | 32 |
| Leiden | 28 |

## The gate was only one of five

The same one-word defect appears **five times** in `book/[id]/page.tsx`. The one nobody was looking for: the `DublinCoreMeta year=` prop — the date library crawlers harvest — has been `undefined` on **every book page, in both of that component's returns** (the #3916 two-returns trap). All five fixed.

## Safety — checked, not assumed

The flip set contains 779 Kloss takedown books, so this needed proving rather than asserting:

- All **1,517** `cmc_kloss` books are `visible: false`; none sits in the `visible: null` loophole `isHiddenBook` deliberately leaves ungated.
- The download route applies `isBookReadable` **independently** of the license gate, 404ing every hidden book unless the caller is an editor or carries CRON_SECRET.

The license gate is not what holds Kloss shut. Of the 10,253 books that flip, 5,413 are `visible: false` and stay 404'd; 4,840 are genuinely released.

## Also lands #4132

704 `cmc_kloss` books were hidden under reasons that turned out to be not merely unhelpful but **false**: 532 said `no-pages-catalog-stub` and 172 said `unprocessed`, while **every one has `pages_count > 0`** and real page documents (2,490 across a 200-book sample). Presumably stamped before the pages landed and never revisited. A sweep keyed on `hidden_reason: /kloss/i` therefore saw 813 of 1,517.

`scripts/maintenance/kloss-hidden-reason-backfill.mjs`:
- keeps the prior value in `hidden_reason_prior` — reversible and auditable, not a destructive overwrite of provenance
- **refuses to run** if any `cmc_kloss` book is not already `visible: false` (stamping a takedown reason on a public book would look like a takedown while leaving it public — worse than the gap)
- asserts the invariant after writing and exits non-zero if it does not hold

Applied to production: `matched=704 modified=704`, verify count **0**.

## Verification

- `npx tsc --noEmit` clean; **2,813 tests across 208 files** pass
- The new test is an **absence invariant** — the one case a source-shape assertion earns its keep per `tests-that-are-not-guards.md`, since re-introducing the dead field name *is* the failure mode. Comments are stripped before matching so it cannot be satisfied by prose, and it separately pins that the `< 1930` rule itself survives (deleting the rule would otherwise also make it pass).
- **Negative control run**: restoring `year_published` turns it red; restoring the fix turns it green.

## Review before release

**Allard Pierson (437 books)** is the BPH/EFM partner. A partner agreement is a different question from a public-domain determination, and that call is Derek's — excluding them is a one-line addition to the classifier.

## Out of scope

Neither branch of the license query is indexed and the `$or` scans the visible set. Pre-existing; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC54GMgv8cdmbVojFrwhGq