### PR TITLE
feat(es): the Spanish band is one card into the full list, not a slider

### DIFF
--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -9,7 +9,8 @@ import GalleryMasonry from '@/components/GalleryMasonry';
 import ResearchNotesSlider from '@/components/home/ResearchNotesSlider';
 import RecentlyRead from '@/components/home/RecentlyRead';
 import SignUpCTA from '@/components/auth/SignUpCTA';
-import { type HomeData, SPANISH_COLLECTION_SLUG } from '@/lib/home-data';
+import { type HomeData } from '@/lib/home-data';
+import CollectionCardImage from '@/components/collections/CollectionCardImage';
 import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
 import { localePath } from '@/lib/locale-path';
 
@@ -23,7 +24,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
   // catalog, browse, podcast, blog…) are returned untouched by localePath and go
   // to their English page rather than a 404. See .claude/docs/i18n.md rule 5.
   const lp = (href: string) => localePath(href, lang);
-  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts } = data;
+  const { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts, featuredPodcast, spanishCollection, localizedCollectionCounts } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
   // The grid card's count line. On /es it says how many of the collection's
   // books can actually be READ in Spanish — the same thing /es/collections
@@ -44,52 +45,27 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
 
       {/* Read in Spanish — the first thing under the hero on /es, because it is
           the one section whose BOOKS (not just chrome) are in the visitor's
-          language. Most-read first; each card's href carries the `/es` prefix,
-          which is the ONLY thing that decides reading language (#4112 removed
-          the localStorage preference that used to follow the reader off the
-          prefix — see .claude/docs/i18n.md rule 6).
-          spanishBooks is empty on the English homepage, so nothing renders there. */}
-      {spanishBooks.length > 0 && (
-        <section className="bg-white py-16 md:py-24">
+          language. One card, the same block /es/collections leads with, opening
+          the full Spanish list; the `/es` prefix on the link is the only thing
+          that decides reading language (.claude/docs/i18n.md rule 6).
+          spanishCollection is null on the English homepage, so nothing renders there. */}
+      {spanishCollection && (
+        <section className="bg-white py-10 md:py-14">
           <div className="px-6 md:px-12 max-w-[1500px] mx-auto">
-            <div className="flex items-end justify-between gap-4 mb-3">
-              <h2 className="text-3xl md:text-4xl text-primary font-display">
-                {t.spanishHeading}
-              </h2>
-              <Link
-                href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)}
-                className="text-sm text-muted hover:text-accent-rust transition-colors whitespace-nowrap hidden sm:inline-flex"
-              >
-                {t.spanishViewAll} &rarr;
-              </Link>
-            </div>
-            <p className="text-muted mb-2 max-w-2xl">
-              {t.spanishSubtitle}
-            </p>
-            {/* Say the size, the way the Collections header below does: one
-                inline line of counts. Pages and books are the work done; the
-                firsts and the source languages are why it matters. */}
-            {spanishCounts && (
-              <p className="text-sm text-muted/80 mb-6">
-                {nf(spanishCounts.pages)} {t.spanishStatPages}
-                {' '}&middot;{' '}
-                {nf(spanishCounts.books + spanishCounts.nativeBooks)} {t.spanishStatBooks}
-                {spanishCounts.firstTranslations > 0 && (
-                  <>
-                    {' '}&middot;{' '}
-                    {nf(spanishCounts.firstTranslations)} {t.spanishStatFirsts}
-                  </>
-                )}
-                {' '}&middot;{' '}
-                {nf(spanishCounts.sourceLanguages)} {t.spanishStatLanguages}
-              </p>
-            )}
-            <BookSlider books={spanishBooks as unknown as MiniBook[]} lang={lang} />
-            <div className="mt-6 sm:hidden">
-              <Link href={lp(`/collections/${SPANISH_COLLECTION_SLUG}`)} className="text-sm text-accent-rust hover:underline">
-                {t.spanishViewAll} &rarr;
-              </Link>
-            </div>
+            <Link
+              href={lp(`/collections/${spanishCollection.slug}`)}
+              className="group grid sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-0 overflow-hidden rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:shadow-md transition-[border-color,box-shadow]"
+            >
+              <div className="relative aspect-square sm:aspect-auto sm:min-h-[220px]">
+                <CollectionCardImage candidates={spanishCollection.imageCandidates} alt="" sizes="(max-width: 640px) 100vw, 33vw" priority />
+              </div>
+              <div className="p-6 sm:p-8 flex flex-col justify-center">
+                <p className="text-xs uppercase tracking-[0.2em] text-accent-rust mb-2">{t.spanishHeading}</p>
+                <h2 className="text-2xl sm:text-3xl font-display text-primary mb-2 group-hover:text-accent-rust transition-colors">{spanishCollection.name}</h2>
+                <p className="text-muted leading-relaxed mb-4">{t.spanishSubtitle}</p>
+                <p className="text-sm text-secondary">{nf(spanishCollection.bookCount)} {t.booksLabel} &rarr;</p>
+              </div>
+            </Link>
           </div>
         </section>
       )}

--- a/src/lib/es-collections.ts
+++ b/src/lib/es-collections.ts
@@ -166,6 +166,34 @@ const esPinRank = (slug: string) => {
   return i === -1 ? ES_PINNED.length : i;
 };
 
+/** What the /es homepage card needs from the `en-espanol` collection — and nothing more. */
+export interface EsSpanishCollectionCard {
+  slug: string;
+  name: string;
+  bookCount: number;
+  imageCandidates: string[];
+}
+
+/**
+ * The `en-espanol` collection as a single card: one findOne, no book scan.
+ * `getEsCollection` walks the whole branch (books, parent, children, counts)
+ * and is far too much for a homepage band that only links to the page.
+ */
+export async function getEsSpanishCollectionCard(): Promise<EsSpanishCollectionCard | null> {
+  const db = await getReadDb();
+  const doc = await db.collection('collections').findOne(
+    { slug: 'en-espanol', ...PUBLIC_COLLECTION },
+    { projection: { _id: 0, slug: 1, name: 1, localized: 1, book_count: 1, total_book_count: 1, featured_images: 1, hero_image: 1 }, maxTimeMS: 8000 },
+  );
+  if (!doc) return null;
+  return {
+    slug: doc.slug as string,
+    name: spanishCopy(doc).name,
+    bookCount: (doc.total_book_count ?? doc.book_count ?? 0) as number,
+    imageCandidates: imageCandidates(doc.featured_images, doc.slug as string, doc.hero_image),
+  };
+}
+
 export async function getEsCollectionList(): Promise<EsCollectionSummary[]> {
   const db = await getReadDb();
   // Which collections hold Spanish editions, and how many — indexed by the small

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -7,8 +7,8 @@ import { browseBooks, type CatalogBook } from '@/lib/books-catalog';
 import { toGalleryCardUrl } from '@/lib/utils';
 import { type Plate } from '@/components/GalleryMasonry';
 import { type HomeLang } from '@/lib/home-i18n';
-import { isNativeEdition, localizedEditionFilter, type LocalizedBookMap } from '@/lib/localized';
-import { spanishReaderHref } from '@/lib/es-collections';
+import { getEsSpanishCollectionCard, type EsSpanishCollectionCard } from '@/lib/es-collections';
+import { localizedEditionFilter } from '@/lib/localized';
 import type { Locale } from '@/lib/locale-path';
 
 // Shared data layer for the homepage. Both the English `/` route and the
@@ -693,60 +693,10 @@ async function getFeaturedPodcast(language: HomeLang): Promise<FeaturedPodcast |
   };
 }
 
-/**
- * How much of the library a Spanish reader can actually read.
- *
- * Stated on the page because the honest answer is "a small, growing corner":
- * 103 books of 37,821. A Spanish front door that shows fifteen covers and says
- * nothing about scale implies a Spanish library, and the reader finds out by
- * clicking. Counted live rather than hard-coded — the number grows every time
- * the worker runs.
- */
-export interface SpanishCounts {
-  /** Books TRANSLATED into Spanish (the counter) — the pipeline's own output. */
-  books: number;
-  pages: number;
-  /** Books WRITTEN in Spanish — Cogolludo, Landa, Aguilar; no counter, no translation. */
-  nativeBooks: number;
-  /** Translated books whose Spanish edition is a published first translation. */
-  firstTranslations: number;
-  /** Distinct `books.language` values among the translated set (Latin, Nahuatl, Sanskrit…). */
-  sourceLanguages: number;
-}
-
-async function getSpanishCounts(): Promise<SpanishCounts | null> {
-  const db = await getReadDb();
-  const live = { visible: true, pages_count: { $gt: 0 } };
-  const translated = { ...live, pages_translated_es: { $gt: 0 } };
-  // All three concurrently: each is ~2s of round trip from far away, and the
-  // band is on an 8s budget shared with the rest of the page's queries.
-  const [[row], nativeBooks, firstTranslations] = await Promise.all([
-    db.collection('books').aggregate<{ books: number; pages: number; languages: string[] }>([
-      { $match: translated },
-      { $group: { _id: null, books: { $sum: 1 }, pages: { $sum: '$pages_translated_es' }, languages: { $addToSet: '$language' } } },
-      { $project: { _id: 0, books: 1, pages: 1, languages: 1 } },
-    ], { maxTimeMS: 8000 }).toArray(),
-    // Native editions: everything the Spanish surface selects MINUS the translated set.
-    db.collection('books').countDocuments(
-      { ...live, ...localizedEditionFilter('es'), pages_translated_es: { $not: { $gt: 0 } }, content_type: { $ne: 'artwork' } },
-      { maxTimeMS: 8000 },
-    ),
-    // Same gate the card's badge uses (isPublishedFirstTranslation): the flag
-    // minus any disposition that withholds the claim. Count, don't assert more.
-    db.collection('books').countDocuments(
-      { ...translated, is_first_translation: true, ft_disposition: { $nin: ['demoted', 'needs_review', 'rejected'] } },
-      { maxTimeMS: 8000 },
-    ),
-  ]);
-  if (!row) return null;
-  return {
-    books: row.books,
-    pages: row.pages,
-    nativeBooks,
-    firstTranslations,
-    sourceLanguages: (row.languages ?? []).filter((l): l is string => typeof l === 'string' && l.length > 0).length,
-  };
-}
+// ---------- The Spanish collection card (the /es "Leer en español" band) ----------
+// One card linking to /es/collections/en-espanol, the same block /es/collections
+// leads with. The band used to be a 15-cover slider plus counts; a single
+// door into the full list was the call (#4158 → #4161 → here).
 
 /**
  * How many books in each collection can be read in `lang` — the "· 57 en
@@ -772,79 +722,6 @@ async function getLocalizedCollectionCounts(lang: Exclude<Locale, 'en'>): Promis
 
 // ---------- Aggregate ----------
 
-// ---------- Books with a Spanish edition (the "Leer en español" band) ----------
-
-/** Slug of the curated collection that gathers every book with a Spanish edition. */
-export const SPANISH_COLLECTION_SLUG = 'en-espanol';
-const SPANISH_BOOKS_COUNT = 15;
-
-// Minimal card shape for the slider: BookSlider's MiniBook plus the Spanish
-// counter that switches on the card's "Español" tag.
-export interface SpanishBook {
-  id: string;
-  slug?: string;
-  title: string;
-  display_title?: string;
-  author?: string;
-  year?: number;
-  language?: string;
-  pages_count?: number;
-  pages_ocr?: number;
-  pages_translated?: number;
-  pages_translated_es?: number;
-  localized?: LocalizedBookMap;
-  is_first_translation?: boolean;
-  ft_disposition?: string;
-  thumbnail?: string;
-  thumbnail_blob?: string;
-  image_display?: string;
-  image_thumb?: string;
-  /** Straight into the reader in Spanish (first chapter / first readable page). */
-  href: string;
-}
-
-// Most-read first (`read_count`), so the band leads with what Spanish readers
-// are most likely to be looking for. `pages_translated_es` is the book-level
-// counter kept by scripts/maintenance/sync-pages-translated-es.mjs — the per-
-// page fields are not indexed and must never be scanned on a request path.
-//
-// The band selects through localizedEditionFilter('es'), so it holds books that
-// are in Spanish EITHER WAY: translated into it, or written in it. A Spanish
-// original has no counter and never will, and selecting on the counter alone
-// hid 67 live books — Cogolludo, Landa, Aguilar — from the Spanish homepage.
-// Books with a counter still sort first; a native edition has none, so within a
-// read_count tie it follows, which is the right order for a band whose subject
-// is our Spanish editions.
-async function getSpanishBooks(): Promise<SpanishBook[]> {
-  const db = await getReadDb();
-  const books = await db.collection('books').find(
-    {
-      ...localizedEditionFilter('es'),
-      visible: true, pages_count: { $gt: 0 }, content_type: { $ne: 'artwork' },
-    },
-    {
-      projection: {
-        _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1,
-        pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1, localized: 1,
-        is_first_translation: 1, ft_disposition: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1,
-        'chapters.pageNumber': 1,
-      },
-      sort: { read_count: -1, pages_translated_es: -1 },
-      limit: SPANISH_BOOKS_COUNT,
-      maxTimeMS: 8000,
-    },
-  ).toArray();
-  // The card opens the Spanish reader directly — the English book page would
-  // drop the reader out of the Spanish experience (until #4082 gives it a twin).
-  type Raw = Omit<SpanishBook, 'href'> & { chapters?: { pageNumber?: number }[] };
-  return JSON.parse(JSON.stringify((books as unknown as Raw[]).map(({ chapters, ...b }) => ({
-    ...b,
-    href: spanishReaderHref({ ...b, chapters }),
-  })))) as SpanishBook[];
-}
-
-// ---------- Aggregate ----------
-
 export interface HomeData {
   featuredItems: FeaturedItem[];
   discoverBooks: Book[];
@@ -854,10 +731,8 @@ export interface HomeData {
   collections: CollectionForGrid[];
   blogPosts: HomeBlogPost[];
   featuredPodcast: FeaturedPodcast | null;
-  /** Books with a Spanish edition, most-read first. Empty on the English homepage. */
-  spanishBooks: SpanishBook[];
-  /** Size of the Spanish corpus, for the honest scale line. Null off /es. */
-  spanishCounts: SpanishCounts | null;
+  /** The `en-espanol` collection card. Null on the English homepage. */
+  spanishCollection: EsSpanishCollectionCard | null;
   /**
    * Books readable in the page's language, per collection slug — what the grid
    * card's "· N en español" line reads. Empty on the English homepage, where
@@ -871,7 +746,7 @@ export interface HomeData {
 // keeps the two homepages structurally identical (see the note at the top of
 // this file).
 export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
-  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts] = await Promise.all([
+  const [featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, featuredPodcast, spanishCollection, localizedCollectionCounts] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getRecentlyTranslated(), 20000, [] as CatalogBook[]),
@@ -879,12 +754,11 @@ export async function getHomeData(lang: HomeLang = 'en'): Promise<HomeData> {
     getBookCounts(),
     withTimeout(getRemainingCollections(), 20000, SORTED_FALLBACK_COLLECTIONS),
     withTimeout(getFeaturedPodcast(lang), 8000, null),
-    lang === 'es' ? withTimeout(getSpanishBooks(), 8000, [] as SpanishBook[]) : Promise.resolve([] as SpanishBook[]),
-    lang === 'es' ? withTimeout(getSpanishCounts(), 8000, null) : Promise.resolve(null),
+    lang === 'es' ? withTimeout(getEsSpanishCollectionCard(), 8000, null) : Promise.resolve(null),
     lang === 'en'
       ? Promise.resolve({} as Record<string, number>)
       : withTimeout(getLocalizedCollectionCounts(lang), 8000, {} as Record<string, number>),
   ]);
 
-  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishBooks, spanishCounts, localizedCollectionCounts };
+  return { featuredItems, discoverBooks, recentlyTranslated, galleryPlates, counts, collections, blogPosts: BLOG_POSTS, featuredPodcast, spanishCollection, localizedCollectionCounts };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -77,12 +77,6 @@ export interface HomeStrings {
   // so the two editions keep one shape.
   spanishHeading: string;
   spanishSubtitle: string;
-  spanishViewAll: string;
-  // The inline count line under the Spanish band heading. Numbers arrive locale-formatted.
-  spanishStatPages: string;
-  spanishStatBooks: string;
-  spanishStatFirsts: string;
-  spanishStatLanguages: string;
 
   // Gallery masonry (homepage)
   galleryHeading: string;
@@ -194,12 +188,7 @@ const en: HomeStrings = {
   recentlyTranslatedHeading: 'Recently translated',
   recentlyTranslatedSubtitle: 'The latest works Source Library has brought into a modern, readable translation.',
   spanishHeading: 'Read in Spanish',
-  spanishSubtitle: 'The most-read works in the library, with a Spanish edition you can open page by page beside the original.',
-  spanishViewAll: 'All books in Spanish',
-  spanishStatPages: 'pages translated',
-  spanishStatBooks: 'books in Spanish',
-  spanishStatFirsts: 'first translations',
-  spanishStatLanguages: 'source languages',
+  spanishSubtitle: 'The works in the library that already have a Spanish edition, page by page beside the original.',
   galleryHeading: 'Gallery',
   gallerySubtitle: 'Plates, figures, and engravings from rare books across the library.',
   galleryViewAll: (n) => `View all ${n.toLocaleString('en-US')} illustrations`,
@@ -311,12 +300,7 @@ const es: HomeStrings = {
   recentlyTranslatedHeading: 'Traducidas recientemente',
   recentlyTranslatedSubtitle: 'Las obras más recientes que Source Library ha traducido a una versión moderna y legible.',
   spanishHeading: 'Leer en español',
-  spanishSubtitle: 'Las obras más leídas de la biblioteca, con una edición en español que puedes abrir página a página junto al original.',
-  spanishViewAll: 'Todos los libros en español',
-  spanishStatPages: 'páginas traducidas',
-  spanishStatBooks: 'libros en español',
-  spanishStatFirsts: 'primeras traducciones',
-  spanishStatLanguages: 'lenguas de origen',
+  spanishSubtitle: 'Las obras de la biblioteca que ya cuentan con una edición en español, página a página junto al original.',
   galleryHeading: 'Galería',
   gallerySubtitle: 'Láminas, figuras y grabados de libros raros de toda la biblioteca.',
   galleryViewAll: (n) => `Ver las ${n.toLocaleString('es-ES')} ilustraciones`,


### PR DESCRIPTION
At the top of `/es`, the 15-cover slider is replaced by the `en-espanol` collection card that `/es/collections` already leads with — plate, "Leer en español" eyebrow, collection name, one line of copy, "173 libros →" — so a visitor clicks straight through to every Spanish book.

- `getEsSpanishCollectionCard()` in `es-collections.ts`: one `findOne`, no book scan.
- `home-data.ts`: the slider and counts queries are removed; `HomeData.spanishCollection` replaces `spanishBooks`/`spanishCounts`. `getLocalizedCollectionCounts` (#4159) is unchanged.
- `HomeView.tsx`: same markup as the `/es/collections` card. Renders only on `/es`.
- Dead band strings pruned from `home-i18n.ts`.

Out of scope: the card's copy and image come from the collection document, so any wording/plate change is a curation edit, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULhJT2eog1PfKeHjKYS8Ag