### PR TITLE
docs(supabase): an IPv4-only lookup reads exactly like a dead host

### DIFF
--- a/.claude/docs/supabase.md
+++ b/.claude/docs/supabase.md
@@ -233,10 +233,39 @@ The translation text in `page_translations` has XML tags stripped and whitespace
 
 ## Common Operations
 
-### Run a one-off SQL query
+### Run a one-off SQL query (including DDL)
+
+The short path: `SUPABASE_DB_URL` lives in secret-lover, and the `pg` module's own
+connection-string parser handles it as-is.
+
+```bash
+secret-lover run -- node scripts/migration/<your-migration>.mjs
+# inside: new pg.Client({ connectionString: process.env.SUPABASE_DB_URL,
+#                         ssl: { rejectUnauthorized: false } })
+```
+
+Touch ID means **foreground only** — `secret-lover` cannot reach the Keychain from a
+background process. Node's `--env-file` does NOT override variables already in the
+environment, so `secret-lover run -- node --env-file=… ` lets a stale keychain value
+win over the file; export only what you need from the keychain instead.
+
+**The host is IPv6-only, and an A-record lookup reads exactly like a dead host.**
+`nslookup db.ykhxaecbbxaaqlujuzde.supabase.co` answers "No answer" because it asks for
+an **A** record and there is none; `dig +short AAAA` returns an address and the
+connection works. On 2026-08-13 that lookup was read as "Supabase retired this
+hostname", DDL was declared impossible without a human pasting into the SQL editor, and
+a migration was blocked for a week. Verified working from both the laptop and Hetzner on
+2026-08-21 (created `page_texts`, three RPCs, a trigger and four indexes). **Check AAAA
+before concluding a Supabase host is gone.**
+
+Two things that genuinely do not work, so you don't retry them: the service-role key
+cannot run DDL (it only reaches PostgREST), and the `exec_sql` RPC some older scripts
+reference does not exist (`PGRST202`).
+
+Ephemeral credentials via the CLI still work as an alternative:
+
 ```bash
 supabase link --project-ref ykhxaecbbxaaqlujuzde
-# Get ephemeral credentials:
 supabase db dump --linked --dry-run 2>&1 | grep "^export PG"
 # Use those with psql or node pg client (SET ROLE postgres for DDL)
 ```


### PR DESCRIPTION
On 2026-08-13, `nslookup db.ykhxaecbbxaaqlujuzde.supabase.co` answered "No answer". That was read as *Supabase retired this hostname*; DDL was declared impossible without a human pasting into the SQL editor, and `add-bph-uuid-keyed-revisions.sql` (#3985) sat blocked for a week.

The lookup asks for an **A** record and there is none. `dig +short AAAA` returns an address, and the connection works — verified from both the laptop and Hetzner on 2026-08-21 while creating `page_texts`, three RPCs, a trigger and four indexes for #4095.

The failure mode is the reason this is worth a doc change: the diagnosis was *specific, internally consistent, and wrong*, and it fails in the direction that looks responsible (you stop and wait for a human). Same shape as the `[r]` bracket in the entities-sweep interlock.

Also records, in the same section:
- the short path — `secret-lover get SUPABASE_DB_URL` + `pg`'s own connection-string parser, no manual splitting on the last `@`;
- Touch ID means **foreground only**, so `secret-lover` cannot run in a background process;
- Node's `--env-file` does **not** override variables already in the environment, so `secret-lover run -- node --env-file=…` lets a stale keychain value beat the file (this bit me this session — an invalid `GEMINI_API_KEY_TIER3` from the keychain overrode a working one in `.env.production.local`);
- the two things that genuinely don't work, so nobody retries them: the service-role key cannot run DDL, and the `exec_sql` RPC some older scripts reference does not exist.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ