### PR TITLE
feat(reader): a Type toggle, and the fount for every early Aldine set in this roman

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -247,10 +247,12 @@ h1, h2, h3, h4 {
    English translation — are then set in the facsimile traced from that book's
    own pages, with Cardo behind it for scripts the fount never had.
    Display only: the DOM text is untouched, so search, copy and citation are
-   unaffected.
+   unaffected. The reader can switch back to the library's face from the
+   reading-settings popover — that sets data-reader-fount="modern" on the reader
+   root, and these rules stop matching.
 --------------------------------------------------------------------------- */
-.aldine-fount [data-reader-panel] .prose-manuscript,
-.aldine-fount [data-reader-panel] > .prose {
+.aldine-fount [data-reader-fount="original"] [data-reader-panel] .prose-manuscript,
+.aldine-fount [data-reader-fount="original"] [data-reader-panel] > .prose {
   font-family: var(--font-aldine-aetna), var(--font-cardo), 'Newsreader', Georgia, serif;
   /* liga: the ct/ſt/fi sorts. calt: rotate the three impressions of each common
      letter so neighbours are never the same cast — hand-set, not typeset. */
@@ -263,7 +265,7 @@ h1, h2, h3, h4 {
    German-source and modernised views use a `.prose` div that sets font-size
    inline (a React style prop beats a stylesheet rule whatever its specificity),
    so that one — and only that one — needs !important. */
-.aldine-fount [data-reader-panel] > .prose {
+.aldine-fount [data-reader-fount="original"] [data-reader-panel] > .prose {
   font-size: calc(var(--reader-font-size, 15px) * 1.04) !important;
 }
 

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -30,7 +30,8 @@ import {
   AlertCircle,
   Crosshair,
 } from 'lucide-react';
-import { useReaderPreferences, type ReaderTheme } from '@/hooks/useReaderPreferences';
+import { useReaderPreferences, type ReaderTheme, type ReaderFount } from '@/hooks/useReaderPreferences';
+import { isAldineFount } from '@/lib/fonts/aldine-fount';
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import TraceAlignment, { type TraceStatus } from '@/components/reader/TraceAlignment';
 import AiBadge from '@/components/ui/AiBadge';
@@ -520,7 +521,9 @@ export default function TranslationEditor({
     translation: page.translation?.data || '',
     summary: page.summary?.data || '',
   });
-  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize, theme, setTheme } = useReaderPreferences();
+  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize, theme, setTheme, fount, setFount } = useReaderPreferences();
+  // Does this book have a facsimile of its own type? (src/lib/fonts/aldine-fount.ts)
+  const hasFount = isAldineFount(book.id);
 
   // Modernized text toggle
   const [modernizedMode, setModernizedMode] = useState(() => {
@@ -1238,7 +1241,7 @@ export default function TranslationEditor({
     const isFullyTranslated = ocrText && translationText;
 
     return (
-      <div className="h-screen flex flex-col" data-reader-theme={theme} style={{ background: 'var(--bg-cream)' }}>
+      <div className="h-screen flex flex-col" data-reader-theme={theme} data-reader-fount={hasFount ? fount : undefined} style={{ background: 'var(--bg-cream)' }}>
         {/* Header - Two rows on mobile, one row on desktop */}
         <header className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
           {/* Row 1: Back + Title ... Chapter Nav ... Page Navigator */}
@@ -1502,6 +1505,38 @@ export default function TranslationEditor({
                           </button>
                         ))}
                       </div>
+                      {/* Books we hold a facsimile of their own type (#4083): let the
+                          reader choose the book's letterforms or the library's reading face. */}
+                      {hasFount && (
+                        <>
+                          <div className="text-[10px] uppercase tracking-widest text-center mt-4 mb-3" style={{ color: 'var(--text-muted)' }}>{rs.typeface}</div>
+                          <div className="flex items-center justify-between gap-2">
+                            {([
+                              ['original', rs.typeOriginal, rs.typeOriginalTitle, 'var(--font-aldine-aetna), var(--font-cardo), Georgia, serif'],
+                              ['modern', rs.typeModern, rs.typeModernTitle, "'Newsreader', Georgia, serif"],
+                            ] as [ReaderFount, string, string, string][]).map(([key, label, hint, family]) => (
+                              <button
+                                key={key}
+                                onClick={() => setFount(key)}
+                                className="flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+                                style={{
+                                  background: 'var(--bg-white)',
+                                  color: 'var(--text-primary)',
+                                  borderColor: fount === key ? 'var(--accent-rust)' : 'var(--border-light)',
+                                }}
+                                aria-pressed={fount === key}
+                                title={hint}
+                              >
+                                <span className="text-base leading-none" style={{ fontFamily: family }}>Aa</span>
+                                <span className="text-[10px]">{label}</span>
+                              </button>
+                            ))}
+                          </div>
+                          <p className="text-[10px] leading-snug mt-2 text-center" style={{ color: 'var(--text-muted)' }}>
+                            {rs.typeCaption}
+                          </p>
+                        </>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/hooks/useReaderPreferences.ts
+++ b/src/hooks/useReaderPreferences.ts
@@ -9,6 +9,11 @@ const STEP = 2;
 const DEFAULT_SIZE = 18;
 
 export type ReaderTheme = 'paper' | 'sepia' | 'night';
+/** Which type the text is set in, for books we hold a facsimile fount for
+ *  (see src/lib/fonts/aldine-fount.ts). 'original' = the book's own letterforms. */
+export type ReaderFount = 'original' | 'modern';
+const FOUNTS: ReaderFount[] = ['original', 'modern'];
+const DEFAULT_FOUNT: ReaderFount = 'original';
 const THEMES: ReaderTheme[] = ['paper', 'sepia', 'night'];
 const DEFAULT_THEME: ReaderTheme = 'paper';
 
@@ -20,10 +25,11 @@ function computeLineHeight(fontSize: number): number {
 interface ReaderPrefs {
   fontSize: number;
   theme: ReaderTheme;
+  fount: ReaderFount;
 }
 
 function loadPrefs(): ReaderPrefs {
-  const defaults: ReaderPrefs = { fontSize: DEFAULT_SIZE, theme: DEFAULT_THEME };
+  const defaults: ReaderPrefs = { fontSize: DEFAULT_SIZE, theme: DEFAULT_THEME, fount: DEFAULT_FOUNT };
   if (typeof window === 'undefined') return defaults;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -32,6 +38,7 @@ function loadPrefs(): ReaderPrefs {
       return {
         fontSize: parsed.fontSize >= MIN_SIZE && parsed.fontSize <= MAX_SIZE ? parsed.fontSize : DEFAULT_SIZE,
         theme: THEMES.includes(parsed.theme) ? parsed.theme : DEFAULT_THEME,
+        fount: FOUNTS.includes(parsed.fount) ? parsed.fount : DEFAULT_FOUNT,
       };
     }
   } catch { /* ignore */ }
@@ -47,11 +54,13 @@ function savePrefs(prefs: ReaderPrefs) {
 export function useReaderPreferences() {
   const [fontSize, setFontSize] = useState(DEFAULT_SIZE);
   const [theme, setThemeState] = useState<ReaderTheme>(DEFAULT_THEME);
+  const [fount, setFountState] = useState<ReaderFount>(DEFAULT_FOUNT);
 
   useEffect(() => {
     const prefs = loadPrefs();
     setFontSize(prefs.fontSize);
     setThemeState(prefs.theme);
+    setFountState(prefs.fount);
   }, []);
 
   const increaseFontSize = useCallback(() => {
@@ -80,6 +89,11 @@ export function useReaderPreferences() {
     savePrefs({ ...loadPrefs(), theme: next });
   }, []);
 
+  const setFount = useCallback((next: ReaderFount) => {
+    setFountState(next);
+    savePrefs({ ...loadPrefs(), fount: next });
+  }, []);
+
   return {
     fontSize,
     lineHeight: computeLineHeight(fontSize),
@@ -91,5 +105,7 @@ export function useReaderPreferences() {
     isDefaultSize: fontSize === DEFAULT_SIZE,
     theme,
     setTheme,
+    fount,
+    setFount,
   };
 }

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -337,6 +337,12 @@ export interface ReaderStrings {
   themePaper: string;
   themeSepia: string;
   themeNight: string;
+  typeface: string;
+  typeOriginal: string;
+  typeModern: string;
+  typeOriginalTitle: string;
+  typeModernTitle: string;
+  typeCaption: string;
   // footer + search
   likeThisPage: string;
   searchThisBook: string;
@@ -419,6 +425,12 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     themePaper: 'Paper',
     themeSepia: 'Sepia',
     themeNight: 'Night',
+    typeface: 'Type',
+    typeOriginal: 'Original',
+    typeModern: 'Modern',
+    typeOriginalTitle: 'Set in the type this book was printed in',
+    typeModernTitle: 'Set in the reading face used across the library',
+    typeCaption: 'Griffo\u2019s roman for Aldus Manutius, traced from the 1496 De Aetna.',
 
     likeThisPage: 'Like this page',
     searchThisBook: 'Search this book...',
@@ -499,6 +511,12 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     themePaper: 'Papel',
     themeSepia: 'Sepia',
     themeNight: 'Noche',
+    typeface: 'Letra',
+    typeOriginal: 'Original',
+    typeModern: 'Moderna',
+    typeOriginalTitle: 'Compuesto con la letrería original del libro',
+    typeModernTitle: 'Compuesto con la letra de lectura habitual de la biblioteca',
+    typeCaption: 'La redonda de Griffo para Aldo Manucio, calcada del De Aetna de 1496.',
 
     likeThisPage: 'Me gusta esta página',
     searchThisBook: 'Buscar en este libro...',

--- a/src/lib/fonts/aldine-fount.ts
+++ b/src/lib/fonts/aldine-fount.ts
@@ -3,35 +3,64 @@
  *
  * A *fount* is the case of sorts a book was set from. Where we hold a facsimile
  * of that fount — traced from our own scans, see `scripts/fonts/aldine-aetna/` —
- * the reader can set the transcription and the English translation in it, so the
- * page image and the live text are the same letterforms.
+ * the reader sets the transcription and the English translation in it, so the
+ * page image and the live text are the same letterforms. Readers can switch back
+ * to the library's reading face from the reading-settings popover; the choice is
+ * remembered (`sl_reader_prefs.fount`).
  *
- * This is a PILOT (issue #4083). One book is enabled: Bembo's *De Aetna*, the
- * 1496 Aldine the type was traced from — the one case where facsimile and
- * original are provably the same metal. Widen the list only after looking at
- * real pages: the other books set in this fount are listed below, commented,
- * ready to switch on.
+ * Everything below is the **roman Francesco Griffo cut for Aldus Manutius**,
+ * first used in 1495 and in service until the 1501 italic octavos. Each entry
+ * was checked against a page image: same a, e, ampersand, the ct/ſt ligatures,
+ * the same abbreviation marks. Editions we hold in more than one scan are all
+ * listed — same fount, different copy.
  *
  * Display only. Nothing here changes stored text: no ſ is substituted, no
- * orthography is normalised, and copying a passage yields exactly the
- * characters in `pages.ocr.data`. The facsimile carries no Greek, Hebrew or
- * Arabic, so Cardo (a revival of the same Griffo roman) sits behind it in the
- * stack and those scripts render as they always did.
+ * orthography is normalised, and copying a passage yields exactly the characters
+ * in `pages.ocr.data`. The facsimile carries no Greek, Hebrew or Arabic, so Cardo
+ * (a revival of the same Griffo roman) sits behind it in the stack and those
+ * scripts render as they always did.
  */
 
 /** Books whose reader text is set in Aldine Aetna. Keys are `books.id`. */
 export const ALDINE_FOUNT_BOOKS: Record<string, string> = {
-  // The pilot: the book the type was traced from (BNCF copy, IA ita-bnc-ald-00000673-001).
-  '6a06d1f39a48d51399960d08': 'De Aetna (Aldus Manutius, Venice 1496)',
+  // ── 1495–96 · the type's first years, and the book it was traced from ──
+  '6a06d1f39a48d51399960d08': 'Bembo, De Aetna (Aldus, Venice 1496) — the book this type was traced from',
+  '69b220c6f79d8af0eab7fcef': 'Bembo, De Aetna (Aldus, Venice 1496)',
+  '69aeabd767e6731bc1366d91': 'Bembo, De Aetna (Aldus, Venice 1496)',
+  // Lascaris is Greek with a facing Latin translation: the Greek falls back to Cardo.
+  '6a08574849638a50931c42e9': 'Lascaris, Erotemata (Aldus, Venice 1495)',
+  '69b220ccf79d8af0eab7fd3a': 'Lascaris, Erotemata (Aldus, Venice 1495)',
 
-  // Same fount, verified by eye and used as glyph sources — enable after the pilot is judged:
-  // '69b220c6f79d8af0eab7fcef': 'De Aetna, second copy (ita-bnc-ald-00000039)',
-  // '69b220de56715b0e3247381a': 'Leoniceno, De morbo gallico (1497)',
-  // '69b220da56715b0e32473793': 'Maiolo, Epiphyllides (1497)',
-  // '69b220cff79d8af0eab7fe91': 'Maiolo, De gradibus medicinarum (1497)',
-  // '69b220ccf79d8af0eab7fd3a': 'Lascaris, Erotemata (1495) — Greek falls back to Cardo',
-  // '69b220f356715b0e32473bd0': 'Perotti, Cornucopiae (1499) — smaller roman, figures came from here',
+  // ── 1497 ──
+  '69b220de56715b0e3247381a': 'Leoniceno, De morbo gallico (Aldus, Venice 1497)',
+  '6a08514215c643eb1af4a33f': 'Leoniceno, De morbo gallico (Aldus, Venice 1497)',
+  '69b220da56715b0e32473793': 'Maiolo, Epiphyllides in dialecticis (Aldus, Venice 1497)',
+  '69b220cff79d8af0eab7fe91': 'Maiolo, De gradibus medicinarum (Aldus, Venice 1497)',
+  '6a08569515c643eb1af59560': 'Maiolo, De gradibus medicinarum (Aldus, Venice 1497)',
+  '912cf0da-035c-425b-8975-e5a195a47767': 'Iamblichus, De mysteriis Aegyptiorum, tr. Ficino (Aldus, Venice 1497)',
+  '69540d5d790862145d7de805': 'Iamblichus, De mysteriis Aegyptiorum, tr. Ficino (Aldus, Venice 1497)',
+
+  // ── 1498–99 ──
+  '69aeac38ce3ea0f6a5a79b9a': 'Poliziano, Opera (Aldus, Venice 1498)',
+  '69b220e256715b0e32473869': 'Amaseus, Vaticinium (Aldus, Venice 1499)',
+  // The Cornucopiae index is set in the shop's smaller roman — the same design at a
+  // smaller body, and the source of the facsimile's figures.
+  '69b220f356715b0e32473bd0': 'Perotti, Cornucopiae linguae Latinae (Aldus, Venice 1499)',
 };
+
+/**
+ * Deliberately NOT listed, so nobody adds them by pattern-matching on "early Aldine":
+ *
+ * - **Hypnerotomachia Poliphili (1499)**, all four copies. Set in Griffo's *recut*
+ *   roman — the type later revived as Poliphilus. A near relation, not this fount;
+ *   claiming otherwise would be a claim we cannot support from the page.
+ * - **The Greek editions** (Aristotle, Aristophanes, Theocritus, Dioscorides, the
+ *   Psalters, the letter collections…). Set in Aldus's Greek types, which this
+ *   facsimile does not contain at all.
+ * - **Firmicus, Astronomici veteres (1499)** and **Ficino, De Voluptate (1497)**:
+ *   plausible, but their scans could not be pulled at a resolution that settles the
+ *   fount. Check a page before adding.
+ */
 
 /** True when this book should be read in its own fount. */
 export function isAldineFount(bookId: string | undefined | null): boolean {


### PR DESCRIPTION
Derek, on the pilot: *"looks good. maybe for all early aldine? need a toggle here?"* — yes to both.

## The toggle
The reading-settings popover (the **AA** control, beside Font Size and Theme) gains a **TYPE** section: **Original / Modern**. Each button previews its own face, so the choice is visible before you make it. Shown **only** for books we hold a fount for.

- Persists in `sl_reader_prefs` alongside size and theme (`useReaderPreferences`).
- Drives `data-reader-fount` on the reader root — exactly how `data-reader-theme` already works — and the CSS keys on `[data-reader-fount="original"]`, so "Modern" simply stops the rules matching. No second font-family declaration to keep in sync.
- Default stays **Original**: on these books the point is to see the type.
- A one-line caption names what you are looking at ("Griffo's roman for Aldus Manutius, traced from the 1496 *De Aetna*") — without it, an unfamiliar face reads as a bug. en + es.

## All early Aldines — the ones that are actually this type
**15 books**, each checked against a page image rather than inferred from a date: De Aetna (3 copies), Lascaris 1495 (2), Leoniceno 1497 (2), Maiolo 1497 (3), Iamblichus 1497 (2), Poliziano 1498, Amaseus 1499, Perotti's *Cornucopiae* 1499.

**Deliberately excluded, documented in the file so nobody adds them by pattern-matching on "early Aldine":**
- **Hypnerotomachia Poliphili (1499)**, all four copies — Griffo's *recut*, the type later revived as Poliphilus. A near relation, not this fount.
- **The Greek editions** (Aristotle, Aristophanes, Dioscorides, the Psalters…) — Aldus's Greek types, which this facsimile does not contain at all.
- **Firmicus 1499** and **Ficino, De Voluptate 1497** — plausible, but their scans would not pull at a resolution that settles it. Marked "check a page before adding".

Lascaris is Greek with facing Latin: the Greek falls through to Cardo, as designed.

`npx tsc --noEmit` clean. (The one eslint error in `useReaderPreferences` pre-exists on main — same effect, shifted line number.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)