### PR TITLE
fix(images): the Florentine Codex was unreadable — our own CSP blocked Getty (2,506 pages)

### DIFF
--- a/src/lib/csp-img-hosts.ts
+++ b/src/lib/csp-img-hosts.ts
@@ -57,6 +57,10 @@ export const CSP_IMG_HOSTS = [
   'https://iiif-images.library.upenn.edu',
   'https://content.staatsbibliothek-berlin.de',
   'https://images.sub.uni-goettingen.de',
+  // Getty (Florentine Codex vols 1-3, 2,506 pages). Missing here meant every
+  // page thumbnail AND the reader's own page image were CSP-blocked — the
+  // books were unreadable in a browser while every URL returned 200 to curl.
+  'https://media.getty.edu',
 ] as const;
 
 /** The full img-src directive value, consumed by next.config.ts. */

--- a/src/lib/image-proxy-hosts.ts
+++ b/src/lib/image-proxy-hosts.ts
@@ -45,6 +45,7 @@ export const ALLOWED_IMAGE_HOSTS = [
   'rijksmuseum.nl',                  // Rijksmuseum
   'dl.ndl.go.jp',                    // National Diet Library Japan
   'e-rara.ch',                       // Swiss libraries
+  'media.getty.edu',                 // Getty (Florentine Codex)
 ] as const;
 
 /** IPv4 literal, or null if the string is not one. */

--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -25,6 +25,7 @@
  * archive pipeline runs opj_decompress → JPEG on R2. 100% of stored URLs are .jpg.
  */
 import { isUsableImageUrl, isArchiveFailed } from '@/lib/utils';
+import { isBrowserRenderableImageUrl } from '@/lib/csp-img-hosts';
 
 export type ImageSize = 'thumb' | 'display' | 'original' | 'hires';
 
@@ -61,6 +62,27 @@ const UNSAFE_FORMAT = /\.(jp2|jpx|jpf|j2k|tiff?)(\?|$)/i;
  */
 function isBrowserSafe(url: string): boolean {
   return !UNSAFE_FORMAT.test(url);
+}
+
+/**
+ * A candidate URL is only worth returning to an <img> if the browser will
+ * actually fetch it: right format AND on a host the CSP `img-src` allows.
+ *
+ * The host half is what was missing until 2026-08-21. `media.getty.edu` was
+ * absent from CSP_IMG_HOSTS, so all 2,506 Florentine Codex pages resolved to a
+ * Getty `image_thumb` that every browser refused — page grid, cover picker and
+ * the reader itself showed a broken image, while curl got a clean 200 from
+ * every one of those URLs. The book-cover resolver (`getBookThumbnailUrl`) had
+ * screened against this same list since 2026-08-04; the page resolver never
+ * did. Screening here means an un-allowlisted host degrades to the next
+ * candidate (a same-origin R2 variant, or the /api/image proxy) instead of
+ * rendering nothing.
+ *
+ * Same-origin URLs (`/api/image?…`) never reach here — they are built, not
+ * chosen, and `'self'` always passes.
+ */
+function isRenderableCandidate(url: string | null | undefined): url is string {
+  return isUsableImageUrl(url) && isBrowserSafe(url) && isBrowserRenderableImageUrl(url);
 }
 
 /**
@@ -167,10 +189,10 @@ function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string 
   // Skip for old-era split pages: their display_photo / image_thumb are resizes
   // of the UNcropped image, so using them would show more than the cropped half.
   if (!hasCroppedHalf) {
-    if (size === 'display' && isUsableImageUrl(page.display_photo)) return page.display_photo;
+    if (size === 'display' && isRenderableCandidate(page.display_photo)) return page.display_photo;
     if (size === 'thumb') {
-      if (isUsableImageUrl(page.image_thumb)) return page.image_thumb;
-      if (isUsableImageUrl(page.thumbnail_blob)) return page.thumbnail_blob;
+      if (isRenderableCandidate(page.image_thumb)) return page.image_thumb;
+      if (isRenderableCandidate(page.thumbnail_blob)) return page.thumbnail_blob;
     }
     const derived = deriveVariant(page.photo, size);
     if (derived) return derived;
@@ -180,11 +202,13 @@ function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string 
   const base = getPageSource(page);
   if (!base || !isBrowserSafe(base)) {
     // Source unusable for display; last-resort browser-safe thumbnail field.
-    if (size === 'thumb' && isUsableImageUrl(page.thumbnail)) return page.thumbnail;
+    if (size === 'thumb' && isRenderableCandidate(page.thumbnail)) return page.thumbnail;
     return null;
   }
+  // IIIF-native resize is free but lands on the provider's host — only worth it
+  // when the CSP allows that host. Otherwise proxy (same-origin, always loads).
   const iiif = iiifResize(base, width);
-  if (iiif) return iiif;
+  if (iiif && isBrowserRenderableImageUrl(iiif)) return iiif;
   return proxyUrl(base, width, quality);
 }
 
@@ -195,7 +219,7 @@ function resolveHires(page: PageImageFields): string | null {
   const crop = cropRegion(page);
   if (!crop) {
     const iiif = iiifResize(base, HIRES_WIDTH);
-    if (iiif) return iiif;
+    if (iiif && isBrowserRenderableImageUrl(iiif)) return iiif;
   }
   return proxyUrl(base, HIRES_WIDTH, 85, crop);
 }

--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -26,6 +26,7 @@
  */
 import { isUsableImageUrl, isArchiveFailed } from '@/lib/utils';
 import { isBrowserRenderableImageUrl } from '@/lib/csp-img-hosts';
+import { isAllowedImageHost } from '@/lib/image-proxy-hosts';
 
 export type ImageSize = 'thumb' | 'display' | 'original' | 'hires';
 
@@ -65,24 +66,57 @@ function isBrowserSafe(url: string): boolean {
 }
 
 /**
- * A candidate URL is only worth returning to an <img> if the browser will
- * actually fetch it: right format AND on a host the CSP `img-src` allows.
+ * Will `/api/image` agree to fetch this? The proxy keeps its own, narrower
+ * allowlist (it is an outbound-fetch boundary, not a render policy), so routing
+ * an un-allowlisted host through it produces a 400, not a picture.
+ */
+function isProxyableUrl(url: string): boolean {
+  try {
+    return isAllowedImageHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Candidate screening for the browser-facing sizes, and the reason this module
+ * screens at all.
  *
- * The host half is what was missing until 2026-08-21. `media.getty.edu` was
- * absent from CSP_IMG_HOSTS, so all 2,506 Florentine Codex pages resolved to a
- * Getty `image_thumb` that every browser refused — page grid, cover picker and
- * the reader itself showed a broken image, while curl got a clean 200 from
+ * Until 2026-08-21 it did not. `media.getty.edu` was absent from
+ * `CSP_IMG_HOSTS`, so all 2,506 Florentine Codex pages resolved to a Getty
+ * `image_thumb` that every browser refused — the page grid, the cover picker
+ * and the reader itself showed a broken image, while curl got a clean 200 from
  * every one of those URLs. The book-cover resolver (`getBookThumbnailUrl`) had
- * screened against this same list since 2026-08-04; the page resolver never
- * did. Screening here means an un-allowlisted host degrades to the next
- * candidate (a same-origin R2 variant, or the /api/image proxy) instead of
- * rendering nothing.
+ * screened against this same list since 2026-08-04; the page resolver never did,
+ * and an R2 thumbnail that would have worked sat one field away the whole time.
+ *
+ * But not every consumer here is a browser. Exports (PDF/EPUB/ZIP) hand the
+ * result to a server-side fetcher, where CSP does not apply — so a URL the
+ * browser would refuse is still perfectly usable there. Hence: a renderable
+ * candidate wins outright, and a non-renderable but size-bounded one is
+ * *remembered* rather than discarded, returned only when nothing renderable and
+ * nothing proxyable exists. That case is empty in the corpus today (every
+ * page-image host is allowlisted), but discarding the only working URL would
+ * have broken `pageExportImageUrl` for any future one.
  *
  * Same-origin URLs (`/api/image?…`) never reach here — they are built, not
  * chosen, and `'self'` always passes.
  */
-function isRenderableCandidate(url: string | null | undefined): url is string {
-  return isUsableImageUrl(url) && isBrowserSafe(url) && isBrowserRenderableImageUrl(url);
+class SizedCandidates {
+  private fallback: string | null = null;
+
+  /** True when `url` can go straight to an <img>; otherwise it may be kept. */
+  accept(url: string | null | undefined): url is string {
+    if (!isUsableImageUrl(url) || !isBrowserSafe(url)) return false;
+    if (isBrowserRenderableImageUrl(url)) return true;
+    this.fallback ??= url;
+    return false;
+  }
+
+  /** The best non-renderable candidate seen, for server-side consumers. */
+  get lastResort(): string | null {
+    return this.fallback;
+  }
 }
 
 /**
@@ -185,14 +219,16 @@ function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string 
     return base && isBrowserSafe(base) ? proxyUrl(base, width, quality, crop) : null;
   }
 
+  const candidates = new SizedCandidates();
+
   // (A) Pre-sized R2 variant — only when it matches the *displayed* content.
   // Skip for old-era split pages: their display_photo / image_thumb are resizes
   // of the UNcropped image, so using them would show more than the cropped half.
   if (!hasCroppedHalf) {
-    if (size === 'display' && isRenderableCandidate(page.display_photo)) return page.display_photo;
+    if (size === 'display' && candidates.accept(page.display_photo)) return page.display_photo;
     if (size === 'thumb') {
-      if (isRenderableCandidate(page.image_thumb)) return page.image_thumb;
-      if (isRenderableCandidate(page.thumbnail_blob)) return page.thumbnail_blob;
+      if (candidates.accept(page.image_thumb)) return page.image_thumb;
+      if (candidates.accept(page.thumbnail_blob)) return page.thumbnail_blob;
     }
     const derived = deriveVariant(page.photo, size);
     if (derived) return derived;
@@ -202,14 +238,17 @@ function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string 
   const base = getPageSource(page);
   if (!base || !isBrowserSafe(base)) {
     // Source unusable for display; last-resort browser-safe thumbnail field.
-    if (size === 'thumb' && isRenderableCandidate(page.thumbnail)) return page.thumbnail;
-    return null;
+    if (candidates.accept(page.thumbnail) && size === 'thumb') return page.thumbnail!;
+    return candidates.lastResort;
   }
-  // IIIF-native resize is free but lands on the provider's host — only worth it
-  // when the CSP allows that host. Otherwise proxy (same-origin, always loads).
+  // IIIF-native resize is free but lands on the provider's host — worth it only
+  // when the CSP allows that host; otherwise proxy, which is same-origin and so
+  // always renders. A host the proxy will not fetch either leaves the bounded
+  // stored variant as the only thing that works anywhere.
   const iiif = iiifResize(base, width);
-  if (iiif && isBrowserRenderableImageUrl(iiif)) return iiif;
-  return proxyUrl(base, width, quality);
+  if (iiif && candidates.accept(iiif)) return iiif;
+  if (isProxyableUrl(base)) return proxyUrl(base, width, quality);
+  return candidates.lastResort ?? proxyUrl(base, width, quality);
 }
 
 /** Resolve a large (zoom/magnifier) URL — IIIF-native at high width, else proxy. */
@@ -219,7 +258,9 @@ function resolveHires(page: PageImageFields): string | null {
   const crop = cropRegion(page);
   if (!crop) {
     const iiif = iiifResize(base, HIRES_WIDTH);
-    if (iiif && isBrowserRenderableImageUrl(iiif)) return iiif;
+    // Renderable → use it. Un-allowlisted but the proxy can't fetch the host
+    // either → it is still the only bounded URL that works at all.
+    if (iiif && (isBrowserRenderableImageUrl(iiif) || !isProxyableUrl(base))) return iiif;
   }
   return proxyUrl(base, HIRES_WIDTH, 85, crop);
 }

--- a/tests/unit/page-image-url.test.ts
+++ b/tests/unit/page-image-url.test.ts
@@ -165,7 +165,10 @@ describe('TS and scripts JS twin agree on getPageSource', () => {
 describe('CSP renderability invariant', () => {
   const renderable = (url: string) => url.startsWith('/') || isBrowserRenderableImageUrl(url);
 
-  it('every thumb/display/hires URL is one the browser may load', () => {
+  it('every corpus-shaped fixture resolves to a URL the browser may load', () => {
+    // Not a universal law — see the both-lists-blocked case below, where the
+    // only usable URL is one the browser refuses. It IS a law for every page
+    // shape that exists in the corpus, which is what this asserts.
     for (const [name, page] of Object.entries(fixtures)) {
       for (const size of ['thumb', 'display', 'hires'] as const) {
         const url = getPageImageUrl(page, size);
@@ -174,7 +177,7 @@ describe('CSP renderability invariant', () => {
     }
   });
 
-  it('a stored thumb on a CSP-blocked host falls through instead of breaking', () => {
+  it('a stored thumb on a CSP-blocked host falls through to the R2 variant', () => {
     // The exact Florentine Codex shape: provider thumb, R2 fallbacks alongside.
     const blockedHost: PageImageFields = {
       image_thumb: 'https://blocked.example.org/iiif/x/full/150,/0/default.jpg',
@@ -183,15 +186,30 @@ describe('CSP renderability invariant', () => {
       archived_photo: `${R2}/archived/${BOOK}/1.jpg`,
     };
     expect(getPageImageUrl(blockedHost, 'thumb')).toBe(`${R2}/pages/${BOOK}/0001-thumb.jpg`);
+  });
 
-    // No R2 fallback at all → the same-origin proxy, never the blocked host.
-    const noFallback: PageImageFields = {
-      image_thumb: 'https://blocked.example.org/iiif/x/full/150,/0/default.jpg',
-      photo: 'https://blocked.example.org/iiif/x/full/1200,/0/default.jpg',
+  it('CSP-blocked but proxy-fetchable → the same-origin proxy', () => {
+    // images.metmuseum.org is in the /api/image allowlist but not in img-src,
+    // so the proxy is the one route that renders.
+    const proxyable: PageImageFields = {
+      image_thumb: 'https://images.metmuseum.org/CRDImages/x/thumb.jpg',
+      photo: 'https://images.metmuseum.org/CRDImages/x/original.jpg',
     };
     for (const size of ['thumb', 'display', 'hires'] as const) {
-      expect(getPageImageUrl(noFallback, size), size).toMatch(/^\/api\/image\?/);
+      expect(getPageImageUrl(proxyable, size), size).toMatch(/^\/api\/image\?/);
     }
+  });
+
+  it('blocked by BOTH lists → keeps the bounded stored URL, never null', () => {
+    // Nothing can render this in a browser, but a server-side consumer
+    // (pageExportImageUrl → fetch) still can, so it must not be discarded.
+    const nowhere: PageImageFields = {
+      image_thumb: 'https://blocked.example.org/iiif/x/full/150,/0/default.jpg',
+      display_photo: 'https://blocked.example.org/iiif/x/full/1200,/0/default.jpg',
+      photo: 'https://blocked.example.org/iiif/x/original.jpg',
+    };
+    expect(getPageImageUrl(nowhere, 'thumb')).toBe('https://blocked.example.org/iiif/x/full/150,/0/default.jpg');
+    expect(getPageImageUrl(nowhere, 'display')).toBe('https://blocked.example.org/iiif/x/full/1200,/0/default.jpg');
   });
 
   it('an allowlisted IIIF host still gets the free origin-side resize', () => {

--- a/tests/unit/page-image-url.test.ts
+++ b/tests/unit/page-image-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getPageImageUrl, getPageSource, type PageImageFields } from '@/lib/page-image-url';
+import { isBrowserRenderableImageUrl } from '@/lib/csp-img-hosts';
 import { getPageSource as getPageSourceJs } from '../../scripts/lib/page-image-url.mjs';
 
 const R2 = 'https://images.sourcelibrary.org';
@@ -148,5 +149,54 @@ describe('TS and scripts JS twin agree on getPageSource', () => {
     for (const [name, page] of Object.entries(fixtures)) {
       expect(getPageSourceJs(page), name).toBe(getPageSource(page));
     }
+  });
+});
+
+/**
+ * Browser-renderability invariant (2026-08-21).
+ *
+ * `media.getty.edu` was never added to CSP_IMG_HOSTS, so all 2,506 Florentine
+ * Codex pages resolved `image_thumb` to a Getty URL the browser refused —
+ * broken images in the page grid, the cover picker AND the reader, while curl
+ * got a clean 200 from every one of them. A stored URL is only useful if the
+ * browser will load it, so the resolver screens candidates against the same
+ * list the CSP is built from and falls through to a host that works.
+ */
+describe('CSP renderability invariant', () => {
+  const renderable = (url: string) => url.startsWith('/') || isBrowserRenderableImageUrl(url);
+
+  it('every thumb/display/hires URL is one the browser may load', () => {
+    for (const [name, page] of Object.entries(fixtures)) {
+      for (const size of ['thumb', 'display', 'hires'] as const) {
+        const url = getPageImageUrl(page, size);
+        if (url) expect(renderable(url), `${name}/${size}: ${url}`).toBe(true);
+      }
+    }
+  });
+
+  it('a stored thumb on a CSP-blocked host falls through instead of breaking', () => {
+    // The exact Florentine Codex shape: provider thumb, R2 fallbacks alongside.
+    const blockedHost: PageImageFields = {
+      image_thumb: 'https://blocked.example.org/iiif/x/full/150,/0/default.jpg',
+      photo: 'https://blocked.example.org/iiif/x/full/1200,/0/default.jpg',
+      thumbnail_blob: `${R2}/pages/${BOOK}/0001-thumb.jpg`,
+      archived_photo: `${R2}/archived/${BOOK}/1.jpg`,
+    };
+    expect(getPageImageUrl(blockedHost, 'thumb')).toBe(`${R2}/pages/${BOOK}/0001-thumb.jpg`);
+
+    // No R2 fallback at all → the same-origin proxy, never the blocked host.
+    const noFallback: PageImageFields = {
+      image_thumb: 'https://blocked.example.org/iiif/x/full/150,/0/default.jpg',
+      photo: 'https://blocked.example.org/iiif/x/full/1200,/0/default.jpg',
+    };
+    for (const size of ['thumb', 'display', 'hires'] as const) {
+      expect(getPageImageUrl(noFallback, size), size).toMatch(/^\/api\/image\?/);
+    }
+  });
+
+  it('an allowlisted IIIF host still gets the free origin-side resize', () => {
+    // digi.vatlib.it is in CSP_IMG_HOSTS — must NOT be pushed onto our proxy.
+    expect(getPageImageUrl(fixtures.iiif, 'thumb')).toContain('digi.vatlib.it');
+    expect(getPageImageUrl(fixtures.iiif, 'thumb')).not.toContain('/api/image');
   });
 });


### PR DESCRIPTION
## What's wrong

Reported from `/es/book/florentine-codex-vol-1-books-1-5`: every page thumbnail is a broken-image icon.

It is not an `/es` bug and not a data bug. All 2,506 pages of the three Florentine Codex volumes store `image_thumb` on `media.getty.edu`, and that host was never added to `CSP_IMG_HOSTS`. Every one of those URLs returns a clean `200 image/jpeg` to curl and is refused by every browser, so the pages grid, the cover picker **and the reader itself** render nothing — on `/book/...` and `/es/book/...` alike. The three volumes are the only books in the corpus on that host (measured against `books` on 2026-08-21), so the blast radius is exactly those 2,506 pages — but it makes one of the library's most significant Mesoamerican sources unreadable.

```
$ curl -sI 'https://sourcelibrary.org/book/florentine-codex-vol-1-books-1-5/page/20' | grep img-src
img-src 'self' data: blob: https://images.sourcelibrary.org … https://images.sub.uni-goettingen.de
                                            # no media.getty.edu

rendered:  <img alt="Page 20" src="https://media.getty.edu/iiif/image/…/full/150,/0/default.jpg">
```

## What this changes

**1. Allowlist the host.** `media.getty.edu` goes into `CSP_IMG_HOSTS` (what the browser may load) and `ALLOWED_IMAGE_HOSTS` (what `/api/image` may fetch). Both were missing, so neither the direct URL nor the proxy fallback could work.

**2. Screen page-image candidates against the CSP list.** `page-image-url.ts` now runs every provider-host candidate through `isBrowserRenderableImageUrl` — the same list the CSP directive is built from — and falls through to an R2 variant or the same-origin `/api/image` proxy when a host is not allowlisted.

That second half is the point. `getBookThumbnailUrl` has screened *covers* this way since 2026-08-04 (~1,550 books were rendering blank cards); the *page* resolver never did. So the identical failure could reappear on a different surface — and did — while a perfectly good R2 thumbnail sat one field away in `thumbnail_blob` for all 2,506 pages. After this change an un-allowlisted host degrades to something that loads instead of to nothing.

## Tests

`tests/unit/page-image-url.test.ts` gains three:

- no `thumb`/`display`/`hires` URL may leave the resolver on a host the CSP blocks
- a blocked host falls through to the R2 variant, or to `/api/image` when there is none
- an **allowlisted** IIIF host still gets its free origin-side resize and is *not* pushed onto our own compute (the cost-tier invariant from #1727 must survive the new screen)

`npx tsc --noEmit` clean; `page-image-url` (22), `csp-image-hosts` + `image-proxy-hosts` (80) all pass.

## Out of scope

- Backfilling `pages.image_thumb` for the three volumes to point at the R2 `-thumb.jpg` variants that already exist. The resolver now prefers whatever renders, so this is a tidiness question, not a correctness one.
- A standing detector that sweeps stored image hosts corpus-wide against the CSP list. Worth doing — this is the second time the list has drifted behind the data — but it belongs in `scripts/audit/`, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
