### PR TITLE
docs(i18n): verify a localized surface by structure, not by its words (+ fix a wrong issue ref)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -183,3 +183,20 @@ link the component writes, and it knew about tenants and embeds but not
 locales — so share links, the page-metadata link and in-book search silently
 dropped `/es`. If you add a prefix concept anywhere, check who else composes a
 URL from it.
+
+## Verifying a localized surface — probe on structure, not on words
+
+Once a surface is localized, **every string-literal check against it is
+locale-specific**, and a probe written in English reports "missing" on a twin
+that is working perfectly. On 2026-08-21 a production check for the reader's
+EN/ES control grepped `aria-label="Reading language"`; the Spanish twin renders
+`Idioma de lectura`, so the probe said the control was absent from `/es` — a
+regression that did not exist, on the exact page the session had just shipped.
+
+Probe on what does not translate: the `href` (`/book/…` vs `/es/book/…`), a
+`role`, `aria-current`, a `data-` attribute. If you must match visible text,
+match the set for every locale, and run the probe first against the locale you
+expect to PASS — a "not found" is worthless until the probe has returned "found"
+somewhere (`lesson: a probe needs a positive control`). The same trap catches
+any check written against a surface that later gets translated, so a grep that
+hard-codes English is a latent false alarm even when it passes today.

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -402,7 +402,7 @@ export default function PageEditorClient({
 
   // EN/ES as LINKS between `/book/…` and `/es/book/…`, not as a view toggle:
   // the language a reader is in is always the URL they are on (#4112). It rides
-  // INSIDE the reader's own header (#4116) rather than in a band above it — a
+  // INSIDE the reader's own header (#4124) rather than in a band above it — a
   // separate strip made the ~100 books with a Spanish edition look like they
   // carried a site notice, and put the one control that changes what you are
   // reading outside the bar holding every other reading control.

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -196,7 +196,7 @@ interface TranslationEditorProps {
   /**
    * EN/ES reading-language links, built by the caller (PageEditorClient) because
    * the target URLs are locale paths, not editor state. Rendered inside the
-   * reader header rather than as a band above it (#4116); null when the book has
+   * reader header rather than as a band above it (#4124); null when the book has
    * no Spanish edition, or on a tenant/embed/pinned-version surface.
    */
   languageSwitch?: ReactNode;
@@ -503,7 +503,7 @@ export default function TranslationEditor({
   // The panel TOGGLE names the panel; the panel's own header names the language
   // it holds (translationLangLabel, above). Labelling the toggle with the target
   // language put a control reading "Español" a few pixels from the EN/ES
-  // reading-language links (#4116) — two language-shaped controls side by side,
+  // reading-language links (#4124) — two language-shaped controls side by side,
   // only one of which changes the language. On an English-language book the
   // panel is not a translation at all (the OCR panel holds the diplomatic
   // transcription, this one the modernization), so it keeps its own name.


### PR DESCRIPTION
Two prose fixes, no behaviour change.

## 1. A rule for `.claude/docs/i18n.md`

From a false alarm this session produced against its own work. Verifying #4124 on production, a check for the reader's EN/ES control grepped `aria-label="Reading language"`. The Spanish twin renders `Idioma de lectura` — so the probe reported the control missing from `/es`, on the page that had just shipped it. Structural checks (the `href`, `aria-current`) showed it rendering correctly in both locales.

The generalization: once a surface is localized, every string-literal check against it is locale-specific, and a grep hard-coding English is a latent false alarm even while it passes today. Probe on what doesn't translate; run the probe against the locale you expect to pass before believing a "not found" — the positive-control rule, applied to locales.

## 2. Corrects a wrong cross-reference in three code comments

#4124 and #4133 landed comments citing **"#4116"** for the reader-header work. #4116 is an unrelated closed issue (Spanish librarian); the correct reference is #4124. Fixed in `PageEditorClient.tsx` and `TranslationEditor.tsx` (×2). The legitimate `#4116` in `src/app/es/librarian/page.tsx` is untouched.

Bundling this with the doc change rather than opening a third PR: both are the same class of fix — prose that points somewhere wrong — and splitting a three-token correction into its own PR costs more review than it saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjRSQoY7i6PndpRXWyQLBf