### PR TITLE
docs(invariants): two allowlists decide whether an image appears, and only one resolver was reading them

### DIFF
--- a/.claude/docs/invariants/image-host-allowlists.md
+++ b/.claude/docs/invariants/image-host-allowlists.md
@@ -1,0 +1,58 @@
+# Two allowlists decide whether an image appears — and every resolver must consult them
+
+**Read this when:** adding or editing an image-URL resolver; adding a provider host; storing a new `image_*` / `*_photo` / `thumbnail*` field; or triaging "the images are broken" when the URLs return 200 to curl.
+
+*Written 2026-08-21 after #4163: 2,506 pages of the Florentine Codex were unreadable in every browser for months while every one of their image URLs returned a clean `200 image/jpeg`.*
+
+---
+
+## The two lists
+
+| list | file | governs | consequence of a miss |
+|---|---|---|---|
+| CSP `img-src` | `src/lib/csp-img-hosts.ts` → `CSP_IMG_HOSTS` | what the **browser** will load | broken image, silently — the block fires before React hydrates, so `onError` never runs and no fallback swaps in |
+| proxy fetch policy | `src/lib/image-proxy-hosts.ts` → `ALLOWED_IMAGE_HOSTS` | what **`/api/image`** will fetch | 400 from the proxy |
+
+They are **not** the same list and neither is a superset of the other. `images.metmuseum.org` is proxy-fetchable and not CSP-listed; several IIIF hosts are the reverse. Adding a provider usually means editing **both**.
+
+## The failure mode: a resolver that doesn't screen
+
+`getBookThumbnailUrl` (`src/lib/utils.ts`) has screened stored cover URLs with `isBrowserRenderableImageUrl()` since 2026-08-04, when ~1,550 books were found rendering blank cards. The **page**-image resolver (`src/lib/page-image-url.ts`) did not, for another two and a half weeks — and that is the whole of #4163:
+
+- `media.getty.edu` was never added to `CSP_IMG_HOSTS`.
+- All 2,506 pages of the three Florentine Codex volumes store `image_thumb` there.
+- Page grid, cover picker **and the reader itself** rendered nothing, on `/book/…` and `/es/book/…` alike.
+- An R2 thumbnail that would have worked sat one field away in `thumbnail_blob` the entire time.
+
+**A stored URL is only useful if the consumer will load it.** Screen at every resolver, not at one of them. Corpus-wide check at the time: `media.getty.edu` was the *only* blocked host among page thumbnails (3.8M pages on allowlisted hosts, 2,506 on Getty) — so the gap was small, invisible, and total for the books it touched.
+
+## Not every consumer is a browser
+
+`getPageImageUrl` serves the UI **and** `pageExportImageUrl` (PDF/EPUB/ZIP), which hands the result to a server-side fetcher where CSP does not apply. The first fix for #4163 screened unconditionally and broke exports — pushing them onto a proxy whose allowlist is narrower than the CSP's, i.e. a guaranteed 400. Caught by `tests/unit/download-route-parity.test.ts`, not by review.
+
+The resolved order, by how many consumers each satisfies:
+
+1. renderable candidate → return it (browser + server)
+2. proxy-fetchable source → `/api/image` (browser + server, our compute)
+3. neither → the bounded stored URL, **kept rather than discarded** (server only, but nothing else works at all)
+
+Tier 3 is empty in the corpus today. It exists so that the day a host is not on either list, exports keep working instead of silently losing every image.
+
+## Diagnosing "the images are broken"
+
+The tell that you are here rather than in a data problem: **`curl` gets a 200 and the browser shows nothing.** Check the served header first —
+
+```
+curl -sI https://sourcelibrary.org/book/<slug> | grep -o "img-src[^;]*"
+```
+
+— and compare the host in the rendered `<img src>` against it. A host missing from that list is this bug, not a bad scan, not a missing page, and not a caching problem.
+
+## Rules
+
+1. A new provider host goes in `CSP_IMG_HOSTS` **and** `ALLOWED_IMAGE_HOSTS` unless you can say why only one applies.
+2. A new image-URL resolver screens with `isBrowserRenderableImageUrl()` for browser-facing sizes, and must not discard a URL a server-side consumer could still use.
+3. Never assume the two lists agree — read them, as `isProxyableUrl()` in `page-image-url.ts` does.
+4. `next.config.ts` `images.remotePatterns` is a third list, already guarded: `tests/unit/csp-image-hosts.test.ts` asserts every remotePatterns host is covered by `img-src`.
+
+Related: `content-urls-and-libraries.md` (provider prefixes), `image-quality-and-bboxes.md` (crops and bboxes), `text-helpers-and-exports.md` (the export surfaces that consume these URLs).

--- a/.claude/docs/invariants/image-host-allowlists.md
+++ b/.claude/docs/invariants/image-host-allowlists.md
@@ -2,7 +2,7 @@
 
 **Read this when:** adding or editing an image-URL resolver; adding a provider host; storing a new `image_*` / `*_photo` / `thumbnail*` field; or triaging "the images are broken" when the URLs return 200 to curl.
 
-*Written 2026-08-21 after #4163: 2,506 pages of the Florentine Codex were unreadable in every browser for months while every one of their image URLs returned a clean `200 image/jpeg`.*
+*Written 2026-08-21 after #4163: every page thumbnail on 2,506 Florentine Codex pages was refused by every browser for months, while each of those URLs returned a clean `200 image/jpeg` to curl.*
 
 ---
 
@@ -21,8 +21,23 @@ They are **not** the same list and neither is a superset of the other. `images.m
 
 - `media.getty.edu` was never added to `CSP_IMG_HOSTS`.
 - All 2,506 pages of the three Florentine Codex volumes store `image_thumb` there.
-- Page grid, cover picker **and the reader itself** rendered nothing, on `/book/…` and `/es/book/…` alike.
 - An R2 thumbnail that would have worked sat one field away in `thumbnail_blob` the entire time.
+
+**Which surfaces broke — the answer is per-TIER, not per-book.** These pages carry `display_photo` on R2 and `image_thumb` on Getty, so the damage tracked the size tier:
+
+| surface | tier | outcome |
+|---|---|---|
+| page grid (`getPageGridUrl`) | thumb | **broken** — no upgrade path |
+| cover picker | thumb | **broken** |
+| book cover at `thumb` size | thumb | placeholder instead of a cover |
+| adjacent-page prefetch | thumb | silently failed (perf only) |
+| **the reader's main image** | display → R2 | **worked** |
+
+The reader deserves the detail, because it looks broken and is not. `ImageWithMagnifier` paints `thumbnail` first and background-decodes the full-size `src`, swapping when ready — so a reader on these books saw a broken placeholder on first paint and then the correct page once the R2 display image decoded. **Degraded, not dead.**
+
+The server-rendered HTML contains only the *thumb* `<img>`; the display image is swapped in by script. So curling the reader page and reading its single `<img>` tag over-reports the severity — which is what this document's first draft did, and what the #4163 PR body still says.
+
+**The general form:** one resolver is called at several size tiers, and a host can be missing for one tier and present for another. Ask which TIER a surface uses before declaring it broken, and check whether anything upgrades away from it.
 
 **A stored URL is only useful if the consumer will load it.** Screen at every resolver, not at one of them. Corpus-wide check at the time: `media.getty.edu` was the *only* blocked host among page thumbnails (3.8M pages on allowlisted hosts, 2,506 on Getty) — so the gap was small, invisible, and total for the books it touched.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - Reusing a text helper on a new surface; exports (PDF, `/text`, corpus snapshot); `<page-type>` → `text-helpers-and-exports.md`
 - `gallery_quality` / `scan_quality`, image crops, deep-zoom bbox remapping → `image-quality-and-bboxes.md`
 - Detectors over page images, spread splitting, corpus-wide image repair sweeps → `image-classifiers-and-splits.md`
+- An image-URL resolver, a new provider host, or "images broken but curl returns 200" → `image-host-allowlists.md`
 
 **Routing, access & the edge**
 - `src/proxy.ts`, `src/app/embed/**`, `src/app/[tenant]/**`, any URL on a partner subdomain → `tenant-lockdown.md`

--- a/src/lib/csp-img-hosts.ts
+++ b/src/lib/csp-img-hosts.ts
@@ -57,9 +57,11 @@ export const CSP_IMG_HOSTS = [
   'https://iiif-images.library.upenn.edu',
   'https://content.staatsbibliothek-berlin.de',
   'https://images.sub.uni-goettingen.de',
-  // Getty (Florentine Codex vols 1-3, 2,506 pages). Missing here meant every
-  // page thumbnail AND the reader's own page image were CSP-blocked — the
-  // books were unreadable in a browser while every URL returned 200 to curl.
+  // Getty (Florentine Codex vols 1-3, 2,506 pages). Missing here CSP-blocked
+  // every page THUMBNAIL on those books — page grid and cover picker rendered
+  // nothing — while every one of those URLs returned 200 to curl. The reader
+  // itself was fine: those pages carry `display_photo` on R2, so the damage
+  // tracked the size tier, not the book. See invariants/image-host-allowlists.md.
   'https://media.getty.edu',
 ] as const;
 

--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -84,11 +84,15 @@ function isProxyableUrl(url: string): boolean {
  *
  * Until 2026-08-21 it did not. `media.getty.edu` was absent from
  * `CSP_IMG_HOSTS`, so all 2,506 Florentine Codex pages resolved to a Getty
- * `image_thumb` that every browser refused — the page grid, the cover picker
- * and the reader itself showed a broken image, while curl got a clean 200 from
- * every one of those URLs. The book-cover resolver (`getBookThumbnailUrl`) had
- * screened against this same list since 2026-08-04; the page resolver never did,
- * and an R2 thumbnail that would have worked sat one field away the whole time.
+ * `image_thumb` that every browser refused — the page grid and the cover picker
+ * rendered nothing — while curl got a clean 200 from every one of those URLs.
+ * The book-cover resolver (`getBookThumbnailUrl`) had screened against this same
+ * list since 2026-08-04; the page resolver never did, and an R2 thumbnail that
+ * would have worked sat one field away the whole time.
+ *
+ * Note the blast radius is per SIZE TIER, not per book: those same pages carry
+ * `display_photo` on R2, so the reader's main image was never affected. A host
+ * can be missing for one tier and present for another.
  *
  * But not every consumer here is a browser. Exports (PDF/EPUB/ZIP) hand the
  * result to a server-side fetcher, where CSP does not apply — so a URL the


### PR DESCRIPTION
Doc-only. The invariant behind #4163, written down so the next image resolver reads both lists.

## Why this needs a doc rather than a code comment

#4163 made 2,506 pages of the Florentine Codex unreadable in every browser for months while every one of their image URLs returned a clean `200 image/jpeg` to curl. One host was missing from `CSP_IMG_HOSTS`. That part is a one-line fix.

The part worth recording is **why it lasted**: `getBookThumbnailUrl` has screened stored cover URLs against that list since 2026-08-04, when ~1,550 books were found rendering blank cards. `getPageImageUrl` — a second resolver, written later, in a different file — never did. Same class of failure, different surface, invisible for weeks, with a working R2 thumbnail sitting one field away in `thumbnail_blob` the whole time.

The failure is silent **by construction**: the CSP block fires before React hydrates, so `onError` never runs and no fallback swaps in. There is no error anywhere — just a blank cell.

## What the doc covers

- **The two lists** — `CSP_IMG_HOSTS` (what the browser loads) and `ALLOWED_IMAGE_HOSTS` (what `/api/image` fetches) — and that neither is a superset of the other. `images.metmuseum.org` is proxy-fetchable and not CSP-listed; several IIIF hosts are the reverse.
- **Not every consumer is a browser.** `pageExportImageUrl` (PDF/EPUB/ZIP) hands the result to a server-side fetcher where CSP does not apply. The first fix for #4163 screened unconditionally and broke exports by routing them onto a proxy with a *narrower* allowlist — a guaranteed 400. Caught by `download-route-parity.test.ts`, not by review.
- **The resolved three-tier order**, and why tier 3 (keep the bounded stored URL rather than discard it) exists even though it is empty in the corpus today.
- **The one-line diagnosis**: curl gets 200, browser shows nothing → compare the rendered `<img src>` host against the served `img-src` header. That distinguishes this from a bad scan, a missing page, or a caching problem, all of which it looks like.

## Budget

CLAUDE.md gains one routing line and stays inside the ~250-line cap at **237**. The rule has a nameable trigger — any image-URL resolver, any new provider host — so per the knowledge-layer rule it belongs in `invariants/`, not in the body.

## Down-pass

The `/gnite` ratchet runs both directions, so: I re-measured the `Stack` numbers this session actually leaned on — **37,826** visible / **79,714** with pages / **104,707** total, against the doc's 37,821 / 79,697 / 104,690 from 08-18. Still accurate, left alone. The #4025 Vercel-integration entry also matched observed behaviour today (two merges deployed and auto-purged; the CSP change was live on prod 400s after merge), so its "intermittent — verify, assume neither" framing stands unchanged. Nothing found stale enough to demote or delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
