### PR TITLE
docs(invariants): the corrected language-drift number, and the three things `contradict` mixes

### DIFF
--- a/.claude/docs/invariants/language-fields.md
+++ b/.claude/docs/invariants/language-fields.md
@@ -151,6 +151,47 @@ early modern vernacular scholarship. These belong in `languages[]` as an
 addition, never as a replacement of `language`, and they are the standing reason
 the detector's `contradict` bucket is a review queue and not a patch.
 
+## How much drift is actually there — the corrected corpus-wide number
+
+The two figures above (5 apparent mislabels, 6,230 bilingual books) come from the
+detector's FIRST run and are artifacts. Here is the whole live corpus after both
+fixes, so nobody has to re-derive it: `detect-book-languages.mjs`, all 21,481
+live books with OCR, 2026-08-21.
+
+| bucket | books | what it means |
+|---|---:|---|
+| `agree` | 14,332 | catalogue matches the pages |
+| `add_second` | 3,775 | monolingual record, real second language ≥10% of pages |
+| `contradict` | **1,015** | catalogue disagrees with the pages |
+| `no_tag` / `thin` / `unparsed` | 2,146 | not enough tagged pages to judge |
+| `unsupported_claim` | 109 | catalogued bilingual, second language not measurable |
+| `no_catalogue_value` | 104 | no `language` to compare against |
+
+**The 1,015 `contradict` rows are three different things, and only the last two
+are defects.** Splitting them is the whole job — a sweep that treats them as one
+bucket is #2184 repeating:
+
+| class | books | disposition |
+|---|---:|---|
+| **hanmun** — `Korean` → Classical Chinese | 211 (21%) | **correctly catalogued.** The largest single cluster is the known artifact, exactly as this document predicts. |
+| **source-vs-edition** — catalogued language IS on the pages, just not dominant | 457 | Latin editions of Greek authors (Hero ed. Commandino 1575; Archimedes; Jerome's *Opera Omnia*, 99% Latin, catalogued Greek). `language` should be the edition's, with the source moving to `original_language`. Never delete the source language. |
+| **record-vs-pages** — catalogued language is absent from its own pages entirely | 347 | the real queue. Eliot's Massachusett Bible catalogued `Hebrew,Greek`; Wycliffe catalogued `Hebrew,Greek`, pages Middle English; Avicenna's *Canon* catalogued `Arabic`, pages 99% Latin (Gerard of Cremona). |
+
+347 of 22,073 live books = **1.6%**. Not a wave, and not nothing.
+
+Two cautions the numbers do not show on their own:
+
+- **The detector's top language can be wrong even when the contradiction is
+  right.** Merezhkovsky's *Христос и Антихрист* vol. 2 is catalogued `Russian`,
+  tagged `French` on 100% of pages, and is actually an **English** translation
+  ("THE ROMANCE OF LEONARDO DA VINCI"). The finding held; the proposed label did
+  not. This is why `contradict` is a review queue and not a patch.
+- **The existing `language_review: true` queue is not the same set.** 1,519 live
+  books carry the flag; the detector calls only 496 of them `contradict` and
+  clears 204 outright, while 148 of the 347 hard contradictions were never
+  flagged at all. Neither list supersedes the other; the page tags are the
+  sharper instrument.
+
 ## Four vocabularies, none authoritative
 
 - `src/lib/language-utils.ts` — `CODE_TO_NAME` / `CODE3_TO_NAME` / `expandLanguages` (read path)


### PR DESCRIPTION
Doc-only. Records the corrected corpus-wide language-drift numbers so the next person doesn't have to re-run a 21,481-book walk to learn them.

## Why

`language-fields.md` carried the detector's **first-run** figures — 5 apparent mislabels, 6,230 bilingual books — and then, two sections later, explained that both are artifacts of the detector's own vocabulary. What it never carried was the corrected numbers. A doc that documents its own wrong answer and stops there is worse than one that says nothing, because the wrong answer is the quotable part.

## The numbers

Full walk, `detect-book-languages.mjs`, all 21,481 live books with OCR:

| bucket | books |
|---|---:|
| `agree` | 14,332 |
| `add_second` | 3,775 |
| `contradict` | **1,015** |
| `no_tag` / `thin` / `unparsed` | 2,146 |
| `unsupported_claim` | 109 |
| `no_catalogue_value` | 104 |

## The part worth writing down

`contradict` is **three different things**, and only two are defects. A sweep that treats them as one bucket is #2184 repeating — that one nearly relabelled 547 books.

- **211 (21%) hanmun** — `Korean` → Classical Chinese. Correctly catalogued. The largest single cluster is the known artifact, exactly as the section above it predicts it will be. This is the doc's own "hand-check the biggest cluster" rule paying for itself a third time.
- **457 source-vs-edition** — the catalogued language *is* on the pages, just not dominant. Latin editions of Greek authors: Hero of Alexandria ed. Commandino 1575, Archimedes' *Opera*, Jerome's *Opera Omnia* at 99% Latin catalogued `Greek`. Fix is `language` → the edition's, source → `original_language`. The source language is never deleted.
- **347 record-vs-pages** — the catalogued language is absent from its own pages entirely. The real queue: **1.6% of live books**. Eliot's Massachusett Bible catalogued `Hebrew,Greek`; Wycliffe catalogued `Hebrew,Greek` with Middle English pages; Avicenna's *Canon Medicinae* catalogued `Arabic`, pages 99% Latin (Gerard of Cremona's translation).

## Two cautions, both measured

- **The proposed label can be wrong even when the contradiction is right.** Merezhkovsky's *Христос и Антихрист* vol. 2 is catalogued `Russian`, tagged `French` on 100% of pages, and is in fact an **English** translation — page 40 opens "THE ROMANCE OF LEONARDO DA VINCI". The finding held; the label did not. This is the concrete reason `contradict` stays a review queue and never becomes a patch.
- **The existing `language_review: true` flag is not the same set.** 1,519 live books carry it; the detector calls only 496 of them `contradict` and clears 204 outright, while **148 of the 347** hard contradictions were never flagged at all. Neither list supersedes the other.

## Scope

Doc only. No code, no data written — `detect-book-languages.mjs` has no `--apply` and refuses one if you pass it. Acting on the 347 is a separate decision and a separate PR; #3958 and #2184 are where that belongs.

Prompted by the Magliabechiano recatalogue (#4172) and the obvious follow-up question: how much of this is there? Positive control on that book: the detector measures German 67% / Italian 53% and **zero Nahuatl**, so against the old catalogue value it would have landed in `contradict`. The instrument that would have caught it already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
