### PR TITLE
docs(fonts): Aldine facsimile handoff + the next/font preload trap

### DIFF
--- a/.claude/docs/invariants/rendering-and-seo.md
+++ b/.claude/docs/invariants/rendering-and-seo.md
@@ -61,3 +61,27 @@ Two consequences that bit three surfaces in one day (2026-07-15, PRs #3149/#3151
 Rule: **any page that defines `openGraph` must set `images` explicitly and mirror them in a `twitter` block.** Exempt: routes with a file-convention `opengraph-image.tsx` (book, author, category detail, reader pages, gallery images) — the convention feeds the twitter card automatically.
 
 **The exemption is per ROUTE SEGMENT, and a locale twin is a different segment.** `opengraph-image.tsx` under `/book/[id]` does nothing for `/es/book/[id]`: the twin needs its own file, or it falls back to the site card. And the card ART is language-bearing — the headline is baked into the JPEG — so a Spanish page under the English card announces itself in English at the only moment a reader is deciding whether to click. Both halves shipped that way for months (#4162) even though the rule above was already written down, because `/es/collections` set `openGraph` without `images` and nobody looked at what WhatsApp actually rendered. Per-locale cards: `siteOgImage(lang)` in `src/lib/og-locale.ts`, renderers in `src/lib/og-book-card.tsx` / `og-page-card.tsx`, full rules in `.claude/docs/i18n.md` ("The share card is part of the page"). **Verifying means fetching the page and reading the two meta tags** — `curl … | grep 'og:image\|twitter:image'` — not reading the metadata object. Tenant/embed routes are deliberately image-less pending tenant-scoped cards. New blog notes copy the openGraph+twitter pattern from any existing post; their "Last revised" footer dates come from `src/generated/blog-revisions.json` (regenerated from git history by `deploy-prod.sh` — see `scripts/maintenance/generate-blog-revisions.mjs`).
+
+## A font imported by a shared route is downloaded on every page of that route
+
+`next/font` preloads by default. The reader route (`/book/[id]/page/[pageId]`) is one
+module serving ~80K books, so importing a face there to use on *fifteen* of them shipped
+a `<link rel=preload>` — and the font file — to every reader page in the library. The
+symptom is invisible in review: the page looks right, the CSS is scoped correctly, and
+only the network tab shows 30 KB of 1496 letterforms loading for a Sanskrit manuscript.
+
+**Set `preload: false` on any face that only some pages of a shared route actually
+reference.** The `@font-face` still ships in the route's CSS; the browser fetches the
+file only when a rendered element matches the family — which, with `display: swap`, is
+what you want. Applies equally to a face used behind a feature flag or a user preference.
+
+Reference: `src/lib/fonts/aldine.ts` (Aldine Aetna, the facsimile fount used by the books
+listed in `src/lib/fonts/aldine-fount.ts`).
+
+**Corollary — a per-book display choice is a claim about the book.** Setting a book's
+text in a facsimile fount asserts it was printed in that type. Verify against a page
+image before adding an id; do not infer from date, printer or collection membership.
+`aldine-fount.ts` records the books deliberately *excluded* and why (Griffo's 1499 recut
+is a different fount from his 1495 roman, and looks close enough to fool a date-based
+guess) — keep that list, it is what stops the next sweep re-adding them.
+

--- a/.claude/handoffs/2026-08-21-aldine-facsimile-font.md
+++ b/.claude/handoffs/2026-08-21-aldine-facsimile-font.md
@@ -1,0 +1,98 @@
+# A font traced from our own scans, and books read in it — 2026-08-20/21
+
+Derek asked for "a font based on the Aldine Press font." It ended as **Aldine Aetna**, a
+public-domain facsimile of the roman Francesco Griffo cut for Aldus Manutius, traced
+glyph by glyph from our own scans — plus fifteen early Aldines that now render their
+transcription *and* their English translation in it.
+
+Live: <https://sourcelibrary.org/specimen/aldine> ·
+<https://sourcelibrary.org/book/de-aetna-dialogus-bembo/page/6a06d1f39a48d51399960d1c>
+
+## Shipped (11 PRs, all merged)
+
+| PR | What |
+|----|------|
+| #4081 | v0.1 — the font, the pipeline, the specimen page, Cardo helper |
+| #4084 | v0.2 — `&`, `(`, the fused `Qu` sort, from the 1497 Aldines |
+| #4085 | v0.3 — capital I and a lone Q from Lascaris 1495; per-set scale calibration |
+| #4088 | v0.4 — 15 composed accents, `ę`, the `ſt` fix, f/ſ overhang kerning |
+| #4091 | v0.5 — K X Y Z; full A–Z minus J U W |
+| #4092 | v0.6 — figures 0–9 from the 1499 *Cornucopiae*; J U W reconstructed |
+| #4096 | v0.7 — baseline anchoring, `calt` variation, real z, j k v w, J redesigned |
+| #4097 | English pangrams + a `calt` on/off comparison on the specimen |
+| #4099 | v0.8 — j, k and 9 rebuilt |
+| #4100 | v0.9 — cleaner C and T impressions |
+| #4135 | Reader pilot: *De Aetna* read in its own type |
+| #4155 | Type toggle in the reader + all fifteen early Aldines |
+
+**136 glyphs**, CC0/public domain. Everything is a real impression except eight
+reconstructed sorts (J U W j k v w, and the 9), each flagged as such on the specimen page.
+
+## Where things are
+
+- `public/fonts/aldine-aetna/` — `.ttf`, `.woff2`, `LICENSE.txt`, `specimen.png`
+- `scripts/fonts/aldine-aetna/` — the whole pipeline and its README, which is the real
+  documentation: fetch → binarise → segment → cluster → label → potrace → fontTools
+- `src/lib/fonts/aldine.ts` — `next/font` faces (facsimile + Cardo) and the stacks
+- `src/lib/fonts/aldine-fount.ts` — book id → fount, and the deliberate exclusions
+- `src/app/specimen/aldine/page.tsx` — the specimen
+- `src/hooks/useReaderPreferences.ts` — `fount` preference beside size and theme
+- `src/app/globals.css` — `.aldine-fount` rules, gated on `[data-reader-fount="original"]`
+
+## What cost time, so it doesn't cost it again
+
+**Use the OCR as an index for rare sorts.** Three blind sweeps failed to find K X Y Z.
+`scripts/fonts/aldine-aetna/find_chars.mjs` greps `pages.ocr.data` of the fount-bearing
+books for a letter and prints page numbers; fetch only those leaves. K was in *De Aetna*
+all along ("Kalendis"); X Y Z were in Lascaris' Greek alphabet tables, where Aldus set the
+Greek majuscules from the roman case. Same trick found the figures in the *Cornucopiae*
+index and proved the negatives: every OCR "U"/"J"/"W" hit is a normalised V/I or a modern
+cataloguer's note, and every digit hit outside that index is a folio label — the fount has
+no arabic numerals.
+
+**Never estimate a baseline you can derive.** Glyphs sat visibly off until the per-line
+ink-projection estimate was replaced with facts: a glyph without a descender stands on its
+own bottom edge (round letters overshoot 3 %); a descending glyph is anchored by its known
+*top*. Only punctuation still uses the line estimate.
+
+**Judge an impression in context, never on a contact sheet.** Sheets scale each glyph to
+its cell, which made a lowercase `c` look like `C` and hid that every "f-shaped" cluster
+was really ſ. `context.py` boxes a candidate inside its printed word; it settled f vs ſ,
+the C and T swaps, and caught an `o` masquerading as a `6`.
+
+**Ink weight varies by copy.** The Lascaris and the second De Aetna are inked harder than
+the main scan; K and C needed a one-pixel erosion to sit at the same weight as their
+neighbours. And after stripping a stray speck, re-crop — the anchoring uses the bounding
+box, so a stripped speck left the T floating 70 px.
+
+**Preview deployments 403 book content to anonymous visitors** (by design,
+`alias-host-scope.ts`, documented in `invariants/crawler-access-gate.md`). Verify a reader
+change against the CSS bundle on the preview, then against prod after merge.
+
+**Don't reuse a feature branch after its PR was squash-merged** — the branch still carries
+the pre-squash commit and every later PR from it conflicts. Cherry-pick onto a fresh
+branch from `origin/main`.
+
+## Deliberately not done
+
+- **No ſ substitution.** The font has a real long s and a `hist`-style rule could swap it
+  on screen, but the same panels render English ("ſo"), and silently changing letters in a
+  citable transcription is a trap. If wanted, it belongs behind its own toggle beside TYPE.
+- **The Hypnerotomachia** (4 copies) is Griffo's 1499 *recut* — the Poliphilus type. Close
+  enough to fool a date-based guess, so it is excluded with the reason written down.
+- **The Greek editions** are set in Aldus's Greek types; the facsimile has no Greek at all.
+- **Firmicus 1499 and Ficino 1497**: plausible, but their scans would not pull at a
+  resolution that settles the fount.
+
+## Open threads
+
+- **#4083** is delivered for these books; the ſ question above is what remains of it.
+- **#4089** — `books.language` is a single string, so our two copies of the bilingual
+  Lascaris disagree (Greek vs Latin). Proposal: `languages: string[]`, backfilled from the
+  per-page `<language>` tags the OCR already carries.
+- **#4090** — Cardo as the reading face for original-text panels and as the embedded font
+  in PDF/EPUB exports (`src/lib/pdf-fonts.ts` currently bundles Noto Serif).
+- **The 1501 Virgil italic** — the first italic ever cut, same pipeline, and we hold the
+  octavos. The obvious sequel.
+- **104 missing BNCF Aldines**, all 1501–99 (we hold 635 of 739). Id list:
+  `~/sourcelibrary-ops/missing_bnc_ids.json`.


### PR DESCRIPTION
Session wrap-up for the Aldine facsimile font (11 PRs, #4081 → #4155).

- **`.claude/handoffs/2026-08-21-aldine-facsimile-font.md`** — what shipped and where it lives, the four things that cost real time (use the OCR as an index for rare sorts; never estimate a baseline you can derive; judge an impression in its printed word, never on a scaled contact sheet; ink weight varies by copy), and what was deliberately *not* done (no ſ substitution; the Hypnerotomachia is Griffo's 1499 recut, not this fount). Public-worthy technical postmortem — no PII, secrets, or business material — so `git add -f` into the public repo per CLAUDE.md.
- **`invariants/rendering-and-seo.md`** — `next/font` preloads by default, so a face imported by a shared route ships to *every* page of that route. The reader route serves ~80K books; fifteen use this face. `preload: false`. Invisible in review — the page looks right and only the network tab shows it. Plus the corollary that adding a book id to a fount map is a claim the book was printed in that type, and needs a page image rather than a date.

Also checked as part of the `gnite` ratchet: `CLAUDE.md` is 233 lines (under the ~250 budget, nothing to demote), and the #4060 auto-purge entry is no longer stale — the issue is closed and a warm run from 07:20Z today logs `CF purge: {"success":true}`. Another session had already corrected it; this is an independent confirmation, no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)