### PR TITLE
feat(es): `lang` on every text surface — MCP, quotes, exports (#4095)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -18,6 +18,7 @@ translation is a different layer — `pages.translations.<lang>` — see
 | **metadata** | book title glosses, collection name/subtitle/description | **one language-keyed map per record**: `books.localized = { es: { title } }`, `collections.localized = { es: { name, subtitle, description } }` | `src/lib/localized.ts` |
 | **text** | the pages themselves | `pages.translations.<lang>` (English on `pages.translation`) | `src/lib/page-translations.ts` |
 | **findability** | the vectors + lexical index that make that text searchable | Supabase `page_texts` (`page_id`, `lang`), English on `page_translations` | `match_page_texts` / `search_page_texts` via `src/lib/semantic-search.ts` |
+| **retrieval** | serving that text to an API or MCP caller, and exporting it | every text route takes `?lang=<iso>`, default `en` | `resolveQuoteText(page, bookId, lang)`, `editionsForBook(book)` |
 
 English is never written into `localized`: `display_title` *is* the English
 gloss and `collections.name/…` *is* the English copy. The original title
@@ -103,6 +104,14 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    is not embedded is invisible to search *and indistinguishable from a page
    that simply does not match* — which is how the English page vectors sat two
    months dark over 45% of the corpus.
+
+3c. **Nothing else needs adding for the API.** `lang` is an ISO code everywhere
+   — `/api/search`, `/api/books/:id/{search,quote,text,download}`, the MCP
+   tools, `/q/<code>?lang=` — and `editionsForBook` reads
+   `books.pages_translated_<iso>`, which step 3 already created. The one rule to
+   keep: a response must SAY which edition it served, because falling back to
+   English is the common case, not the edge one
+   (`invariants/text-helpers-and-exports.md`).
 4. `localize-metadata.mjs --lang=<iso> --books-with-editions`.
 5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts`, and the reader's language
    links in `PageEditorClient` (a third locale makes that pair a list — keep it

--- a/.claude/docs/invariants/text-helpers-and-exports.md
+++ b/.claude/docs/invariants/text-helpers-and-exports.md
@@ -6,6 +6,43 @@
 
 ---
 
+## A language-keyed export must SAY which edition it served (#4095)
+
+Since Aug 2026 a page can hold more than one translation: English on
+`pages.translation`, everything else on `pages.translations.<iso>`. Every text
+surface therefore takes an optional `lang` (an ISO code, default `en`) —
+`/api/books/:id/quote`, `/api/books/:id/text`, `/api/books/:id/download`,
+`/api/books/:id/search`, `/api/search`, and the matching MCP tools.
+
+Three rules, all of them about not lying:
+
+- **The fallback is loud.** 103 books of 22,000 have a Spanish edition, so
+  falling back to English is the COMMON case, not the edge one. `quote.lang`,
+  `translation_lang`, `lang_coverage`, `lang_note` exist so a caller can see
+  which edition it actually got. A quote is a claim about words; a silent
+  substitution makes the caller assert something it never checked.
+- **Resolve per PAGE, not per book.** The Spanish worker's length guard skipped
+  ~30 pages across 17 otherwise-complete books, so a book-level claim is wrong
+  on exactly the pages a reader would notice. `/text` reports
+  `lang_coverage: { es, en_fallback }` for this reason, and one batch of
+  `get_quotes` can legitimately mix editions.
+- **`lang` is not `language`.** `language` filters by what is printed on the
+  leaves of the scan; `lang` chooses which rendering of the text to read. A
+  Latin book with a Spanish edition matches both.
+
+Downloads are the exception to "thread the parameter": `download/route.ts`
+substitutes the requested edition into `page.translation` ONCE, right after the
+pages are fetched, so fifteen format generators keep reading one field. The
+language goes into the FILENAME (`plato-es-translation.pdf`) — a downloaded file
+is read months later out of a folder, where a header cannot reach it.
+
+The distributable corpus snapshot carries other editions under a
+`translations` MAP on each page record, never in place of `translation`: the
+English text is what the OCR is aligned to and what existing consumers read, and
+its words are counted ONCE — `edition_pages` in the manifest counts localized
+pages separately so no figure quoted from it is inflated by holding two
+renderings of one passage.
+
 Lessons from 2026-08-04 (#3580/#3598/#3620). The handoff this section originally cited
 (`2026-08-04-export-surfaces-and-unreachable-page-types.md`) was never written — the
 issues above are the record, and the text below is the whole lesson.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -81,6 +81,25 @@ For Claude Desktop or other MCP-compatible clients, install the MCP server for t
 - `search_images` - Search extracted illustrations
 - `list_books` - Browse the full collection
 
+**Reading in another language.** Most of the corpus is served in English, but some
+books also carry a translated edition — as of August 2026, 103 books in Spanish
+(≈38,600 pages), readable at `sourcelibrary.org/es/book/…`. Every tool that
+returns text takes an optional **`lang`** (an ISO code, default `en`):
+`get_quote`, `get_quotes`, `get_book_text`, `search_within_book`,
+`search_translations`, `search_concept`. `list_books` takes **`has_edition`** to
+browse only books that have one, and `get_book` returns an **`editions`** map
+(`{ en: 357, es: 357 }`) saying which languages a book can be read in.
+
+Two rules, because the failure they prevent is silent:
+
+1. **`lang` is not `language`.** `language` filters by what is printed on the
+   leaves of the scan; `lang` chooses which translation of the text to read. A
+   Latin book with a Spanish edition matches `language=Latin` AND `lang=es`.
+2. **Every response says which edition it actually served.** Where the requested
+   edition does not exist the English translation comes back, labelled (`lang`,
+   `translation_lang`, `lang_note`) rather than substituted silently. Never
+   present a fallback as the requested edition — check the field before quoting.
+
 **npm:** https://www.npmjs.com/package/@source-library/mcp-server
 **GitHub:** https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/tree/main/mcp-server
 
@@ -99,6 +118,7 @@ GET /search?q={query}
 |-----------|------|-------------|
 | q | string | Search query (required) - searches titles, authors, and full text |
 | language | string | Filter by original language: Latin, German, French, etc. |
+| lang | string | ISO code of the EDITION to search and quote back, e.g. `es`. Default `en`. Narrows the whole request to books that HAVE that edition — see "Reading in another language" below. |
 | has_doi | boolean | Only return books with DOIs |
 | has_translation | boolean | Only return books with translations |
 | limit | number | Max results (default 20) |
@@ -140,6 +160,7 @@ GET /books/{book_id}/quote?page={page_number}
 | page | number | Page number (required) |
 | include_original | boolean | Include original language text — and, for non-Latin scripts, its romanization (default true) |
 | include_context | boolean | Include adjacent pages for context |
+| lang | string | ISO code of the EDITION to quote, e.g. `es`. `quote.lang` on the response always says which edition was served. |
 
 For pages in a non-Latin script (Greek, Hebrew, Arabic, Cyrillic, Sanskrit…) the
 quote also carries `romanized`, so a citation can be shown in three layers:

--- a/scripts/export/build-corpus-snapshot.mjs
+++ b/scripts/export/build-corpus-snapshot.mjs
@@ -61,6 +61,13 @@ const EXCLUDE_FILE = arg('--exclude-file', null);
 const VERSION = arg('--version', new Date().toISOString().slice(0, 10).replace(/-/g, '.'));
 const VERIFY_SAMPLE = Number(arg('--verify-sample', 200)); // pages spot-checked post-build
 const SKIP_VERIFY = has('--skip-verify');
+// Non-English editions to include alongside the English translation (#4095).
+// `pages.translations.<iso>` — a language-keyed MAP, never a per-language
+// column, so the snapshot gains a key rather than a schema. Comma-separated;
+// `--editions=none` builds the English-only snapshot the earlier versions did.
+const EDITION_LANGS = (arg('--editions', 'es') || '')
+  .split(',').map((l) => l.trim().toLowerCase())
+  .filter((l) => /^[a-z]{2,3}$/.test(l) && l !== 'en' && l !== 'none');
 
 // Mirrors src/lib/license-info.ts CONTENT_LICENSE (scripts can't import TS —
 // same twin situation as strip-editorial-wrappers). Change both together.
@@ -294,7 +301,11 @@ async function build() {
 
   const fetchPages = (bookId) => db.collection('pages')
     .find({ book_id: bookId, page_number: { $not: { $lt: 0 } } })
-    .project({ id: 1, page_number: 1, 'ocr.data': 1, 'translation.data': 1 })
+    .project({
+      id: 1, page_number: 1, 'ocr.data': 1, 'translation.data': 1,
+      ...Object.fromEntries(EDITION_LANGS.map((l) => [`translations.${l}.data`, 1])),
+      ...(EDITION_LANGS.includes('es') ? { 'translation_es.data': 1 } : {}),
+    })
     .sort({ page_number: 1 })
     .toArray();
 
@@ -346,7 +357,25 @@ async function build() {
         shard.words += q.words; nWords += q.words;
         shard.chars += text.length;
       }
-      if (rec.ocr || rec.translation) { outPages.push(rec); shard.pages++; nPages++; }
+      // Other editions of the same leaf, keyed by ISO code. They ride in their
+      // own map rather than replacing `translation`, because the English text
+      // is what the OCR is aligned to and what every existing consumer reads —
+      // a Spanish page arriving under `translation` would silently change the
+      // language of a corpus somebody already trained on. Words and chars are
+      // NOT added to the shard totals: those count the corpus once, and
+      // double-counting a passage because we hold two renderings of it would
+      // inflate every figure quoted from the manifest.
+      for (const l of EDITION_LANGS) {
+        const raw = page.translations?.[l]?.data
+          ?? (l === 'es' ? page.translation_es?.data : null);
+        if (!raw || raw.length > MAX_PAGE_CHARS) continue;
+        const text = stripEditorialWrappers(raw, { keepTables: true }).trim();
+        if (!text || /^\[[^\]]{0,160}\]$/.test(text)) continue;
+        (rec.translations ??= {})[l] = text;
+        shard.edition_pages = (shard.edition_pages || {});
+        shard.edition_pages[l] = (shard.edition_pages[l] || 0) + 1;
+      }
+      if (rec.ocr || rec.translation || rec.translations) { outPages.push(rec); shard.pages++; nPages++; }
     }
     if (!outPages.length) continue;
 
@@ -391,6 +420,11 @@ async function build() {
     file: path.basename(s.path),
     language: s.lang,
     books: s.books, pages: s.pages, words: s.words, chars: s.chars,
+    // Pages carrying a non-English edition, per ISO code. Counted separately
+    // from `pages` on purpose: a page with a Spanish rendering is still ONE
+    // page of corpus, and folding the two together would inflate every figure
+    // downstream.
+    ...(s.edition_pages ? { edition_pages: s.edition_pages } : {}),
     sha256: await sha256Stream(s.path),
     bytes: fs.statSync(s.path).size,
   })));
@@ -400,7 +434,15 @@ async function build() {
     shardEntries,
   });
   fs.writeFileSync(path.join(DIR, 'manifest.json'), JSON.stringify(manifest, null, 2));
-  console.log(`[build] done: ${nBooks.toLocaleString()} books, ${nPages.toLocaleString()} pages, ${nWords.toLocaleString()} words, ${shards.size} shards`);
+  const editionTotals = {};
+  for (const s of shards.values()) {
+    for (const [l, n] of Object.entries(s.edition_pages || {})) editionTotals[l] = (editionTotals[l] || 0) + n;
+  }
+  const editionSummary = Object.entries(editionTotals).map(([l, n]) => `${n.toLocaleString()} ${l}`).join(', ');
+  console.log(`[build] done: ${nBooks.toLocaleString()} books, ${nPages.toLocaleString()} pages, ${nWords.toLocaleString()} words, ${shards.size} shards` +
+    (EDITION_LANGS.length
+      ? `; other editions: ${editionSummary || `none found for ${EDITION_LANGS.join(',')}`}`
+      : ''));
 
   if (!SKIP_VERIFY) await verify(db, manifest);
   await client.close();

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { images } from '@/lib/api-client';
 import { markForExport } from '@/lib/provenance';
+import { getTranslation } from '@/lib/page-translations';
 import { getBookIndex } from '@/lib/book-index';
 import { Readable } from 'stream';
 import { generatePdfTranslationStream, generatePdfFacsimileStream } from '@/lib/pdf-export';
@@ -2474,12 +2475,40 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .sort({ page_number: 1 })
       .toArray();
 
+    // Export a non-English edition (#4095) by SUBSTITUTING it into
+    // `page.translation` right here, once, instead of threading a language
+    // through fifteen format generators (PDF, EPUB in six variants, TXT,
+    // markdown, the facing-page builders). Every downstream reader keeps
+    // reading `page.translation.data` and gets the requested edition, with its
+    // own model/source metadata attached — which is what an export should
+    // record. Pages with no text in that language keep their English
+    // translation rather than dropping out: an export with holes in it is
+    // worse than one that is mostly Spanish, and `lang_coverage` in the
+    // response header says how many of each there are.
+    const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+    const exportLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
+    let localizedPages = 0;
+    if (exportLang !== 'en') {
+      for (const p of pages) {
+        const localized = getTranslation(p as never, exportLang);
+        if (localized?.data) { p.translation = localized; localizedPages++; }
+      }
+      // A file download has no room for a coverage field, so record it here:
+      // `/api/books/{id}/text?lang=<iso>` reports `lang_coverage` for the same
+      // book if a caller needs the number before exporting.
+      console.info(`[download] ${id} format=${format} lang=${exportLang}: ${localizedPages}/${pages.length} pages in ${exportLang}, the rest fall back to English`);
+    }
+
     // Create safe filename base
-    const safeTitle = (book.display_title || book.title || 'untitled')
+    // The language belongs in the FILENAME. A downloaded file leaves the site
+    // and is read months later out of a folder; `plato-es-translation.pdf` says
+    // what it is and `plato-translation.pdf` does not.
+    const langSuffix = exportLang !== 'en' ? `-${exportLang}` : '';
+    const safeTitle = ((book.display_title || book.title || 'untitled')
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
-      .substring(0, 50);
+      .substring(0, 50)) + langSuffix;
 
     // Handle images ZIP download
     if (isImagesZip) {

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -37,6 +37,13 @@ interface QuoteResponse {
     /** Set only when text_source is `ocr_original` — see OCR_ORIGINAL_NOTE. */
     transcription_note?: string;
     /**
+     * ISO code of the language the quoted text is IN — always present, so a
+     * caller branches on it rather than assuming English (#4095).
+     */
+    lang: string;
+    /** Set only when `lang` differs from the `lang` parameter that was asked for. */
+    lang_note?: string;
+    /**
      * Romanization of the original for non-Latin scripts (#3828) — AI-derived
      * apparatus, never a transcription, hence `romanized` and not
      * `original_romanized`. Served only when the page carries a
@@ -86,6 +93,12 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
     const includeOriginal = searchParams.get('include_original') !== 'false';
     const includeContext = searchParams.get('include_context') === 'true';
     const includeImage = searchParams.get('include_image') === 'true';
+    // Which EDITION of the page to quote (#4095). Falls back to English when
+    // the book has no such edition — and SAYS so, in `quote.lang`. A quote is a
+    // claim about words; a silent substitution makes the caller assert
+    // something it never checked.
+    const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+    const requestedLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
 
     if (isNaN(pageNumber) || pageNumber < 1) {
       return NextResponse.json({ error: 'Invalid page number' }, { status: 400 });
@@ -136,7 +149,7 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
 
     // Translation when we have one; the OCR transcription when the leaf is
     // already English and therefore is itself the citable text (#3939).
-    const quotable = resolveQuoteText(page, book.id);
+    const quotable = resolveQuoteText(page, book.id, requestedLang);
 
     // A caller that explicitly said include_original=false wants English we
     // produced, so an English-original page has nothing to give it either.
@@ -170,6 +183,10 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
         // resolveQuoteText, for both text sources.
         ...(quotable.source === 'translation' ? { translation: quotable.text } : {}),
         text_source: quotable.source,
+        lang: quotable.lang,
+        ...(requestedLang !== quotable.lang
+          ? { lang_note: `No ${requestedLang} edition of this page; the text above is the English translation (lang: "${quotable.lang}"). Do not present it as the ${requestedLang} edition.` }
+          : {}),
         ...(quotable.source === 'ocr_original' ? { transcription_note: OCR_ORIGINAL_NOTE } : {}),
         page: pageNumber,
         book_id: book.id,
@@ -180,7 +197,10 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
         language: book.language,
         ...languageApparatusFields(book),
       },
-      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition),
+      // The citation links follow the edition actually served, never the one
+      // asked for — a `/es` URL for a book we fell back on would 307 straight
+      // back to English.
+      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition, quotable.lang),
       license: CONTENT_LICENSE,
     };
 
@@ -221,9 +241,12 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
       // sentence running across the leaf break can be quoted whole — serving it
       // only for translated pages would leave that unreachable exactly where the
       // fallback matters (#3939).
+      // Context exists so a sentence running across a leaf break can be quoted
+      // whole — it must therefore be in the SAME language as the quote, or the
+      // two halves cannot be joined.
       const neighbour = (p: unknown) => {
         const pg = p as Page | null;
-        return pg ? resolveQuoteText(pg, resolvedBookId)?.text : undefined;
+        return pg ? resolveQuoteText(pg, resolvedBookId, quotable.lang)?.text : undefined;
       };
       response.context = {
         previous_page: neighbour(prevPage),

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -6,6 +6,7 @@ import { ObjectId } from 'mongodb';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { withApiAuth } from '@/lib/api-auth';
+import { EDITION_COUNTER_PROJECTION } from '@/lib/page-translations';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
@@ -47,6 +48,10 @@ export const GET = withApiAuth(async (
       // translation-of-a-translation from a source text.
       original_language: 1, text_role: 1, is_translation: 1,
       pages_count: 1, pages_translated: 1,
+      // Per-language edition counters, so get_book can report `editions`
+      // ({ en: 357, es: 357 }) rather than leaving an agent to discover a
+      // Spanish edition by accident (#4095).
+      ...EDITION_COUNTER_PROJECTION,
       categories: 1, reading_summary: 1,
       chapters: 1,
       // Cover art (all four fields of the cover-write contract, see

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -10,6 +10,7 @@ import { CONTENT_LICENSE } from '@/lib/license-info';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { markForExport } from '@/lib/provenance';
 import { attributionBlock, attributionMeta, clientKeyFor, extractionRef } from '@/lib/bot-attribution';
+import { getTranslation } from '@/lib/page-translations';
 
 // This route serves quotable page text (get_book_text tells agents to "copy
 // verbatim from the translation field"), so it MUST strip the AI editorial
@@ -60,6 +61,22 @@ export const GET = withApiAuth(async (
     const partParam = searchParams.get('part');
     const format = searchParams.get('format') || 'json';
     const includeMetadata = searchParams.get('include_metadata') === 'true';
+    // Which EDITION of the translation to export (#4095). Per PAGE, not per
+    // book: ~30 pages across 17 Spanish books were skipped by the translation
+    // worker's length guard and still read English, so a book-level claim would
+    // be wrong on exactly the pages a reader would notice.
+    const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+    const requestedLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
+    const isLocalized = requestedLang !== 'en';
+    /** The translation of one page in the requested language, or English, saying which. */
+    const translationFor = (p: Record<string, unknown>): { data: string; lang: string } | null => {
+      if (isLocalized) {
+        const localized = getTranslation(p as never, requestedLang)?.data;
+        if (localized) return { data: localized, lang: requestedLang };
+      }
+      const en = (p.translation as { data?: string } | undefined)?.data;
+      return en ? { data: en, lang: 'en' } : null;
+    };
 
     if (!['ocr', 'translation', 'both'].includes(content)) {
       return NextResponse.json({ error: 'content must be ocr, translation, or both' }, { status: 400 });
@@ -132,7 +149,23 @@ export const GET = withApiAuth(async (
     const budgetPageCap = (enforce && budget.limit > 0) ? Math.max(1, budget.remaining) : undefined;
 
     // Chapter mode: return pre-materialized chapter text
-    if (chapterParam !== null) {
+    //
+    // Materialized chapter text exists only in English — it is stitched by the
+    // enrichment pipeline from `translation.data`. For a localized request we
+    // therefore resolve the chapter to its PAGE RANGE and serve those pages in
+    // the requested language, rather than handing back English under a `lang=es`
+    // request or refusing outright.
+    let localizedChapterRange: { from: number; to: number; title?: string } | null = null;
+    if (chapterParam !== null && isLocalized) {
+      const chapterIndex = parseInt(chapterParam);
+      const withChapters = await db.collection('books').findOne(
+        { id: resolvedBookId }, { projection: { chapters: 1 } });
+      const ch = withChapters?.chapters?.[chapterIndex];
+      if (!ch) return NextResponse.json({ error: 'Chapter not found' }, { status: 404 });
+      localizedChapterRange = { from: ch.pageStart, to: ch.pageEnd ?? ch.pageStart, title: ch.titleEn || ch.title };
+    }
+
+    if (chapterParam !== null && !localizedChapterRange) {
       const chapterIndex = parseInt(chapterParam);
       if (isNaN(chapterIndex) || chapterIndex < 0) {
         return NextResponse.json({ error: 'chapter must be a non-negative integer' }, { status: 400 });
@@ -233,15 +266,16 @@ export const GET = withApiAuth(async (
     // tightest of: requested `to`, the bot 20% limit, and the per-request budget
     // cap (counted from the start page). budgetMaxPage closes the granularity gap
     // where one big range would otherwise serve past the daily cap in a single call.
-    const startPage = fromPage ?? 1;
+    const startPage = localizedChapterRange?.from ?? fromPage ?? 1;
     const budgetMaxPage = budgetPageCap !== undefined ? startPage + budgetPageCap - 1 : undefined;
-    const pageCaps = [toPage, botPageLimit, budgetMaxPage].filter((v): v is number => v !== undefined);
+    const pageCaps = [localizedChapterRange?.to ?? toPage, botPageLimit, budgetMaxPage].filter((v): v is number => v !== undefined);
     const effectiveToPage = pageCaps.length ? Math.min(...pageCaps) : undefined;
 
+    const effectiveFromPage = localizedChapterRange?.from ?? fromPage;
     const pageFilter: Record<string, unknown> = { book_id: resolvedBookId };
-    if (fromPage !== undefined || effectiveToPage !== undefined) {
+    if (effectiveFromPage !== undefined || effectiveToPage !== undefined) {
       pageFilter.page_number = {};
-      if (fromPage !== undefined) (pageFilter.page_number as Record<string, number>).$gte = fromPage;
+      if (effectiveFromPage !== undefined) (pageFilter.page_number as Record<string, number>).$gte = effectiveFromPage;
       if (effectiveToPage !== undefined) (pageFilter.page_number as Record<string, number>).$lte = effectiveToPage;
     }
 
@@ -263,10 +297,19 @@ export const GET = withApiAuth(async (
     }
     if (content === 'translation' || content === 'both') {
       projection['translation.data'] = 1;
+      if (isLocalized) {
+        projection[`translations.${requestedLang}.data`] = 1;
+        if (requestedLang === 'es') projection['translation_es.data'] = 1;
+      }
       if (includeMetadata) {
         projection['translation.language'] = 1;
         projection['translation.model'] = 1;
         projection['translation.source'] = 1;
+        if (isLocalized) {
+          projection[`translations.${requestedLang}.language`] = 1;
+          projection[`translations.${requestedLang}.model`] = 1;
+          projection[`translations.${requestedLang}.source`] = 1;
+        }
       }
     }
     if (includeMetadata) {
@@ -286,6 +329,8 @@ export const GET = withApiAuth(async (
       lines.push(`# ${book.display_title || book.title}`);
       lines.push(`# ${book.author} (${book.published || 'n.d.'})`);
       lines.push(`# Language: ${book.language}`);
+      if (isLocalized) lines.push(`# Translation edition requested: ${requestedLang} (pages without one are marked [Translation — en])`);
+      if (localizedChapterRange) lines.push(`# Chapter: ${localizedChapterRange.title ?? chapterParam} (pages ${localizedChapterRange.from}–${localizedChapterRange.to})`);
       lines.push(`# Produced by SourceLibrary.org in Amsterdam, 2026`);
       lines.push(`# Source: https://sourcelibrary.org/book/${resolvedBookId}`);
       lines.push(`# License: CC BY-SA 4.0 (https://sourcelibrary.org/terms)`);
@@ -296,7 +341,13 @@ export const GET = withApiAuth(async (
 
       for (const page of pages) {
         const ocr = mark(cleanText(page.ocr?.data));
-        const translation = mark(cleanText(page.translation?.data));
+        const resolved = translationFor(page);
+        const translation = mark(cleanText(resolved?.data));
+        // The label carries the language whenever it is not what was asked for,
+        // so a fallback page cannot be read as part of the Spanish edition.
+        const tLabel = resolved && resolved.lang !== requestedLang
+          ? `[Translation — ${resolved.lang}]`
+          : '[Translation]';
 
         if (content === 'both' && (ocr || translation)) {
           lines.push(`--- Page ${page.page_number} ---`);
@@ -306,7 +357,7 @@ export const GET = withApiAuth(async (
             lines.push('');
           }
           if (translation) {
-            lines.push(`[Translation]`);
+            lines.push(tLabel);
             lines.push(translation);
             lines.push('');
           }
@@ -316,6 +367,7 @@ export const GET = withApiAuth(async (
           lines.push('');
         } else if (content === 'translation' && translation) {
           lines.push(`--- Page ${page.page_number} ---`);
+          if (resolved && resolved.lang !== requestedLang) lines.push(tLabel);
           lines.push(translation);
           lines.push('');
         }
@@ -337,8 +389,8 @@ export const GET = withApiAuth(async (
     // JSON format — structured response
     const pagesWithContent = pages.filter(p => {
       if (content === 'ocr') return p.ocr?.data;
-      if (content === 'translation') return p.translation?.data;
-      return p.ocr?.data || p.translation?.data;
+      if (content === 'translation') return !!translationFor(p);
+      return p.ocr?.data || !!translationFor(p);
     });
 
     const result = {
@@ -359,6 +411,25 @@ export const GET = withApiAuth(async (
       // consumer quoting `pages[].ocr` never picks up words we wrote.
       ...(ref ? { attribution: attributionMeta(ref) } : {}),
       content_type: content,
+      // What was asked for, and what the pages actually carry. A caller that
+      // requested `es` and got 40 English pages back must be able to see it
+      // without diffing the text.
+      lang: requestedLang,
+      ...(isLocalized ? {
+        lang_coverage: {
+          [requestedLang]: pagesWithContent.filter(p => translationFor(p)?.lang === requestedLang).length,
+          en_fallback: pagesWithContent.filter(p => translationFor(p)?.lang === 'en').length,
+        },
+      } : {}),
+      ...(localizedChapterRange ? {
+        chapter: {
+          index: Number(chapterParam),
+          title: localizedChapterRange.title,
+          pageStart: localizedChapterRange.from,
+          pageEnd: localizedChapterRange.to,
+          note: `Chapter text is materialized in English only; this ${requestedLang} response is assembled from the chapter's page range.`,
+        },
+      } : {}),
       total_pages: book.pages_count || pages.length,
       pages_returned: pagesWithContent.length,
       ...(botPageLimit !== undefined ? {
@@ -405,13 +476,18 @@ export const GET = withApiAuth(async (
             };
           }
         }
-        if ((content === 'translation' || content === 'both') && p.translation?.data) {
-          entry.translation = mark(cleanText(p.translation.data));
+        const resolved = (content === 'translation' || content === 'both') ? translationFor(p) : null;
+        if (resolved) {
+          entry.translation = mark(cleanText(resolved.data));
+          // Always present, so a consumer branches on it instead of assuming
+          // every page in a `lang=es` response is Spanish.
+          entry.translation_lang = resolved.lang;
           if (includeMetadata) {
+            const meta = resolved.lang === 'en' ? p.translation : (p.translations?.[resolved.lang] ?? p.translation_es);
             entry.translation_metadata = {
-              language: p.translation.language,
-              model: p.translation.model,
-              source: p.translation.source,
+              language: meta?.language,
+              model: meta?.model,
+              source: meta?.source,
             };
           }
         }

--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -32,6 +32,12 @@ export async function GET(request: NextRequest) {
     const workId = searchParams.get('work_id') || '';
     const firstTranslation = searchParams.get('first_translation') === 'true';
     const hasTranslation = searchParams.get('has_translation') === 'true';
+    // `has_edition=<iso>`: books that carry a reader-ready edition in that
+    // language (#4095). Distinct from `language`, which is the language printed
+    // on the leaves of the original scan — a Latin book with a Spanish edition
+    // matches `language=Latin` AND `has_edition=es`.
+    const hasEditionParam = (searchParams.get('has_edition') || '').trim().toLowerCase();
+    const hasEdition = /^[a-z]{2,3}$/.test(hasEditionParam) && hasEditionParam !== 'en' ? hasEditionParam : '';
     const sort = (searchParams.get('sort') || 'recent-translation') as SortOption;
     const { slug: tenantSlugHeader, id: tenantIdHeader } = getTenantContextFromRequest(request);
     const tenantSlugParam = searchParams.get('tenant_slug') || '';
@@ -49,7 +55,7 @@ export async function GET(request: NextRequest) {
 
     // Serve cached response for cacheable requests (no text search, reasonable pagination)
     const isCacheable = !search.trim() && skip < 200;
-    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}`;
+    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|he:${hasEdition}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}`;
     if (isCacheable) {
       const cached = browseCache.get(cacheKey);
       if (cached && (Date.now() - cached.timestamp) < BROWSE_CACHE_TTL) {
@@ -80,6 +86,10 @@ export async function GET(request: NextRequest) {
         ...(collection ? [{ $match: { collections: collection } }] : []),
         ...(workId ? [{ $match: { work_id: workId } }] : []),
         ...(library ? [{ $match: { 'image_source.provider': library } }] : []),
+        // Applied in BOTH branches. A filter honoured only when the caller
+        // omits `search` is inert exactly where it is most likely to be used,
+        // and reads as active either way (search-filters-and-lanes.md).
+        ...(hasEdition ? [{ $match: { [`pages_translated_${hasEdition}`]: { $gt: 0 } } }] : []),
         ...(tenantId ? [{ $match: { tenantId } }] : []),
       ];
     } else {
@@ -95,6 +105,7 @@ export async function GET(request: NextRequest) {
       if (library) matchConditions.push({ 'image_source.provider': library });
       if (firstTranslation) matchConditions.push({ is_first_translation: true });
       if (hasTranslation) matchConditions.push({ pages_translated: { $gt: 0 } });
+      if (hasEdition) matchConditions.push({ [`pages_translated_${hasEdition}`]: { $gt: 0 } });
       pipelineStart = [{ $match: { $and: matchConditions } }];
     }
 
@@ -153,6 +164,10 @@ export async function GET(request: NextRequest) {
       pages_ocr: 1,
       pages_translated: 1,
       translation_percent: 1,
+      // Only when asked for. Projecting every language's counter would put a
+      // field on 22,000 rows to describe 103 of them, and the counter set grows
+      // with each language.
+      ...(hasEdition ? { [`pages_translated_${hasEdition}`]: 1 } : {}),
       is_first_translation: 1,
       last_processed: 1,
       last_translation_at: 1,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -3,6 +3,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
 import { logMcpToolCall, logMcpInitialize } from '@/lib/mcp-usage';
 import { getClientIp, peekRateLimit } from '@/lib/rate-limit';
+import { editionsForBook } from '@/lib/page-translations';
 import { getShortUrl } from '@/lib/shortlinks';
 import { pageContinuity, continuityHint } from '@/lib/page-continuity';
 import { classifyApiError } from '@/lib/mcp-errors';
@@ -125,11 +126,16 @@ async function searchPassages(args: Record<string, unknown>) {
   if (args.year_from) params.set('year_from', String(args.year_from));
   if (args.year_to) params.set('year_to', String(args.year_to));
   if (args.book_id) params.set('book_id', String(args.book_id));
+  const textLang = langArg(args);
+  if (textLang !== 'en') params.set('lang', textLang);
 
   const result = await apiGet('/search', params) as Record<string, unknown>;
   const passages = ((result.results as Array<Record<string, unknown>>)?.map((r) => {
     const snippetType = r.snippet_type as string | undefined;
-    const snippetLanguage = snippetType === 'ocr' ? r.language : 'English';
+    // The snippet's language: the leaf's own for an OCR hit, otherwise the
+    // edition that was searched. Hard-coding "English" here was correct while
+    // one translation existed per page; it is not any more (#4095).
+    const snippetLanguage = snippetType === 'ocr' ? r.language : (textLang === 'en' ? 'English' : textLang);
     return {
       book_id: r.book_id,
       title: r.display_title || r.title,
@@ -160,6 +166,10 @@ async function searchPassages(args: Record<string, unknown>) {
     total_matches: result.total,
     returned: passages.length,
     offset,
+    lang: textLang,
+    ...(textLang !== 'en' ? {
+      lang_note: `Searched the ${textLang} edition. Only books that HAVE a ${textLang} edition can appear — this is a narrower corpus than the default English search, not a smaller result set for the same books.`,
+    } : {}),
     // BUG 2: surface the backend's lane-timeout signal so callers know the count
     // may be incomplete when a search lane degraded. Only present when true.
     ...(result.partial ? { partial: true } : {}),
@@ -182,6 +192,8 @@ async function searchConcept(args: Record<string, unknown>) {
   if (args.year_from) params.set('year_min', String(args.year_from));
   if (args.year_to) params.set('year_max', String(args.year_to));
   if (args.max_per_book) params.set('max_per_book', String(args.max_per_book));
+  const conceptLang = langArg(args);
+  if (conceptLang !== 'en') params.set('lang', conceptLang);
 
   const result = await apiGet('/search/semantic', params) as Record<string, unknown>;
   const passages = ((result.results as Array<Record<string, unknown>>)?.map((r) => ({
@@ -190,7 +202,7 @@ async function searchConcept(args: Record<string, unknown>) {
     author: r.book_author,
     // Edition language, not the work's — see the note in searchPassages (#3942).
     language: r.book_language,
-    snippet_language: 'English',
+    snippet_language: conceptLang === 'en' ? 'English' : conceptLang,
     published: r.book_year,
     page: r.page_number,
     snippet: stripProvenanceMarks(r.snippet as string),
@@ -209,13 +221,30 @@ async function searchConcept(args: Record<string, unknown>) {
     // not return a separate corpus count), so keep it equal to returned.
     total_matches: passages.length,
     returned: passages.length,
+    lang: (result.lang as string) ?? conceptLang,
+    ...(result.lang_note ? { lang_note: result.lang_note } : {}),
     passages,
     tip: 'language is the language of THIS EDITION\'s pages, which may itself be a translation — call get_book for work_language and text_role before citing a passage as an author\'s own wording. Semantic search always returns English translation text (snippet_language: "English"). Similarity calibration: 0.70+ strong match (quote with confidence); 0.55–0.70 worth reading but verify; below 0.55 mostly conceptual drift. Snippets tagged snippet_type:"summary" are AI continuity notes — paraphrase only, never quote. Always cite using short_url when presenting passages to users.',
   };
 }
 
+/**
+ * The `lang` argument, normalised (#4095).
+ *
+ * An ISO code names which EDITION of the text to read — Spanish covers 103
+ * books of 22,000, so every tool that takes it also has to say which edition it
+ * actually served. `en` and anything malformed collapse to English, the default
+ * store, rather than erroring: a bad language code should not fail a search.
+ */
+function langArg(args: Record<string, unknown>): string {
+  const raw = String(args.lang || '').trim().toLowerCase();
+  return /^[a-z]{2,3}$/.test(raw) ? raw : 'en';
+}
+
 async function searchWithinBook(args: Record<string, unknown>) {
+  const lang = langArg(args);
   const params = new URLSearchParams({ q: String(args.query) });
+  if (lang !== 'en') params.set('lang', lang);
   const result = await apiGet(`/books/${args.book_id}/search`, params) as Record<string, unknown>;
   const results = (result.results as Array<Record<string, unknown>>)?.map((r) => {
     const matches = r.matches as Array<Record<string, unknown>>;
@@ -245,6 +274,9 @@ async function searchWithinBook(args: Record<string, unknown>) {
   const coverage = result.semantic_coverage as { status?: string; caveat?: string } | undefined;
   return {
     book_id: args.book_id, query: result.query, total: result.total, returned: result.returned,
+    // Which edition of the book's text was searched, and which the snippets are
+    // in. Always present so a caller never has to infer it.
+    lang: result.lang ?? 'en',
     ...(frontCount ? { front_matter_results: frontCount } : {}),
     ...(coverage ? { semantic_coverage: coverage } : {}),
     results,
@@ -257,6 +289,11 @@ async function listBooks(args: Record<string, unknown>) {
   if (args.search) params.set('search', String(args.search));
   if (args.language) params.set('language', String(args.language));
   if (args.category) params.set('category', String(args.category));
+  // `has_edition` filters by a language the book can be READ in; `language`
+  // filters by the language printed on its leaves. A Latin book with a Spanish
+  // edition matches both.
+  const hasEdition = String(args.has_edition || '').trim().toLowerCase();
+  if (/^[a-z]{2,3}$/.test(hasEdition) && hasEdition !== 'en') params.set('has_edition', hasEdition);
   if (args.sort) params.set('sort', String(args.sort));
   if (args.limit) params.set('limit', String(Math.min(Number(args.limit), 200)));
   if (args.skip) params.set('skip', String(args.skip));
@@ -265,9 +302,20 @@ async function listBooks(args: Record<string, unknown>) {
   const books = (result.books as Array<Record<string, unknown>>)?.map((b) => ({
     id: b.id, title: b.display_title || b.title, author: b.author, language: b.language,
     published: b.published, pages_count: b.pages_count, pages_translated: b.pages_translated,
-    translation_percent: b.translation_percent, url: `https://sourcelibrary.org/book/${b.slug || b.id}`,
+    translation_percent: b.translation_percent,
+    ...(params.get('has_edition') ? {
+      [`pages_translated_${params.get('has_edition')}`]: b[`pages_translated_${params.get('has_edition')}`],
+      // The reader URL for that edition, which only exists because the filter
+      // guarantees the book has pages in it.
+      url_localized: `https://sourcelibrary.org/${params.get('has_edition')}/book/${b.slug || b.id}`,
+    } : {}),
+    url: `https://sourcelibrary.org/book/${b.slug || b.id}`,
   }));
-  return { total: result.total, showing: books?.length || 0, books };
+  return {
+    total: result.total, showing: books?.length || 0,
+    ...(params.get('has_edition') ? { has_edition: params.get('has_edition') } : {}),
+    books,
+  };
 }
 
 async function getBook(args: Record<string, unknown>) {
@@ -290,6 +338,11 @@ async function getBook(args: Record<string, unknown>) {
     ...languageApparatusFields(result as LanguageApparatusSource),
     categories: result.categories, pages_count: result.pages_count,
     pages_translated: result.pages_translated, doi: result.doi,
+    // Which languages this book can be READ in, and how many pages each covers
+    // (#4095). Always present; `{ en: 357 }` on most books, `{ en: 357, es: 357 }`
+    // where a localized edition exists. Pass the code as `lang` to get_quote /
+    // get_book_text / search_within_book to read that edition.
+    editions: editionsForBook(result),
     reading_summary: result.reading_summary, chapters: result.chapters,
     work_id: result.work_id,
     // What the volume's own running heads say it holds, with page spans. This
@@ -371,6 +424,8 @@ async function getBookText(args: Record<string, unknown>) {
   if (args.content) params.set('content', String(args.content));
   if (args.from !== undefined) params.set('from', String(args.from));
   if (args.to !== undefined) params.set('to', String(args.to));
+  const textLang = langArg(args);
+  if (textLang !== 'en') params.set('lang', textLang);
   const format = String(args.format || 'json');
   params.set('format', format);
 
@@ -453,6 +508,23 @@ const TRANSLATED_ORIGINAL_TIP =
   'translator, and do not present this passage as evidence of what the author wrote in their own ' +
   'tongue. To find an original-language witness, call list_editions with this book_id.';
 
+// The requested edition did not exist for this page and English was served
+// instead (#4095). Loud, because the failure it prevents is a caller presenting
+// English prose to a Spanish reader as "the Spanish edition" — the quote API
+// puts the fact in `quote.lang`, and this makes an agent read it.
+const LANG_FALLBACK_TIP = (requested: string) =>
+  `EDITION NOTICE — no ${requested} text exists for this page, so the English translation was served ` +
+  `(see quote.lang). Do not present it as the ${requested} edition. Most books have no ${requested} ` +
+  `edition at all: call get_book and read \`editions\` to see which languages a book can be read in, ` +
+  `or list_books with has_edition to browse only the ones that have it.`;
+
+/** Set when the served edition is not the one that was asked for. */
+function langFallback(result: Record<string, unknown>, requested: string): boolean {
+  const quote = result.quote as Record<string, unknown> | undefined;
+  const served = typeof quote?.lang === 'string' ? quote.lang : 'en';
+  return requested !== 'en' && served !== requested;
+}
+
 function translationNote(result: Record<string, unknown>): string | null {
   const quote = result.quote as Record<string, unknown> | undefined;
   const note = quote?.translation_note;
@@ -501,6 +573,8 @@ async function getQuote(args: Record<string, unknown>) {
   // Opt-in scan of the cited leaf (#3937): the response then carries
   // quote.page_image_url and the MCP layer attaches the image inline.
   if (args.include_image === true) params.set('include_image', 'true');
+  const quoteLang = langArg(args);
+  if (quoteLang !== 'en') params.set('lang', quoteLang);
 
   const result = await apiGet(`/books/${args.book_id}/quote`, params) as Record<string, unknown>;
 
@@ -534,6 +608,7 @@ async function getQuote(args: Record<string, unknown>) {
   const tips = [ocrOriginalQuote(result) ? OCR_ORIGINAL_TIP : QUOTE_TIP];
   if (hasRomanized(result)) tips.push(ROMANIZED_TIP);
   if (translationNote(result)) tips.push(TRANSLATED_ORIGINAL_TIP);
+  if (langFallback(result, quoteLang)) tips.push(LANG_FALLBACK_TIP(quoteLang));
 
   return {
     ...withCitationLink(result),
@@ -547,6 +622,7 @@ async function getQuote(args: Record<string, unknown>) {
 // single book by explicit list (pages:[...]) or inclusive range (from/to).
 async function getQuotes(args: Record<string, unknown>) {
   const bookId = String(args.book_id);
+  const batchLang = langArg(args);
   let pageNums: number[] = [];
   if (Array.isArray(args.pages)) {
     pageNums = (args.pages as unknown[]).map(Number).filter((n) => Number.isFinite(n));
@@ -566,6 +642,7 @@ async function getQuotes(args: Record<string, unknown>) {
       try {
         const quoteParams = new URLSearchParams({ page: String(page) });
         if (args.include_image === true) quoteParams.set('include_image', 'true');
+        if (batchLang !== 'en') quoteParams.set('lang', batchLang);
         const result = await apiGet(`/books/${bookId}/quote`, quoteParams) as Record<string, unknown>;
         // Same continuity signal get_quote returns. This is the tool where it
         // matters MOST — a batch is how a caller assembles a multi-page dossier,
@@ -608,6 +685,9 @@ async function getQuotes(args: Record<string, unknown>) {
   if (anyTranslationText || !anyOcrOriginal) tips.push(QUOTE_TIP);
   if (anyOcrOriginal) tips.push(OCR_ORIGINAL_TIP);
   if (anyRomanized) tips.push(ROMANIZED_TIP);
+  // A batch can be mixed — the Spanish worker's length guard skipped ~30 pages
+  // across 17 books — so one fallback in the range is enough to warn about.
+  if (settled.some((x) => langFallback(x as Record<string, unknown>, batchLang))) tips.push(LANG_FALLBACK_TIP(batchLang));
   if (anyTranslated) tips.push(TRANSLATED_ORIGINAL_TIP);
 
   return {
@@ -822,6 +902,7 @@ const TOOLS: Tool[] = [
         exclude_languages: { type: 'array', items: { type: 'string' }, description: 'Exclude these languages, e.g. ["Latin", "French", "German", "English"] to surface non-Western sources.' },
         year_from: { type: 'number' }, year_to: { type: 'number' },
         book_id: { type: 'string', description: 'Search within a specific book' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to read, e.g. "es". Default "en". Most books have only English — call get_book and read `editions`, or list_books with has_edition, to find the ones that do not. The response always states which edition it served.' },
         limit: { type: 'number', description: 'Max results per page (default 20, max 50)' },
         offset: { type: 'number', description: 'Pagination offset (use with limit to page through total_matches; default 0)' },
       },
@@ -843,6 +924,7 @@ const TOOLS: Tool[] = [
         year_from: { type: 'number', description: 'Restrict to books published in or after this year (filters out modern editions and translations).' },
         year_to: { type: 'number', description: 'Restrict to books published in or before this year.' },
         max_per_book: { type: 'number', description: 'Cap on passages from any single book. Useful when one book dominates the conceptual neighborhood; set to 1–2 for diverse author/work coverage.' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to read, e.g. "es". Default "en". Most books have only English — call get_book and read `editions`, or list_books with has_edition, to find the ones that do not. The response always states which edition it served.' },
         limit: { type: 'number', description: 'Max passages (default 15, max 50)' },
       },
       required: ['query'],
@@ -858,6 +940,7 @@ const TOOLS: Tool[] = [
       properties: {
         book_id: { type: 'string', description: 'The book ID to search within' },
         query: { type: 'string', description: 'Search query' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to read, e.g. "es". Default "en". Most books have only English — call get_book and read `editions`, or list_books with has_edition, to find the ones that do not. The response always states which edition it served.' },
       },
       required: ['book_id', 'query'],
     },
@@ -872,6 +955,7 @@ const TOOLS: Tool[] = [
       properties: {
         search: { type: 'string', description: 'Filter by title or author' },
         language: { type: 'string' }, category: { type: 'string' },
+        has_edition: { type: 'string', description: 'ISO code — return only books READABLE in that language, e.g. "es". Different from `language`, which is the language printed on the leaves of the scan: a Latin book with a Spanish edition matches language="Latin" AND has_edition="es". Each result then also carries url_localized.' },
         sort: { type: 'string', enum: ['recent-translation', 'recent', 'title-asc', 'title-desc'] },
         limit: { type: 'number', description: 'Max results (default 100, max 200)' },
       },
@@ -880,7 +964,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_book',
     title: 'Get Book',
-    description: 'READ PIPELINE step 1 — DISCOVER. START HERE for any named work or author. Returns the book\'s AI-generated summary, chapter list, edition metadata, DOI, page counts, IIIF manifest, and the cover image (inline, so you and the user can see the book). LANGUAGE: `language` is what is printed on THIS EDITION\'s leaves, which is frequently not the language the work was written in. Where they differ the response also carries `work_language`, `text_role` (original / period-translation / modern-translation) and a `translation_note` — read them before describing a passage as the author\'s own words, because an edition can be a translation of a translation (de Slane\'s 1863 French Muqaddimah, read in English, is English←French←Arabic). Absent `work_language` means the edition is in the work\'s own language. Use list_editions to find an original-language witness. The summary is typically a multi-paragraph orientation covering the book\'s argument, structure, and significance — often answering the question without further searching. Then: get_book_text to read a chapter or page range (step 2), get_quote / get_quotes to lock specific pages with full citation apparatus (step 3). search_within_book locates passages inside this book. MULTI-WORK VOLUMES: where the scans carry running heads, contains_works lists the works the volume ACTUALLY holds with their page spans, taken from the heads the printer put on each leaf. Trust it over the title — collected-works titles routinely name works the volume does not contain, and the volume holding a work often does not name it. If contains_works is absent the scans have no heads to read; status "insufficient-heads" means it was examined and could not be decided.',
+    description: 'READ PIPELINE step 1 — DISCOVER. START HERE for any named work or author. Returns the book\'s AI-generated summary, chapter list, edition metadata, DOI, page counts, IIIF manifest, and the cover image (inline, so you and the user can see the book). LANGUAGE: `language` is what is printed on THIS EDITION\'s leaves, which is frequently not the language the work was written in. Where they differ the response also carries `work_language`, `text_role` (original / period-translation / modern-translation) and a `translation_note` — read them before describing a passage as the author\'s own words, because an edition can be a translation of a translation (de Slane\'s 1863 French Muqaddimah, read in English, is English←French←Arabic). Absent `work_language` means the edition is in the work\'s own language. Use list_editions to find an original-language witness. The summary is typically a multi-paragraph orientation covering the book\'s argument, structure, and significance — often answering the question without further searching. Then: get_book_text to read a chapter or page range (step 2), get_quote / get_quotes to lock specific pages with full citation apparatus (step 3). search_within_book locates passages inside this book. MULTI-WORK VOLUMES: where the scans carry running heads, contains_works lists the works the volume ACTUALLY holds with their page spans, taken from the heads the printer put on each leaf. Trust it over the title — collected-works titles routinely name works the volume does not contain, and the volume holding a work often does not name it. If contains_works is absent the scans have no heads to read; status "insufficient-heads" means it was examined and could not be decided. EDITIONS: `editions` says which languages this book can be READ in and how many pages each covers ({ en: 357 } on most books, { en: 357, es: 357 } where a localized edition exists). Pass a code as `lang` to get_quote, get_quotes, get_book_text or search_within_book to read that edition; without it you get English.',
     annotations: { title: 'Get Book', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -903,6 +987,7 @@ const TOOLS: Tool[] = [
         from: { type: 'number', description: 'Start page number (inclusive). Use with to for explicit page ranges.' },
         to: { type: 'number', description: 'End page number (inclusive). Recommended chunk size: 50 pages. If the response has truncated=true, use the next from/to from truncation_note.' },
         format: { type: 'string', enum: ['json', 'plain'], description: 'json (default, structured with per-page fields) or plain (concatenated text with page markers)' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to read, e.g. "es". Default "en". Resolved PER PAGE: a page with no text in that language comes back as English, labelled `translation_lang: "en"` (json) or `[Translation — en]` (plain), and the response carries lang_coverage. Chapter text is materialized in English only, so `chapter` with a non-English `lang` is served from the chapter\'s page range instead.' },
       },
       required: ['book_id'],
     },
@@ -919,6 +1004,7 @@ const TOOLS: Tool[] = [
         page: { type: 'number', description: 'Page number' },
         context: { type: 'boolean', description: 'Also return the full text of the previous and next pages, so a sentence spanning the page break can be read whole. Set this when continuity.continues_from_previous or continues_on_next came back true on an earlier call, or whenever you are about to quote near a page edge.' },
         include_image: { type: 'boolean', description: 'Also return the scan of the cited leaf as an inline image (display size, ≤1200px). Set this when the user would benefit from SEEING the page — an illustrated leaf, a title page, a diagram, disputed OCR — or asks to see it. The image arrives as an MCP image block you can view and the user sees rendered.' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to quote, e.g. "es". Default "en". `quote.lang` on every response says which edition was actually served — where no such edition exists the English translation comes back with lang: "en" and a lang_note, and it must not be presented as the requested edition. The citation link follows the edition served.' },
       },
       required: ['book_id', 'page'],
     },
@@ -949,6 +1035,7 @@ const TOOLS: Tool[] = [
         from: { type: 'number', description: 'Start page (inclusive) of a range. Use with to.' },
         to: { type: 'number', description: 'End page (inclusive) of a range. Use with from.' },
         include_image: { type: 'boolean', description: 'Also return page scans as inline images (display size). The first 5 pages of the batch get inline image blocks; every entry still carries its page_image_url in the JSON.' },
+        lang: { type: 'string', description: 'ISO code of the EDITION to quote, e.g. "es". Default "en". Resolved per page — one batch can mix editions, so read `quote.lang` on each entry rather than assuming the whole dossier is in one language.' },
       },
       required: ['book_id'],
     },

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -40,6 +40,12 @@ export async function GET(request: NextRequest) {
   const yearMin = searchParams.get('year_min') ? parseInt(searchParams.get('year_min')!, 10) : undefined;
   const yearMax = searchParams.get('year_max') ? parseInt(searchParams.get('year_max')!, 10) : undefined;
   const maxPerBook = searchParams.get('max_per_book') ? parseInt(searchParams.get('max_per_book')!, 10) : undefined;
+  // Which TEXT store to search (#4095) — `en` reads `page_translations`,
+  // anything else reads the language-keyed `page_texts`. Page level only: book
+  // summaries have one embedding, in English, so `level=book` cannot honour it
+  // and says so rather than pretending.
+  const langParam = (searchParams.get('lang') || '').trim().toLowerCase();
+  const textLang = /^[a-z]{2,3}$/.test(langParam) ? langParam : 'en';
 
   if (!query || query.length < 2) {
     return NextResponse.json({ results: [], query: '' });
@@ -50,7 +56,7 @@ export async function GET(request: NextRequest) {
 
   if (level === 'page') {
     try {
-      const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, languages, excludeLanguages, yearMin, yearMax, maxPerBook });
+      const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, languages, excludeLanguages, yearMin, yearMax, maxPerBook, textLang });
       const bookIds = [...new Set(pages.map(p => p.book_id))];
       let slugMap: Record<string, string> = {};
       // Books hidden from the public reader (visible:false OR hidden:true). Embeddings
@@ -80,7 +86,7 @@ export async function GET(request: NextRequest) {
       logSearchQuery({
         request, route: 'search.semantic.page', query: query!,
         total: enriched.length, ms: Date.now() - _searchStart, ok: true,
-        filters: { language, languages, exclude_languages: excludeLanguages, year_min: yearMin, year_max: yearMax, max_per_book: maxPerBook },
+        filters: { language, languages, exclude_languages: excludeLanguages, year_min: yearMin, year_max: yearMax, max_per_book: maxPerBook, lang: textLang },
       });
       return NextResponse.json({
         results: enriched,
@@ -88,6 +94,8 @@ export async function GET(request: NextRequest) {
         total: enriched.length,
         mode: 'semantic',
         level: 'page',
+        // Which text store answered. Snippets are in THIS language.
+        lang: textLang,
       }, {
         headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
       });
@@ -204,6 +212,11 @@ export async function GET(request: NextRequest) {
       query,
       total: results.length,
       mode,
+      // Book-level embeddings are one per book, composed from the English
+      // summary and index. There is no localized store to point `lang` at, so
+      // say `en` plainly rather than echo a request we did not honour.
+      lang: 'en',
+      ...(textLang !== 'en' ? { lang_note: `Book-level semantic search has only English embeddings; use level=page for ${textLang} passages.` } : {}),
     }, {
       headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
     });

--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -24,27 +24,41 @@ export async function GET(request: NextRequest, context: RouteContext) {
     // shortlink encodes an ObjectId, so without the slug every shortlink we
     // publish would land on /book/<objectid>/page/<pageid> and take a second
     // redirect to reach its readable form. One projection, one hop.
+    // `?lang=<iso>` sends the reader to that language's twin (#4095). The code
+    // itself stays canonical — one shortlink per leaf, printable in a footnote
+    // — and the language is a preference laid over it.
+    const requested = (request.nextUrl.searchParams.get('lang') || '').trim().toLowerCase();
+    const lang = /^[a-z]{2,3}$/.test(requested) && requested !== 'en' ? requested : null;
+
     const db = await getReadDb();
     const [page, book] = await Promise.all([
       db.collection('pages').findOne({
         book_id: bookId,
         page_number: pageNumber,
       }) as unknown as Promise<Page | null>,
-      db.collection('books').findOne({ id: bookId }, { projection: { _id: 0, id: 1, slug: 1 } }),
+      db.collection('books').findOne(
+        { id: bookId },
+        // The counter decides whether the localized twin exists. Sending a
+        // reader to `/es/book/…` for a book with no Spanish pages costs them a
+        // second redirect back to English (i18n.md, "an /es URL is a promise"),
+        // so check here rather than hand off a URL that will bounce.
+        { projection: { _id: 0, id: 1, slug: 1, ...(lang ? { [`pages_translated_${lang}`]: 1 } : {}) } },
+      ),
     ]);
     const bookPath = (book?.slug as string) || bookId;
+    const prefix = lang && Number(book?.[`pages_translated_${lang}`] || 0) > 0 ? `/${lang}` : '';
 
     if (!page) {
       // Redirect to book page if specific page not found
       return NextResponse.redirect(
-        new URL(`/book/${bookPath}`, request.url),
+        new URL(`${prefix}/book/${bookPath}`, request.url),
         { status: 302 }
       );
     }
 
     // Redirect to the full page URL
     return NextResponse.redirect(
-      new URL(`/book/${bookPath}/page/${page.id}`, request.url),
+      new URL(`${prefix}/book/${bookPath}/page/${page.id}`, request.url),
       { status: 302 }
     );
   } catch (error) {

--- a/src/lib/citation.ts
+++ b/src/lib/citation.ts
@@ -36,7 +36,16 @@ export function generateCitations(
   bookId: string,
   pageId: string,
   baseUrl: string,
-  edition?: TranslationEdition
+  edition?: TranslationEdition,
+  /**
+   * The reading language of the text being cited (#4095). Only the two link
+   * fields change: the citation PROSE stays as it is, because the apparatus
+   * describes the printed source — author, place, year, the edition being
+   * quoted — none of which a translation into Spanish alters. Passing a
+   * language whose edition the book does not hold would mint a URL that 307s
+   * back to English, so callers pass it only when they served that edition.
+   */
+  lang?: string,
 ): Citation {
   // `published` is free text: 23% of the corpus is not a year, and ~1,500 books
   // carry raw Wikidata QuickStatements ("1573date QS:P571,+1573-...Z/9"). That
@@ -150,10 +159,11 @@ export function generateCitations(
   // API by id would otherwise mint a permanent citation to /book/<objectid>.
   const editionVersion = edition?.version;
   const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
+  const localePrefix = lang && lang !== 'en' ? `/${lang}` : '';
+  const url = `${baseUrl}${localePrefix}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
 
   // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
+  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl, lang);
 
   return {
     inline,

--- a/src/lib/page-translations.ts
+++ b/src/lib/page-translations.ts
@@ -25,6 +25,44 @@ export const TARGET_LANGUAGE_NAMES: Record<string, string> = {
 };
 
 /**
+ * The ISO codes a book-level EDITION counter can exist for —
+ * `books.pages_translated_<iso>`, written by that language's translation worker.
+ *
+ * Derived from the language-name table above so the two cannot drift: a
+ * language a reader can be offered is a language whose counter we look for.
+ * English is not here; its counter is the unsuffixed `pages_translated`.
+ */
+export const TEXT_EDITION_LANGS: string[] = Object.keys(TARGET_LANGUAGE_NAMES);
+
+/** Mongo projection for every edition counter, for `editionsForBook` below. */
+export const EDITION_COUNTER_PROJECTION: Record<string, 1> = {
+  pages_translated: 1,
+  ...Object.fromEntries(TEXT_EDITION_LANGS.map((l) => [`pages_translated_${l}`, 1])),
+};
+
+/**
+ * Which editions of a book's text exist, and how many pages each covers:
+ * `{ en: 357, es: 357 }`. Languages with no pages are omitted — a key with a
+ * zero would read as "we have a Spanish edition, it's empty", which is the
+ * opposite of true.
+ *
+ * The counters are the source of truth here rather than a per-page scan,
+ * because they are what every other surface gates on (the `/es` 307, the card
+ * tag, the derived collection). A caller comparing this against page-level
+ * results is comparing the same number the reader's URL was judged by.
+ */
+export function editionsForBook(book: Record<string, unknown>): Record<string, number> {
+  const out: Record<string, number> = {};
+  const en = Number(book.pages_translated || 0);
+  if (en > 0) out.en = en;
+  for (const l of TEXT_EDITION_LANGS) {
+    const n = Number(book[`pages_translated_${l}`] || 0);
+    if (n > 0) out[l] = n;
+  }
+  return out;
+}
+
+/**
  * All non-English translations available for a page, keyed by ISO code.
  * Folds the legacy `translation_es` into the map (map entry wins on conflict).
  */

--- a/src/lib/quote-text.ts
+++ b/src/lib/quote-text.ts
@@ -25,6 +25,7 @@ import type { Page } from '@/lib/types';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { markForExport } from '@/lib/provenance';
 import { isEnglishOriginalPage } from '@/lib/english-page-language';
+import { getTranslation } from '@/lib/page-translations';
 
 export type QuoteTextSource = 'translation' | 'ocr_original';
 
@@ -32,6 +33,13 @@ export interface QuotableText {
   /** Wrapper-stripped, verbatim, ready to be put inside quotation marks. */
   text: string;
   source: QuoteTextSource;
+  /**
+   * The ISO code of the language `text` is actually IN — not the one that was
+   * asked for. A caller that requested `es` and received `en` must be able to
+   * see that it happened; a quote is a claim about words, and a silent
+   * substitution makes the caller assert something it never checked (#4095).
+   */
+  lang: string;
 }
 
 /**
@@ -54,15 +62,28 @@ export const OCR_ORIGINAL_NOTE =
  * `translation.data` is nothing but a `<meta>` block has no verbatim text in it,
  * and serving an empty string as a quote is worse than saying so.
  */
-export function resolveQuoteText(page: Page, bookId: string): QuotableText | null {
+export function resolveQuoteText(page: Page, bookId: string, lang: string = 'en'): QuotableText | null {
+  // A non-English edition is tried FIRST and falls back to English, reporting
+  // which one it served. Never the other way round, and never silently: the
+  // Spanish edition covers 103 books out of 22,000, so the fallback is the
+  // common case and a caller that cannot see it has no way to know whether the
+  // words it is about to quote are the ones a Spanish reader sees.
+  if (lang && lang !== 'en') {
+    const localized = getTranslation(page, lang)?.data;
+    const cleaned = localized ? stripEditorialWrappers(localized).trim() : '';
+    if (cleaned) return { text: markForExport(cleaned, bookId), source: 'translation', lang };
+  }
+
   const translation = page.translation?.data
     ? stripEditorialWrappers(page.translation.data).trim()
     : '';
-  if (translation) return { text: markForExport(translation, bookId), source: 'translation' };
+  if (translation) return { text: markForExport(translation, bookId), source: 'translation', lang: 'en' };
 
   const ocrRaw = page.ocr?.data || '';
   const ocr = ocrRaw ? stripEditorialWrappers(ocrRaw).trim() : '';
-  if (ocr && isEnglishOriginalPage(ocrRaw)) return { text: ocr, source: 'ocr_original' };
+  // The leaf's own English. Its language is a property of the page, not of the
+  // request — asking for Spanish cannot make a 1570 English leaf Spanish.
+  if (ocr && isEnglishOriginalPage(ocrRaw)) return { text: ocr, source: 'ocr_original', lang: 'en' };
 
   return null;
 }

--- a/src/lib/shortlinks.ts
+++ b/src/lib/shortlinks.ts
@@ -177,8 +177,14 @@ export function decodeShortlink(code: string): { bookId: string; pageNumber: num
  * @param baseUrl - Optional base URL (e.g. "https://bph.sourcelibrary.org") used for tenant subdomains.
  *                  Defaults to https://sourcelibrary.org so existing API consumers are unchanged.
  */
-export function getShortUrl(bookId: string, pageNumber: number, pageId?: string, baseUrl?: string): string {
+export function getShortUrl(bookId: string, pageNumber: number, pageId?: string, baseUrl?: string, lang?: string): string {
   const base = (baseUrl || 'https://sourcelibrary.org').replace(/\/+$/, '');
+  // The CODE stays canonical — it encodes a book and a page and nothing else,
+  // which is what makes a shortlink safe to print in a footnote. The reading
+  // language rides as a query parameter that `/q/[code]` honours, so the same
+  // citation resolves to the Spanish reader for a Spanish reader without
+  // minting a second, divergent identifier for the same leaf (#4095).
+  const langQ = lang && lang !== 'en' ? `?lang=${encodeURIComponent(lang)}` : '';
   // Both ObjectIds and UUIDs encode statelessly (#3940); the page number still
   // has to fit the 2 bytes both schemes reserve for it.
   if (
@@ -186,15 +192,16 @@ export function getShortUrl(bookId: string, pageNumber: number, pageId?: string,
     Number.isInteger(pageNumber) && pageNumber >= 1 && pageNumber <= 65535
   ) {
     const code = encodeShortlink(bookId, pageNumber);
-    return `${base}/q/${code}`;
+    return `${base}/q/${code}${langQ}`;
   }
   // Fallback to the regular URL for anything else (other ID formats, or a page
   // number outside the encodable range).
+  const prefix = lang && lang !== 'en' ? `/${lang}` : '';
   if (pageId) {
-    return `${base}/book/${bookId}/page/${pageId}`;
+    return `${base}${prefix}/book/${bookId}/page/${pageId}`;
   }
   // Last resort: link to book page (user can navigate to specific page)
-  return `${base}/book/${bookId}#page-${pageNumber}`;
+  return `${base}${prefix}/book/${bookId}#page-${pageNumber}`;
 }
 
 /**

--- a/tests/unit/english-original-quote.test.ts
+++ b/tests/unit/english-original-quote.test.ts
@@ -135,7 +135,9 @@ describe('isEnglishOriginalPage', () => {
 describe('resolveQuoteText', () => {
   it('prefers a translation when one exists', () => {
     const r = resolveQuoteText(page(LATIN_PAGE, 'That which is below is as that which is above.'), 'bk');
-    expect(r).toEqual({ text: 'That which is below is as that which is above.', source: 'translation' });
+    // `lang` names the edition the text is IN — English here, and stated
+    // rather than assumed, because a page can now carry several (#4095).
+    expect(r).toEqual({ text: 'That which is below is as that which is above.', source: 'translation', lang: 'en' });
   });
 
   it('falls back to the transcription on an English-original leaf', () => {

--- a/tests/unit/quote-lang-edition.test.ts
+++ b/tests/unit/quote-lang-edition.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { resolveQuoteText } from '@/lib/quote-text';
+import { editionsForBook } from '@/lib/page-translations';
+import { generateCitations } from '@/lib/citation';
+import { getShortUrl } from '@/lib/shortlinks';
+import type { Book, Page } from '@/lib/types';
+
+/**
+ * Quoting a NON-ENGLISH edition (#4095).
+ *
+ * A page can now hold more than one translation — English on
+ * `pages.translation`, everything else on `pages.translations.<iso>` — and 103
+ * books of 22,000 have a Spanish one. So the fallback to English is the COMMON
+ * case, and the property that matters is not "Spanish comes back when it
+ * exists" (easy) but "the response SAYS which edition it served" (silent when
+ * wrong, and wrong in a way that makes a caller assert something it never
+ * checked: a quote is a claim about words).
+ *
+ * The citation links are pinned alongside, because they are the other half of
+ * the same claim — a `/es` URL for a book with no Spanish pages 307s back to
+ * English, so the link has to follow the edition SERVED, never the one asked
+ * for.
+ */
+
+const page = (over: Record<string, unknown> = {}): Page => ({
+  id: 'p1',
+  book_id: 'b1',
+  page_number: 42,
+  ocr: { data: 'Lapis philosophorum est.' },
+  translation: { data: 'The philosophers stone is.' },
+  ...over,
+} as unknown as Page);
+
+describe('resolveQuoteText — which edition, and saying so', () => {
+  it('serves the requested edition and labels it', () => {
+    const got = resolveQuoteText(page({ translations: { es: { data: 'La piedra filosofal es.' } } }), 'b1', 'es');
+    expect(got?.lang).toBe('es');
+    expect(got?.text).toContain('La piedra filosofal');
+  });
+
+  it('falls back to English and says lang: "en" — never silently', () => {
+    const got = resolveQuoteText(page(), 'b1', 'es');
+    expect(got?.text).toContain('The philosophers stone');
+    // The whole point. A caller that reads `lang` sees the substitution; one
+    // that assumes its request was honoured does not.
+    expect(got?.lang).toBe('en');
+  });
+
+  it('labels English as English when English was asked for', () => {
+    expect(resolveQuoteText(page(), 'b1')?.lang).toBe('en');
+    expect(resolveQuoteText(page(), 'b1', 'en')?.lang).toBe('en');
+  });
+
+  it('folds the legacy translation_es field in', () => {
+    const got = resolveQuoteText(page({ translation_es: { data: 'La piedra.' } }), 'b1', 'es');
+    expect(got?.lang).toBe('es');
+  });
+
+  it('does not let a language request change what an English-original leaf is', () => {
+    // A 1570 English leaf has no translation and needs none. Asking for Spanish
+    // cannot make it Spanish — the leaf's language is a property of the page.
+    const englishLeaf = page({
+      translation: undefined,
+      ocr: { data: '<language>English</language>The Mathematicall Praeface, wherein the excellencie of Arithmetike and Geometrie is declared unto all men of good will and studious minde.' },
+    });
+    const got = resolveQuoteText(englishLeaf, 'b1', 'es');
+    expect(got?.source).toBe('ocr_original');
+    expect(got?.lang).toBe('en');
+  });
+});
+
+describe('editionsForBook', () => {
+  it('reports every language the book can be read in, with page counts', () => {
+    expect(editionsForBook({ pages_translated: 357, pages_translated_es: 357 })).toEqual({ en: 357, es: 357 });
+  });
+
+  it('omits a language with zero pages rather than reporting an empty edition', () => {
+    // `{ es: 0 }` would read as "there is a Spanish edition, it is empty",
+    // which is the opposite of true.
+    expect(editionsForBook({ pages_translated: 12, pages_translated_es: 0 })).toEqual({ en: 12 });
+    expect(editionsForBook({ pages_translated: 12 })).toEqual({ en: 12 });
+  });
+
+  it('is empty for an untranslated book', () => {
+    expect(editionsForBook({ pages_count: 200 })).toEqual({});
+  });
+});
+
+describe('citation links follow the edition served', () => {
+  const book = { id: 'b1', slug: 'splendor-solis', title: 'Splendor Solis', author: 'Trismosin', published: '1582' } as unknown as Book;
+
+  it('prefixes the reader URL with the locale', () => {
+    const es = generateCitations(book, 42, '6953b56577f38f6761bd979d', 'p1', 'https://sourcelibrary.org', undefined, 'es');
+    expect(es.url).toContain('/es/book/splendor-solis');
+  });
+
+  it('leaves English URLs unprefixed — every DOI and footnote already points there', () => {
+    const en = generateCitations(book, 42, '6953b56577f38f6761bd979d', 'p1', 'https://sourcelibrary.org');
+    expect(en.url).toContain('/book/splendor-solis');
+    expect(en.url).not.toContain('/es/');
+    expect(en.short_url).not.toContain('lang=');
+  });
+
+  it('keeps the shortlink CODE canonical and carries the language as a parameter', () => {
+    // One shortlink per leaf, printable in a footnote. A second, divergent code
+    // per language would be a second identifier for the same page.
+    const en = getShortUrl('6953b56577f38f6761bd979d', 42);
+    const es = getShortUrl('6953b56577f38f6761bd979d', 42, undefined, undefined, 'es');
+    expect(es).toBe(`${en}?lang=es`);
+  });
+});


### PR DESCRIPTION
Workstreams **3 and 4** of #4095, on top of #4130. That PR made the Spanish text *searchable*; this one makes it **retrievable** — an MCP client can ask for it, a citation points at it, an export ships it.

## The parameter

`lang`, an ISO code, default `en`:

| surface | what it does |
|---|---|
| `/api/books/:id/quote` | quotes that edition; `quote.lang` says which one came back |
| `/api/books/:id/text` | per-page; adds `translation_lang` and `lang_coverage` |
| `/api/books/:id/download` | PDF/EPUB/TXT in that edition, language in the filename |
| `/api/search/semantic` | page level; book level says `lang: "en"` and why |
| `/q/<code>?lang=es` | redirects to the localized reader when the book has one |
| MCP `get_quote`, `get_quotes`, `get_book_text`, `search_within_book`, `search_translations`, `search_concept` | same, with an EDITION NOTICE tip when a fallback happened |
| MCP `list_books` | `has_edition=es` — books READABLE in that language |
| MCP `get_book` | returns `editions: { en: 357, es: 357 }` |

`get_book`'s `editions` map is the discovery path: without it an agent finds a Spanish edition only by accident.

## What this PR is really about: the fallback

103 books of 22,000 have a Spanish edition, so **falling back to English is the common case, not the edge one** — and a quote is a claim about words, so a silent substitution makes the caller assert something it never checked.

Every response therefore states the edition it actually served: `quote.lang` + `lang_note`, `translation_lang` + `lang_coverage` on `/text`, `lang` on both search routes, and an MCP tip that fires **only** when the fallback happened, telling the agent to call `get_book`/`list_books` rather than guess.

Resolution is **per page**, not per book: the Spanish worker's length guard skipped ~30 pages across 17 otherwise-complete books, so a book-level claim would be wrong on exactly the pages a reader would notice. One `get_quotes` batch can legitimately mix editions, and the tips say so.

## Citations

Links follow the edition **served**, never the one requested — an `/es` URL for a book we fell back on would 307 straight back to English.

The shortlink **code stays canonical**: one identifier per leaf, printable in a footnote. The language rides as `?lang=es`, which `/q/<code>` honours — checking `pages_translated_<iso>` first, so it never hands out a URL that bounces. Minting a second code per language would have made two identifiers for one page.

Citation *prose* is untouched. The apparatus describes the printed source — author, place, year, edition — none of which a translation into Spanish alters.

## Two places the shape differs, deliberately

**Chapter text is materialized in English only** (the pipeline stitches it from `translation.data`). `get_book_text(chapter, lang=es)` therefore resolves the chapter to its page range and serves those pages, rather than returning English under a Spanish request.

**Downloads take the parameter once, at the fetch.** The requested edition is substituted into `page.translation` immediately after the pages load, so fifteen format generators — PDF, six EPUB variants, TXT, markdown, the facing-page builders — keep reading one field unchanged. The language goes into the **filename** (`plato-es-translation.pdf`): a downloaded file is read months later out of a folder, where a response header cannot reach it.

## Corpus snapshot

Other editions ride in a `translations` map per page record (`--editions=es`, default), **never in place of `translation`** — the English text is what the OCR is aligned to and what existing consumers read, and a Spanish page arriving under `translation` would silently change the language of a corpus somebody already trained on.

Their words are **not** added to the shard totals. A page with a Spanish rendering is still one page of corpus; `edition_pages` in the manifest counts localized pages separately, so no figure quoted from it is inflated by holding two renderings of one passage.

## `lang` is not `language`

`language` keeps its meaning everywhere: the language printed on the leaves of the scan. `lang` chooses which rendering of the text to read. A Latin book with a Spanish edition matches `language=Latin` **and** `lang=es`. Both rules are now in `llms.txt` for the agents that read it, and in `invariants/text-helpers-and-exports.md` for us.

## Tests

`tests/unit/quote-lang-edition.test.ts` pins the loud fallback, the `editions` map (a language with zero pages is **omitted**, not reported as an empty edition), and that the citation link follows the served edition. One existing assertion in `english-original-quote.test.ts` gained the new `lang: 'en'` field.

## Out of scope

`/es/search` — still blocked on localizing the search page's chrome (#4119). Tenant reading rooms keep the English quote route untouched (`tenant-lockdown.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ
