### PR TITLE
fix(es): six ways a Spanish reader fell back into English

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -246,3 +246,46 @@ expect to PASS — a "not found" is worthless until the probe has returned "foun
 somewhere (`lesson: a probe needs a positive control`). The same trap catches
 any check written against a surface that later gets translated, so a grep that
 hard-codes English is a latent false alarm even when it passes today.
+
+## A localized page leaks through its least-attended link site
+
+`/es` was audited by crawling every page and following all 638 links (#4164).
+No page 404'd, every canonical and `hreflang` was right, and the deliberate
+`/es/book/<id>` → `/book/<id>` 307s behaved. **Eight defects, and every one of
+them was a link** — a hard-coded `href="/"` on the header logo and again on the
+footer wordmark, one `BookSlider` out of several missing its `lang`, a card
+guard that counted the wrong thing, a sign-up CTA nobody had ever passed a
+locale to.
+
+The lesson is where to look, not what to fix. A localized route is not one
+surface; it is the surface plus every component it mounts, and the locale is
+carried by a prop or a hook that any one of them can silently fail to take.
+Rendering correctly says nothing about linking correctly, so:
+
+- **Audit the hrefs, not the pages.** Crawl the localized tree and, for every
+  outbound link, ask whether the target has a twin in the registry
+  (`LOCALIZED_PATHS` / `LOCALIZED_PATTERNS` in `src/lib/locale-path.ts`). A link
+  to a path with a twin, without the prefix, is a leak. A link to a path with no
+  twin is correct and must be left alone.
+- **A crawl cannot see the whole page.** Three of the eight were invisible to it:
+  `SignUpCTA` renders only for signed-OUT visitors *after* hydration, the
+  "recently looked at" band only for signed-IN ones, and one CTA only under
+  `embedPolicy`. An anonymous SSR fetch shows none of them. Finish the sweep by
+  grepping for hard-coded twin-route hrefs — `href="/"`, `href="/collections"`,
+  `href="/librarian"`, `href="/support"`, `href="/auth/signin"` — across every
+  component the localized route mounts.
+- **Prefer the registry to a per-item ternary.** `locale === 'es' ? '/es/x' :
+  '/x'` is correct the day it is written and wrong the day the next twin ships:
+  that is exactly how the Spanish nav went on pointing at the English librarian
+  after `/es/librarian` existed. `localePath(href, locale)` knows.
+- **Both sides of an edition guard must read the same locale.** A card asks "does
+  this book exist in this language?" and then calls `localePath`, which prefixes
+  from the URL. Ask the question about the URL's locale too — asking about a
+  `lang` prop lets a component that forgot to take one promise an `/es` page that
+  does not exist.
+
+Corollary from the same audit: the fix landed in the guard and the gap stayed
+open anyway, because `books_catalog` has no `pages_translated_es` and the guard
+could not see books *translated* into Spanish (only ones *written* in it) —
+#4166. **A link-side fix is only as good as the fields the link site is given**,
+which is rule 2's fill-rate point wearing different clothes.

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2547,6 +2547,7 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
         <SignUpCTA
           bgImageUrl="https://images.sourcelibrary.org/artwork/woman-of-the-apocalypse-hortus-deliciarum.jpg"
           bgAttribution={{ text: 'Woman of the Apocalypse, Hortus Deliciarum (12th c.)', href: '/collections/visions-ecstasies' }}
+          lang={lang}
         />
       )}
     </div>

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2060,11 +2060,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                   return (
                     <div className="mt-5">
                       <Link
-                        href={`/book/${bookSlug}/page-number/${firstChapterPageNumber}`}
+                        href={lp(`/book/${bookSlug}/page-number/${firstChapterPageNumber}`)}
                         className="inline-flex items-center gap-2.5 px-6 py-3 bg-accent-rust hover:bg-accent-rust/90 text-white font-medium rounded-lg transition-colors text-base"
                       >
                         <BookOpen className="w-5 h-5" />
-                        Read this book
+                        {t.readThisBook}
                       </Link>
                     </div>
                   );
@@ -2075,11 +2075,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 return (
                   <div className="mt-5">
                     <Link
-                      href={`/book/${bookSlug}/page/${readPage.id}`}
+                      href={lp(`/book/${bookSlug}/page/${readPage.id}`)}
                       className="inline-flex items-center gap-2.5 px-6 py-3 bg-accent-rust hover:bg-accent-rust/90 text-white font-medium rounded-lg transition-colors text-base"
                     >
                       <BookOpen className="w-5 h-5" />
-                      Read this book
+                      {t.readThisBook}
                     </Link>
                   </div>
                 );

--- a/src/app/librarian/page.tsx
+++ b/src/app/librarian/page.tsx
@@ -61,28 +61,39 @@ async function getFeaturedPassage() {
       }
       if (text.length >= 60) {
         // Resolve page _id for deep linking (notebook stores slug, pages use book.id)
-        const bookSlug = f.source.bookSlug || f.source.bookId;
-        let pageId: string | undefined;
+        const notebookSlug = f.source.bookSlug || f.source.bookId;
         const bookDoc = await db.collection('books').findOne(
-          { $or: [{ slug: bookSlug }, { id: bookSlug }] },
-          { projection: { id: 1 }, maxTimeMS: 3000 }
+          { $or: [{ slug: notebookSlug }, { id: notebookSlug }] },
+          { projection: { id: 1, slug: 1 }, maxTimeMS: 3000 }
         );
+        // The whole passage is a LINK. A notebook slug that resolves to no book
+        // used to be returned anyway — the lookup's only job was the pageId and
+        // its failure was ignored — so the "Librarian is reading" card pointed
+        // at a 404. Measured 2026-08-21: 28 of 1,041 quotable findings (2.7%)
+        // name a book that no longer exists under that slug (renames, deletions,
+        // and a few malformed slugs with a `/page-number/N` tail baked in), and
+        // the passage is picked at random, so ~1 in 37 librarian page loads —
+        // English and Spanish alike — offered a dead link. If it does not
+        // resolve, fall through to the random-passage path below rather than
+        // render an unfollowable quote.
         if (bookDoc) {
           const pageDoc = await db.collection('pages').findOne(
             { book_id: bookDoc.id, page_number: f.source.pageNumber },
             { projection: { _id: 1 }, maxTimeMS: 3000 }
           );
-          pageId = pageDoc?._id?.toString();
+          return {
+            text,
+            bookTitle: f.source.bookTitle,
+            bookAuthor: f.source.bookAuthor,
+            bookYear: null,
+            // The book's OWN slug, not the notebook's copy of it: a book that
+            // has been re-slugged still resolves by `id` above, and echoing the
+            // stale slug back into the href would 404 just as surely.
+            bookSlug: (bookDoc.slug as string) || (bookDoc.id as string),
+            pageNumber: f.source.pageNumber,
+            pageId: pageDoc?._id?.toString(),
+          };
         }
-        return {
-          text,
-          bookTitle: f.source.bookTitle,
-          bookAuthor: f.source.bookAuthor,
-          bookYear: null,
-          bookSlug: bookSlug,
-          pageNumber: f.source.pageNumber,
-          pageId,
-        };
       }
     }
 

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -12,8 +12,8 @@ import BookCoverPlaceholder from '@/components/BookCoverPlaceholder';
 import { getEffectiveByline } from '@/lib/byline';
 import { useEmbed, useEmbedHref } from '@/lib/EmbedContext';
 import PlaceholderCover from '@/components/book/PlaceholderCover';
-import { useLocalePath, type Locale } from '@/lib/i18n';
-import { localizedTitle, originalTitleIfDifferent, type LocalizedBookMap } from '@/lib/localized';
+import { useLocale, useLocalePath, type Locale } from '@/lib/i18n';
+import { localizedTitle, originalTitleIfDifferent, type LocalizedBookMap, hasLocalizedEdition } from '@/lib/localized';
 
 export interface CollectionBook {
   bookId?: string;
@@ -131,6 +131,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   // in Spanish, and a book without one has no Spanish page to point at.
   // localePath is registry-guarded on top of that, so /artwork/… is untouched.
   const localePath = useLocalePath();
+  const urlLocale = useLocale();
 
   const isArtwork = !!book.resource_type;
   const pageCount = book.pages_count || book.pages || 0;
@@ -139,8 +140,19 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
   const slug = book.slug || book.id || book.bookId || '';
 
-  const hasSpanishEdition = (book.pages_translated_es ?? 0) > 0;
-  const localized = (href: string) => (hasSpanishEdition ? localePath(href) : href);
+  // "Does this book exist in the surface language?" — asked through the shared
+  // helper, never by reading a counter here. A book WRITTEN in Spanish is a
+  // Spanish edition with no translated pages at all (#4120), so the old
+  // `pages_translated_es > 0` test sent Cogolludo, Landa and Scherzer from an
+  // /es grid straight to their ENGLISH page. `hasLocalizedEdition` returns null
+  // when `language` was not projected and it genuinely cannot tell; treat that
+  // as "no" so an /es URL is never a promise we can't keep.
+  // Asked against the URL's locale, not the `lang` PROP: `localePath` prefixes
+  // with whatever the URL says, so testing the prop would let a card that was
+  // rendered without `lang` on an /es page prefix every book — including ones
+  // with no Spanish page at all. Both sides of the guard read the same locale.
+  const hasLocalizedTwin = hasLocalizedEdition(book as unknown as Record<string, unknown>, urlLocale) === true;
+  const localized = (href: string) => (hasLocalizedTwin ? localePath(href) : href);
   const bookHref = localized(embedHref(`${bookUrlPrefix || ''}/book/${encodeURIComponent(slug)}`));
   const artworkHref = embedHref(`${bookUrlPrefix || ''}/artwork/${encodeURIComponent(slug)}`);
 

--- a/src/components/auth/SignUpCTA.tsx
+++ b/src/components/auth/SignUpCTA.tsx
@@ -4,6 +4,37 @@ import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import ParallaxImage from '@/components/ParallaxImage';
+import { localePath, type Locale } from '@/lib/locale-path';
+
+// Chrome strings. This band was hard-coded English, and it renders on the
+// Spanish book page and inside the Spanish homepage's own (already localized)
+// "Ayuda a recuperar…" section — so the one thing on those pages ASKING a
+// reader to join was in a language they may not read, and its button pointed at
+// the English sign-in while `/es/auth/signin` exists. It is client-only and
+// hidden for signed-in visitors, which is why a crawl never sees it.
+const STRINGS: Record<Locale, {
+  inlineNudge: string; inlineLink: string;
+  eyebrow: string; heading: string; body: string; cta: string; footnote: string;
+}> = {
+  en: {
+    inlineNudge: 'Create a free account to save books and track your reading.',
+    inlineLink: 'Sign in with email',
+    eyebrow: 'Join the project',
+    heading: 'Help recover the lost intellectual heritage of humanity',
+    body: "Create a free account to save books, track your reading, and follow new translations as they're published.",
+    cta: 'Create free account',
+    footnote: 'Sign in with email \u00b7 No spam, ever',
+  },
+  es: {
+    inlineNudge: 'Crea una cuenta gratuita para guardar libros y seguir tus lecturas.',
+    inlineLink: 'Entra con tu correo',
+    eyebrow: 'Súmate al proyecto',
+    heading: 'Ayuda a recuperar el patrimonio intelectual perdido de la humanidad',
+    body: 'Crea una cuenta gratuita para guardar libros, seguir tus lecturas y enterarte de cada nueva traducción.',
+    cta: 'Crea tu cuenta gratuita',
+    footnote: 'Entra con tu correo \u00b7 Nunca enviamos spam',
+  },
+};
 
 interface SignUpCTAProps {
   variant?: 'section' | 'inline';
@@ -11,6 +42,8 @@ interface SignUpCTAProps {
   bgImageUrl?: string;
   /** Optional credit for the background image, shown bottom-centre with a link. */
   bgAttribution?: { text: string; href: string };
+  /** Surface language — picks the copy and the sign-in href. */
+  lang?: Locale;
 }
 
 // Default background for the shared "Join the project" section: the Flamsteed
@@ -26,9 +59,12 @@ export default function SignUpCTA({
   variant = 'section',
   bgImageUrl = DEFAULT_BG_IMAGE_URL,
   bgAttribution = DEFAULT_BG_ATTRIBUTION,
+  lang = 'en',
 }: SignUpCTAProps) {
   const { status } = useStableSession();
   const isEmbedded = useIsEmbedded();
+  const t = STRINGS[lang];
+  const signInHref = localePath('/auth/signin', lang);
 
   // Don't show when embedded, authenticated, or while loading
   if (isEmbedded || status !== 'unauthenticated') return null;
@@ -38,14 +74,14 @@ export default function SignUpCTA({
     return (
       <div className="text-center mt-10 pt-8" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}>
         <p className="text-sm mb-3" style={{ color: '#6b6560' }}>
-          Create a free account to save books and track your reading.
+          {t.inlineNudge}
         </p>
         <Link
-          href="/auth/signin"
+          href={signInHref}
           className="text-sm font-medium hover:underline"
           style={{ color: 'var(--accent-gold)' }}
         >
-          Sign in with email
+          {t.inlineLink}
         </Link>
       </div>
     );
@@ -65,30 +101,29 @@ export default function SignUpCTA({
           className="text-sm uppercase tracking-[0.2em] mb-6"
           style={{ color: 'var(--accent-gold)' }}
         >
-          Join the project
+          {t.eyebrow}
         </p>
         <h2
           className="text-2xl md:text-3xl lg:text-4xl font-display mb-5 leading-snug"
           style={{ color: '#f5f0e8' }}
         >
-          Help recover the lost intellectual heritage of humanity
+          {t.heading}
         </h2>
         <p
           className="text-base md:text-lg mb-10 max-w-lg mx-auto leading-relaxed"
           style={{ color: bgImageUrl ? '#e7e1d7' : '#a09a90' }}
         >
-          Create a free account to save books, track your reading, and follow
-          new translations as they&apos;re published.
+          {t.body}
         </p>
         <Link
-          href="/auth/signin"
+          href={signInHref}
           className="inline-flex items-center gap-2.5 px-8 py-3.5 rounded-full text-sm font-medium transition-all hover:brightness-110"
           style={{ background: 'var(--accent-rust)', color: '#fff' }}
         >
-          Create free account
+          {t.cta}
         </Link>
         <p className="text-xs mt-5" style={{ color: bgImageUrl ? '#cfc8bc' : '#6b6560' }}>
-          Sign in with email &middot; No spam, ever
+          {t.footnote}
         </p>
       </div>
       {bgImageUrl && bgAttribution && (

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -283,7 +283,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
       {/* Recently looked at — personalized slider from the signed-in reader's
           history, tucked right under the collections grid. Self-hides for
           anonymous visitors and readers with no history. */}
-      <RecentlyRead />
+      <RecentlyRead lang={lang} />
 
       {/* Recently translated — the same slider as the Mycology collection's
           "First translations" band, auto-filled with the 15 works most recently
@@ -306,7 +306,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
             <p className="text-muted mb-6 max-w-2xl">
               {t.recentlyTranslatedSubtitle}
             </p>
-            <BookSlider books={recentlyTranslated as unknown as MiniBook[]} />
+            <BookSlider books={recentlyTranslated as unknown as MiniBook[]} lang={lang} />
           </div>
         </section>
       )}

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -557,7 +557,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
           </div>
 
           {/* Free account nudge — for anonymous users only */}
-          <SignUpCTA variant="inline" />
+          <SignUpCTA variant="inline" lang={lang} />
         </div>
       </section>
 

--- a/src/components/home/RecentlyRead.tsx
+++ b/src/components/home/RecentlyRead.tsx
@@ -6,6 +6,17 @@ import { ArrowRight } from 'lucide-react';
 import { useStableSession } from '@/hooks/useStableSession';
 import { readingHistory } from '@/lib/api-client';
 import BookSlider, { type MiniBook } from '@/components/BookSlider';
+import { localePath, type Locale } from '@/lib/locale-path';
+
+// Chrome strings. The whole band used to be hard-coded English, so the Spanish
+// homepage carried an English heading, subtitle and "See all" over Spanish
+// cards — the thing rule 4 of .claude/docs/i18n.md exists to prevent. Labels
+// only; the hrefs go through `localePath`, which prefixes exactly the routes
+// that have a Spanish twin.
+const STRINGS: Record<Locale, { heading: string; subtitle: string; seeAll: string }> = {
+  en: { heading: 'Recently looked at', subtitle: 'Pick up where you left off.', seeAll: 'See all' },
+  es: { heading: 'Vistos recientemente', subtitle: 'Retoma donde lo dejaste.', seeAll: 'Ver todo' },
+};
 
 /**
  * "Recently looked at" — a personalized slider drawn from the signed-in reader's
@@ -18,7 +29,7 @@ import BookSlider, { type MiniBook } from '@/components/BookSlider';
  * Renders nothing for anonymous users or when there's no history yet, so the
  * homepage is unchanged for logged-out visitors.
  */
-export default function RecentlyRead() {
+export default function RecentlyRead({ lang = 'en' }: { lang?: Locale } = {}) {
   const { data: session, status } = useStableSession();
   const [books, setBooks] = useState<MiniBook[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -51,7 +62,7 @@ export default function RecentlyRead() {
   // Hidden entirely for anonymous users and until we have something to show.
   if (!session || !loaded || books.length === 0) return null;
 
-  return <RecentlyReadSlider books={books} />;
+  return <RecentlyReadSlider books={books} lang={lang} />;
 }
 
 /**
@@ -60,25 +71,26 @@ export default function RecentlyRead() {
  * without a live session. Uses the shared BookSlider so the cards and slider
  * mechanics match the rest of the site.
  */
-export function RecentlyReadSlider({ books }: { books: MiniBook[] }) {
+export function RecentlyReadSlider({ books, lang = 'en' }: { books: MiniBook[]; lang?: Locale }) {
+  const t = STRINGS[lang];
   return (
     <section className="bg-[#f3ede6] pb-16 md:pb-24 -mt-4">
       <div className="px-6 md:px-12 max-w-[1500px] mx-auto">
         <div className="flex items-baseline justify-between mb-6">
           <div>
-            <h2 className="text-2xl md:text-3xl text-primary font-display">Recently looked at</h2>
-            <p className="text-muted mt-1 text-sm">Pick up where you left off.</p>
+            <h2 className="text-2xl md:text-3xl text-primary font-display">{t.heading}</h2>
+            <p className="text-muted mt-1 text-sm">{t.subtitle}</p>
           </div>
           <Link
-            href="/reading-history"
+            href={localePath('/reading-history', lang)}
             className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-rust hover:text-accent-rust/80 transition-colors"
           >
-            See all
+            {t.seeAll}
             <ArrowRight className="w-3.5 h-3.5" />
           </Link>
         </div>
 
-        <BookSlider books={books} />
+        <BookSlider books={books} lang={lang} />
       </div>
     </section>
   );

--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -72,7 +72,7 @@ export default function GlobalFooter() {
 
         {/* Zone 1: Brand + Mission */}
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4 py-8 border-b border-white/[0.08]">
-          <Link href="/" className="group">
+          <Link href={localePath('/')} className="group">
             <Image
               src="/brand/png/logo-compact--white-on-transparent--96h.png"
               alt="Source Library"

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { localePath, type Locale } from '@/lib/locale-path';
 
 interface LogoProps {
   /** White text/stroke for dark backgrounds */
@@ -7,9 +8,18 @@ interface LogoProps {
   compact?: boolean;
   /** Extra-compact: icon only on mobile, text on sm+ (used in reader header) */
   mini?: boolean;
+  /**
+   * Surface locale. The wordmark is the most-clicked nav element on the site and
+   * its href used to be a hard-coded `/`: on every `/es` page it dropped a
+   * Spanish reader onto the ENGLISH homepage, silently ending their localized
+   * session. Passed down (not read from `usePathname`) because the homepage is
+   * statically prerendered, where the pathname is null at build time and the
+   * link would only become correct after hydration.
+   */
+  lang?: Locale;
 }
 
-export default function Logo({ white, compact, mini }: LogoProps) {
+export default function Logo({ white, compact, mini, lang = 'en' }: LogoProps) {
   const strokeColor = white ? 'white' : 'currentColor';
 
   const iconSize = mini
@@ -35,7 +45,7 @@ export default function Logo({ white, compact, mini }: LogoProps) {
 
   return (
     <Link
-      href="/"
+      href={localePath('/', lang)}
       className={`inline-flex items-center ${mini ? 'gap-1.5' : 'gap-3'} ${
         white
           ? 'text-white hover:opacity-80'

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -202,7 +202,7 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
     >
       <div className="flex items-center justify-between px-6 md:px-12 max-w-[var(--container-wide)] mx-auto">
         <div className="flex items-center gap-3">
-          <Logo white={isWhiteText} compact={!!breadcrumbs} />
+          <Logo white={isWhiteText} compact={!!breadcrumbs} lang={locale} />
           {breadcrumbs?.map((crumb) => (
             <span key={crumb.href} className="flex items-center gap-3">
               <span className={isWhiteText ? 'text-white/40 hidden sm:inline' : 'text-stone-400 hidden sm:inline'}>/</span>

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -4,7 +4,7 @@ import { signOut } from 'next-auth/react';
 import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useLocale } from '@/lib/i18n';
+import { useLocale, localePath } from '@/lib/i18n';
 
 interface UserMenuProps {
   variant?: 'hero' | 'default';
@@ -41,7 +41,7 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
 
     return (
       <Link
-        href={locale === 'es' ? '/es/auth/signin' : '/auth/signin'}
+        href={localePath('/auth/signin', locale)}
         className={`text-sm font-medium transition-colors hover:opacity-80 ${textColor}`}
         style={textStyle}
       >
@@ -153,7 +153,7 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
               Reading History
             </Link>
             <Link
-              href="/support"
+              href={localePath('/support', locale)}
               className="block px-4 py-2 text-sm hover:opacity-70 transition-opacity"
               style={{ color: 'var(--text-primary)' }}
               onClick={() => setIsOpen(false)}


### PR DESCRIPTION
Crawled every `/es` surface on production and followed each link — 638 unique links across the homepage, `/es/collections`, three collection pages, three book/reader pages, `/es/librarian`, `/es/support`, `/es/support/business` and `/es/auth/signin`.

**The pages are fine.** No `/es` page 404s. Canonical and `hreflang` are correct on every one. The `/es/book/<id>` → `/book/<id>` 307s for books with no Spanish edition are the intended #4104 behaviour, and `/page-number/N` → `/page/<id>` stays inside `/es`.

The defects are all in the links, and all the same shape: something on a Spanish page quietly hands the reader back to English.

## Fixed here

| | Surface | Defect |
|---|---|---|
| 1 | every `/es/*` page | header `Logo` hard-coded `href="/"` — the most-clicked nav element dropped the reader on the English homepage |
| 2 | every `/es/*` page | `GlobalFooter`'s brand wordmark, same defect one component over (the footer's three link columns already went through `localePath`) |
| 3 | `/es` | "Traducidas recientemente" was the one `BookSlider` on the page without `lang` |
| 4 | `/es` | "Recently looked at" — heading, subtitle and "See all" in English, over Spanish cards |
| 5 | `/es` grids and rails | `CollectionBookCard` counted only *translated* Spanish pages, missing books **written** in Spanish (#4120) |
| 6 | `/es/book/*` and `/es` | `SignUpCTA` hard-coded English — heading, body, button, footnote — pointing at `/auth/signin` while `/es/auth/signin` exists |
| 7 | `/librarian` **and** `/es/librarian` | the featured passage linked to a book that does not exist |
| 8 | embed/tenant book page | "Read this book" CTA unprefixed and hard-coded English |

Also routed `UserMenu`'s sign-in and support links through `localePath` instead of hand-written `locale === 'es'` ternaries. That per-item style is what left `/librarian` pointing at the English librarian in the Spanish nav until #4159 fixed it by hand.

## The two worth explaining

**#7 is not a Spanish bug — it hits English just as hard.** `getFeaturedPassage` looked the notebook's book up only to obtain a `pageId` and ignored a miss, returning the passage with an unresolvable slug. The passage *is* the link, and it's chosen at random, so a measurable share of librarian loads offered a 404: **28 of 1,041 quotable findings (2.7%)** name a book gone under that slug — renames, deletions, and a few malformed slugs with a `/page-number/N` tail baked in. It now falls through to the random-passage path, and returns the **book's** slug rather than the notebook's possibly-stale copy of it.

**#5 — which locale the guard asks about.** The edition test now goes through `hasLocalizedEdition` (the shared helper that counts natives), and asks it about the **URL's** locale rather than the card's `lang` prop. `localePath` prefixes with whatever the URL says; testing the prop would let a card rendered without `lang` on an `/es` page prefix every book, including ones with no Spanish page — and an `/es` URL is a promise. Both sides of the guard now read the same locale.

## Verified on the preview

Diffed the crawl of `sourcelibrary-v2-hkx1v7z07` against the same crawl of production:

- header logo `/` → **`/es`**; footer wordmark `/` → **`/es`**. The only remaining bare `/` anchor on `/es` is the `EN` language toggle, which is correct.
- "Traducidas recientemente" now localizes the Spanish-native book in it.
- the librarian's featured passage now resolves (`/book/elvcidarivs-…/page/…` → 200).

Two caveats on that verification, stated rather than glossed:

- **preview 403s every book route** for anonymous callers (the #4082 preview content gate), so link *statuses* on the preview are meaningless — I compared link *shapes*, and re-checked statuses against production.
- **#4, #6 and #8 are client-only or embed-only** (they render post-hydration for signed-out visitors, or behind `embedPolicy`), so no crawl can see them. Those three were found and verified by reading the code, not by measurement.

## Known remaining gap — #4166

Fix #5 closes the **native** Spanish case but not the **translated** one. The homepage rails come from Supabase `books_catalog`, which carries `language` but has no `pages_translated_es` column at all — so `hasLocalizedEdition` can see a book *written* in Spanish and cannot see a book *translated* into it. Measured on the rail as it stood today: **2 of 15 books are readable in Spanish and still link to English** (`libro-de-chilam-balam-de-kaua-scribes`, 39 Spanish pages; `the-books-of-chilan-balam-…-brinton`, 19).

Not fixed here on purpose: it needs a column, a sync-writer change and a backfill, and the writer is the dangerous half — widening a read rule without moving the writer is what #4120/#4141 cost. Filed as **#4166**.

## Also out of scope

- `/es/search` — still owed, tracked in #4119.
- Non-Spanish books linking to `/book/…` from `/es` collection grids: deliberate (`es-collections.ts` avoids a pointless 307 hop), and the heading above them says those works read in their original language and in English. Note this also means the collection pages pass an explicit `href`, so fix #5 does not change them.
- Related-book notices on the book page (`RelatedBooks`, `TranslatedSiblingNotice`, `AuthorCrossReference`) keep English hrefs. Same class as #5, but they'd need per-book edition data plumbed in; folding that in here would have made the diff a data change wearing a nav fix's clothes.
- `/give` in the header stays English on `/es`. `/es/support` is the Spanish donate front door and the homepage CTA already points there, so the header pill is arguably wrong — but changing where a donate button goes is a product call, not a silent drive-by.

## Checks

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MojJdMhnuk3PkZfpTPyA7k
