### PR TITLE
fix(es): the findability audit was blind to the books #4146 added

### DIFF
--- a/scripts/audit/page-texts-coverage.mjs
+++ b/scripts/audit/page-texts-coverage.mjs
@@ -31,6 +31,7 @@ import { MongoClient } from 'mongodb';
 import pg from 'pg';
 import { pageFilterForLang, pageProjectionForLang } from '../lib/embed-book-page-texts.mjs';
 import { pageTextForLang } from '../lib/page-embedding-text.mjs';
+import { embeddableEditionFilter, isNativeEditionLanguage } from '../lib/native-edition-language.mjs';
 
 const args = process.argv.slice(2);
 const arg = (n, d = null) => { const m = args.find(a => a.startsWith(`--${n}=`)); return m ? m.slice(n.length + 3) : d; };
@@ -57,17 +58,27 @@ async function main() {
   await client.query('SET statement_timeout = 120000');
 
   try {
+    // The books the WRITER would embed — imported, never re-typed, so a gap
+    // here always means work the worker would actually do. Selecting on the
+    // counter alone is the drift this audit exists to catch, committed by the
+    // audit itself: it left the 68 native Spanish books out of its own
+    // denominator, so it would have reported clean over exactly the state
+    // #4146 described — 19,464 pages visible on /es and unfindable.
     const books = await db.collection('books')
-      .find({ [COUNTER]: { $gt: 0 } }, { projection: { id: 1, title: 1, display_title: 1, visible: 1, [COUNTER]: 1 } })
+      .find(embeddableEditionFilter(LANG), { projection: { id: 1, title: 1, display_title: 1, visible: 1, language: 1, [COUNTER]: 1 } })
       .toArray();
     const byId = new Map(books.map(b => [b.id, b]));
+    /** Derived ONCE per book from its language, never guessed per page. */
+    const isNative = (id) => isNativeEditionLanguage(byId.get(id)?.language, LANG);
+    const nativeBooks = books.filter(b => isNative(b.id)).length;
 
     // What a reader can read: pages actually carrying text in this language.
     // Counted per book (the book_id index makes this cheap); a corpus-wide
     // count on translations.<lang> is unindexed and would take minutes.
     const mongoPages = new Map();
     for (const b of books) {
-      mongoPages.set(b.id, await db.collection('pages').countDocuments({ book_id: b.id, ...pageFilterForLang(LANG) }));
+      const nativeEdition = isNative(b.id);
+      mongoPages.set(b.id, await db.collection('pages').countDocuments({ book_id: b.id, ...pageFilterForLang(LANG, { nativeEdition }) }));
     }
 
     const { rows: supaRows } = await client.query(
@@ -81,16 +92,27 @@ async function main() {
     // alone cannot tell you what Mongo says now.
     let staleRows = 0;
     const staleBooks = [];
+    // Rows for books the selector no longer admits — e.g. a book relabelled out
+    // of the language. Counted rather than skipped, so an orphaned row set
+    // cannot sit in the store looking like nothing at all.
+    let orphanBooks = 0, orphanRows = 0;
     for (const r of supaRows) {
+      if (!byId.has(r.book_id)) { orphanBooks++; orphanRows += r.rows; continue; }
       if (!r.newest) { staleRows += r.rows; staleBooks.push({ book_id: r.book_id, reason: 'no watermark' }); continue; }
+      const nativeEdition = isNative(r.book_id);
       const newer = await db.collection('pages').countDocuments({
-        book_id: r.book_id, ...pageFilterForLang(LANG),
+        book_id: r.book_id, ...pageFilterForLang(LANG, { nativeEdition }),
         $or: [
           { [`translations.${LANG}.updated_at`]: { $gt: r.newest } },
           ...(LANG === 'es' ? [{ 'translation_es.updated_at': { $gt: r.newest } }] : []),
+          // A native row is sourced from OCR and its watermark tracks
+          // `ocr.updated_at` (buildPageTextRow). Keying staleness only on a
+          // translation that will never exist would let a re-OCRed page keep a
+          // stale snippet and a stale vector forever, unflagged.
+          ...(nativeEdition ? [{ 'ocr.updated_at': { $gt: r.newest } }] : []),
         ],
       });
-      if (newer > 0) { staleRows += newer; staleBooks.push({ book_id: r.book_id, reason: `${newer} page(s) re-translated after embedding` }); }
+      if (newer > 0) { staleRows += newer; staleBooks.push({ book_id: r.book_id, reason: `${newer} page(s) ${nativeEdition ? 're-OCRed' : 're-translated'} after embedding` }); }
     }
 
     const rawGaps = books
@@ -115,28 +137,36 @@ async function main() {
         'SELECT page_id FROM page_texts WHERE book_id = $1 AND lang = $2', [g.id, LANG],
       );
       const have = new Set(present.map(r => r.page_id));
+      const nativeEdition = isNative(g.id);
       const candidates = await db.collection('pages')
-        .find({ book_id: g.id, ...pageFilterForLang(LANG) }, { projection: pageProjectionForLang(LANG) })
+        .find({ book_id: g.id, ...pageFilterForLang(LANG, { nativeEdition }) }, { projection: pageProjectionForLang(LANG) })
         .toArray();
       let empty = 0, missing = 0;
       for (const p of candidates) {
         if (have.has(p.id)) continue;
-        if (pageTextForLang(p, LANG)) missing++; else empty++;
+        if (pageTextForLang(p, LANG, { nativeEdition })) missing++; else empty++;
       }
       emptyPages += empty;
       if (missing > 0) gaps.push({ ...g, gap: missing, empty });
     }
     gaps.sort((a, b) => b.gap - a.gap);
 
+    /** Readable pages contributed by books WRITTEN in the language. */
+    const nativePages = books.reduce((a, b) => a + (isNative(b.id) ? (mongoPages.get(b.id) || 0) : 0), 0);
+
     const totals = {
       lang: LANG,
       books: books.length,
+      native_pages: nativePages,
       counter: books.reduce((a, b) => a + (b[COUNTER] || 0), 0),
       mongo: [...mongoPages.values()].reduce((a, n) => a + n, 0),
       supabase_rows: supaRows.reduce((a, r) => a + r.rows, 0),
       supabase_embedded: supaRows.reduce((a, r) => a + r.embedded, 0),
+      native_books: nativeBooks,
       books_with_no_rows: books.filter(b => !supa.has(b.id)).length,
       stale_rows: staleRows,
+      orphan_books: orphanBooks,
+      orphan_rows: orphanRows,
       // Pages that hold text in this language but nothing QUOTABLE once the
       // editorial wrappers are dropped. Expected, not a defect.
       empty_after_cleaning: emptyPages,
@@ -154,9 +184,15 @@ async function main() {
     if (AS_JSON) {
       console.log(JSON.stringify({ totals, gaps, stale_books: staleBooks }, null, 2));
     } else {
-      console.log(`\n${LANG.toUpperCase()} findability — ${totals.books} book(s)`);
-      console.log(`  counter (${COUNTER}):    ${totals.counter}`);
-      console.log(`  readable (Mongo pages):  ${totals.mongo}${totals.mongo !== totals.counter ? '   ← counter disagrees with the pages' : ''}`);
+      console.log(`\n${LANG.toUpperCase()} findability — ${totals.books} book(s), ${totals.native_books} written in ${LANG}`);
+      // The counter only ever describes the TRANSLATED books: a book written in
+      // the language has no pivot pages and its counter is 0 for good reason.
+      // So the two lines are expected to differ by the natives' pages, and
+      // flagging that as a disagreement would make green unreachable.
+      const translatedPages = totals.mongo - nativePages;
+      console.log(`  counter (${COUNTER}):    ${totals.counter}   (translated books only)`);
+      console.log(`  readable (Mongo pages):  ${totals.mongo} = ${translatedPages} translated + ${nativePages} native` +
+        (translatedPages !== totals.counter ? '   ← counter disagrees with the pages' : ''));
       console.log(`  findable (page_texts):   ${totals.supabase_embedded} embedded of ${totals.supabase_rows} rows`);
       console.log(`  books with NO rows:      ${totals.books_with_no_rows}`);
       console.log(`  pages with no quotable text once wrappers are dropped (expected): ${totals.empty_after_cleaning}`);
@@ -170,6 +206,9 @@ async function main() {
         for (const g of gaps) console.log(`    ${String(g.gap).padStart(6)}  ${g.title}  [${g.id}]${g.empty ? ` (+${g.empty} empty after cleaning)` : ''}`);
       } else if (gaps.length) {
         console.log(`\n  ${gaps.length} book(s) with a gap — pass --books to list them.`);
+      }
+      if (orphanBooks) {
+        console.log(`\n  ${orphanBooks} book(s) / ${orphanRows} row(s) in the store are no longer readable in ${LANG} — relabelled or un-translated since embedding.`);
       }
       if (staleBooks.length) {
         console.log(`\n  ${staleBooks.length} book(s) with stale rows — re-run: scripts/workers/embed-page-texts.mjs --lang=${LANG}`);

--- a/scripts/lib/native-edition-language.mjs
+++ b/scripts/lib/native-edition-language.mjs
@@ -37,3 +37,31 @@ export function localizedEditionFilter(lang) {
     ],
   };
 }
+
+/**
+ * Mongo fragment: books the `page_texts` store should hold text for in `lang`.
+ *
+ * NOT the same question as `localizedEditionFilter`, which answers "can a reader
+ * read this in `lang`" and leaves visibility to each caller. This one answers
+ * "would the writer embed it", so it carries the two guards the writer needs: a
+ * native edition must be `visible` (we do not embed hidden books) and must have
+ * `pages_ocr > 0`, since for a native edition the OCR *is* the text.
+ *
+ * It exists because the WRITER and its AUDIT have to select the same set. When
+ * the worker built this inline and `page-texts-coverage.mjs` selected on the
+ * counter alone, the audit left every native book out of its own denominator
+ * and would have reported clean over the exact state #4146 described. Two
+ * copies of a selector disagree the first time one of them is corrected — which
+ * is the whole reason this module exists (see the header).
+ */
+export function embeddableEditionFilter(lang) {
+  const pattern = NATIVE_EDITION_LANGUAGE[lang];
+  return {
+    $or: [
+      { [`pages_translated_${lang}`]: { $gt: 0 } },
+      // Only for a language we have a native pattern for; otherwise the counter
+      // remains the whole rule, exactly as it was before #4146.
+      ...(pattern ? [{ language: pattern, visible: true, pages_ocr: { $gt: 0 } }] : []),
+    ],
+  };
+}

--- a/scripts/workers/embed-page-texts.mjs
+++ b/scripts/workers/embed-page-texts.mjs
@@ -42,7 +42,7 @@
 
 import { MongoClient } from 'mongodb';
 import pg from 'pg';
-import { NATIVE_EDITION_LANGUAGE, isNativeEditionLanguage } from '../lib/native-edition-language.mjs';
+import { embeddableEditionFilter, isNativeEditionLanguage } from '../lib/native-edition-language.mjs';
 import { embedBookPageTexts, EMBED_MODEL } from '../lib/embed-book-page-texts.mjs';
 import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
 
@@ -98,12 +98,11 @@ async function main() {
     // holding 19,464 pages — visible on /es and unfindable by Spanish search,
     // which is indistinguishable from having no matches. A native edition also
     // needs `pages_ocr > 0`, since its text IS the OCR.
-    const nativePattern = NATIVE_EDITION_LANGUAGE[LANG];
-    const clauses = [{ [COUNTER]: { $gt: 0 } }];
-    // Only for a language we have a native pattern for; otherwise the counter
-    // remains the whole rule, exactly as before.
-    if (nativePattern) clauses.push({ language: nativePattern, visible: true, pages_ocr: { $gt: 0 } });
-    const match = BOOK ? { id: { $in: BOOK.split(',') } } : { $or: clauses };
+    // The rule is imported, not written here: `page-texts-coverage.mjs` has to
+    // select the SAME set or its gap number is meaningless, and when this was
+    // inline the audit was still on the counter-only rule and blind to every
+    // native book it added.
+    const match = BOOK ? { id: { $in: BOOK.split(',') } } : embeddableEditionFilter(LANG);
     // Select first, order second — sorting before the limit once picked the
     // shortest books in the library rather than the intended set (2026-08-20).
     let books = await db.collection('books')

--- a/tests/unit/native-edition-embedding.test.ts
+++ b/tests/unit/native-edition-embedding.test.ts
@@ -4,7 +4,7 @@ import { pageTextForLang } from '../../scripts/lib/page-embedding-text.mjs';
 // @ts-expect-error — .mjs script lib, no types
 import { pageFilterForLang } from '../../scripts/lib/embed-book-page-texts.mjs';
 // @ts-expect-error — .mjs script lib, no types
-import { isNativeEditionLanguage, NATIVE_EDITION_LANGUAGE } from '../../scripts/lib/native-edition-language.mjs';
+import { isNativeEditionLanguage, NATIVE_EDITION_LANGUAGE, embeddableEditionFilter, localizedEditionFilter } from '../../scripts/lib/native-edition-language.mjs';
 
 /**
  * #4146 — a language-keyed row is a PROMISE that the text is that language, so
@@ -62,5 +62,53 @@ describe('which languages count as native', () => {
   it('has no pattern for a language it has not been taught', () => {
     expect(NATIVE_EDITION_LANGUAGE.fr).toBeUndefined();
     expect(isNativeEditionLanguage('French', 'fr')).toBe(false);
+  });
+});
+
+/**
+ * The WRITER (`embed-page-texts.mjs`) and its AUDIT (`page-texts-coverage.mjs`)
+ * must select the same books, or the audit's gap number describes a different
+ * corpus than the one the worker would fill. When the worker built this filter
+ * inline and the audit selected on `pages_translated_es > 0`, the audit left
+ * every native book out of its own denominator and reported CLEAN over the
+ * exact state #4146 describes: 68 books and ~19.5K pages of Spanish, visible on
+ * /es and unfindable. Measured against production while fixing it — the audit
+ * saw 107 books before and 175 after, which is the worker's own count.
+ */
+describe('embeddableEditionFilter — one selector, two callers', () => {
+  it('admits a book translated into the language', () => {
+    const f = embeddableEditionFilter('es') as { $or: Record<string, unknown>[] };
+    expect(f.$or[0]).toEqual({ pages_translated_es: { $gt: 0 } });
+  });
+
+  // These three guards are the difference between "readable in Spanish" and
+  // "the store should hold it", and dropping any one of them silently changes
+  // what a gap means: without `visible` the audit counts hidden books the
+  // worker will never embed (measured: 203 books, 21 phantom gaps, exit 1 — a
+  // check that can never go green is one people learn to ignore).
+  it('admits a NATIVE book only when it is visible and has OCR', () => {
+    const f = embeddableEditionFilter('es') as { $or: Record<string, unknown>[] };
+    expect(f.$or[1]).toEqual({
+      language: NATIVE_EDITION_LANGUAGE.es,
+      visible: true,
+      pages_ocr: { $gt: 0 },
+    });
+  });
+
+  // For a language with no native pattern the counter stays the whole rule —
+  // otherwise the clause would read `{ language: undefined }` and match nothing
+  // in a way that looks deliberate.
+  it('falls back to the counter alone for an untaught language', () => {
+    const f = embeddableEditionFilter('fr') as { $or: Record<string, unknown>[] };
+    expect(f.$or).toHaveLength(1);
+    expect(f.$or[0]).toEqual({ pages_translated_fr: { $gt: 0 } });
+  });
+
+  it('is NOT the same rule as the read-side "readable in this language"', () => {
+    // localizedEditionFilter answers a different question and leaves visibility
+    // to its callers; conflating them is how a hidden book would reach /es.
+    const read = localizedEditionFilter('es') as { $or: Record<string, unknown>[] };
+    expect(read.$or[1]).toEqual({ language: NATIVE_EDITION_LANGUAGE.es });
+    expect(read).not.toEqual(embeddableEditionFilter('es'));
   });
 });


### PR DESCRIPTION
Follows #4178. That PR fixed the writer and backfilled; this fixes the instrument that is supposed to notice when the writer is wrong.

## The gap

#4178 taught `page_texts` that a book **written** in Spanish belongs in the Spanish search store, and backfilled 68 books / 19,489 pages. Its audit, `scripts/audit/page-texts-coverage.mjs`, was left on the old rule — it selects books by `pages_translated_es > 0`, which is `0` for every native edition and always will be.

So the detector built to catch *"an unembedded book and a book with no matches return the same empty list"* had those 68 books **outside its own denominator**, and would have reported `exit 0 / clean` over the exact state #4146 describes. Measured: **107 books in scope before, 175 after** — 175 being the worker's own count.

This is the same #4120 drift the #4146 issue itself enumerated (`sync-es-collection`, `/es/collections/[id]`, the embed worker), landing a fourth time in the auditor.

## Three blindnesses, one cause

- **Book selection** on the counter alone — natives never in scope.
- **`pageFilterForLang` / `pageTextForLang` called without `nativeEdition`** — so even had a native book been in scope, its OCR pages were neither counted as readable nor composed to check for a gap.
- **Staleness** looked only at `translations.<lang>.updated_at`, while `buildPageTextRow` keys a native row on `ocr.updated_at`. A re-OCRed native page would have kept a stale snippet **and** a stale vector indefinitely, unflagged. This one is not a scope bug and would have outlived the other two.

## One selector, two callers

The fix is `embeddableEditionFilter(lang)` in `native-edition-language.mjs`, imported by **both** the worker and the audit rather than written twice.

That indirection earns its place: the worker had the rule inline **with two guards the shared helper lacks** — `visible: true` and `pages_ocr > 0`. So the obvious fix (import the existing `localizedEditionFilter`) is wrong, and measurably so: it pulls in hidden books and reports **203 books with 21 phantom gaps, exit 1** — a check that can never go green, which this file's own comments warn is a check people learn to ignore.

`localizedEditionFilter` is deliberately untouched. It answers a different question — "can a reader read this in `lang`" — and every one of its six callers adds `visible` itself. A test pins that the two are not the same rule, so a future merge cannot quietly collapse them.

## Verified against production

```
ES findability — 175 book(s), 68 written in es
  counter (pages_translated_es):    39643   (translated books only)
  readable (Mongo pages):  59132 = 39643 translated + 19489 native
  findable (page_texts):   58730 embedded of 58730 rows
  books with NO rows:      0
  pages with no quotable text once wrappers are dropped (expected): 402
  rows re-translated since embedding: 0
```
`59,132 − 58,730 = 402` exactly. Exit 0.

Independently confirmed the store really is complete by walking every native book through the **writer's own** composer rather than a re-typed rule: **19,094 composable pages, 19,094 rows, zero books short.** (My first pass used a crude `ocr.data is non-empty` test and "found" 395 missing pages — those are apparatus-only pages the composer correctly strips to nothing. The writer's own functions settled it; a hand-rolled predicate would have filed a false bug.)

And #4146's own end-to-end criterion, which #4178 could not run because it merged while the backfill was still going: a phrase **lifted from a stored Scherzer row** (not invented) is returned by the Spanish keyword lane, ranked `0.45`, with a nonsense control returning `0`.

## Negative controls

- Removing `visible`/`pages_ocr` from the shared filter turns two tests red.
- The gap path and the `exit 1` flip were exercised for real by the intermediate wrong-selector run above (21 gaps), so this is not a check that only knows how to pass.

`tsc --noEmit` clean; **2,875 tests** pass.

## Out of scope

- **Other languages.** Everything is language-keyed; `es` is simply the only language with a native pattern today, and a test pins that an untaught language falls back to the counter alone rather than emitting `{ language: undefined }`.
- **Orphan rows** — books holding rows while no longer selectable (relabelled out of the language) are now *counted and reported* rather than silently skipped, but nothing deletes them. That needs a decision about whether removal is ever automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MojJdMhnuk3PkZfpTPyA7k