### PR TITLE
fix: the "embedding is free" claim was in ten files, not one

### DIFF
--- a/scripts/analysis/experience-map/README.md
+++ b/scripts/analysis/experience-map/README.md
@@ -10,7 +10,8 @@ PEACE framework (`/peace`).
 
 **Bulk data lives in `scripts/output/experience-map/` — which is gitignored.**
 Only the pipeline is tracked here. Regenerating the data costs ~$3 in
-`gemini-3.1-flash-lite` calls; embeddings are free-tier.
+`gemini-3.1-flash-lite` calls, plus a few cents of embedding — which is BILLED,
+not free-tier (see `.claude/docs/embeddings.md`).
 
 ## Pipeline
 

--- a/scripts/analysis/experience-map/build/build-and-embed-jhana.mjs
+++ b/scripts/analysis/experience-map/build/build-and-embed-jhana.mjs
@@ -12,7 +12,9 @@
  *     genre and author, which is why an argument about the unity of the animal
  *     kind scored 0.77 against an ego-dissolution probe.
  *
- * Free: embedding is free-tier.
+ * Cost: embedding is BILLED ($0.20/1M input tokens, ~4.29 chars/token —
+ * see .claude/docs/embeddings.md). Negligible at this scale, but not free:
+ * every GEMINI_API_KEY* in the env is a paid key.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/analysis/experience-map/build/build-and-embed-v2.mjs
+++ b/scripts/analysis/experience-map/build/build-and-embed-v2.mjs
@@ -12,7 +12,9 @@
  *     genre and author, which is why an argument about the unity of the animal
  *     kind scored 0.77 against an ego-dissolution probe.
  *
- * Free: embedding is free-tier.
+ * Cost: embedding is BILLED ($0.20/1M input tokens, ~4.29 chars/token —
+ * see .claude/docs/embeddings.md). Negligible at this scale, but not free:
+ * every GEMINI_API_KEY* in the env is a paid key.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/analysis/experience-map/build/build-and-embed.mjs
+++ b/scripts/analysis/experience-map/build/build-and-embed.mjs
@@ -12,7 +12,9 @@
  *     genre and author, which is why an argument about the unity of the animal
  *     kind scored 0.77 against an ego-dissolution probe.
  *
- * Free: embedding is free-tier.
+ * Cost: embedding is BILLED ($0.20/1M input tokens, ~4.29 chars/token —
+ * see .claude/docs/embeddings.md). Negligible at this scale, but not free:
+ * every GEMINI_API_KEY* in the env is a paid key.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/analysis/experience-map/retrieve/retrieve-probeset.mjs
+++ b/scripts/analysis/experience-map/retrieve/retrieve-probeset.mjs
@@ -16,7 +16,8 @@
  * one. Tibetan gets the same 144 queries English does. The stratification is
  * recorded per row so downstream analysis can weight it back if it wants to.
  *
- * Free: embeddings are free-tier and cached; the RPC is a Supabase query.
+ * Cost: embeddings are BILLED (see .claude/docs/embeddings.md) but cached, so a
+ * repeat run is free; the RPC is a Supabase query.
  */
 import { readFileSync, writeFileSync, existsSync, createWriteStream } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/analysis/experience-map/retrieve/retrieve-v3.mjs
+++ b/scripts/analysis/experience-map/retrieve/retrieve-v3.mjs
@@ -15,7 +15,8 @@
  * the English/German skew of the unsliced pass. For the largest languages we
  * additionally slice by era, which is correct on this path.
  *
- * Free: embeddings are free-tier and cached to disk; the RPC is a Supabase query.
+ * Cost: embeddings are BILLED (see .claude/docs/embeddings.md) but cached to disk,
+ * so a repeat run is free; the RPC is a Supabase query.
  */
 import { readFileSync, writeFileSync, existsSync, createWriteStream } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/analysis/experience-map/retrieve/retrieve-v4.mjs
+++ b/scripts/analysis/experience-map/retrieve/retrieve-v4.mjs
@@ -16,7 +16,8 @@
  * one. Tibetan gets the same 144 queries English does. The stratification is
  * recorded per row so downstream analysis can weight it back if it wants to.
  *
- * Free: embeddings are free-tier and cached; the RPC is a Supabase query.
+ * Cost: embeddings are BILLED (see .claude/docs/embeddings.md) but cached, so a
+ * repeat run is free; the RPC is a Supabase query.
  */
 import { readFileSync, writeFileSync, existsSync, createWriteStream } from 'node:fs';
 import { createRequire } from 'node:module';

--- a/scripts/maintenance/delete-stale-embeddings.mjs
+++ b/scripts/maintenance/delete-stale-embeddings.mjs
@@ -6,7 +6,8 @@
  *
  * SCOPE: pure vector embedding tables only — book_embeddings, artwork_embeddings,
  * gallery_text_embeddings, clip_embeddings. Deletes are recoverable by re-running
- * the embed worker (free Tier).
+ * the embed worker — which is BILLED, so a delete is not costless to undo
+ * (see .claude/docs/embeddings.md).
  *
  * NOT in scope: `page_translations`. That table holds the **translation text
  * itself** (column `translation`, the Gemini Batch API output), not just an

--- a/scripts/migration/backfill-book-embeddings.mjs
+++ b/scripts/migration/backfill-book-embeddings.mjs
@@ -7,7 +7,10 @@
  *
  * For unenriched books, falls back to title + author + description + categories.
  *
- * Cost: $0 (Gemini free tier). Time: ~20 min for 17K books.
+ * Cost: BILLED, but small — one embedding per book, not per page. At $0.20/1M
+ * input tokens and the measured 4.29 chars/token, ~17K books of summary text is
+ * roughly $2-3 per full pass. (This line used to read "$0 (Gemini free tier)";
+ * see .claude/docs/embeddings.md.) Time: ~20 min for 17K books.
  *
  * Usage:
  *   set -a; source .env.production.local; set +a

--- a/scripts/workers/embed-gemini.mjs
+++ b/scripts/workers/embed-gemini.mjs
@@ -3,13 +3,25 @@
  * Embed pages for semantic search using Gemini embedding-2-preview.
  *
  * Embeds BOTH ocr.data and translation.data per page into Supabase
- * page_translations table. Uses Gemini API (free tier, 768 dims).
+ * page_translations table. Uses Gemini API (768 dims).
  *
  * Replaces the old e5-base backfill (embed-translations.mjs).
  * The Gemini model is much better for Latin, Greek, Arabic, Sanskrit.
  *
- * Cost: $0 (free tier, rate-limited to ~13 texts/sec sustained).
- * Time: ~5-6 days for full 3M-page backfill.
+ * COST — THIS IS BILLED, AND AT THIS SCALE IT IS THE LARGEST SINGLE EMBEDDING
+ * SPEND IN THE REPO. gemini-embedding-2-preview is $0.20 per 1M input tokens on
+ * the paid tier, and every GEMINI_API_KEY* in the env is a paid key. At the
+ * measured 4.29 chars/token (see .claude/docs/embeddings.md) a FULL 3.9M-page
+ * pass is roughly **$180**. This header used to say "Cost: $0 (free tier)";
+ * that line was believed and acted on in Aug 2026 and cost ~$12 on a corpus
+ * 100x smaller. --incremental and --missing-only are cheap because they touch
+ * few pages; --full is not. ASK BEFORE A FULL PASS.
+ *
+ * Note the budget dial this script consults (budgetAllowsDispatch) cannot SEE
+ * embedding spend — nothing here logs to gemini_usage (#4162) — so it brakes on
+ * OCR/translation spend only.
+ *
+ * Time: ~5-6 days for full 3M-page backfill (~13 texts/sec sustained).
  *
  * Modes:
  *   --full        Process all pages with OCR or translation


### PR DESCRIPTION
#4160 corrected `embeddings.md` and the Spanish worker. Then I ran the `git grep` I should have run *before* spending anything, and found the same claim in **eight more files**.

## The two that matter

**`scripts/workers/embed-gemini.mjs`** — the English page embedder — said:

> `Cost: $0 (free tier, rate-limited to ~13 texts/sec sustained).`

A full 3.9M-page pass is roughly **$180** at $0.20/1M input tokens and the measured 4.29 chars/token. That is the largest single embedding spend in the repo, and its own header advertised it as free. `--incremental` and `--missing-only` are genuinely cheap because they touch few pages; `--full` is not, and the header now says so.

**`scripts/migration/backfill-book-embeddings.mjs`** said the same. One vector per *book* rather than per page, so ~$2–3 per pass — small, but not zero, and worth stating rather than denying.

## The softer six

The experience-map build/retrieve scripts ("Free: embedding is free-tier") and `delete-stale-embeddings.mjs` ("recoverable by re-running the embed worker (free Tier)"). Each is genuinely cheap at its own scale. But *"a delete is recoverable for nothing"* is exactly the kind of sentence that gets acted on, and the retrieve scripts are free only because they **cache** — which is a different claim, so they now say that instead.

## Left alone, deliberately

`scripts/workers/embedding-server.mjs` keeps its `Cost: $0` — it runs a local model on Hetzner CPU and is the one place in the repo where the claim is true.

## The shape of it

Every corrected line now names the rate, the measured ratio, and points at `.claude/docs/embeddings.md`, so the next person computes rather than believes. That is the actual fix: the original line wasn't wrong because someone was careless, it was wrong because it stated a *conclusion* ("$0") with no way to check it.

Comments and docs only — no behaviour change. Follows #4160, #4095; related #4162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ
