### PR TITLE
docs(i18n): rule 7 — language travels in the request for generated surfaces

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -84,6 +84,21 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    the stale key. **Do not reintroduce a cross-URL language preference in any
    form.**
 
+7. **For a generated surface, the language travels in the REQUEST, not just the
+   prompt.** A model answers in whatever language it is addressed in — that is
+   free and proves nothing. What it cannot do on its own is quote the edition we
+   hold: the Librarian's tools read `translation.data` (English), so a Spanish
+   reader got Spanish prose wrapped around English quotes, or the model's own
+   re-translation of them. `POST /api/embassy/chat` therefore takes `lang` (from
+   the URL locale), and the text tools swap in `pages.translations.<lang>` for
+   every page they return, tagging each passage `[text: Spanish edition]` or
+   `[text: English only]` so the model quotes ours where it exists and *labels*
+   the English where it doesn't — rule 4, applied to quotations. Links the model
+   is handed carry the prefix (`siteBase(lang)`), and the citation verifier
+   accepts it (`SITE_HOST_PATTERN`). Search queries stay English: the index is
+   English. Verify such a surface by matching a returned blockquote against the
+   stored edition, never by noticing that the answer is in Spanish (#4116, #4134).
+
 ## Adding a language (checklist)
 
 1. `Locale` + `SUPPORTED_LOCALES` + prefix check in `src/lib/i18n.ts`; fill


### PR DESCRIPTION
Up-ratchet from the Spanish librarian session (#4116 / #4134): a model answering in Spanish proves nothing; the tools must be handed the edition we hold, labelled, and the check is a blockquote matched against `translations.es`, not the language of the prose. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZ59KjPZ6Fyt8kzgcopknR