### PR TITLE
feat(es): Spanish collection copy, Spanish counts on the /es grid, Spanish librarian in the nav

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -31,9 +31,27 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    `description_es` are forbidden — that is the column sprawl #3969 cleaned up
    (477 fields on `books`). `localized` is declared once in
    `scripts/lib/book-docs.mjs`; a new language adds a KEY, not a field.
-2. **Written by one script.** `scripts/maintenance/localize-metadata.mjs
-   --lang=<iso>` glosses titles (and `--collection=<slug>` copy) and logs a
-   `sweep_log` row per write. Hand edits go in the same map.
+2. **Written by one script, and it must have a BULK mode.**
+   `scripts/maintenance/localize-metadata.mjs --lang=<iso>` glosses titles;
+   `--all-collections` / `--collections-with-editions` / `--collection=<slug>`
+   gloss collection copy. It logs a `sweep_log` row per write. Hand edits go in
+   the same map.
+
+   The bulk flags were added in #4159, after the single-slug form had been run
+   exactly once: `collections.localized.es` covered **1 of 325** collections, so
+   nearly every `/es/collections/<slug>` showed the labelled English intro of
+   rule 4. Nothing was broken — the fallback is *designed* to look finished, so
+   an empty store and a complete one render the same shape. **The health of a
+   localized surface is the FILL RATE of its map, never the correctness of the
+   read path.** Check it with a count before reading any component, and give a
+   new language's writer a bulk mode on the day you write it.
+
+   A bulk pass over authored copy also needs an output check, not a write count:
+   19 of 134 collection names came back still in English and all 19 "succeeded".
+   Compare against the source (identical string, length ratio) and re-run the
+   failures. Hand-curated values — `ES_COLLECTION_NAMES` — must be SEEDED into
+   the map, or the bulk run silently downgrades them, because the read path
+   prefers the map.
 3. **Read through the helpers.** `localizedTitle(book, lang)`,
    `localizedCollection(doc, lang)`. A surface that reads `localized.es.title`
    directly will half-localize the next language.
@@ -127,7 +145,11 @@ shown with the original beneath it (`originalTitleIfDifferent`).
    keep: a response must SAY which edition it served, because falling back to
    English is the common case, not the edge one
    (`invariants/text-helpers-and-exports.md`).
-4. `localize-metadata.mjs --lang=<iso> --books-with-editions`.
+4. `localize-metadata.mjs --lang=<iso> --books-with-editions`, then
+   `--lang=<iso> --collections-with-editions` for the collection copy (the
+   collections holding a book readable in that language, plus their parents —
+   a parent left untranslated puts an English breadcrumb over a localized
+   branch). `--all-collections` covers the rest of the library.
 5. `TARGET_LANGUAGE_NAMES` in `page-translations.ts`, and the reader's language
    links in `PageEditorClient` (a third locale makes that pair a list — keep it
    built from `localeHref`, one link per prefixed locale).

--- a/scripts/maintenance/localize-metadata.mjs
+++ b/scripts/maintenance/localize-metadata.mjs
@@ -12,6 +12,10 @@
  *   --books-with-editions           every book with pages_translated_<lang> > 0 (default selection)
  *   --book-ids=a,b,c                explicit books
  *   --collection=<slug>             also gloss one collection's name/subtitle/description
+ *   --all-collections               gloss EVERY visible collection's copy (the /es collection pages)
+ *   --collections-with-editions     only the collections a reader of <lang> can reach (holds such a book, + parents)
+ *   --slugs=a,b,c                   restrict the collection sweep to these slugs (with --force, a re-run)
+ *   --limit=<n>                     cap how many collections --all-collections does in one run
  *   --migrate-collection=<slug>     move legacy name_es/subtitle_es/description_es into localized.es and unset them
  *   --force                         rewrite existing glosses
  *   --dry-run
@@ -20,6 +24,7 @@
  *
  *   node --env-file=.env.production.local scripts/maintenance/localize-metadata.mjs --lang=es --books-with-editions
  */
+import { readFileSync } from 'node:fs';
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { recordSweepAction } from '../lib/sweep-log.mjs';
@@ -103,27 +108,158 @@ if (migrate) {
   }
 }
 
+/**
+ * The curated Spanish collection names the homepage already ships
+ * (`ES_COLLECTION_NAMES` in src/lib/home-i18n.ts). They are hand-written and
+ * better than anything a model returns for a slug like `natural-philosophy`
+ * ("Filosofía natural y ciencia", not a literal rendering of the English
+ * name) — so a bulk gloss must SEED them rather than overwrite them. Once the
+ * curated name is in `localized.<lang>.name`, `spanishCopy()` prefers it and
+ * the hand map becomes the fallback for whatever has not been written yet,
+ * which is the direction .claude/docs/i18n.md asks for (one map per record).
+ *
+ * Read out of the TS source instead of duplicated here: two copies of these
+ * 22 names would drift the first time one is edited.
+ */
+function curatedNames(lang) {
+  if (lang !== 'es') return {};
+  const src = readFileSync(new URL('../../src/lib/home-i18n.ts', import.meta.url), 'utf8');
+  const body = src.slice(src.indexOf('ES_COLLECTION_NAMES'));
+  const literal = body.slice(body.indexOf('{'), body.indexOf('};') + 1);
+  const out = {};
+  for (const m of literal.matchAll(/^\s*'?([a-z0-9-]+)'?:\s*'([^']+)',/gm)) out[m[1]] = m[2];
+  return out;
+}
+const CURATED = curatedNames(LANG);
+
+/**
+ * Translate one collection's editorial copy. Returns null rather than a
+ * half-result: a Spanish page falls back to labelled English, which is honest,
+ * so writing a truncated or untranslated description would be strictly worse
+ * than writing nothing.
+ */
+async function glossCollection(doc) {
+  const out = await ask(`Translate this library collection's copy into ${LANGUAGE}. Keep the register (editorial, concise) and the paragraph breaks. Do not add or drop information, and do not add counts or dates.
+
+The "name" is a shelf label, not a book title: translate it. Leave it unchanged ONLY when a ${LANGUAGE} library would print that exact string — a personal name, or a Latin/Arabic/Sanskrit term already used in ${LANGUAGE} (Corpus Hermeticum, Falsafa, Yoga). An English noun phrase is never one of those, so "Signs in the Sky" and "Sacred Plants" must come back in ${LANGUAGE}. Inside the description, book titles and institution names stay as a ${LANGUAGE} edition would print them.
+
+Return JSON only: {"name": "...", "subtitle": "...", "description": "..."}.\n\n${JSON.stringify({ name: doc.name, subtitle: doc.subtitle, description: doc.description || doc.expanded_description })}`);
+  let parsed = null;
+  try { parsed = JSON.parse(String(out).replace(/^```json\s*|```$/g, '').trim()); } catch { /* fallthrough */ }
+  if (!parsed || typeof parsed.name !== 'string' || !parsed.name.trim() || parsed.name.length > 160) return null;
+
+  const source = doc.description || doc.expanded_description || '';
+  const fields = { name: (CURATED[doc.slug] || parsed.name).trim() };
+  if (typeof parsed.subtitle === 'string' && parsed.subtitle.trim() && parsed.subtitle.length <= 240) {
+    fields.subtitle = parsed.subtitle.trim();
+  }
+  if (source) {
+    const d = typeof parsed.description === 'string' ? parsed.description.trim() : '';
+    // A model that returns a summary instead of a translation, or that stops
+    // early, shows up as a length far off the source. Spanish runs a little
+    // longer than English, so the window is asymmetric.
+    if (d.length >= source.length * 0.6 && d.length <= source.length * 2.2) fields.description = d;
+    else if (d) console.warn(`  ! ${doc.slug}: description ${d.length}ch vs source ${source.length}ch — not written`);
+  }
+  return fields;
+}
+
+const COLLECTION_PROJECTION = { _id: 0, slug: 1, name: 1, subtitle: 1, description: 1, expanded_description: 1, localized: 1 };
+
+async function writeCollection(doc) {
+  if (doc.localized?.[LANG]?.name && !FORCE) return 'skipped';
+  const fields = DRY ? { name: '(dry)' } : await glossCollection(doc);
+  if (!fields) { console.error(`  ! ${doc.slug}: model did not return usable JSON`); return 'failed'; }
+  console.log(`${DRY ? '[dry] ' : ''}${doc.slug}: ${fields.name}${fields.description ? ` · ${fields.description.length}ch` : ' · (no intro)'}`);
+  if (DRY) return 'written';
+  const r = await db.collection('collections').updateOne(
+    { slug: doc.slug },
+    { $set: { [`localized.${LANG}`]: fields, updated_at: new Date() } },
+  );
+  if (r.modifiedCount !== 1) return 'failed';
+  await recordSweepAction(db, {
+    sweep: SWEEP,
+    // `book_id` is the helper's required "thing this action touched" and it
+    // validates non-empty; namespace the slug so a collection row can never be
+    // mistaken for a book id when the log is queried.
+    book_id: `collection:${doc.slug}`,
+    action: 'set-localized-collection-copy',
+    detail: { lang: LANG, name: fields.name, curated_name: !!CURATED[doc.slug], description: fields.description?.length ?? 0 },
+  });
+  return 'written';
+}
+
 const colSlug = val('--collection');
 if (colSlug) {
-  const doc = await db.collection('collections').findOne({ slug: colSlug }, { projection: { slug: 1, name: 1, subtitle: 1, description: 1, localized: 1 } });
+  const doc = await db.collection('collections').findOne({ slug: colSlug }, { projection: COLLECTION_PROJECTION });
   if (!doc) { console.error(`collection ${colSlug} not found`); process.exit(1); }
-  if (doc.localized?.[LANG]?.name && !FORCE) console.log(`${colSlug}: already has localized.${LANG} (use --force)`);
-  else {
-    const out = await ask(`Translate this library collection's copy into ${LANGUAGE}. Keep the register (editorial, concise). Return JSON only: {"name": "...", "subtitle": "...", "description": "..."}.\n\n${JSON.stringify({ name: doc.name, subtitle: doc.subtitle, description: doc.description })}`);
-    let parsed = null;
-    try { parsed = JSON.parse(out.replace(/^```json\s*|```$/g, '')); } catch { /* fallthrough */ }
-    if (!parsed?.name) console.error(`${colSlug}: model did not return usable JSON`);
-    else {
-      console.log(`${DRY ? '[dry] ' : ''}${colSlug}: ${JSON.stringify(parsed).slice(0, 200)}`);
-      if (!DRY) await db.collection('collections').updateOne({ slug: colSlug }, { $set: { [`localized.${LANG}`]: parsed, updated_at: new Date() } });
-    }
-  }
+  const r = await writeCollection(doc);
+  if (r === 'skipped') console.log(`${colSlug}: already has localized.${LANG} (use --force)`);
+}
+
+// Every visible collection, because every one of them is reachable at
+// /<lang>/collections/<slug>. Before this the sweep ran one slug at a time and
+// exactly ONE of 325 had been done, so a Spanish reader met English editorial
+// copy on effectively every collection page — the fallback working as designed,
+// with nothing behind it.
+
+/**
+ * The collections a reader of `LANG` can actually reach by clicking: the ones
+ * holding a book readable in that language, PLUS their parents — because
+ * `/<lang>/collections` lists a sub-collection only when it holds such books,
+ * and the collection page links up to its parent by name. Without the parents
+ * the breadcrumb above a Spanish branch stays English.
+ *
+ * Same selection rule as the read path (`localizedEditionFilter` in
+ * src/lib/localized.ts): translated INTO the language, or written in it.
+ */
+const NATIVE_EDITION_LANGUAGE = {
+  es: /^\s*(spanish|espa(?:ñ|n)ol|castellano|castilian)\s*$/i,
+};
+async function slugsReachableIn(lang) {
+  const editionFilter = NATIVE_EDITION_LANGUAGE[lang]
+    ? { $or: [{ [`pages_translated_${lang}`]: { $gt: 0 } }, { language: NATIVE_EDITION_LANGUAGE[lang] }] }
+    : { [`pages_translated_${lang}`]: { $gt: 0 } };
+  const counts = await db.collection('books').aggregate([
+    { $match: { ...editionFilter, visible: true } },
+    { $unwind: '$collections' },
+    { $group: { _id: '$collections', count: { $sum: 1 } } },
+  ], { maxTimeMS: 20000 }).toArray();
+  const slugs = counts.map((c) => c._id).filter((s) => typeof s === 'string');
+  const held = await db.collection('collections')
+    .find({ visible: true, slug: { $in: slugs } }, { projection: { _id: 0, slug: 1, parent: 1 } })
+    .toArray();
+  const out = new Set(held.map((d) => d.slug));
+  for (const d of held) for (const p of [].concat(d.parent || [])) if (typeof p === 'string') out.add(p);
+  return [...out];
+}
+
+if (has('--all-collections') || has('--collections-with-editions')) {
+  const limit = Number(val('--limit')) || 0;
+  const query = { visible: true, ...(FORCE ? {} : { [`localized.${LANG}.name`]: { $exists: false } }) };
+  if (has('--collections-with-editions')) query.slug = { $in: await slugsReachableIn(LANG) };
+  if (val('--slugs')) query.slug = { $in: val('--slugs').split(',').map((x) => x.trim()).filter(Boolean) };
+  const docs = await db.collection('collections')
+    .find(query, { projection: COLLECTION_PROJECTION })
+    .sort({ book_count: -1 })
+    .limit(limit || 0)
+    .toArray();
+  console.log(`${docs.length} collections to gloss into ${LANGUAGE}${DRY ? ' (dry run)' : ''}`);
+
+  // Four at a time: flash-lite rate limits are generous and 325 serial calls is
+  // twenty minutes of nothing.
+  const counts = { written: 0, skipped: 0, failed: 0 };
+  const queue = docs.slice();
+  await Promise.all(Array.from({ length: 4 }, async () => {
+    for (let doc = queue.shift(); doc; doc = queue.shift()) counts[await writeCollection(doc)]++;
+  }));
+  console.log(`\n${docs.length} collections: ${counts.written} written, ${counts.skipped} already done, ${counts.failed} failed.`);
 }
 
 // ---------- books ----------
 let bookFilter = null;
 if (val('--book-ids')) bookFilter = { id: { $in: val('--book-ids').split(',').map((s) => s.trim()).filter(Boolean) } };
-else if (has('--books-with-editions') || (!migrate && !colSlug)) bookFilter = { [`pages_translated_${LANG}`]: { $gt: 0 } };
+else if (has('--books-with-editions') || (!migrate && !colSlug && !has('--all-collections') && !has('--collections-with-editions'))) bookFilter = { [`pages_translated_${LANG}`]: { $gt: 0 } };
 
 // Summary + chapter titles for the Spanish book page (#4082). One call per field.
 async function localizeSummary(b) {

--- a/src/app/es/collections/page.tsx
+++ b/src/app/es/collections/page.tsx
@@ -74,7 +74,8 @@ export default async function EsCollectionsPage() {
         <p className="text-muted max-w-2xl leading-relaxed">
           La biblioteca, ordenada por tradiciones. Primero las colecciones que ya contienen libros con edición en
           español; debajo, el resto de la biblioteca, en su lengua original y con traducción al inglés en muchos casos.
-          Los títulos y las introducciones de cada colección están en inglés salvo donde se indica.
+          Las colecciones con libros en español llevan su nombre y su introducción traducidos; en el resto, la
+          introducción aparece en inglés y así se indica.
         </p>
       </div>
 

--- a/src/app/es/page.tsx
+++ b/src/app/es/page.tsx
@@ -37,9 +37,11 @@ export default async function HomePageEs() {
   const data = await getHomeData('es');
   return (
     <>
-      {/* Arriving via the Spanish front door means "I read Spanish": books
-          opened afterwards start in their Spanish edition where one exists.
-          Client-side localStorage only — this page stays ISR and cache-safe. */}
+      {/* Reading language is the URL prefix and nothing else: links out of this
+          page keep `/es` where a twin route exists (localePath), and no
+          preference is stored anywhere. #4112 removed the localStorage flag that
+          used to follow the reader off the prefix — do not reintroduce it in any
+          form (.claude/docs/i18n.md rule 6). */}
       <HomeView data={data} lang="es" />
     </>
   );

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -23,8 +23,17 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
   // catalog, browse, podcast, blog…) are returned untouched by localePath and go
   // to their English page rather than a 404. See .claude/docs/i18n.md rule 5.
   const lp = (href: string) => localePath(href, lang);
-  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts } = data;
+  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
+  // The grid card's count line. On /es it says how many of the collection's
+  // books can actually be READ in Spanish — the same thing /es/collections
+  // tells you, and the only number on the card a Spanish visitor can act on.
+  // Empty on `/`, where every book is already in the page's language.
+  const countLabel = (slug: string, bookCount: number) => {
+    const localized = localizedCollectionCounts[slug] ?? 0;
+    const base = `${nf(bookCount)} ${t.booksLabel}`;
+    return localized > 0 ? `${base} · ${nf(localized)} ${t.inThisLanguage}` : base;
+  };
 
   return (
     <div className="min-h-screen">
@@ -35,8 +44,10 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
 
       {/* Read in Spanish — the first thing under the hero on /es, because it is
           the one section whose BOOKS (not just chrome) are in the visitor's
-          language. Most-read first; the reader opens these in Spanish because
-          /es stores the reading-language preference (ReadingLanguagePreference).
+          language. Most-read first; each card's href carries the `/es` prefix,
+          which is the ONLY thing that decides reading language (#4112 removed
+          the localStorage preference that used to follow the reader off the
+          prefix — see .claude/docs/i18n.md rule 6).
           spanishBooks is empty on the English homepage, so nothing renders there. */}
       {spanishBooks.length > 0 && (
         <section className="bg-white py-16 md:py-24">
@@ -132,7 +143,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                 <div className="absolute bottom-0 left-0 right-0 p-4">
                   <p className="text-white/50 text-xs mb-1 hidden sm:block">
-                    {col.book_count} {t.booksLabel}
+                    {countLabel(col.slug, col.book_count)}
                   </p>
                   <h3 className="font-serif text-sm sm:text-base lg:text-lg text-white group-hover:text-accent-gold transition-colors line-clamp-2">
                     {collectionName(lang, col.slug, col.name)}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
 import { Search, ChevronDown } from 'lucide-react';
-import { useLocale, localeHref, hasLocalizedTwin, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
+import { useLocale, localeHref, hasLocalizedTwin, localePath, canonicalPath, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
 import { isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import { trackEvent } from '@/lib/track-event';
@@ -19,12 +19,17 @@ interface NavLink {
 }
 
 // Labels are resolved per-locale from NAV_STRINGS so the nav stays in one place
-// as languages are added. Hrefs are constant EXCEPT where a Spanish twin route
-// exists (`/es/collections`, see LOCALIZED_PREFIXES in i18n.ts) — the thin-i18n
-// bargain means every other item still points at the English page.
+// as languages are added. Hrefs are written in their ENGLISH (canonical) form
+// and localized at the end of this function by `localePath`, which is guarded by
+// the route registry in locale-path.ts: an item with a twin gets the `/es`
+// prefix, an item without one is returned untouched and lands on its English
+// page. Doing it per-item by hand is what left `/librarian` pointing at the
+// English librarian from the Spanish header while `/collections` was localized
+// by a ternary two lines above it — the registry knows about `/es/librarian`,
+// the hand-written ternary did not.
 function buildNavLinks(t: NavStrings, locale: Locale): NavLink[] {
-  return [
-    { label: t.collections, href: locale === 'es' ? '/es/collections' : '/collections', activePrefix: locale === 'es' ? '/es/collections' : '/collections' },
+  const links: NavLink[] = [
+    { label: t.collections, href: '/collections', activePrefix: '/collections' },
     { label: t.gallery, href: '/gallery' },
     {
       label: t.browse,
@@ -52,6 +57,17 @@ function buildNavLinks(t: NavStrings, locale: Locale): NavLink[] {
     // where that traffic is meant to come from. Episodes also stay reachable
     // from their librarian threads and the footer.
   ];
+
+  if (locale === 'en') return links;
+  // `activePrefix` must move with the href, or the Spanish nav highlights
+  // nothing: the pathname is `/es/collections` and the prefix would say
+  // `/collections`.
+  return links.map((link) => ({
+    ...link,
+    href: localePath(link.href, locale),
+    ...(link.activePrefix ? { activePrefix: localePath(link.activePrefix, locale) } : {}),
+    ...(link.children ? { children: link.children.map((c) => ({ ...c, href: localePath(c.href, locale) })) } : {}),
+  }));
 }
 
 interface Breadcrumb {
@@ -112,11 +128,15 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   // a global-only path; `/works` under Browse is the first that does, and an
   // unfiltered child would put a proxy-404 link in a partner's own header —
   // the one thing the shared list exists to prevent.
+  //
+  // The hrefs arriving here are already locale-prefixed, so the global-only test
+  // runs on the CANONICAL path: `/es/explore` is the same global-only surface as
+  // `/explore` and a prefix-blind lookup would miss it.
   const NAV_LINKS = buildNavLinks(t, locale)
-    .filter(link => !(isTenantHost && isGlobalOnlyNavHref(link.href)))
+    .filter(link => !(isTenantHost && isGlobalOnlyNavHref(canonicalPath(link.href))))
     .map(link =>
       link.children && isTenantHost
-        ? { ...link, children: link.children.filter(child => !isGlobalOnlyNavHref(child.href)) }
+        ? { ...link, children: link.children.filter(child => !isGlobalOnlyNavHref(canonicalPath(child.href))) }
         : link
     );
   // The Support button is deliberately NOT in buildNavLinks: it is an action,

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -9,6 +9,7 @@ import { type Plate } from '@/components/GalleryMasonry';
 import { type HomeLang } from '@/lib/home-i18n';
 import { isNativeEdition, localizedEditionFilter, type LocalizedBookMap } from '@/lib/localized';
 import { spanishReaderHref } from '@/lib/es-collections';
+import type { Locale } from '@/lib/locale-path';
 
 // Shared data layer for the homepage. Both the English `/` route and the
 // Spanish `/es` route fetch through getHomeData() so the two pages can never
@@ -713,9 +714,31 @@ async function getSpanishCounts(): Promise<SpanishCounts | null> {
   return row ?? null;
 }
 
+/**
+ * How many books in each collection can be read in `lang` — the "· 57 en
+ * español" half of the homepage grid's count line.
+ *
+ * Same selection rule as `/es/collections` (`localizedEditionFilter`): a book
+ * counts if it was TRANSLATED into the language or WRITTEN in it. Sharing the
+ * filter is what stops the homepage card and the collections card from
+ * disagreeing about the same collection. Indexed off the small set of books
+ * that have an edition, never by scanning collections × books.
+ */
+async function getLocalizedCollectionCounts(lang: Exclude<Locale, 'en'>): Promise<Record<string, number>> {
+  const db = await getReadDb();
+  const rows = await db.collection('books').aggregate<{ _id: string; count: number }>([
+    { $match: { ...localizedEditionFilter(lang), visible: true, pages_count: { $gt: 0 } } },
+    { $unwind: '$collections' },
+    { $group: { _id: '$collections', count: { $sum: 1 } } },
+  ], { maxTimeMS: 8000 }).toArray();
+  const out: Record<string, number> = {};
+  for (const r of rows) if (typeof r._id === 'string') out[r._id] = r.count;
+  return out;
+}
+
 // ---------- Aggregate ----------
 
-// ---------- Books with a Spanish edition (the /es "Leer en español" band) ----------
+// ---------- Books with a Spanish edition (the "Leer en español" band) ----------
 
 /** Slug of the curated collection that gathers every book with a Spanish edition. */
 export const SPANISH_COLLECTION_SLUG = 'en-espanol';
@@ -801,6 +824,12 @@ export interface HomeData {
   spanishBooks: SpanishBook[];
   /** Size of the Spanish corpus, for the honest scale line. Null off /es. */
   spanishCounts: SpanishCounts | null;
+  /**
+   * Books readable in the page's language, per collection slug — what the grid
+   * card's "· N en español" line reads. Empty on the English homepage, where
+   * every book is already in the page's language and the line would be noise.
+   */
+  localizedCollectionCounts: Record<string, number>;
 }
 
 // `lang` selects the podcast episode's language and the Spanish-edition band,
@@ -808,7 +837,7 @@ export interface HomeData {
 // keeps the two homepages structurally identical (see the note at the top of
 // this file).
 export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
-  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts] = await Promise.all([
+  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getRecentlyTranslated(), 20000, [] as CatalogBook[]),
@@ -818,7 +847,10 @@ export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
     withTimeout(getFeaturedPodcast(lang), 8000, null),
     lang === 'es' ? withTimeout(getSpanishBooks(), 8000, [] as SpanishBook[]) : Promise.resolve([] as SpanishBook[]),
     lang === 'es' ? withTimeout(getSpanishCounts(), 8000, null) : Promise.resolve(null),
+    lang === 'en'
+      ? Promise.resolve({} as Record<string, number>)
+      : withTimeout(getLocalizedCollectionCounts(lang), 8000, {} as Record<string, number>),
   ]);
 
-  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts };
+  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -56,6 +56,13 @@ export interface HomeStrings {
   illustrationsLabel: string;
   browseCatalog: string;
   booksLabel: string;
+  /**
+   * Suffix on a collection card's second count: "1.234 libros · 57 en español".
+   * Never rendered on the English homepage — every book there is already in the
+   * page's language — but it lives in both dictionaries so the two editions keep
+   * one shape (the rule at the top of this file).
+   */
+  inThisLanguage: string;
   seeMore: (n: number) => string;
   collectionsWord: string;
   curatedExhibitions: string;
@@ -175,6 +182,7 @@ const en: HomeStrings = {
   illustrationsLabel: 'illustrations',
   browseCatalog: 'Browse Catalog',
   booksLabel: 'books',
+  inThisLanguage: 'in English',
   seeMore: (n) => `See ${n} more`,
   collectionsWord: 'collections',
   curatedExhibitions: 'Browse curated exhibitions',
@@ -289,6 +297,7 @@ const es: HomeStrings = {
   illustrationsLabel: 'ilustraciones',
   browseCatalog: 'Explorar el catálogo',
   booksLabel: 'libros',
+  inThisLanguage: 'en español',
   seeMore: (n) => `Ver ${n} más`,
   collectionsWord: 'colecciones',
   curatedExhibitions: 'Explorar exposiciones comisariadas',

--- a/tests/unit/tenant-global-paths.test.ts
+++ b/tests/unit/tenant-global-paths.test.ts
@@ -210,9 +210,15 @@ describe('wiring', () => {
     // `/works` sits under the Browse dropdown and is global-only. Filtering only
     // `link.href` would leave it in a partner's header pointing at a page the
     // proxy 404s — the exact failure this shared list exists to prevent.
+    //
+    // The child's href may be normalised on the way into the predicate — the nav
+    // localizes hrefs, so a Spanish header holds `/es/works` and the lookup runs
+    // on `canonicalPath(child.href)`. What this guard is for is that `child.href`
+    // REACHES the predicate at all; pinning the exact argument expression made it
+    // fail on a change that strengthened the very thing it protects.
     const src = read('src/components/layout/SiteHeader.tsx');
     expect(src, 'children must be run through the predicate too').toMatch(
-      /children.*\.filter\(\s*child\s*=>\s*!isGlobalOnlyNavHref\(child\.href\)\s*\)/s
+      /children.*?\.filter\(\s*child\s*=>\s*!isGlobalOnlyNavHref\([^)]*child\.href/s
     );
   });
 


### PR DESCRIPTION
Three faults reported from `/es`, one cause: the Spanish surfaces were built with correct fallbacks and then nothing was put behind them.

## 1. Collection pages were English (`/es/collections/secret-societies`)

`collections.localized.es` had been written for exactly **one of 325** visible collections (`en-espanol`). Every other `/es/collections/<slug>` therefore rendered the stored English intro under the `Introducción disponible en inglés` label — the fallback working exactly as `.claude/docs/i18n.md` rule 4 prescribes, with nothing behind it.

`scripts/maintenance/localize-metadata.mjs` could only gloss one slug per invocation, which is why it had been run once. It now takes:

- `--all-collections` — every visible collection
- `--collections-with-editions` — the ones a reader of `<lang>` can actually reach: holds a book readable in that language (same `localizedEditionFilter` the read path uses), plus their parents, so the breadcrumb above a Spanish branch is Spanish too
- `--slugs=a,b,c` — a targeted re-run
- `--limit=<n>`, and 4-way concurrency

**Ran over the reachable set: 134 collections written, 0 failed, 0 intros left falling back to English.** ~$0.01 in flash-lite calls (approved at a wrong estimate of ~50 collections; the real reachable set was 134, same order of cost).

The 22 curated names in `ES_COLLECTION_NAMES` are **seeded**, not model-rewritten — read out of the TS source rather than duplicated, so the map and the DB cannot drift. A first pass left 19 names in English; the prompt now states that a collection name is a shelf label and must be translated unless a Spanish library would print that exact string. Re-ran those 14; the 5 that remain identical are correct (`Corpus Hermeticum`, `Falsafa`, `Maya`, `Drama`, `Yoga`).

A description is written only if its length lands within 0.6×–2.2× the source — a model that summarises instead of translating, or stops early, leaves the honest labelled English in place rather than writing a truncation.

## 2. `/es` homepage cards showed a bare count

The grid card said `1644 libros`. It now says `1.644 libros · 57 en español` — the same line `/es/collections` shows, computed from the shared `localizedEditionFilter`, so the two surfaces cannot disagree about the same collection. Counts are locale-formatted. Empty on `/`, where the second number would be noise.

## 3. The header's Librarian link went to the English librarian

`/es/librarian` exists and `LOCALIZED_PATHS` knows about it, but the nav localized `/collections` with a hand-written ternary and left every other href alone. Nav hrefs are now written in canonical English form and run through `localePath`, which is registry-guarded — a twinned path gets the prefix, an untwinned one is returned untouched and lands on its English page (rule 5). `activePrefix` moves with the href, or the Spanish nav highlights nothing.

The tenant global-only filter now tests `canonicalPath(href)`: `/es/explore` is the same global-only surface as `/explore`, and a prefix-blind lookup would miss it on a partner subdomain.

## Also

- The `/es/collections` intro still promised "los títulos y las introducciones de cada colección están en inglés" — now false for 134 of them.
- Two comments claimed `/es` stores a reading-language preference. #4112 removed that and rule 6 forbids reintroducing it; the comments were the last thing still describing the mechanism.

## Out of scope

- The 191 visible collections with **no** Spanish books still show English intros. Deliberate — Derek scoped this run to the reachable set. One command finishes them: `--all-collections`, ~$0.01.
- `/es/search` (#4146) and the Spanish book-page surfaces are untouched.

## Verification

- `npx tsc --noEmit` clean
- 134/134 written, 0 failed; audit re-run confirms 0 intros falling back and 5 intentionally-identical names
- Spot-checked copy: proper names correctly Hispanicised (Paracelso, Basilio Valentín, Aldo Manucio, "Bodas químicas")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182mSJbjTXEZtmSqoMLhFnn