### PR TITLE
feat(es): the English collection page offers its Spanish twin

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -25,6 +25,7 @@ import { ftRenderProps, type FtRenderSource } from '@/lib/first-translation/rend
 import { browseBooks } from '@/lib/books-catalog';
 import { supabase } from '@/lib/supabase';
 import { authorUrl } from '@/lib/slugify';
+import { localizedEditionFilter } from '@/lib/localized';
 import { ObjectId } from 'mongodb';
 
 // ISR: rebuild at most once per day
@@ -722,6 +723,17 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     8000, [],
   );
 
+  // How many books here are readable in Spanish — translated into it, or written
+  // in it (#4120). Only used to decide whether this page offers its Spanish twin,
+  // so it fails to 0 (no link) rather than blocking the render.
+  const spanishBookCount = await withTimeout(
+    db.collection('books').countDocuments(
+      { collections: id, visible: true, ...localizedEditionFilter('es'), ...(tenantId ? { tenantId } : {}) },
+      { maxTimeMS: 3000 },
+    ),
+    3000, 0,
+  );
+
   const { _id, ...collectionClean } = collection;
 
   // Sanitize thumbnails to prevent /api/image wrapper URLs from crashing Next.js Image
@@ -839,6 +851,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     exhibitionBooks,
     childCollections: (childCollections.map(({ _id, ...rest }) => rest) as ChildCollection[])
       .sort((a, b) => childCardCount(b).count - childCardCount(a).count),
+    spanishBookCount,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     artworks: artworks as any[],
   };
@@ -919,7 +932,7 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
   // tenant-scoped mismatch can still return null here.
   if (!data) notFound();
 
-  const { collection, books, highlights: curatedHighlightsData, firstTranslations, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, galleryTotalCount, exhibition, exhibitionBooks, childCollections, artworks } = data;
+  const { collection, books, highlights: curatedHighlightsData, firstTranslations, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, galleryTotalCount, exhibition, exhibitionBooks, childCollections, artworks, spanishBookCount } = data;
 
   // Collections that carry an Index catalogue (index_catalogs editions) render
   // the catalogue browser as their centrepiece — hide the Visual Art section
@@ -1130,6 +1143,25 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
               <>
                 <span className="w-px h-4 bg-white/20" />
                 <span>{languages.map((l: { lang: string }) => l.lang).join(', ')}</span>
+              </>
+            )}
+            {/* The bridge only ran one way: the Spanish twin links here ("Ver esta
+                colección … en inglés") and this page had NO reference to
+                /es/collections at all, so a Spanish reader was told to go read
+                English and an English reader never learned a Spanish page existed.
+                Shown only when the collection really has Spanish books — a link
+                into an empty Spanish page is the broken promise the route gate
+                exists to prevent. Tenants keep their own prefix and never get it. */}
+            {!tenantSlug && spanishBookCount > 0 && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <Link
+                  href={`/es/collections/${collection.slug || id}`}
+                  hrefLang="es"
+                  className="hover:text-white/80 transition-colors underline underline-offset-2 decoration-white/30"
+                >
+                  Leer en español ({spanishBookCount.toLocaleString('es-ES')})
+                </Link>
               </>
             )}
           </div>


### PR DESCRIPTION
## The bug

The cross-language bridge ran **one way only**.

The Spanish collection page links here — *"Ver esta colección con su aparato completo (en inglés)"*. This page had **zero** references to `/es/collections`; `git grep` returns none.

So a Spanish reader was told to go read English, and an English reader never learned a Spanish page existed. Derek found it by asking whether `/collections/en-espanol` should send him to `/es`.

## The fix

A "Leer en español (N)" link in the hero meta row, beside the book count and languages.

Shown **only when the collection really has Spanish books**, counted with `localizedEditionFilter('es')` so it agrees with every other /es surface about what "has a Spanish edition" means (#4120: translated into it **or** written in it). A link into an empty Spanish page is exactly the broken promise the route gate exists to prevent.

The count is wrapped in `withTimeout(…, 3000, 0)` — it only decides whether to offer a link, so it fails to *no link* rather than blocking the render.

Tenant subdomains never get it: they keep their own prefix and have no /es twin.

## Not a redirect

`/collections/en-espanol` stays put. It is the English page *about* Spanish books, an English-speaking browser has a legitimate reason to see it, and redirecting on the slug would strand arrivals from search.

## Verification

`npx tsc --noEmit` clean; **2,853 tests** pass.

## Related, not fixed here

- The `/es` collection page is a deliberately thin twin — the English one carries ~1,700 lines of editorial apparatus the Spanish one was scoped out of (#4079). That gap is a design question, filed separately.
- The intermittent black hero plate: measured, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC54GMgv8cdmbVojFrwhGq