### PR TITLE
fix(embeddings): record what embedding spends (#4162)

### DIFF
--- a/.claude/docs/embeddings.md
+++ b/.claude/docs/embeddings.md
@@ -138,5 +138,25 @@ genuinely negligible (a few hundred pages at a time); **bulk backfills and any
 `--force` re-embed are not**, and the difference is the number of pages, not the
 mechanism.
 
+**Embedding spend is now RECORDED** (#4162). Both page embedders accumulate
+characters and write `gemini_usage` rows with `type: 'embedding'` via
+`scripts/lib/embedding-usage.mjs`, so `budgetAllowsDispatch` can finally see it
+and it shows up in any report built on that table. Two things to know about
+those rows:
+
+- **Tokens are estimated, not billed.** `batchEmbedContents` returns no
+  `usageMetadata`, so the row converts characters at the measured 4.29
+  chars/token. `cost_usd` in this table is already documented as computed rather
+  than billed truth, so this is consistent with its neighbours — and far better
+  than the zero that was there before.
+- **Rows are aggregated deliberately**: one per book for the per-book writers,
+  one per 5,000 texts for the streaming `embed-gemini`. One row per 50-text
+  batch would be ~78,000 rows for a full English pass, and the spend guard
+  treats >40,000 rows in a day as over-budget and **fails closed** — logging
+  spend must not be able to halt the pipeline.
+
+The image-side backfills (artwork / gallery / CLIP) still do not log; they are
+smaller and were out of scope for #4162.
+
 The artwork / gallery / CLIP cron runs on Tier 3 because it batches across many tables
 and would otherwise risk hitting rate limits at burst times.

--- a/scripts/lib/embed-book-page-texts.mjs
+++ b/scripts/lib/embed-book-page-texts.mjs
@@ -28,6 +28,7 @@ import {
   embedTexts,
   EMBED_MODEL,
 } from './page-embedding-text.mjs';
+import { newEmbedUsage, logEmbeddingUsage } from './embedding-usage.mjs';
 
 const EMBED_BATCH_SIZE = 50;   // Gemini batchEmbedContents caps at 100; 50 matches the English worker
 const UPSERT_BATCH_SIZE = 10;  // HNSW index updates are expensive — keep writes small
@@ -105,10 +106,14 @@ export async function embedBookPageTexts({ db, pg, book, lang, apiKey, force = f
   if (work.length === 0) return { embedded: 0, restaled: 0, missing, alreadyPresent };
 
   let embedded = 0;
+  // Spend is recorded once per book (#4162): one row per 50-text batch would be
+  // tens of thousands of rows on a large run, which the spend guard reads as
+  // over-budget and fails closed on.
+  const usage = newEmbedUsage();
   for (let i = 0; i < work.length; i += EMBED_BATCH_SIZE) {
     const batch = work.slice(i, i + EMBED_BATCH_SIZE);
     // Embed the capped text, STORE the full text — see pageTextForLang.
-    const vectors = await embedTexts(batch.map((w) => w.embedText), apiKey);
+    const vectors = await embedTexts(batch.map((w) => w.embedText), apiKey, { usage });
     const rows = batch.map((w, j) => buildPageTextRow({
       page: w.page, book, lang, text: w.text, embedding: vectors[j],
     }));
@@ -119,6 +124,10 @@ export async function embedBookPageTexts({ db, pg, book, lang, apiKey, force = f
     }
     embedded += rows.length;
   }
+
+  // After the loop, so a book that throws part-way still records what it spent
+  // before throwing — the caller catches per book and continues.
+  await logEmbeddingUsage(usage, { model: EMBED_MODEL, bookId: book.id, endpoint: `worker/embed-page-texts:${lang}`, db });
 
   return { embedded, restaled, missing, alreadyPresent };
 }

--- a/scripts/lib/embed-book-pages.mjs
+++ b/scripts/lib/embed-book-pages.mjs
@@ -28,6 +28,7 @@ import {
   embedTexts,
   EMBED_MODEL,
 } from './page-embedding-text.mjs';
+import { newEmbedUsage, logEmbeddingUsage } from './embedding-usage.mjs';
 
 const EMBED_BATCH_SIZE = 50;   // Gemini batchEmbedContents caps at 100; 50 is the worker's setting
 const UPSERT_BATCH_SIZE = 10;  // HNSW index updates are expensive — keep writes small
@@ -98,9 +99,10 @@ export async function embedBookPages({ db, pg, book, apiKey, force = false }) {
   }
 
   let embedded = 0;
+  const usage = newEmbedUsage();  // one gemini_usage row per book (#4162)
   for (let i = 0; i < work.length; i += EMBED_BATCH_SIZE) {
     const batch = work.slice(i, i + EMBED_BATCH_SIZE);
-    const vectors = await embedTexts(batch.map((w) => w.text), apiKey);
+    const vectors = await embedTexts(batch.map((w) => w.text), apiKey, { usage });
     const rows = batch.map((w, j) => buildPageEmbeddingRow({
       page: w.page, book, text: w.text, hasTranslation: w.hasTranslation, embedding: vectors[j],
     }));
@@ -116,6 +118,8 @@ export async function embedBookPages({ db, pg, book, apiKey, force = false }) {
     }
     embedded += rows.length;
   }
+
+  await logEmbeddingUsage(usage, { model: EMBED_MODEL, bookId: book.id, endpoint: 'enrich-worker/phase6-embed', db });
 
   return { embedded, skipped, alreadyPresent: present.size };
 }

--- a/scripts/lib/embedding-usage.mjs
+++ b/scripts/lib/embedding-usage.mjs
@@ -1,0 +1,116 @@
+/**
+ * Embedding spend, recorded (#4162).
+ *
+ * ## Why this exists
+ *
+ * `budgetAllowsDispatch` (scripts/lib/spend-guard.mjs) is the repo's one brake
+ * on Gemini spend: it sums today's `gemini_usage` rows and stops paid dispatch
+ * at the daily ceiling. Neither page embedder wrote to that table, so the brake
+ * was measuring OCR and translation only — embedding was free as far as every
+ * instrument in the building was concerned.
+ *
+ * That is not a theoretical gap. In Aug 2026 the Spanish backfill (#4095) spent
+ * ≈$11.65 that appears in no ledger; it had to be reconstructed afterwards by
+ * measuring the corpus and multiplying by the published rate. A full English
+ * pass is ≈$180 on the same arithmetic. A dial that cannot see the largest
+ * embedding job in the repo does not report that it is blind — it just returns
+ * a smaller number, which is exactly the failure `measurement-instruments.md`
+ * is about.
+ *
+ * ## Tokens are ESTIMATED, and the row says so
+ *
+ * `batchEmbedContents` returns no `usageMetadata`, so there is no billed token
+ * count to record. Rather than call `countTokens` on every batch (another round
+ * trip per 50 texts, for a number that only feeds an estimate), this converts
+ * characters at a ratio measured on the real corpus. `cost_usd` in this table
+ * is already documented as a computed estimate rather than billed truth — see
+ * the spend-guard header — so an estimated embedding row is consistent with its
+ * neighbours, and vastly better than the zero that was there before.
+ *
+ * ## Aggregate before you log
+ *
+ * One row per 50-text batch would be ~78,000 rows for a full English pass, and
+ * the spend guard treats >40,000 rows in a day as over-budget and fails closed.
+ * Logging embedding spend must not be able to halt the pipeline. So callers
+ * accumulate into one of these objects and flush periodically — per book for
+ * the per-book writers, every FLUSH_EVERY_TEXTS for the streaming one.
+ */
+
+import { logUsage } from '../workers/lib/supabase-usage-logger.mjs';
+
+/**
+ * Measured on the Spanish corpus 2026-08-21 with `countTokens` over a 40-page
+ * spread sample: 138,390 chars → 32,224 tokens. Re-measure if the corpus mix
+ * changes a lot; a 10% error here is a 10% error in an estimate, not in a bill.
+ */
+export const EMBED_CHARS_PER_TOKEN = 4.29;
+
+/** gemini-embedding-2-preview, paid tier, text input. Output tokens: none. */
+export const EMBED_USD_PER_1M_TOKENS = 0.20;
+
+/** Flush the streaming accumulator this often, to bound rows per run. */
+export const FLUSH_EVERY_TEXTS = 5000;
+
+/** A fresh accumulator. */
+export function newEmbedUsage() {
+  return { texts: 0, chars: 0 };
+}
+
+/** Record one successful batch against an accumulator. */
+export function addEmbedUsage(usage, texts) {
+  if (!usage || !texts?.length) return;
+  usage.texts += texts.length;
+  for (const t of texts) usage.chars += t.length;
+}
+
+/** Estimated input tokens for a character count. */
+export function estimateTokens(chars) {
+  return Math.round(chars / EMBED_CHARS_PER_TOKEN);
+}
+
+/** Estimated USD for a character count. */
+export function estimateUsd(chars) {
+  return estimateTokens(chars) / 1e6 * EMBED_USD_PER_1M_TOKENS;
+}
+
+/**
+ * Write one `gemini_usage` row for everything accumulated so far, and reset.
+ *
+ * Never throws: a failure to RECORD spend must not stop the work that is
+ * already paid for. It does warn, because a logger that fails silently
+ * reproduces the very hole this module closes.
+ *
+ * @param {{texts:number, chars:number}} usage  accumulator, reset on success
+ * @param {object} opts
+ * @param {string} opts.model      the embedding model id
+ * @param {string} [opts.bookId]   attribution, when the caller knows it
+ * @param {string} opts.endpoint   e.g. 'worker/embed-page-texts'
+ * @param {object} [opts.db]       Mongo handle for the logger's fallback path
+ */
+export async function logEmbeddingUsage(usage, { model, bookId, endpoint, db } = {}) {
+  if (!usage || usage.texts === 0) return;
+  const { texts, chars } = usage;
+  usage.texts = 0;
+  usage.chars = 0;
+  try {
+    await logUsage({
+      type: 'embedding',
+      mode: 'realtime',
+      model,
+      book_id: bookId || null,
+      page_count: texts,
+      input_tokens: estimateTokens(chars),
+      // Embeddings return a vector, not tokens. Zero is the true value here,
+      // not a missing one.
+      output_tokens: 0,
+      // Passed explicitly: the logger's MODEL_PRICING table falls back to
+      // gemini-3-flash-preview for anything it does not know, which would
+      // overstate embedding input by 2.5x.
+      cost_usd: Math.round(estimateUsd(chars) * 1e6) / 1e6,
+      status: 'success',
+      endpoint,
+    }, db || null);
+  } catch (e) {
+    console.warn(`[embedding-usage] could not record ${texts} texts (~$${estimateUsd(chars).toFixed(4)}): ${e.message}`);
+  }
+}

--- a/scripts/lib/page-embedding-text.mjs
+++ b/scripts/lib/page-embedding-text.mjs
@@ -25,6 +25,7 @@
  */
 
 import { stripEditorialWrappers } from './strip-editorial-wrappers.mjs';
+import { addEmbedUsage } from './embedding-usage.mjs';
 
 export const EMBED_MODEL = 'gemini-embedding-2-preview';
 export const EMBED_DIMS = 768;
@@ -206,7 +207,7 @@ export function pageTextUpsertValues(row) {
  * Embed a batch of texts. Retries on 429 with a growing backoff, because the
  * caller is usually a long-running loop that should slow down rather than die.
  */
-export async function embedTexts(texts, apiKey, { signal } = {}) {
+export async function embedTexts(texts, apiKey, { signal, usage } = {}) {
   if (!texts.length) return [];
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${EMBED_MODEL}:batchEmbedContents?key=${apiKey}`;
   const body = JSON.stringify({
@@ -237,6 +238,9 @@ export async function embedTexts(texts, apiKey, { signal } = {}) {
     if (!data.embeddings || data.embeddings.length !== texts.length) {
       throw new Error(`Expected ${texts.length} embeddings, got ${data.embeddings?.length || 0}`);
     }
+    // Counted only on SUCCESS. A 429 that retried was not billed for a result,
+    // and a throw above never produced one.
+    addEmbedUsage(usage, texts);
     return data.embeddings.map((e) => e.values);
   }
   throw new Error('Gemini rate limit did not clear after 6 attempts');

--- a/scripts/workers/embed-gemini.mjs
+++ b/scripts/workers/embed-gemini.mjs
@@ -17,9 +17,11 @@
  * 100x smaller. --incremental and --missing-only are cheap because they touch
  * few pages; --full is not. ASK BEFORE A FULL PASS.
  *
- * Note the budget dial this script consults (budgetAllowsDispatch) cannot SEE
- * embedding spend — nothing here logs to gemini_usage (#4162) — so it brakes on
- * OCR/translation spend only.
+ * Since #4162 this worker RECORDS what it spends: gemini_usage rows with
+ * type 'embedding', flushed every FLUSH_EVERY_TEXTS so a full pass writes ~780
+ * rows rather than 78,000 (the spend guard fails closed above 40,000/day).
+ * Tokens are estimated from characters — batchEmbedContents returns no
+ * usageMetadata. See scripts/lib/embedding-usage.mjs.
  *
  * Time: ~5-6 days for full 3M-page backfill (~13 texts/sec sustained).
  *
@@ -49,6 +51,7 @@ import { createClient } from '@supabase/supabase-js';
 import fs from 'node:fs';
 import { cleanPageText, buildPageEmbeddingRow } from '../lib/page-embedding-text.mjs';
 import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
+import { newEmbedUsage, addEmbedUsage, logEmbeddingUsage, estimateUsd, FLUSH_EVERY_TEXTS } from '../lib/embedding-usage.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -130,6 +133,24 @@ async function getPgClient() {
 
 let rateLimitBackoff = 0;
 
+// Embedding spend, accumulated and flushed periodically (#4162). This worker
+// streams pages rather than walking books, so there is no per-book boundary to
+// flush on; FLUSH_EVERY_TEXTS bounds the row count instead (~780 rows for a
+// full 3.9M-page pass, against the spend guard's 40,000-row/day ceiling — one
+// row per 50-text batch would have been 78,000 and read as over-budget).
+const embedUsage = newEmbedUsage();
+let usageRows = 0;         // gemini_usage rows written this run
+let usageTotalChars = 0;   // characters recorded, for the closing summary
+
+async function flushEmbedUsage(force = false) {
+  if (!force && embedUsage.texts < FLUSH_EVERY_TEXTS) return;
+  const chars = embedUsage.chars;
+  if (!chars) return;
+  await logEmbeddingUsage(embedUsage, { model: MODEL, endpoint: 'worker/embed-gemini' });
+  usageRows += 1;
+  usageTotalChars += chars;
+}
+
 async function embedBatch(texts) {
   const requests = texts.map(t => ({
     model: `models/${MODEL}`,
@@ -162,6 +183,9 @@ async function embedBatch(texts) {
   if (!data.embeddings || data.embeddings.length !== texts.length) {
     throw new Error(`Expected ${texts.length} embeddings, got ${data.embeddings?.length || 0}`);
   }
+  // Counted only on success — a 429 retried above was not billed for a result.
+  addEmbedUsage(embedUsage, texts);
+  await flushEmbedUsage();
   return data.embeddings.map(e => e.values);
 }
 
@@ -503,10 +527,15 @@ for await (const page of cursor) {
 
 if (batch.length > 0) await processBatch(batch);
 
+// Record the tail. Without this, everything since the last flush is spend that
+// happened and was never written down — the exact hole #4162 is about.
+await flushEmbedUsage(true);
+
 await mongoClient.close();
 if (pgClient) await pgClient.end();
 const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 console.log(`\nDone: ${embedded.toLocaleString()} embedded, ${skipped} skipped, ${errors} errors, ${elapsed}s`);
+console.log(`Embedding spend recorded: ~$${estimateUsd(usageTotalChars).toFixed(2)} across ${usageRows} gemini_usage row(s) (estimated from characters — see scripts/lib/embedding-usage.mjs)`);
 
 // After a large full backfill, rebuild the HNSW index if it's missing
 if (FULL_MODE && embedded > 10000) {

--- a/scripts/workers/embed-page-texts.mjs
+++ b/scripts/workers/embed-page-texts.mjs
@@ -107,9 +107,9 @@ async function main() {
     );
 
     // The same brake embed-gemini.mjs uses. A paid bulk writer that does not
-    // consult the dial is a hole in it — and note the dial cannot SEE embedding
-    // spend, because neither embedder logs to gemini_usage, so it is measuring
-    // OCR and translation only. Treat it as a floor, not a full accounting.
+    // consult the dial is a hole in it. Since #4162 this worker also RECORDS
+    // what it spends (one gemini_usage row per book), so the dial accounts for
+    // embedding rather than only braking on OCR and translation.
     if (!DRY_RUN) {
       const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
       if (!await budgetAllowsDispatch(db, `embed-page-texts:${LANG}`, { control })) {

--- a/scripts/workers/lib/supabase-usage-logger.mjs
+++ b/scripts/workers/lib/supabase-usage-logger.mjs
@@ -20,6 +20,9 @@ const MODEL_PRICING = {
   'gemini-2.5-pro': { input: 1.25, output: 5.00 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
+  // Embedding models: input only — they return a vector, not tokens (#4162).
+  'gemini-embedding-2-preview': { input: 0.20, output: 0 },
+  'gemini-embedding-001': { input: 0.15, output: 0 },
 };
 
 function calculateCost(model, inputTokens, outputTokens, isBatch = false) {


### PR DESCRIPTION
Closes #4162.

`budgetAllowsDispatch` sums `gemini_usage` and stops paid dispatch at the daily ceiling. **Neither page embedder wrote to that table**, so the brake was measuring OCR and translation only — embedding was free as far as every instrument in the building was concerned. That is how the Spanish backfill's ≈$11.65 (#4095) came to exist in no ledger and had to be reconstructed afterwards by measuring the corpus and multiplying by the published rate. A full English pass is ≈$180 on the same arithmetic.

Both page embedders now accumulate characters and write rows with `type: 'embedding'` via a new `scripts/lib/embedding-usage.mjs`.

## Three things worth reviewing

**Aggregated on purpose.** One row per 50-text batch is ~78,000 rows for a full English pass — and the spend guard treats >40,000 rows in a day as over-budget and **fails closed**. Logging spend must not be able to halt the pipeline. So: one row per book for the per-book writers, one per 5,000 texts for the streaming `embed-gemini` (~780 rows for a full pass).

**Tokens are estimated, and the row says so.** `batchEmbedContents` returns no `usageMetadata`, so characters are converted at the **4.29 chars/token** measured on the real corpus. `cost_usd` in this table is already documented as computed rather than billed truth, so an estimated embedding row sits consistently with its neighbours — and is vastly better than the zero that was there before.

**`cost_usd` is passed explicitly** because `MODEL_PRICING` had no embedding entry and falls back to `gemini-3-flash-preview`, which would have overstated input **2.5×**. The two embedding models are now in that table too, so the explicit value isn't the only thing standing between us and a wrong number.

## Correctness details

- Counted only on **success** — a 429 that retried was not billed for a result, and a throw never produced one.
- Flushed **after** the per-book loop and at end of run, so a book that throws part-way still records what it spent before throwing.
- `logEmbeddingUsage` never throws: failing to *record* spend must not stop work that is already paid for. It warns, because a logger that fails silently reproduces the hole it exists to close.

## Verified end to end

Against production Supabase, not just a syntax pass:

```
estimated usd for 8580 chars: 0.000400
rows with type=embedding: before 0 after 1
 type='embedding'  model='gemini-embedding-2-preview'  page_count=2
 input_tokens=2000  output_tokens=0  cost_usd=0.000400  endpoint='test/verify-4162'
accumulator reset: {"texts":0,"chars":0}
probe rows deleted: 1
```

(8,580 ÷ 4.29 = 2,000 tokens exactly; 2,000 ÷ 1e6 × $0.20 = $0.0004. Probe row deleted so it never counts as real spend.)

## Out of scope

The image-side backfills (artwork / gallery / CLIP) still don't log — smaller, and a different call path. Worth doing, not worth bundling.

Also updates the three places #4160 left saying "the dial cannot see embedding spend", which is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ
