### PR TITLE
fix(es): the edition-fallback notice read as Spanish inside an English warning (#4095)

### DIFF
--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -185,7 +185,7 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
         text_source: quotable.source,
         lang: quotable.lang,
         ...(requestedLang !== quotable.lang
-          ? { lang_note: `No ${requestedLang} edition of this page; the text above is the English translation (lang: "${quotable.lang}"). Do not present it as the ${requestedLang} edition.` }
+          ? { lang_note: `This page has no text in "${requestedLang}", so the English translation was served (lang: "${quotable.lang}"). Do not present it as the "${requestedLang}" edition.` }
           : {}),
         ...(quotable.source === 'ocr_original' ? { transcription_note: OCR_ORIGINAL_NOTE } : {}),
         page: pageNumber,

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -427,7 +427,7 @@ export const GET = withApiAuth(async (
           title: localizedChapterRange.title,
           pageStart: localizedChapterRange.from,
           pageEnd: localizedChapterRange.to,
-          note: `Chapter text is materialized in English only; this ${requestedLang} response is assembled from the chapter's page range.`,
+          note: `Chapter text is materialized in English only; this "${requestedLang}" response is assembled from the chapter's page range.`,
         },
       } : {}),
       total_pages: book.pages_count || pages.length,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -168,7 +168,7 @@ async function searchPassages(args: Record<string, unknown>) {
     offset,
     lang: textLang,
     ...(textLang !== 'en' ? {
-      lang_note: `Searched the ${textLang} edition. Only books that HAVE a ${textLang} edition can appear — this is a narrower corpus than the default English search, not a smaller result set for the same books.`,
+      lang_note: `Searched the "${textLang}" edition. Only books that HAVE an edition in that language can appear — this is a narrower corpus than the default English search, not a smaller result set for the same books.`,
     } : {}),
     // BUG 2: surface the backend's lane-timeout signal so callers know the count
     // may be incomplete when a search lane degraded. Only present when true.
@@ -513,10 +513,10 @@ const TRANSLATED_ORIGINAL_TIP =
 // English prose to a Spanish reader as "the Spanish edition" — the quote API
 // puts the fact in `quote.lang`, and this makes an agent read it.
 const LANG_FALLBACK_TIP = (requested: string) =>
-  `EDITION NOTICE — no ${requested} text exists for this page, so the English translation was served ` +
-  `(see quote.lang). Do not present it as the ${requested} edition. Most books have no ${requested} ` +
-  `edition at all: call get_book and read \`editions\` to see which languages a book can be read in, ` +
-  `or list_books with has_edition to browse only the ones that have it.`;
+  `EDITION NOTICE — this page has no text in "${requested}", so the English translation was served ` +
+  `(see quote.lang). Do not present it as the "${requested}" edition. Most books have no edition in ` +
+  `that language at all: call get_book and read \`editions\` to see which languages a book can be read ` +
+  `in, or list_books with has_edition to browse only the ones that have it.`;
 
 /** Set when the served edition is not the one that was asked for. */
 function langFallback(result: Record<string, unknown>, requested: string): boolean {


### PR DESCRIPTION
`/api/books/:id/quote?lang=es` on a book with no Spanish edition returned:

> `No es edition of this page; the text above is the English translation…`

`No es` is a Spanish clause. This is a string whose entire purpose is to be parsed correctly by a model deciding whether it may present the text as the Spanish edition — the one place an ambiguity of exactly this kind should not sit.

Rephrased so the code is always quoted and never adjacent to a word it could be read as:

> `This page has no text in "es", so the English translation was served (lang: "en"). Do not present it as the "es" edition.`

Same treatment for the MCP EDITION NOTICE tip, the `search_translations` `lang_note`, and the localized chapter note.

Strings only. Caught by curling production after #4140 deployed, not by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ