### PR TITLE
fix(es): return the Spanish band to the homepage's own shape

### DIFF
--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -30,7 +30,7 @@ export interface MiniBook {
  * shared HorizontalSlider. Extracted from the Mycology "First translations"
  * band so it can be reused on the homepage and beyond.
  */
-export default function BookSlider({ books, lang = 'en', hideStatus = false }: { books: MiniBook[]; lang?: Locale; hideStatus?: boolean }) {
+export default function BookSlider({ books, lang = 'en' }: { books: MiniBook[]; lang?: Locale }) {
   return (
     <HorizontalSlider ariaLabel="books">
       {books.map((b) => (
@@ -39,7 +39,7 @@ export default function BookSlider({ books, lang = 'en', hideStatus = false }: {
           data-card
           className="snap-start shrink-0 basis-[66%] sm:basis-[calc((100%-2rem)/3)] lg:basis-[calc((100%-4rem)/5)]"
         >
-          <CollectionBookCard book={b as unknown as CollectionBook} lang={lang} href={b.href} hideStatus={hideStatus} />
+          <CollectionBookCard book={b as unknown as CollectionBook} lang={lang} href={b.href} />
         </div>
       ))}
     </HorizontalSlider>

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -89,12 +89,6 @@ interface CollectionBookCardProps {
    * beneath, or the original alone when no gloss exists yet. Default English.
    */
   lang?: Locale;
-  /**
-   * Drop the OCR/Translated status line. For a band whose every book is, by
-   * selection, fully readable (the /es Spanish editions), the line is pipeline
-   * telemetry the reader does not need — the cover, title and tag carry it.
-   */
-  hideStatus?: boolean;
 }
 
 function pctOf(n?: number, d?: number): number {
@@ -116,7 +110,7 @@ function Status({ label, pctValue, doneClass }: { label: string; pctValue: numbe
  * language pill · year · pages, and a single OCR/Translated status line (books
  * only). Keeps the robust data handling: artwork, embed placeholders, DOI.
  */
-export default function CollectionBookCard({ book, priority = false, bookUrlPrefix, href, lang = 'en', hideStatus = false }: CollectionBookCardProps) {
+export default function CollectionBookCard({ book, priority = false, bookUrlPrefix, href, lang = 'en' }: CollectionBookCardProps) {
   const labels = CARD_LABELS[lang];
   const shownTitle = localizedTitle(book, lang);
   const originalLine = lang === 'en' ? null : originalTitleIfDifferent(book, lang);
@@ -236,7 +230,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
             : (pageCount > 0 ? <span>{pageCount.toLocaleString('en-US')} {labels.pages}</span> : null)}
         </div>
 
-        {!isArtwork && !hideStatus && pageCount > 0 && (
+        {!isArtwork && pageCount > 0 && (
           <div className="flex items-center gap-3 mt-auto pt-3 text-[11px]">
             <Status label={labels.ocr} pctValue={ocrPct} doneClass="text-status-info" />
             <Status label={labels.translated} pctValue={translatedPct} doneClass="text-status-success" />

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -12,8 +12,6 @@ import SignUpCTA from '@/components/auth/SignUpCTA';
 import { type HomeData, SPANISH_COLLECTION_SLUG } from '@/lib/home-data';
 import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
 import { localePath } from '@/lib/locale-path';
-import { localizedTitle } from '@/lib/localized';
-import { isPublishedFirstTranslation } from '@/lib/book';
 
 // Shared homepage body. The English `/` route renders it with lang="en"; the
 // Spanish `/es` route with lang="es". Keeping a single component means the two
@@ -25,9 +23,8 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
   // catalog, browse, podcast, blog…) are returned untouched by localePath and go
   // to their English page rather than a 404. See .claude/docs/i18n.md rule 5.
   const lp = (href: string) => localePath(href, lang);
-  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts, spanishShowpiece } = data;
+  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
-  const spanishFirsts = spanishBooks.filter(isPublishedFirstTranslation).slice(0, 6);
 
   return (
     <div className="min-h-screen">
@@ -55,112 +52,31 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 {t.spanishViewAll} &rarr;
               </Link>
             </div>
-            <p className="text-muted mb-8 max-w-2xl">
+            <p className="text-muted mb-2 max-w-2xl">
               {t.spanishSubtitle}
             </p>
-
-            {/* Say the size — as what has been done, not as a share of the
-                library. Pages and books are the work; first translations and
-                source languages are why it matters. The total sits underneath
-                as the upside, which is the honest frame for a corpus this young. */}
+            {/* Say the size, the way the Collections header below does: one
+                inline line of counts. Pages and books are the work done; the
+                firsts and the source languages are why it matters. */}
             {spanishCounts && (
-              <div className="mb-10">
-                <ul className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-6 border-y border-border-light py-6 list-none">
-                  {([
-                    [spanishCounts.pages, t.spanishStatPages],
-                    [spanishCounts.books + spanishCounts.nativeBooks, t.spanishStatBooks],
-                    [spanishCounts.firstTranslations, t.spanishStatFirsts],
-                    [spanishCounts.sourceLanguages, t.spanishStatLanguages],
-                  ] as const).filter(([n]) => n > 0).map(([n, label]) => (
-                    <li key={label}>
-                      <p className="font-display text-3xl md:text-4xl text-primary tabular-nums leading-none">{nf(n)}</p>
-                      <p className="text-xs uppercase tracking-[0.15em] text-muted mt-2">{label}</p>
-                    </li>
-                  ))}
-                </ul>
-                <p className="text-sm text-muted/80 mt-3">{t.spanishUpside(nf(counts.totalBooks))}</p>
-              </div>
-            )}
-
-            {/* One page, seen. The image is the real scan and both sentences
-                were found verbatim in the page's stored text before render
-                (home-data.ts getSpanishShowpiece) — the block hides rather
-                than misquotes. */}
-            {spanishShowpiece && (
-              <Link
-                href={spanishShowpiece.href}
-                className="group grid md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] gap-6 md:gap-10 items-stretch mb-12 border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-[border-color,box-shadow] bg-warm/40"
-              >
-                <div className="relative aspect-[3/4] md:aspect-auto md:min-h-[420px] bg-warm overflow-hidden">
-                  <Image
-                    src={spanishShowpiece.imageUrl}
-                    alt={`${spanishShowpiece.title}, p. ${spanishShowpiece.pageNumber}`}
-                    fill
-                    sizes="(max-width: 768px) 100vw, 40vw"
-                    className="object-cover object-top group-hover:scale-[1.02] transition-transform duration-500"
-                  />
-                </div>
-                <div className="flex flex-col justify-center p-6 md:pr-10 md:py-8">
-                  <p className="text-xs uppercase tracking-[0.2em] text-accent-rust mb-3">{t.spanishShowpieceEyebrow}</p>
-                  <p className="font-display text-xl md:text-2xl text-primary leading-snug">{spanishShowpiece.title}</p>
-                  <p className="text-sm text-muted mt-1 mb-6">
-                    {[spanishShowpiece.author, spanishShowpiece.year, spanishShowpiece.language].filter(Boolean).join(' · ')}
-                  </p>
-                  <div className="grid sm:grid-cols-2 gap-6">
-                    <div>
-                      <p className="text-[11px] uppercase tracking-[0.15em] text-muted mb-2">{t.spanishShowpieceOriginal}</p>
-                      <p className="font-display italic text-secondary leading-relaxed" lang={spanishShowpiece.language === 'Latin' ? 'la' : undefined}>{spanishShowpiece.original}</p>
-                    </div>
-                    <div>
-                      <p className="text-[11px] uppercase tracking-[0.15em] text-muted mb-2">{t.spanishShowpieceSpanish}</p>
-                      <p className="text-primary leading-relaxed" lang="es">{spanishShowpiece.spanish}</p>
-                    </div>
-                  </div>
-                  <p className="text-sm text-accent-rust mt-6 group-hover:underline">
-                    {t.spanishShowpieceOpen(nf(spanishShowpiece.pageNumber))} &rarr;
-                  </p>
-                </div>
-              </Link>
-            )}
-
-            {/* Named, not badged: the titles that exist in Spanish for the
-                first time are the band's strongest claim. Same gate as the
-                card tag (isPublishedFirstTranslation), so the list can never
-                say more than the cards do. */}
-            {spanishFirsts.length > 0 && (
-              <p className="text-sm text-muted mb-6 leading-relaxed">
-                <span className="text-primary font-medium">{t.spanishFirstsLabel}:</span>{' '}
-                {spanishFirsts.map((b, i) => (
-                  <span key={b.id}>
-                    <Link href={b.href} className="text-primary hover:text-accent-rust underline decoration-border-light underline-offset-4 hover:decoration-accent-rust transition-colors">
-                      {localizedTitle(b, lang)}
-                    </Link>
-                    {i < spanishFirsts.length - 1 ? ', ' : '.'}
-                  </span>
-                ))}
+              <p className="text-sm text-muted/80 mb-6">
+                {nf(spanishCounts.pages)} {t.spanishStatPages}
+                {' '}&middot;{' '}
+                {nf(spanishCounts.books + spanishCounts.nativeBooks)} {t.spanishStatBooks}
+                {spanishCounts.firstTranslations > 0 && (
+                  <>
+                    {' '}&middot;{' '}
+                    {nf(spanishCounts.firstTranslations)} {t.spanishStatFirsts}
+                  </>
+                )}
+                {' '}&middot;{' '}
+                {nf(spanishCounts.sourceLanguages)} {t.spanishStatLanguages}
               </p>
             )}
-
-            <BookSlider books={spanishBooks as unknown as MiniBook[]} lang={lang} hideStatus />
+            <BookSlider books={spanishBooks as unknown as MiniBook[]} lang={lang} />
             <div className="mt-6 sm:hidden">
               <Link href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)} className="text-sm text-accent-rust hover:underline">
                 {t.spanishViewAll} &rarr;
-              </Link>
-            </div>
-
-            {/* The ask, where the evidence is. /es/support exists and is the
-                Spanish twin of /support. */}
-            <div className="mt-12 flex flex-col md:flex-row md:items-center md:justify-between gap-5 border border-border-light bg-warm/60 px-6 py-6">
-              <div>
-                <p className="font-display text-xl md:text-2xl text-primary leading-snug">{t.spanishSupportHeading}</p>
-                <p className="text-sm text-muted mt-1 max-w-xl">{t.spanishSupportBody}</p>
-              </div>
-              <Link
-                href={lp('/support')}
-                className="inline-flex items-center justify-center gap-1.5 text-sm font-medium px-5 py-2.5 rounded-lg bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors whitespace-nowrap"
-              >
-                {t.spanishSupportCta}
-                <span className="text-xs">&rarr;</span>
               </Link>
             </div>
           </div>

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -9,8 +9,6 @@ import { type Plate } from '@/components/GalleryMasonry';
 import { type HomeLang } from '@/lib/home-i18n';
 import { isNativeEdition, localizedEditionFilter, type LocalizedBookMap } from '@/lib/localized';
 import { spanishReaderHref } from '@/lib/es-collections';
-import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
-import { stripAiAnnotations } from '@/lib/notes-off';
 
 // Shared data layer for the homepage. Both the English `/` route and the
 // Spanish `/es` route fetch through getHomeData() so the two pages can never
@@ -749,82 +747,6 @@ async function getSpanishCounts(): Promise<SpanishCounts | null> {
   };
 }
 
-// ---------- The bilingual showpiece (the /es band's "see it, don't tell it") ----------
-
-/**
- * One page of one book, shown as its image beside a sentence of the original
- * and the same sentence in Spanish. The EXCERPTS ARE CURATED HERE, but they are
- * only ever rendered after being found, verbatim, in the live page text — so
- * the block can never quote words that are not on the page (the #2232 rule),
- * and a re-OCR or re-translation that changes the sentence hides the block
- * instead of misquoting. Swap the showpiece by editing this constant after
- * reading the page in the reader.
- */
-const SPANISH_SHOWPIECE = {
-  bookId: '69593413b282844d7b277aaf', // Fludd, Utriusque Cosmi Historia, Tomus Primus (1617)
-  pageNumber: 51, // "FIAT" — the creation engraving, Tractatus I, Lib. II, cap. III
-  original: 'Difficilis videtur cognitio dispositionis dierum ante Solis creationem factæ, cùm inter ipsos quoque Patres Theologos differentia haud exigua de dierum illorum natura oriatur.',
-  spanish: 'La comprensión de la disposición de los días establecidos antes de la creación del Sol parece difícil, puesto que entre los mismos Padres Teológicos surge no poca diferencia de opinión respecto a la naturaleza de esos días.',
-};
-
-export interface SpanishShowpiece {
-  title: string;
-  author?: string;
-  year?: number;
-  language?: string;
-  pageNumber: number;
-  imageUrl: string;
-  original: string;
-  spanish: string;
-  /** The Spanish reader, open on this very page. */
-  href: string;
-}
-
-// Whitespace-, case-, and markup-insensitive containment: the stored text has
-// a drop-cap ("DIfficilis"), bold markers around names, and line breaks where
-// the excerpt has spaces. Inline <note> glosses are removed before comparing
-// because they sit mid-sentence and are not the page's words.
-function normalizeForMatch(text: string): string {
-  return stripEditorialWrappers(stripAiAnnotations(text))
-    .replace(/[*_]/g, '')
-    .replace(/\s+/g, ' ')
-    .toLowerCase();
-}
-
-async function getSpanishShowpiece(): Promise<SpanishShowpiece | null> {
-  const db = await getReadDb();
-  const { bookId, pageNumber, original, spanish } = SPANISH_SHOWPIECE;
-  const [book, page] = await Promise.all([
-    db.collection('books').findOne(
-      { id: bookId, visible: true },
-      { projection: { _id: 0, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, localized: 1 }, maxTimeMS: 8000 },
-    ),
-    db.collection('pages').findOne(
-      { book_id: bookId, page_number: pageNumber },
-      { projection: { _id: 0, display_photo: 1, archived_photo: 1, 'ocr.data': 1, 'translations.es.data': 1 }, maxTimeMS: 8000 },
-    ),
-  ]);
-  if (!book || !page) return null;
-  const imageUrl = (page.display_photo || page.archived_photo) as string | undefined;
-  const ocr = page.ocr?.data as string | undefined;
-  const es = page.translations?.es?.data as string | undefined;
-  if (!imageUrl || !ocr || !es) return null;
-  if (!normalizeForMatch(ocr).includes(normalizeForMatch(original))) return null;
-  if (!normalizeForMatch(es).includes(normalizeForMatch(spanish))) return null;
-  const localizedTitle = (book.localized as LocalizedBookMap | undefined)?.es?.title;
-  return {
-    title: localizedTitle || book.display_title || book.title,
-    author: book.author,
-    year: book.year,
-    language: book.language,
-    pageNumber,
-    imageUrl,
-    original,
-    spanish,
-    href: `${spanishReaderHref({ slug: book.slug, id: bookId })}/page-number/${pageNumber}`,
-  };
-}
-
 // ---------- Aggregate ----------
 
 // ---------- Books with a Spanish edition (the /es "Leer en español" band) ----------
@@ -913,8 +835,6 @@ export interface HomeData {
   spanishBooks: SpanishBook[];
   /** Size of the Spanish corpus, for the honest scale line. Null off /es. */
   spanishCounts: SpanishCounts | null;
-  /** One verified page, original beside its Spanish. Null off /es or when the excerpt no longer matches. */
-  spanishShowpiece: SpanishShowpiece | null;
 }
 
 // `lang` selects the podcast episode's language and the Spanish-edition band,
@@ -922,7 +842,7 @@ export interface HomeData {
 // keeps the two homepages structurally identical (see the note at the top of
 // this file).
 export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
-  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts, spanishShowpiece] = await Promise.all([
+  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getRecentlyTranslated(), 20000, [] as CatalogBook[]),
@@ -932,8 +852,7 @@ export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
     withTimeout(getFeaturedPodcast(lang), 8000, null),
     lang === 'es' ? withTimeout(getSpanishBooks(), 8000, [] as SpanishBook[]) : Promise.resolve([] as SpanishBook[]),
     lang === 'es' ? withTimeout(getSpanishCounts(), 8000, null) : Promise.resolve(null),
-    lang === 'es' ? withTimeout(getSpanishShowpiece(), 8000, null) : Promise.resolve(null),
   ]);
 
-  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts, spanishShowpiece };
+  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -70,25 +70,12 @@ export interface HomeStrings {
   // so the two editions keep one shape.
   spanishHeading: string;
   spanishSubtitle: string;
-  /** The honest scale line. Counts arrive already locale-formatted by nf(). */
-  spanishScale: (books: string, pages: string, total: string) => string;
   spanishViewAll: string;
-  // Stat tiles over the Spanish band. Numbers arrive locale-formatted.
+  // The inline count line under the Spanish band heading. Numbers arrive locale-formatted.
   spanishStatPages: string;
   spanishStatBooks: string;
   spanishStatFirsts: string;
   spanishStatLanguages: string;
-  /** Under the tiles: the upside, framed as what a gift opens, not a share. */
-  spanishUpside: (total: string) => string;
-  // The bilingual showpiece: one page, original beside its Spanish.
-  spanishShowpieceEyebrow: string;
-  spanishShowpieceOriginal: string;
-  spanishShowpieceSpanish: string;
-  spanishShowpieceOpen: (page: string) => string;
-  spanishFirstsLabel: string;
-  spanishSupportHeading: string;
-  spanishSupportBody: string;
-  spanishSupportCta: string;
 
   // Gallery masonry (homepage)
   galleryHeading: string;
@@ -200,22 +187,11 @@ const en: HomeStrings = {
   recentlyTranslatedSubtitle: 'The latest works Source Library has brought into a modern, readable translation.',
   spanishHeading: 'Read in Spanish',
   spanishSubtitle: 'The most-read works in the library, with a Spanish edition you can open page by page beside the original.',
-  spanishScale: (books, pages, total) =>
-    `${books} of the library's ${total} books can be read in full in Spanish — ${pages} translated pages beside the original. The rest are in their own language, with an English translation in many cases.`,
   spanishViewAll: 'All books in Spanish',
-  spanishStatPages: 'pages translated into Spanish',
-  spanishStatBooks: 'books readable in Spanish',
-  spanishStatFirsts: 'first translations into Spanish',
+  spanishStatPages: 'pages translated',
+  spanishStatBooks: 'books in Spanish',
+  spanishStatFirsts: 'first translations',
   spanishStatLanguages: 'source languages',
-  spanishUpside: (total) => `A library of ${total} works, and every gift opens more of it in Spanish.`,
-  spanishShowpieceEyebrow: 'Original beside its Spanish',
-  spanishShowpieceOriginal: 'Original',
-  spanishShowpieceSpanish: 'Spanish',
-  spanishShowpieceOpen: (page) => `Open page ${page} in the reader`,
-  spanishFirstsLabel: 'In Spanish for the first time',
-  spanishSupportHeading: 'Help bring the next thousand pages into Spanish',
-  spanishSupportBody: 'Every translation is published open access, page by page beside the original, for readers anywhere.',
-  spanishSupportCta: 'Support Spanish translation',
   galleryHeading: 'Gallery',
   gallerySubtitle: 'Plates, figures, and engravings from rare books across the library.',
   galleryViewAll: (n) => `View all ${n.toLocaleString('en-US')} illustrations`,
@@ -327,22 +303,11 @@ const es: HomeStrings = {
   recentlyTranslatedSubtitle: 'Las obras más recientes que Source Library ha traducido a una versión moderna y legible.',
   spanishHeading: 'Leer en español',
   spanishSubtitle: 'Las obras más leídas de la biblioteca, con una edición en español que puedes abrir página a página junto al original.',
-  spanishScale: (books, pages, total) =>
-    `${books} de los ${total} libros de la biblioteca se pueden leer completos en español — ${pages} páginas traducidas junto al original. Los demás están en su lengua original, con traducción al inglés en muchos casos.`,
   spanishViewAll: 'Todos los libros en español',
-  spanishStatPages: 'páginas traducidas al español',
-  spanishStatBooks: 'libros que se leen en español',
-  spanishStatFirsts: 'primeras traducciones al español',
+  spanishStatPages: 'páginas traducidas',
+  spanishStatBooks: 'libros en español',
+  spanishStatFirsts: 'primeras traducciones',
   spanishStatLanguages: 'lenguas de origen',
-  spanishUpside: (total) => `Una biblioteca de ${total} obras, y cada donación abre más de ella en español.`,
-  spanishShowpieceEyebrow: 'El original junto a su español',
-  spanishShowpieceOriginal: 'Original',
-  spanishShowpieceSpanish: 'Español',
-  spanishShowpieceOpen: (page) => `Abrir la página ${page} en el lector`,
-  spanishFirstsLabel: 'Por primera vez en español',
-  spanishSupportHeading: 'Ayuda a traer las próximas mil páginas al español',
-  spanishSupportBody: 'Cada traducción se publica en acceso abierto, página a página junto al original, para lectores de cualquier lugar.',
-  spanishSupportCta: 'Apoya la traducción al español',
   galleryHeading: 'Galería',
   gallerySubtitle: 'Láminas, figuras y grabados de libros raros de toda la biblioteca.',
   galleryViewAll: (n) => `Ver las ${n.toLocaleString('es-ES')} ilustraciones`,


### PR DESCRIPTION
Reverts the visual additions of #4158 (tiles, eyebrow labels, bilingual showpiece, firsts row, CTA) — they read as generated and unlike the English homepage. Keeps the one thing worth keeping: the count line under the heading now says what was done (pages translated · books in Spanish · first translations · source languages) instead of "105 of 22,068", in the same inline style as the Collections header. Cards get their OCR/Translated line back; the showpiece query and its strings are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULhJT2eog1PfKeHjKYS8Ag