### PR TITLE
docs: segment 0 ownership is an allowlist (#4127/#4136 scar tissue)

### DIFF
--- a/.claude/docs/invariants/content-urls-and-libraries.md
+++ b/.claude/docs/invariants/content-urls-and-libraries.md
@@ -46,3 +46,28 @@ encodes that:
    main checkout. Don't recreate them (`create-all-provider-tenants.mjs` is
    the legacy writer — don't run it). New contributing libraries go in
    `LIBRARY_PARTNERS`, not in the `tenants` collection.
+5. **Segment 0 of a URL is shared by three namespaces, and ownership is
+   decided by an ALLOWLIST of tenants — never by a denylist of routes.**
+   `/bph/…` (tenant), `/es/…` (locale prefix) and `/book/…`, `/upload`,
+   `/encyclopedia/…` (~90 global route roots) all compete for the same
+   position. `getTenantSlugFromPathname` in `src/lib/api-client/client.ts`
+   used to answer "is this a tenant?" by excluding the global roots from a
+   hand-written set, which meant every new route had to remember to register
+   itself. It didn't: the set was **39 entries short**, so those pages'
+   api-client calls went to `/api/<root>/…` — tenant-scoped, resolving to no
+   tenant, answered with a bare 404. On `/es/book/<id>` that surfaced as
+   **"Book not found" inside the cover picker** (#4127); on `/upload` it
+   meant `POST /api/upload/books` 404'd while `/api/books` was right there
+   (#4136). Nothing logged, nothing failed a build, and the `/upload` case
+   had been broken long enough that nobody connected the two.
+   The resolver now matches `TENANT_ROOT_PATHS` from `src/lib/tenant-roots.ts`
+   — a leaf module (no imports, so the browser can read it without pulling in
+   `LIBRARY_PARTNERS`) shared with the proxy's own gate, so client and server
+   cannot disagree about what a tenant is. Order matters and is the design:
+   strip a locale prefix → `/embed/<tenant>/…` reserved slot → allowlist.
+   **Adding a tenant means adding it to `TENANT_ROOT_PATHS`; adding a route
+   root or a locale means doing nothing at all.** `tests/unit/locale-prefix-not-tenant.test.ts`
+   sweeps every directory under `src/app/` and fails if one resolves to a
+   tenant. General rule: when two sets compete for a namespace, match the
+   small closed one. A wrong allowlist entry is visible on the first page
+   load; a missing denylist entry is invisible forever.

--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -1,46 +1,43 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import { PREFIXED_LOCALES } from '@/lib/locale-path';
 
-// Global routes that are not tenant slugs; keep in sync with proxy routing rules.
-const NON_TENANT_SEGMENTS = new Set([
-  'platform', 'auth', 'api', '_next', 'account', 'about', 'privacy',
-  'terms', 'press-release', 'brand', 'roadmap', 'feedback', 'status',
-  'support', 'unauthorized', 'design-options', 'experiments',
-  'ficino-society', 'contribute', 'census', 'oauth', 'developers',
-  'founding-donors', 'libraries', 'blog', '_archived', '.well-known',
-  'gallery', 'browse', 'explore', 'librarian', 'podcast', 'search',
-  'favorites', 'reading-history', 'timeline', 'topics', 'languages',
-  'categories', 'catalog', 'artwork', 'artist', 'book', 'collections',
-  'author', 'work', 'connect', 'data', 'read', 'research', 'embed', 'shwep',
-  'identify', 'for-researchers', 'admin',
-  'map', 'constellation', 'analytics', 'traffic',
-]);
+import { TENANT_ROOT_PATHS } from '@/lib/tenant-roots';
 
+/**
+ * Resolve the tenant slug that owns `pathname`, or null when the URL is a
+ * global (corpus-wide) route.
+ *
+ * Segment 0 is shared by three namespaces — tenants (`/bph/…`), locale
+ * prefixes (`/es/…`) and every global route root (`/book/…`, `/gallery/…`,
+ * `/encyclopedia/…`) — so the order of the checks below is the whole design:
+ *
+ *   1. strip a locale prefix: it decorates a global route, it never owns one
+ *   2. `/embed/<tenant>/…`: the slug sits in a RESERVED position, so anything
+ *      well-formed there is a tenant claim (the server resolves it against the
+ *      `tenants` collection and 404s an unknown one) — no global route can
+ *      collide with it
+ *   3. a bare first segment is a tenant ONLY if it is on TENANT_ROOT_PATHS,
+ *      the same allowlist the proxy gates on
+ *
+ * Step 3 used to be a denylist of global route roots, which is the wrong
+ * shape: it has to name every route that has ever been added, and it was 39
+ * entries short — `/es`, `/encyclopedia`, `/upload`, `/qa`, `/give` and the
+ * rest all read as tenants, so client calls from those pages went to
+ * `/api/<route>/…` and 404'd. See `@/lib/tenant-roots`.
+ */
 export function getTenantSlugFromPathname(pathname: string): string | null {
   const segments = pathname.split('/').filter(Boolean);
-  // A locale prefix is NOT a tenant. `/es/book/x` is the Spanish rendering of a
-  // GLOBAL route, so every client call it fires must go to `/api/books/...`,
-  // not `/api/es/books/...` — a tenant-scoped URL whose slug resolves to
-  // nothing, which the API answers with a flat 404 ("Book not found" in the
-  // cover picker, "Tenant not found" in analytics). Strip the prefix and let
-  // the rest of the resolution run unchanged; a real tenant page under a
-  // locale (`/es/bph/...`) still resolves to `bph`.
+
   if (segments[0] && (PREFIXED_LOCALES as string[]).includes(segments[0])) {
     segments.shift();
   }
-  // Handle /embed/{tenant}/... paths (tenant subdomains rewrite to /embed/bph/...)
+
   if (segments[0] === 'embed' && segments[1]) {
-    const embedTenant = segments[1];
-    if (/^[a-z0-9-]+$/.test(embedTenant) && !NON_TENANT_SEGMENTS.has(embedTenant)) {
-      return embedTenant;
-    }
-    return null;
+    return /^[a-z0-9-]+$/.test(segments[1]) ? segments[1] : null;
   }
+
   const slug = segments[0] || '';
-  if (!slug) return null;
-  if (!/^[a-z0-9-]+$/.test(slug)) return null;
-  if (NON_TENANT_SEGMENTS.has(slug)) return null;
-  return slug;
+  return TENANT_ROOT_PATHS.has(slug) ? slug : null;
 }
 
 // Browser-only wrapper. Returns the tenant slug for the current page, or ''

--- a/src/lib/provider-prefix.ts
+++ b/src/lib/provider-prefix.ts
@@ -1,11 +1,16 @@
 import { LIBRARY_PARTNERS } from '@/lib/library-partners';
+import { TENANT_ROOT_PATHS } from '@/lib/tenant-roots';
 
 /**
  * Tenant slugs that own real URL space (partner subdomains with scoped UI).
  * The proxy's path-based tenant resolution is gated on this set; it must
  * never overlap with the provider-prefix strip below.
+ *
+ * The constant itself now lives in `@/lib/tenant-roots` — a leaf module the
+ * browser can import without pulling in `LIBRARY_PARTNERS` and its logo data.
+ * Re-exported here so existing server-side import sites keep working.
  */
-export const TENANT_ROOT_PATHS = new Set(['bph', 'kloss-collection', 'bhutan']);
+export { TENANT_ROOT_PATHS };
 
 /**
  * Contributing-library slugs that must never claim URL space. Content lives

--- a/src/lib/tenant-roots.ts
+++ b/src/lib/tenant-roots.ts
@@ -1,0 +1,25 @@
+/**
+ * Tenant slugs that own real URL space (partner subdomains with scoped UI).
+ *
+ * This is the ALLOWLIST for "is the first path segment a tenant?" — the one
+ * question the proxy and the browser must answer identically. It lives in its
+ * own leaf module (no imports) so a client bundle can read it without dragging
+ * in `library-partners.ts` and its logo data.
+ *
+ * Segment 0 of a URL is claimed by three different namespaces: tenants
+ * (`/bph/…`), locale prefixes (`/es/…`) and ~90 global route roots
+ * (`/book/…`, `/gallery/…`, `/encyclopedia/…`). Deciding by *excluding* the
+ * global routes cannot work — that list has to be maintained by hand and
+ * silently rots every time a route is added (it was 39 entries short when this
+ * module was extracted, which is how `/es/book/<id>` ended up calling
+ * `/api/es/books/<id>` and answering "Book not found" in the cover picker).
+ * The tenant set is small, closed and already known to the proxy, so match
+ * against it and treat everything else as global. A missing entry here fails
+ * loudly and immediately (a partner's pages read as global); a missing entry
+ * in a denylist fails silently forever.
+ *
+ * Read by `src/proxy.ts` (via `@/lib/provider-prefix`) and by
+ * `src/lib/api-client/client.ts`. Must never overlap with the provider-prefix
+ * strip in `provider-prefix.ts` or with `PREFIXED_LOCALES` in `locale-path.ts`.
+ */
+export const TENANT_ROOT_PATHS = new Set(['bph', 'kloss-collection', 'bhutan']);

--- a/tests/unit/locale-prefix-not-tenant.test.ts
+++ b/tests/unit/locale-prefix-not-tenant.test.ts
@@ -1,23 +1,66 @@
 /**
- * A locale prefix is not a tenant slug.
+ * Who owns the first path segment.
  *
- * `/es/book/<id>` is the Spanish rendering of a GLOBAL route, but the
- * client-side tenant resolver read its first path segment and returned `es`,
- * so every api-client call fired from a Spanish page went to `/api/es/...`.
- * No tenant has that slug, so the route answered 404 — which surfaced to a
- * reader as "Book not found" inside the cover picker on /es/book/…, and as
- * "Tenant not found" on the loading-analytics endpoint.
+ * Segment 0 is claimed by three namespaces — tenants (`/bph/…`), locale
+ * prefixes (`/es/…`) and every global route root (`/book/…`, `/upload`, …).
+ * The client-side resolver decided by EXCLUDING global routes from a
+ * hand-written list, which had drifted 39 entries behind `src/app/`. Anything
+ * missing from it read as a tenant, so api-client sent that page's calls to
+ * `/api/<segment>/…` — a tenant-scoped URL resolving to no tenant, answered
+ * with a flat 404. Measured on production before the fix:
  *
- * The resolver must strip a locale prefix before looking for a tenant, while
- * still resolving a real tenant that happens to sit under one.
+ *   PATCH /api/es/books/<id>      404 {"error":"Book not found"}   (cover picker on /es/book/…)
+ *   POST  /api/upload/books       404, vs 401 on /api/books        (upload page)
+ *   POST  /api/es/analytics/loading 400 {"error":"Tenant not found"}
+ *
+ * The resolver now matches an ALLOWLIST (`TENANT_ROOT_PATHS`, shared with the
+ * proxy). These tests pin that inversion: the tenant roots resolve, and every
+ * route root in `src/app/` resolves to null — including ones added after this
+ * test was written, which is the part a denylist could never guarantee.
  */
+import { readdirSync } from 'fs';
+import path from 'path';
+
 import { describe, it, expect } from 'vitest';
 
 import { getTenantSlugFromPathname } from '@/lib/api-client/client';
 import { PREFIXED_LOCALES } from '@/lib/locale-path';
+import { TENANT_ROOT_PATHS } from '@/lib/tenant-roots';
+
+/** Route roots as Next.js sees them: real directories under src/app, minus
+ *  dynamic segments and route groups. */
+function appRouteRoots(): string[] {
+  return readdirSync(path.join(process.cwd(), 'src/app'), { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('[') && !d.name.startsWith('('))
+    .map(d => d.name);
+}
 
 describe('getTenantSlugFromPathname', () => {
-  it('returns null for global routes under a locale prefix', () => {
+  it('resolves the tenant roots the proxy gates on', () => {
+    for (const slug of TENANT_ROOT_PATHS) {
+      expect(getTenantSlugFromPathname(`/${slug}`)).toBe(slug);
+      expect(getTenantSlugFromPathname(`/${slug}/book/x`)).toBe(slug);
+    }
+  });
+
+  it('treats every global route root as global, including future ones', () => {
+    const roots = appRouteRoots();
+    // Guard the guard: if this ever reads zero directories the assertion below
+    // passes vacuously.
+    expect(roots.length).toBeGreaterThan(50);
+
+    const claimed = roots.filter(
+      r =>
+        !TENANT_ROOT_PATHS.has(r) &&
+        // `/embed` is the one root that deliberately carries a tenant in its
+        // NEXT segment; covered by its own test below.
+        r !== 'embed' &&
+        getTenantSlugFromPathname(`/${r}/anything`) !== null,
+    );
+    expect(claimed).toEqual([]);
+  });
+
+  it('does not mistake a locale prefix for a tenant', () => {
     for (const locale of PREFIXED_LOCALES) {
       expect(getTenantSlugFromPathname(`/${locale}`)).toBeNull();
       expect(getTenantSlugFromPathname(`/${locale}/`)).toBeNull();
@@ -26,17 +69,24 @@ describe('getTenantSlugFromPathname', () => {
     }
   });
 
-  it('still resolves a tenant that sits under a locale prefix', () => {
+  it('still resolves a tenant sitting under a locale prefix', () => {
     for (const locale of PREFIXED_LOCALES) {
       expect(getTenantSlugFromPathname(`/${locale}/bph/book/x`)).toBe('bph');
       expect(getTenantSlugFromPathname(`/${locale}/embed/bph/book/x`)).toBe('bph');
     }
   });
 
-  it('leaves unprefixed routes alone', () => {
+  it('reads the tenant from the reserved slot in /embed/<tenant>/…', () => {
+    expect(getTenantSlugFromPathname('/embed/bph/book/x')).toBe('bph');
+    // Embed-only partners need no entry in TENANT_ROOT_PATHS — the position is
+    // unambiguous, and the server resolves the slug against the DB.
+    expect(getTenantSlugFromPathname('/embed/some-partner/book/x')).toBe('some-partner');
+    expect(getTenantSlugFromPathname('/embed')).toBeNull();
+  });
+
+  it('leaves unprefixed global routes alone', () => {
+    expect(getTenantSlugFromPathname('/')).toBeNull();
     expect(getTenantSlugFromPathname('/book/celestial-hierarchy')).toBeNull();
     expect(getTenantSlugFromPathname('/gallery')).toBeNull();
-    expect(getTenantSlugFromPathname('/bph/book/x')).toBe('bph');
-    expect(getTenantSlugFromPathname('/embed/bph/book/x')).toBe('bph');
   });
 });


### PR DESCRIPTION
Records the invariant behind #4127 and #4136 in `content-urls-and-libraries.md`, which is already the doc the CLAUDE.md index routes to for "book/page/gallery/collection routes, provider prefixes, contributing libraries."

The rule: segment 0 is shared by tenants, locale prefixes and ~90 global route roots, and ownership is decided by an allowlist of tenants — never a denylist of routes. Adding a tenant means editing `TENANT_ROOT_PATHS`; adding a route root or a locale means doing nothing.

No new routing line in CLAUDE.md — this fires on a subsystem the index already points at, and the budget rule says a subsystem invariant belongs one tier down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuWqyiLFfftfiKfXyawPgc