### PR TITLE
fix(es): the catalog mirror carries the Spanish page counter (#4166)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -231,11 +231,21 @@ it is enforced at the ROUTE, not at link sites:
   which a crawler will index. Measured: the page-level version returned 200
   with `NEXT_REDIRECT` in the body. Same reason `notFound()` lives up there.
 - `hasLocalizedEdition` returns **`boolean | null`**. `null` means the payload
-  could not answer — the counter is a Mongo field and the Supabase catalog
-  fast-path lacks it. Never read that as false: it would 307 a genuinely
-  Spanish book away. Where the counter WAS explicitly projected, resolve with
-  `?? false` — absence is then an answer. Both halves of this were gotten wrong
-  once each and caught by measurement, not by review.
+  could not answer — a hand-built card object, a narrowed API select, anything
+  that carries neither `language` nor the counter. Never read that as false: it
+  would 307 a genuinely Spanish book away. Where the counter WAS explicitly
+  projected, resolve with `?? false` — absence is then an answer. Both halves of
+  this were gotten wrong once each and caught by measurement, not by review.
+- **The store that feeds a card must carry BOTH signals, or the guard answers
+  with half the truth.** Supabase `books_catalog` carried `language` and not
+  `pages_translated_es` — the column did not exist — so `/es` rails resolved
+  Spanish *originals* and sent books *translated into* Spanish to their English
+  page (#4166). Nothing errored; the helper was correct and the data behind it
+  was missing (#4159's shape). When you add a localization signal, walk every
+  mirror, select list and card interface that feeds a `CollectionBookCard`, and
+  remember the **writer**: a mirror column needs the field in the row builder
+  *and* the Mongo projection, or the sync writes 0 for every book and
+  un-localizes the corpus while reporting success (#4120/#4141).
 
 What this rule buys: the `/es` index contains only pages that are actually in
 Spanish, and a Spanish reader who clicks a book we haven't translated lands on

--- a/scripts/maintenance/sync-pages-translated-es.mjs
+++ b/scripts/maintenance/sync-pages-translated-es.mjs
@@ -98,7 +98,11 @@ for (const b of existing) {
   changed++;
   console.log(`${dryRun ? '[dry] ' : ''}${b.id}  ${prev} → ${next} / ${b.pages_count ?? '?'}  ${(b.title || '').slice(0, 60)}`);
   if (dryRun) continue;
-  const r = await books.updateOne({ id: b.id }, { $set: { pages_translated_es: next } });
+  // `updated_at` is load-bearing, not cosmetic: the Supabase catalog sync is
+  // incremental on `updated_at`, and books_catalog now mirrors this counter
+  // (#4166). A counter changed here without the bump would never reach the
+  // mirror, so a /es card would keep linking to the English page (#3445).
+  const r = await books.updateOne({ id: b.id }, { $set: { pages_translated_es: next, updated_at: new Date() } });
   if (r.modifiedCount !== 1) console.warn(`  ! updateOne for ${b.id} modified ${r.modifiedCount}`);
   await recordSweepAction(db, {
     sweep: 'sync-pages-translated-es',

--- a/scripts/migration/add-books-catalog-pages-translated-es.mjs
+++ b/scripts/migration/add-books-catalog-pages-translated-es.mjs
@@ -1,0 +1,111 @@
+/**
+ * #4166 — project `books.pages_translated_es` into Supabase `books_catalog`.
+ *
+ * Why: `hasLocalizedEdition()` (src/lib/localized.ts) answers "does this book
+ * exist in Spanish?" from either a native `language` match (#4120) or
+ * `pages_translated_es > 0`. Catalog-fed surfaces — the /es homepage rails,
+ * anything rendering CollectionBookCard without an explicit href — read
+ * `CatalogBook`, which carried `language` but not the counter, because the
+ * column did not exist on the table at all. So natives resolved and
+ * translated-into-Spanish books silently linked to their ENGLISH page,
+ * dropping the reader off the /es prefix mid-visit.
+ *
+ * What it does (idempotent, safe to re-run):
+ *   1. ADD COLUMN IF NOT EXISTS pages_translated_es integer NOT NULL DEFAULT 0
+ *      — DEFAULT 0 so every pre-existing row reads as "no Spanish edition",
+ *        which is the fail-toward direction: a missing counter must never
+ *        mint an /es URL we cannot serve.
+ *   2. Partial index WHERE pages_translated_es > 0 (the only predicate any
+ *      caller uses; the column is 0 for nearly every row).
+ *   3. Backfill from Mongo — SET for every book with a nonzero counter, and
+ *      RESET to 0 for any catalog row that carries one Mongo no longer does
+ *      (a re-run repairs drift in both directions).
+ *
+ * The writer half of this lives in scripts/workers/sync-books-catalog.mjs:
+ * the field must be in BOTH the Mongo projection and the row builder. The
+ * upsert is `onConflict: 'id'`, so a column left out of the row object is
+ * left untouched rather than zeroed — but a field in the row builder and NOT
+ * in the projection reads `undefined` and writes 0 for every book. Those two
+ * edits are a pair (#4120/#4141 is the cost of landing half a widening).
+ *
+ * Usage:
+ *   secret-lover run -- node scripts/migration/add-books-catalog-pages-translated-es.mjs [--dry-run]
+ *   (foreground only — SUPABASE_DB_URL needs Touch ID)
+ */
+import pg from 'pg';
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!SUPABASE_DB_URL || !MONGODB_URI) {
+  console.error('Missing SUPABASE_DB_URL or MONGODB_URI');
+  process.exit(1);
+}
+
+async function main() {
+  const c = new pg.Client({ connectionString: SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  console.log('1. ALTER TABLE books_catalog ADD COLUMN pages_translated_es...');
+  if (!DRY_RUN) {
+    await c.query(`ALTER TABLE books_catalog ADD COLUMN IF NOT EXISTS pages_translated_es integer NOT NULL DEFAULT 0`);
+    await c.query(`CREATE INDEX IF NOT EXISTS books_catalog_pages_translated_es_idx ON books_catalog (pages_translated_es) WHERE pages_translated_es > 0`);
+  }
+
+  console.log('2. Reading Mongo counters (books.pages_translated_es > 0)...');
+  const docs = await db.collection('books')
+    .find({ pages_translated_es: { $gt: 0 } }, { projection: { _id: 0, id: 1, pages_translated_es: 1 } })
+    .toArray();
+  console.log(`   ${docs.length} books carry a Spanish page count in Mongo.`);
+
+  const { rows: before } = await c.query(
+    `SELECT id FROM books_catalog WHERE pages_translated_es > 0`
+  );
+  console.log(`   ${before.length} catalog rows currently carry one.`);
+
+  const mongoIds = new Set(docs.map(d => d.id));
+  const stale = before.map(r => r.id).filter(id => !mongoIds.has(id));
+
+  if (DRY_RUN) {
+    const inCatalog = await c.query(`SELECT id FROM books_catalog WHERE id = ANY($1)`, [[...mongoIds]]);
+    console.log(`   ${inCatalog.rows.length} of them exist in books_catalog (the rest are hidden/unsynced).`);
+    console.log(`   ${stale.length} catalog rows would be reset to 0.`);
+    console.log('DRY RUN — nothing written.');
+  } else {
+    let updated = 0;
+    for (let i = 0; i < docs.length; i += 1000) {
+      const chunk = docs.slice(i, i + 1000);
+      const res = await c.query(
+        `UPDATE books_catalog b SET pages_translated_es = v.n
+           FROM (SELECT unnest($1::text[]) AS id, unnest($2::int[]) AS n) v
+          WHERE b.id = v.id AND b.pages_translated_es IS DISTINCT FROM v.n`,
+        [chunk.map(d => d.id), chunk.map(d => d.pages_translated_es)]
+      );
+      updated += res.rowCount;
+    }
+    console.log(`   Set ${updated} catalog rows.`);
+
+    if (stale.length) {
+      const res = await c.query(
+        `UPDATE books_catalog SET pages_translated_es = 0 WHERE id = ANY($1)`, [stale]
+      );
+      console.log(`   Reset ${res.rowCount} stale rows to 0.`);
+    }
+
+    const check = await c.query(
+      `SELECT count(*) AS n, coalesce(sum(pages_translated_es), 0) AS pages
+         FROM books_catalog WHERE pages_translated_es > 0`
+    );
+    console.log(`\nDone. books_catalog: ${check.rows[0].n} rows with a Spanish edition, ${check.rows[0].pages} Spanish pages total.`);
+  }
+
+  await c.end();
+  await mongo.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/migration/rebuild-books-catalog.mjs
+++ b/scripts/migration/rebuild-books-catalog.mjs
@@ -52,6 +52,8 @@ function transformBook(book) {
     pages_count: book.pages_count || 0,
     pages_ocr: book.pages_ocr || 0,
     pages_translated: book.pages_translated || 0,
+    // #4166 — paired with `pages_translated_es: 1` in the projection below.
+    pages_translated_es: book.pages_translated_es || 0,
     pages_blank: book.pages_blank || 0,
     is_first_translation: book.is_first_translation === true,
     visible: book.visible === true,
@@ -107,7 +109,7 @@ const projection = {
   id: 1, slug: 1, title: 1, display_title: 1, author: 1,
   thumbnail: 1, thumbnail_blob: 1, photo: 1, language: 1, year: 1, published: 1,
   read_count: 1, pages_blank: 1,
-  pages_count: 1, pages_ocr: 1, pages_translated: 1,
+  pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1,
   is_first_translation: 1, visible: 1, quality_score: 1,
   last_translation_at: 1, updated_at: 1, created_at: 1,
   categories: 1, collections: 1, collection_relevance: 1,

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -83,6 +83,11 @@ function transformBook(book) {
     pages_count: book.pages_count || 0,
     pages_ocr: book.pages_ocr || 0,
     pages_translated: book.pages_translated || 0,
+    // Per-language counter (#4166). Paired with `pages_translated_es: 1` in the
+    // projection below — a field in this builder but NOT in the projection reads
+    // `undefined` and writes 0 for every book, which would un-localize every
+    // catalog-fed /es card. Move the two together, always.
+    pages_translated_es: book.pages_translated_es || 0,
     pages_blank: book.pages_blank || 0,
     is_first_translation: book.is_first_translation === true,
     // LISTING predicate: matches the canonical public-listing filter
@@ -184,7 +189,7 @@ const projection = {
   id: 1, slug: 1, title: 1, display_title: 1, author: 1,
   thumbnail: 1, thumbnail_blob: 1, photo: 1, language: 1, year: 1, published: 1,
   read_count: 1, pages_blank: 1,
-  pages_count: 1, pages_ocr: 1, pages_translated: 1,
+  pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1,
   is_first_translation: 1, visible: 1, quality_score: 1,
   last_translation_at: 1, updated_at: 1, created_at: 1,
   categories: 1, collections: 1, collection_relevance: 1,

--- a/src/app/api/books/browse/route.ts
+++ b/src/app/api/books/browse/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
     // Build query
     let query = supabase
       .from('books_catalog')
-      .select('id, slug, title, display_title, author, thumbnail, thumbnail_blob, language, published, pages_count, pages_ocr, pages_translated, is_first_translation, last_translation_at, quality_score, image_source_provider', { count: 'exact' })
+      .select('id, slug, title, display_title, author, thumbnail, thumbnail_blob, language, published, pages_count, pages_ocr, pages_translated, pages_translated_es, is_first_translation, last_translation_at, quality_score, image_source_provider', { count: 'exact' })
       .eq('visible', true)
       .gt('pages_count', 0);
 

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2475,9 +2475,11 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
   // is translated its /es URL must start working, and a 308 would sit poisoned
   // in browser caches. The ISR entry self-heals within its revalidate window.
   //
-  // `hasLocalizedEdition` returns null when the payload cannot answer — the
-  // counter is a Mongo field and the Supabase catalog fast-path lacks it. Ask
-  // Atlas then, and on a failed lookup do NOTHING: reading absence as "no
+  // `hasLocalizedEdition` returns null when the payload cannot answer. Since
+  // #4166 the Supabase catalog fast-path carries both inputs, so this rarely
+  // fires — keep it anyway, for payloads that predate the column or come from
+  // a narrower select. Ask Atlas then, and on a failed lookup do NOTHING:
+  // reading absence as "no
   // Spanish edition" would redirect a genuinely Spanish book away.
   if (lang !== 'en') {
     const canonicalSlug = (earlyBook as { slug?: string }).slug;

--- a/src/components/BookSlider.tsx
+++ b/src/components/BookSlider.tsx
@@ -15,6 +15,9 @@ export interface MiniBook {
   pages_count?: number;
   pages_ocr?: number;
   pages_translated?: number;
+  /** Feeds hasLocalizedEdition() in the card — drop it and every /es card links
+   *  to its English page (#4166). Keep it on anything you map into MiniBook. */
+  pages_translated_es?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
   thumbnail?: string;

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -38,6 +38,14 @@ export interface CatalogBook {
   pages_count: number;
   pages_ocr: number;
   pages_translated: number;
+  /**
+   * Pages carrying a Spanish edition (#4166). Mirrors `books.pages_translated_es`.
+   * Read it only through `hasLocalizedEdition()` — a book WRITTEN in Spanish has
+   * no translated pages and would score zero here (#4120). Without this field a
+   * catalog-fed `CollectionBookCard` cannot tell a Spanish-readable book from an
+   * English-only one and links every card to its English page.
+   */
+  pages_translated_es: number;
   pages_blank: number;
   photo: string | null;
   thumbnail: string | null;
@@ -86,7 +94,10 @@ export interface CatalogBookDetail extends CatalogBook {
   updated_at: string | null;
 }
 
-const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
+// Exported so tests can assert the localization counter is in it (#4166) —
+// a card cannot tell a Spanish-readable book from an English-only one without
+// a field the query never asked for.
+export const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_translated_es, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 

--- a/src/lib/localized.ts
+++ b/src/lib/localized.ts
@@ -131,8 +131,11 @@ export function localizedEditionFilter(lang: Exclude<Locale, 'en'>): Record<stri
  * (`NATIVE_EDITION_LANGUAGE`). Either way the promise `/es` makes is kept. A
  * title gloss alone is still chrome, not an edition.
  *
- * Returns `null` when the payload cannot answer — both inputs are Mongo fields
- * and the Supabase catalog fast-path carries neither. Callers must treat `null`
+ * Returns `null` when the payload cannot answer — a hand-built card object, a
+ * narrowed API select, anything carrying neither input. (The Supabase catalog
+ * fast-path carries both since #4166; it carried only `language` before, which
+ * is worse than carrying neither: half a signal answers confidently and
+ * wrongly.) Callers must treat `null`
  * as "ask, or do nothing", NEVER as false: reading an absent field as "no
  * Spanish edition" would 307 a genuinely Spanish book to English, which is the
  * absence-is-not-failure trap this codebase keeps re-learning. Note both fields

--- a/tests/unit/catalog-localized-counter.test.ts
+++ b/tests/unit/catalog-localized-counter.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { BOOK_SELECT } from '@/lib/books-catalog';
+import { hasLocalizedEdition } from '@/lib/localized';
+
+/**
+ * #4166 — the Supabase `books_catalog` mirror must carry the per-language page
+ * counter, or every catalog-fed card links a Spanish-readable book to its
+ * ENGLISH page.
+ *
+ * `hasLocalizedEdition` answers from two signals: a native `language` match
+ * (#4120) or `pages_translated_es > 0`. The catalog carried `language` and not
+ * the counter, so natives resolved and translated-into-Spanish books did not —
+ * a correct guard with nothing behind it (#4159).
+ *
+ * The read half is a value assertion below. The write half is a source
+ * assertion, which is only ever legitimate for an ABSENCE invariant
+ * (.claude/docs/invariants/tests-that-are-not-guards.md) — and this is one:
+ * the failure mode is literally one of a pair going missing. Comments are
+ * stripped before matching, because both files explain the pairing in prose
+ * that would otherwise satisfy the match on its own. Negative control was run
+ * for every assertion here: each fails with its guarded token removed.
+ */
+describe('books_catalog carries the Spanish page counter', () => {
+  it('BOOK_SELECT asks Supabase for it', () => {
+    expect(BOOK_SELECT.split(/\s*,\s*/)).toContain('pages_translated_es');
+  });
+
+  // Both catalog writers build a full row from a Mongo projection and upsert on
+  // `id`. A field in the row builder but NOT in the projection reads `undefined`
+  // and writes 0 for EVERY book — which would un-localize every /es card while
+  // looking like a successful sync. The two edits are a pair; this is the guard
+  // that they stay one.
+  const WRITERS = [
+    'scripts/workers/sync-books-catalog.mjs',
+    'scripts/migration/rebuild-books-catalog.mjs',
+  ];
+
+  for (const rel of WRITERS) {
+    it(`${rel} projects AND writes it`, () => {
+      const src = readFileSync(join(process.cwd(), rel), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      // Row builder: `pages_translated_es: book.pages_translated_es || 0,`
+      expect(src).toMatch(/pages_translated_es:\s*book\.pages_translated_es/);
+      // Mongo projection: `pages_translated_es: 1`
+      expect(src).toMatch(/pages_translated_es:\s*1\b/);
+    });
+  }
+
+  // The two production cases the issue was measured on, as the catalog now
+  // holds them. Neither is a Spanish original, so the native path cannot save
+  // them — the counter is the only thing that keeps their /es link.
+  it('resolves the measured cases from catalog-shaped rows', () => {
+    // libro-de-chilam-balam-de-kaua-scribes
+    expect(hasLocalizedEdition({ language: 'Yucatec Maya', pages_translated_es: 39 }, 'es')).toBe(true);
+    // the-books-of-chilan-balam-the-prophetic-and-historic-brinton
+    expect(hasLocalizedEdition({ language: 'English', pages_translated_es: 19 }, 'es')).toBe(true);
+    // Positive control: the native Spanish edition in the same rail, which
+    // resolved correctly before this change and must still.
+    expect(hasLocalizedEdition({ language: 'Spanish', pages_translated_es: 0 }, 'es')).toBe(true);
+    // And an English-only neighbour, which must stay English.
+    expect(hasLocalizedEdition({ language: 'Latin', pages_translated_es: 0 }, 'es')).toBe(false);
+  });
+});

--- a/tests/unit/localized-edition-promise.test.ts
+++ b/tests/unit/localized-edition-promise.test.ts
@@ -47,7 +47,9 @@ describe('hasLocalizedEdition', () => {
   });
 
   it('returns null — never false — when the payload cannot answer', () => {
-    // The counter is a Mongo field; the Supabase catalog fast-path lacks it.
+    // A payload can still arrive with neither signal — a hand-built card object,
+    // a narrowed API select. (The Supabase catalog USED to be that payload; it
+    // carries the counter since #4166, which is why the /es rails now resolve.)
     // Reading that absence as "no Spanish edition" would 307 a genuinely
     // Spanish book to English, and a caller that does `=== false` silently
     // never fires. Both mistakes were made and caught by measurement.


### PR DESCRIPTION
Closes #4166.

## The defect

`hasLocalizedEdition()` answers "does this book exist in Spanish?" from two signals — a native `language` match (#4120) or `pages_translated_es > 0`. Supabase `books_catalog` carried the first and **not** the second: the column did not exist on the table at all (`err: column books_catalog.pages_translated_es does not exist`).

So on `/es`, every catalog-fed `CollectionBookCard` rendered without an explicit `href` resolved Spanish *originals* correctly and sent books *translated into* Spanish to their **English** page — dropping the reader off the `/es` prefix for the rest of the visit. The guard was right; the data behind it was missing. Same shape as #4159.

## What changed

**Data.** `scripts/migration/add-books-catalog-pages-translated-es.mjs` adds `pages_translated_es` (`int NOT NULL DEFAULT 0`) plus a partial index, and backfills from Mongo in both directions — sets nonzero counters, resets rows Mongo no longer counts — so a re-run repairs drift rather than only growing. **Applied to production already:** 107 books, 39,643 Spanish pages. `DEFAULT 0` is the fail-toward direction: a missing counter must never mint an `/es` URL we cannot serve.

**Writers.** Both full-row writers (`scripts/workers/sync-books-catalog.mjs`, `scripts/migration/rebuild-books-catalog.mjs`) gain the field in the row builder **and** the Mongo projection. That pairing is the whole risk and the reason this wasn't a rider on #4164: the upsert is `onConflict: 'id'`, so an omitted column is left untouched — but a field in the builder and *not* in the projection reads `undefined` and writes `0` for **every** book, which looks like a clean sync while un-localizing the entire corpus. Exactly #4120/#4141.

`scripts/maintenance/sync-pages-translated-es.mjs` now bumps `updated_at` when it moves a counter. The catalog sync is incremental on `updated_at`; without the bump, a counter changed by that sweep would never reach the mirror and the card would keep linking to English (#3445).

**Read side.** `BOOK_SELECT`, the `CatalogBook` interface, `MiniBook`, and the `/api/books/browse` select list. The last one has no `/es` twin today so it is inert — it is in scope because it feeds `CollectionBookCard` with no `href`, and would fail silently the day an `/es` browse ships. That is the generalization the issue names.

## Verification

Read back from `books_catalog` after the backfill, pinned to the slugs the issue measured (the rail rotates, so a count would prove nothing):

| slug | `language` | `pages_translated_es` | |
|---|---|---|---|
| `libro-de-chilam-balam-de-kaua-scribes` | Yucatec Maya | **39** | now localizes |
| `the-books-of-chilan-balam-…-brinton` | English | **19** | now localizes |
| `las-historias-…-scherzer` | Spanish | 0 | positive control — still resolves via the native path |

`tests/unit/catalog-localized-counter.test.ts` pins the read half by value and the writer pairing by source (comments stripped, because both files explain the pairing in prose that would otherwise satisfy the match on its own). **Negative control run on all three assertions** — each goes red with its guarded token removed, per `tests-that-are-not-guards.md`. Full suite: 2,858 passing; `tsc --noEmit` clean.

## Out of scope

- **Rendering confirmation on a live `/es`.** The data and the helper are verified; the end-to-end crawl belongs to the preview build and is noted below rather than claimed here.
- **`RecentlyRead`** builds `MiniBook`s from the reading-history API, a different payload lane with its own select. Untouched.
- **Languages beyond `es`.** `TRANSLATED_COUNTER` is a one-entry map; a second language needs a second column and the same writer pair, which is a decision, not a rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MojJdMhnuk3PkZfpTPyA7k