### PR TITLE
feat(es): the Spanish reader can search the library (#4180)

### DIFF
--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -332,3 +332,41 @@ open anyway, because `books_catalog` has no `pages_translated_es` and the guard
 could not see books *translated* into Spanish (only ones *written* in it) —
 #4166. **A link-side fix is only as good as the fields the link site is given**,
 which is rule 2's fill-rate point wearing different clothes.
+
+## Adding a twin to an EXISTING route breaks things that were correct
+
+The section above is about a localized page leaking outward. This is the
+mirror image: the moment a path enters `LOCALIZED_PATHS`, code that was
+right the day it was written becomes wrong, silently, and in two places
+nobody looks. Learned adding `/es/search` (#4180); #4119 is a backlog of
+the same move, so expect it each time.
+
+- **Every hard-coded `href` to that path is now a leak.** Not a new leak — the
+  same line, newly wrong, because until today the unprefixed link was the
+  *correct* answer (no twin ⇒ leave it alone). `/search` had four: the header's
+  search icon, the header's mobile menu entry, the homepage's search `<form
+  action>`, and two homepage stat links. Grep the path as a literal — `href="/x"`,
+  `action="/x"`, `` href={`/x?… `` — across every component a localized route
+  mounts, and route them through `localePath`/`useLocalePath`.
+- **An active-state test keyed on the raw pathname stops matching.**
+  `pathname === '/search'` never fires on `/es/search`, so the nav item silently
+  stops highlighting. Those comparisons belong on `canonicalPath(pathname)`.
+- **A test whose FIXTURE used that path as a twin-less example now fails, and
+  the test is not wrong.** `reading-language-url.test.ts` asserted
+  `legacyLangRedirect('/search', '?lang=es')` is null, with `/search` standing
+  in for "a path with no /es route". The guard is still exactly right; the
+  *example* expired. Swap the exemplar for one that still qualifies and promote
+  the old one to the positive case — never delete the assertion to get green,
+  which is how a guard becomes decoration
+  (`invariants/tests-that-are-not-guards.md`).
+- **Check who else composes a prefix from path segment 0.** `UnifiedSearch`
+  derived ONE prefix for tenants and locales from `pathname.split('/')[0]`, so
+  it read `es` as a tenant slug and emitted `/es/gallery/image/…` — a 404 that
+  predated this PR and was invisible because nobody clicks a hero-typeahead
+  image result on `/es`. A tenant prefix is carried verbatim onto every link; a
+  locale prefix is re-applied PER LINK by the registry. One variable cannot be
+  both.
+
+Cheapest way to find all four: after adding the path to the registry, `git grep`
+it as a literal string and read every hit, then run the full test suite. Neither
+step is optional — the grep finds the links, only the suite finds the fixtures.

--- a/src/app/es/search/layout.tsx
+++ b/src/app/es/search/layout.tsx
@@ -1,0 +1,47 @@
+import { Suspense } from 'react';
+import { Metadata } from 'next';
+import { siteOgImage, OG_LOCALE } from '@/lib/og-locale';
+
+// Spanish twin of src/app/search/layout.tsx. The `<Suspense>` boundary is not
+// decoration: the page reads `useSearchParams`, which needs one, and the
+// English route gets its own from here too.
+
+const TITLE = 'Buscar - Source Library';
+const DESCRIPTION =
+  'Busca en la biblioteca en español: fuentes primarias sobre alquimia, hermetismo, cábala y filosofía natural, con los resultados y los fragmentos tomados de la edición en español.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: '/es/search',
+    languages: { en: '/search', es: '/es/search', 'x-default': '/search' },
+  },
+  // Both blocks, always. Declaring only `openGraph` leaves the root layout's
+  // ENGLISH `twitter` block in place, which is how /es/collections shipped an
+  // English share card over a Spanish page (#4162, i18n.md "the share card").
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: 'Source Library',
+    type: 'website',
+    locale: OG_LOCALE.es,
+    url: 'https://sourcelibrary.org/es/search',
+    images: [siteOgImage('es')],
+  },
+  twitter: {
+    card: 'summary',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [siteOgImage('es')],
+  },
+};
+
+export default function EsSearchLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense>
+      <h1 className="sr-only">Buscar en Source Library</h1>
+      {children}
+    </Suspense>
+  );
+}

--- a/src/app/es/search/page.tsx
+++ b/src/app/es/search/page.tsx
@@ -1,0 +1,33 @@
+import SearchPage from '@/app/search/page';
+
+/**
+ * Spanish search — the SAME page as `/search`, rendered with `lang='es'`
+ * (#4180). One page, two URLs: the shape the book page set in #4082 phase 2.
+ *
+ * The data half shipped in #4095: `/api/search?lang=es` searches the Spanish
+ * text store, returns Spanish snippets, and narrows every lane to books that
+ * HAVE a Spanish edition — so every card here links to a page the reader can
+ * actually open, and the `/es/book/…` promise is kept.
+ *
+ * What this route deliberately does NOT offer, because the lane behind it takes
+ * no `lang` and would answer in English under Spanish chrome (i18n.md rule 4 —
+ * label or omit, never machine-translate at render time):
+ *
+ *   - the "All" tab (`/api/search/unified`)
+ *   - the "Index" tab (`/api/search/index`, whose entries are English)
+ *   - the AI-expand narration (`/api/search/ai-expand`)
+ *   - the known-entity capture card (English editorial copy)
+ *
+ * The gallery tab is KEPT and labelled instead, because the images are the
+ * content and only their descriptions are an English index.
+ *
+ * Known gap, tracked in #4146: the 67 books WRITTEN in Spanish have no
+ * `page_texts` rows, so they are visible on /es and still absent from these
+ * results. That is a store-side fix, not a page-side one.
+ *
+ * Metadata and the `<Suspense>` boundary that `useSearchParams` needs live in
+ * `layout.tsx`, mirroring `/search`.
+ */
+export default function EsSearchPage() {
+  return <SearchPage lang="es" />;
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   description: 'Search over 10,000 translated primary sources — alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit, Chinese classics, Arabic philosophy, and more.',
   alternates: {
     canonical: '/search',
+    languages: { en: '/search', es: '/es/search', 'x-default': '/search' },
   },
   openGraph: {
     images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -10,6 +10,10 @@ import {
   ChevronLeft, ChevronRight, ArrowUpDown, ImageIcon, ChevronDown
 } from 'lucide-react';
 import { useSearchParams, useRouter, useParams, usePathname } from 'next/navigation';
+import { useLocale, useLocalePath } from '@/lib/i18n';
+import type { Locale } from '@/lib/locale-path';
+import { SEARCH_STRINGS, EXAMPLE_QUERIES, type SearchStrings } from '@/lib/search-i18n';
+import { localizedCollection } from '@/lib/localized';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { useEmbed } from '@/lib/EmbedContext';
 import { useDebouncedCallback } from 'use-debounce';
@@ -42,15 +46,24 @@ const PREVIEW_IMAGES = 6;
 const DEFAULT_RESULTS_PER_PAGE = 20;
 const RESULTS_PER_PAGE_OPTIONS = [20, 48, 96];
 
-const INDEX_TYPES = [
-  { value: '', label: 'All Types', icon: Search },
-  { value: 'concept', label: 'Concepts', icon: Lightbulb },
-  { value: 'person', label: 'People', icon: User },
-  { value: 'place', label: 'Places', icon: MapPin },
-  { value: 'quote', label: 'Quotes', icon: Quote },
-  { value: 'keyword', label: 'Keywords', icon: BookOpen },
-  { value: 'vocabulary', label: 'Vocabulary', icon: Languages },
+// `labelKey` indexes SEARCH_STRINGS rather than carrying a literal, so the
+// index-type pills and the IndexResultCard badge speak the page's language from
+// one place. The `value`s are API parameters and never localize.
+const INDEX_TYPES: { value: string; labelKey: keyof SearchStrings; icon: typeof Search }[] = [
+  { value: '', labelKey: 'indexAllTypes', icon: Search },
+  { value: 'concept', labelKey: 'indexConcepts', icon: Lightbulb },
+  { value: 'person', labelKey: 'indexPeople', icon: User },
+  { value: 'place', labelKey: 'indexPlaces', icon: MapPin },
+  { value: 'quote', labelKey: 'indexQuotes', icon: Quote },
+  { value: 'keyword', labelKey: 'indexKeywords', icon: BookOpen },
+  { value: 'vocabulary', labelKey: 'indexVocabulary', icon: Languages },
 ];
+
+/** The label for an index type in `lang` (falls back to the raw API value). */
+function indexTypeLabel(type: string, t: SearchStrings): string {
+  const key = INDEX_TYPES.find((x) => x.value === type)?.labelKey;
+  return key ? (t[key] as string) : type;
+}
 
 interface LanguageOption { value: string; label: string; }
 interface CategoryOption { value: string; label: string; icon?: string; }
@@ -80,7 +93,7 @@ interface BphCatalogMatch {
 
 type ViewMode = 'unified' | 'books' | 'index' | 'images';
 
-export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { defaultLibrary?: string; forceEmbedded?: boolean } = {}) {
+export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang: langProp }: { defaultLibrary?: string; forceEmbedded?: boolean; lang?: Locale } = {}) {
   const router = useRouter();
   const { tenant } = useParams<{ tenant: string }>();
   const searchParams = useSearchParams();
@@ -88,7 +101,36 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   const embedFromContext = useEmbed();
   const embed = forceEmbedded || embedFromContext;
 
-  const initialMode = (searchParams.get('mode') as ViewMode) || 'unified';
+  // The locale comes from the URL prefix; the `lang` prop that the `/es/search`
+  // twin passes is the explicit form of the same answer. Defaulting to the
+  // pathname means a caller that forgets the prop still renders the right
+  // language rather than English chrome on an `/es` URL (i18n.md, "both sides
+  // of an edition guard must read the same locale").
+  const urlLocale = useLocale();
+  const lang: Locale = langProp ?? urlLocale;
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
+  const nf = (n: number) => n.toLocaleString(t.numberLocale);
+
+  // A localized surface gets only the lanes that can answer in its language.
+  // `/api/search` (the books lane) takes `lang` and narrows to books that HAVE
+  // that edition, so every result is openable at `/es/book/…`. The unified
+  // ("All") lane, the index lane and the AI-expand stream do not take `lang`
+  // and would return English under Spanish chrome — hidden rather than shown
+  // broken (see the note in src/lib/search-i18n.ts). The gallery lane is kept
+  // and LABELLED, because the images are the content.
+  const localized = lang !== 'en';
+  const defaultMode: ViewMode = localized ? 'books' : 'unified';
+  const langParam = localized ? lang : undefined;
+
+  // `?mode=` is user-supplied, so the clamp lives here rather than only in the
+  // tab list: a hand-typed /es/search?mode=unified must not render the English
+  // lane. Both hidden modes fall back to the books lane, which is also what
+  // browse mode renders (it keys on `viewMode !== 'images'`).
+  const rawInitialMode = (searchParams.get('mode') as ViewMode) || defaultMode;
+  const initialMode: ViewMode = localized && (rawInitialMode === 'unified' || rawInitialMode === 'index')
+    ? 'books'
+    : rawInitialMode;
   const [query, setQuery] = useState(searchParams.get('q') || '');
   const [viewMode, setViewMode] = useState<ViewMode>(initialMode);
   const [loading, setLoading] = useState(false);
@@ -160,8 +202,8 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   const [hasTranslation, setHasTranslation] = useState(searchParams.get('has_translation') === 'true');
   const [firstTranslation, setFirstTranslation] = useState(searchParams.get('first_translation') === 'true');
   const [library, setLibrary] = useState(searchParams.get('library') || defaultLibrary || '');
-  const [languages, setLanguages] = useState<LanguageOption[]>([{ value: '', label: 'All Languages' }]);
-  const [categories, setCategories] = useState<CategoryOption[]>([{ value: '', label: 'All Categories' }]);
+  const [languages, setLanguages] = useState<LanguageOption[]>([{ value: '', label: t.allLanguages }]);
+  const [categories, setCategories] = useState<CategoryOption[]>([{ value: '', label: t.allCategories }]);
   const [collectionsList, setCollectionsList] = useState<Collection[]>([]);
 
   // Results per page
@@ -242,7 +284,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     utils.languages().then((langData) => {
       if (langData.languages) {
         setLanguages([
-          { value: '', label: 'All Languages' },
+          { value: '', label: t.allLanguages },
           ...langData.languages.map((l: any) => ({ value: l.code, label: `${l.name} (${l.book_count})` })),
         ]);
       }
@@ -251,7 +293,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     categoriesApi.list().then((catData) => {
       if (catData.categories) {
         setCategories([
-          { value: '', label: 'All Categories' },
+          { value: '', label: t.allCategories },
           ...catData.categories
             .filter((c: any) => c.book_count > 0)
             .map((c: any) => ({ value: c.id, label: `${c.icon ? c.icon + ' ' : ''}${c.name} (${c.book_count})`, icon: c.icon })),
@@ -264,7 +306,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         setCollectionsList(colData.collections);
       }
     }).catch(() => { });
-  }, []);
+  }, [t]);
 
   // Track current narration/terms in refs so startAiStream doesn't need them as deps
   const aiNarrationRef = useRef(aiNarration);
@@ -305,6 +347,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     baseImagesSet.current = false;
     pendingAiImages.current = [];
 
+    // /api/search/ai-expand answers in English and expands to English terms
+    // against an English index. On a localized surface that is a paragraph of
+    // English prose above Spanish results, so the lane is skipped entirely
+    // rather than shown in the wrong language (i18n.md rule 7 — the language
+    // has to travel in the REQUEST, which this endpoint does not yet take).
+    if (localized) return;
     if (!q || q.length < 3) return;
     setAiStreaming(true);
 
@@ -384,7 +432,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     );
     aiAbortRef.current = abort;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bookResults]);
+  }, [bookResults, localized]);
 
   const performSearch = useCallback(async (q: string, mode: ViewMode = viewMode, pageOffset = 0) => {
     if (!q || q.length < 2) {
@@ -625,6 +673,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         }
       } else if (mode === 'books') {
         const data = await searchApi.search(q, {
+          // The TEXT language of the answer. Anything but `en` also narrows the
+          // request to books that HAVE that edition, so every card links to a
+          // page the reader can actually open (#4095).
+          lang: langParam,
           language: language || undefined,
           category: category || undefined,
           date_from: dateFrom || undefined,
@@ -674,17 +726,17 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
       }
     } catch (error) {
       console.error('Search error:', error);
-      toast.error('Search failed. Please try again.');
+      toast.error(t.searchFailed);
     } finally {
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewMode, indexType, language, category, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, resultsPerPage]);
+  }, [viewMode, indexType, language, category, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, resultsPerPage, langParam, t]);
 
   const updateUrl = useCallback((q: string, mode: ViewMode, pageOffset = 0) => {
     const params = new URLSearchParams();
     if (q) params.set('q', q);
-    if (mode !== 'unified') params.set('mode', mode);
+    if (mode !== defaultMode) params.set('mode', mode);
     if (mode === 'index' && indexType) params.set('type', indexType);
     // Persist filters in URL for all modes
     if (language) params.set('language', language);
@@ -708,7 +760,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
       ? currentPathname
       : (tenant ? `/${tenant}/search` : '/search');
     router.replace(`${basePath}?${params.toString()}`, { scroll: false });
-  }, [router, currentPathname, tenant, indexType, language, category, collection, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, browseSortBy, resultsPerPage]);
+  }, [router, currentPathname, tenant, defaultMode, indexType, language, category, collection, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, browseSortBy, resultsPerPage]);
 
   // Client-side search cache — avoids re-fetching on backspace/retype
   const searchCache = useRef(new Map<string, { ts: number; books: SearchResult[]; bookTotal: number; index: IndexSearchResult[]; indexTotal: number; images: GalleryItem[]; imageTotal: number }>());
@@ -754,9 +806,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   // entry card above results instead of being left to the LLM's guess. Suppressed
   // in embed/tenant mode — these hrefs (/collections, /libraries) point
   // off-tenant and would leak past the subdomain lockdown.
+  // Also suppressed on a localized surface: the entity titles and descriptions
+  // are English editorial copy with no localized map behind them, so the card
+  // would be an English block above Spanish results.
   const knownEntity = useMemo(
-    () => (embed ? null : matchKnownEntity(query, { collections: collectionsList })),
-    [embed, query, collectionsList]
+    () => (embed || localized ? null : matchKnownEntity(query, { collections: collectionsList })),
+    [embed, localized, query, collectionsList]
   );
 
   // Browse mode: fetch books when no query
@@ -895,7 +950,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   const hasActiveFilters = language || category || collection || dateFrom || dateTo || hasDoi || hasTranslation || firstTranslation || (library && library !== defaultLibrary) || sortBy !== 'relevance';
 
   return (
-    <div className="bg-cream">
+    <div className="bg-cream" lang={lang}>
       {!embed && <SiteHeader variant="light" />}
 
       {/* Search Bar */}
@@ -909,7 +964,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 value={query}
                 onChange={(e) => handleQueryChange(e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter') handleSearchSubmit(); }}
-                placeholder="Search books, concepts, people, images..."
+                placeholder={t.searchPlaceholder}
                 className="w-full pl-12 pr-4 py-3 border border-border-medium rounded-xl bg-cream/50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust/40 text-lg text-primary font-body"
                 autoFocus
               />
@@ -925,10 +980,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                   onChange={(e) => { setSortBy(e.target.value as any); setOffset(0); }}
                   className="w-full sm:w-auto pl-9 pr-3 py-3 border border-border-medium rounded-xl text-sm text-secondary bg-white focus:outline-none focus:ring-2 focus:ring-accent-rust/30 appearance-none cursor-pointer"
                 >
-                  <option value="relevance">Relevance</option>
-                  <option value="date_desc">Year (newest)</option>
-                  <option value="date_asc">Year (oldest)</option>
-                  <option value="title">Title A-Z</option>
+                  <option value="relevance">{t.sortRelevance}</option>
+                  <option value="date_desc">{t.sortYearNewest}</option>
+                  <option value="date_asc">{t.sortYearOldest}</option>
+                  <option value="title">{t.sortTitleAz}</option>
                 </select>
               </div>
             )}
@@ -940,12 +995,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                   onChange={(e) => { setBrowseSortBy(e.target.value); setOffset(0); }}
                   className="w-full sm:w-auto pl-9 pr-3 py-3 border border-border-medium rounded-xl text-sm text-secondary bg-white focus:outline-none focus:ring-2 focus:ring-accent-rust/30 appearance-none cursor-pointer"
                 >
-                  <option value="recent-translation">Recently translated</option>
-                  <option value="recent">Recently added</option>
-                  <option value="date_desc">Oldest first</option>
-                  <option value="date_asc">Newest first</option>
-                  <option value="title-asc">Title A-Z</option>
-                  <option value="title-desc">Title Z-A</option>
+                  <option value="recent-translation">{t.browseRecentTranslation}</option>
+                  <option value="recent">{t.browseRecent}</option>
+                  <option value="date_desc">{t.browseOldestFirst}</option>
+                  <option value="date_asc">{t.browseNewestFirst}</option>
+                  <option value="title-asc">{t.browseTitleAsc}</option>
+                  <option value="title-desc">{t.browseTitleDesc}</option>
                 </select>
               </div>
             )}
@@ -955,15 +1010,22 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
           <div className="mt-3 flex gap-1 border-b border-border-light -mx-4 px-4">
             {(isBrowseMode
               ? [
-                { mode: 'unified' as ViewMode, label: 'Books', icon: Book },
-                { mode: 'images' as ViewMode, label: 'Images', icon: ImageIcon },
+                { mode: defaultMode, label: t.tabBooks, icon: Book },
+                { mode: 'images' as ViewMode, label: t.tabImages, icon: ImageIcon },
               ]
-              : [
-                { mode: 'unified' as ViewMode, label: 'All', icon: Search },
-                { mode: 'books' as ViewMode, label: 'Books', icon: Book },
-                { mode: 'index' as ViewMode, label: 'Index', icon: Lightbulb },
-                { mode: 'images' as ViewMode, label: 'Images', icon: ImageIcon },
-              ]
+              : localized
+                // No "All" and no "Index" on a localized surface: neither lane
+                // takes `lang`. See the `localized` note above.
+                ? [
+                  { mode: 'books' as ViewMode, label: t.tabBooks, icon: Book },
+                  { mode: 'images' as ViewMode, label: t.tabImages, icon: ImageIcon },
+                ]
+                : [
+                  { mode: 'unified' as ViewMode, label: t.tabAll, icon: Search },
+                  { mode: 'books' as ViewMode, label: t.tabBooks, icon: Book },
+                  { mode: 'index' as ViewMode, label: t.tabIndex, icon: Lightbulb },
+                  { mode: 'images' as ViewMode, label: t.tabImages, icon: ImageIcon },
+                ]
             ).map(({ mode, label, icon: Icon }) => (
               <button
                 key={mode}
@@ -975,14 +1037,14 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               >
                 <Icon className="w-4 h-4" />
                 {label}
-                {!isBrowseMode && mode === 'books' && bookTotal > 0 && viewMode !== 'unified' && (
-                  <span className="text-xs text-muted">({bookTotal})</span>
+                {!isBrowseMode && mode === 'books' && bookTotal > 0 && (localized || viewMode !== 'unified') && (
+                  <span className="text-xs text-muted">({nf(bookTotal)})</span>
                 )}
                 {!isBrowseMode && mode === 'index' && indexTotal > 0 && viewMode !== 'unified' && (
-                  <span className="text-xs text-muted">({indexTotal})</span>
+                  <span className="text-xs text-muted">({nf(indexTotal)})</span>
                 )}
-                {!isBrowseMode && mode === 'images' && imageTotal > 0 && viewMode !== 'unified' && (
-                  <span className="text-xs text-muted">({imageTotal})</span>
+                {!isBrowseMode && mode === 'images' && imageTotal > 0 && (localized || viewMode !== 'unified') && (
+                  <span className="text-xs text-muted">({nf(imageTotal)})</span>
                 )}
               </button>
             ))}
@@ -1003,7 +1065,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       }`}
                   >
                     <Icon className="w-3.5 h-3.5" />
-                    {type.label}
+                    {t[type.labelKey] as string}
                   </button>
                 );
               })}
@@ -1018,7 +1080,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             >
               <ChevronDown className={`w-4 h-4 transition-transform ${showFilters ? '' : '-rotate-90'}`} />
               <Filter className="w-3.5 h-3.5" />
-              Filters
+              {t.filters}
               {hasActiveFilters && <span className="w-1.5 h-1.5 bg-accent-rust rounded-full" />}
             </button>
           </div>
@@ -1030,49 +1092,49 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               <div className="md:hidden fixed inset-0 bg-black/30 z-40" onClick={() => setShowFilters(false)} />
               <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[70vh] overflow-y-auto animate-in slide-in-from-bottom duration-200">
                 <div className="sticky top-0 bg-white border-b border-border-light px-4 py-3 flex items-center justify-between">
-                  <span className="text-sm font-medium text-primary">Filters</span>
+                  <span className="text-sm font-medium text-primary">{t.filters}</span>
                   <div className="flex items-center gap-3">
                     {hasActiveFilters && (
                       <button onClick={clearFilters} className="text-sm text-muted hover:text-primary flex items-center gap-1">
-                        <X className="w-3.5 h-3.5" /> Clear
+                        <X className="w-3.5 h-3.5" /> {t.clear}
                       </button>
                     )}
                     <button onClick={() => setShowFilters(false)} className="text-sm font-medium text-accent-rust">
-                      Done
+                      {t.done}
                     </button>
                   </div>
                 </div>
                 <div className="p-4 grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Language</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterLanguage}</label>
                     <select value={language} onChange={(e) => setLanguage(e.target.value)}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
                       {languages.map((l) => <option key={l.value} value={l.value}>{l.label}</option>)}
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Subject</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterSubject}</label>
                     <select value={category} onChange={(e) => setCategory(e.target.value)}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
                       {categories.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Collection</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterCollection}</label>
                     <select value={collection} onChange={(e) => { setCollection(e.target.value); setOffset(0); }}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
-                      <option value="">All Collections</option>
+                      <option value="">{t.allCollections}</option>
                       {collectionsList.map((c) => (
-                        <option key={c.slug} value={c.slug}>{c.name} ({c.book_count})</option>
+                        <option key={c.slug} value={c.slug}>{localizedCollection(c, lang).name} ({nf(c.book_count)})</option>
                       ))}
                     </select>
                   </div>
                   {!defaultLibrary && !embed && (
                     <div>
-                      <label className="block text-sm text-secondary mb-1">Library</label>
+                      <label className="block text-sm text-secondary mb-1">{t.filterLibrary}</label>
                       <select value={library} onChange={(e) => setLibrary(e.target.value)}
                         className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
-                        <option value="">All Libraries</option>
+                        <option value="">{t.allLibraries}</option>
                         {Object.values(LIBRARY_PARTNERS).map((p) => (
                           <option key={p.providerKey} value={p.providerKey}>{p.name}</option>
                         ))}
@@ -1080,27 +1142,27 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                     </div>
                   )}
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Published after</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterPublishedAfter}</label>
                     <input type="text" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)}
-                      placeholder="e.g., 1500" className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
+                      placeholder={t.yearFromPlaceholder} className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Published before</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterPublishedBefore}</label>
                     <input type="text" value={dateTo} onChange={(e) => setDateTo(e.target.value)}
-                      placeholder="e.g., 1700" className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
+                      placeholder={t.yearToPlaceholder} className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
                   </div>
                   <div className="col-span-2 flex flex-wrap gap-x-6 gap-y-2">
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={hasTranslation} onChange={(e) => setHasTranslation(e.target.checked)}
-                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> Has translation
+                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> {t.hasTranslation}
                     </label>
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={firstTranslation} onChange={(e) => setFirstTranslation(e.target.checked)}
-                        className="rounded border-border-medium text-accent-gold focus:ring-accent-gold/30" /> First translation
+                        className="rounded border-border-medium text-accent-gold focus:ring-accent-gold/30" /> {t.firstTranslation}
                     </label>
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={hasDoi} onChange={(e) => setHasDoi(e.target.checked)}
-                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> Has DOI
+                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> {t.hasDoi}
                     </label>
                   </div>
                 </div>
@@ -1111,41 +1173,41 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 <div className="flex items-center justify-between mb-3">
                   {hasActiveFilters && (
                     <button onClick={clearFilters} className="text-sm text-muted hover:text-primary flex items-center gap-1 ml-auto">
-                      <X className="w-4 h-4" /> Clear all
+                      <X className="w-4 h-4" /> {t.clearAll}
                     </button>
                   )}
                 </div>
                 <div className="grid grid-cols-3 gap-4">
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Language</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterLanguage}</label>
                     <select value={language} onChange={(e) => setLanguage(e.target.value)}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
                       {languages.map((l) => <option key={l.value} value={l.value}>{l.label}</option>)}
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Subject</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterSubject}</label>
                     <select value={category} onChange={(e) => setCategory(e.target.value)}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
                       {categories.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Collection</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterCollection}</label>
                     <select value={collection} onChange={(e) => { setCollection(e.target.value); setOffset(0); }}
                       className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
-                      <option value="">All Collections</option>
+                      <option value="">{t.allCollections}</option>
                       {collectionsList.map((c) => (
-                        <option key={c.slug} value={c.slug}>{c.name} ({c.book_count})</option>
+                        <option key={c.slug} value={c.slug}>{localizedCollection(c, lang).name} ({nf(c.book_count)})</option>
                       ))}
                     </select>
                   </div>
                   {!defaultLibrary && !embed && (
                     <div>
-                      <label className="block text-sm text-secondary mb-1">Library</label>
+                      <label className="block text-sm text-secondary mb-1">{t.filterLibrary}</label>
                       <select value={library} onChange={(e) => setLibrary(e.target.value)}
                         className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30">
-                        <option value="">All Libraries</option>
+                        <option value="">{t.allLibraries}</option>
                         {Object.values(LIBRARY_PARTNERS).map((p) => (
                           <option key={p.providerKey} value={p.providerKey}>{p.name}</option>
                         ))}
@@ -1153,27 +1215,27 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                     </div>
                   )}
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Published after</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterPublishedAfter}</label>
                     <input type="text" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)}
-                      placeholder="e.g., 1500" className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
+                      placeholder={t.yearFromPlaceholder} className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
                   </div>
                   <div>
-                    <label className="block text-sm text-secondary mb-1">Published before</label>
+                    <label className="block text-sm text-secondary mb-1">{t.filterPublishedBefore}</label>
                     <input type="text" value={dateTo} onChange={(e) => setDateTo(e.target.value)}
-                      placeholder="e.g., 1700" className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
+                      placeholder={t.yearToPlaceholder} className="w-full px-3 py-2 border border-border-medium rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30" />
                   </div>
                   <div className="flex flex-col gap-2 justify-end">
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={hasTranslation} onChange={(e) => setHasTranslation(e.target.checked)}
-                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> Has translation
+                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> {t.hasTranslation}
                     </label>
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={firstTranslation} onChange={(e) => setFirstTranslation(e.target.checked)}
-                        className="rounded border-border-medium text-accent-gold focus:ring-accent-gold/30" /> First translation
+                        className="rounded border-border-medium text-accent-gold focus:ring-accent-gold/30" /> {t.firstTranslation}
                     </label>
                     <label className="flex items-center gap-2 text-sm text-secondary cursor-pointer">
                       <input type="checkbox" checked={hasDoi} onChange={(e) => setHasDoi(e.target.checked)}
-                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> Has DOI
+                        className="rounded border-border-medium text-accent-rust focus:ring-accent-rust/30" /> {t.hasDoi}
                     </label>
                   </div>
                 </div>
@@ -1189,13 +1251,11 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {signInRequired && (
           <div className="text-center py-16 max-w-lg mx-auto">
             <Search className="w-16 h-16 text-border-medium mx-auto mb-4" />
-            <h2 className="text-2xl font-serif font-medium text-primary mb-2">Sign in to keep searching</h2>
-            <p className="text-secondary mb-6">
-              You&rsquo;ve used your free searches for now. Sign in &mdash; it&rsquo;s free &mdash; to keep exploring over 10,000 primary sources.
-            </p>
-            <Link href="/auth/signin?callbackUrl=/search&reason=limit"
+            <h2 className="text-2xl font-serif font-medium text-primary mb-2">{t.signInHeading}</h2>
+            <p className="text-secondary mb-6">{t.signInBody}</p>
+            <Link href={`${lp('/auth/signin')}?callbackUrl=${lp('/search')}&reason=limit`}
               className="inline-block px-6 py-3 rounded-xl bg-accent-rust text-white font-medium hover:bg-accent-rust/90 transition-colors">
-              Sign in &mdash; free
+              {t.signInCta}
             </Link>
           </div>
         )}
@@ -1205,17 +1265,17 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <div className="mb-4 flex items-center justify-between flex-wrap gap-2">
               {!browseImageLoading && browseImageTotal > 0 && (
                 <div className="text-muted">
-                  <span className="font-medium text-primary">{browseImageTotal.toLocaleString('en-US')}</span> images
+                  {t.imagesCount(nf(browseImageTotal))}
                   {browseImageTotal > resultsPerPage && (
                     <span className="ml-2 text-faint">
-                      (showing {offset + 1}&ndash;{Math.min(offset + resultsPerPage, browseImageTotal)})
+                      {t.showingRange(offset + 1, Math.min(offset + resultsPerPage, browseImageTotal))}
                     </span>
                   )}
                 </div>
               )}
               <div className="flex items-center gap-4">
                 <div className="flex items-center gap-2 text-sm text-muted">
-                  <span>Show</span>
+                  <span>{t.show}</span>
                   <select
                     value={resultsPerPage}
                     onChange={(e) => { setResultsPerPage(Number(e.target.value)); setOffset(0); }}
@@ -1225,7 +1285,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       <option key={n} value={n}>{n}</option>
                     ))}
                   </select>
-                  <span>per page</span>
+                  <span>{t.perPage}</span>
                 </div>
               </div>
             </div>
@@ -1243,8 +1303,8 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!browseImageLoading && browseImages.length === 0 && (
               <div className="text-center py-16">
                 <ImageIcon className="w-16 h-16 text-border-medium mx-auto mb-4" />
-                <h2 className="text-2xl font-serif font-medium text-primary mb-2">No images found</h2>
-                <p className="text-base text-muted">Try searching for a subject, figure, or symbol.</p>
+                <h2 className="text-2xl font-serif font-medium text-primary mb-2">{t.noImagesFound}</h2>
+                <p className="text-base text-muted">{t.noImagesBody}</p>
               </div>
             )}
 
@@ -1272,9 +1332,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       : 'bg-warm text-secondary hover:bg-accent-rust/10 hover:text-accent-rust border border-border-light'
                       }`}
                   >
-                    All books
+                    {t.allBooks}
                     {!collection && browseTotal > 0 && (
-                      <span className="ml-1.5 text-white/80">({browseTotal})</span>
+                      <span className="ml-1.5 text-white/80">({nf(browseTotal)})</span>
                     )}
                   </button>
                   {/* Show all on desktop, truncated on mobile */}
@@ -1288,9 +1348,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                           : 'bg-warm text-secondary hover:bg-accent-rust/10 hover:text-accent-rust border border-border-light'
                         }`}
                     >
-                      {col.name}
+                      {localizedCollection(col, lang).name}
                       <span className={`ml-1.5 ${collection === col.slug ? 'text-white/80' : 'text-muted'}`}>
-                        ({col.book_count})
+                        ({nf(col.book_count)})
                       </span>
                     </button>
                   ))}
@@ -1299,7 +1359,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       onClick={() => setShowAllCollections(true)}
                       className="sm:hidden px-4 py-2 rounded-full text-sm font-medium bg-warm text-muted border border-border-light hover:text-secondary transition-colors"
                     >
-                      +{collectionsList.length - MOBILE_COLLECTION_LIMIT} more
+                      {t.andNMore(collectionsList.length - MOBILE_COLLECTION_LIMIT)}
                     </button>
                   )}
                 </div>
@@ -1310,19 +1370,19 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!browseLoading && browseTotal > 0 && (
               <div className="mb-4 flex items-center justify-between flex-wrap gap-2">
                 <div className="text-muted">
-                  <span className="font-medium text-primary">{browseTotal}</span> books
+                  {t.booksCount(nf(browseTotal))}
                   {collection && collectionsList.find(c => c.slug === collection) && (
-                    <span> in <span className="font-medium text-primary">{collectionsList.find(c => c.slug === collection)!.name}</span></span>
+                    <span> {t.inCollection} <span className="font-medium text-primary">{localizedCollection(collectionsList.find(c => c.slug === collection)!, lang).name}</span></span>
                   )}
                   {browseTotal > resultsPerPage && (
                     <span className="ml-2 text-faint">
-                      (showing {offset + 1}&ndash;{Math.min(offset + resultsPerPage, browseTotal)})
+                      {t.showingRange(offset + 1, Math.min(offset + resultsPerPage, browseTotal))}
                     </span>
                   )}
                 </div>
                 <div className="flex items-center gap-4">
                   <div className="flex items-center gap-2 text-sm text-muted">
-                    <span>Show</span>
+                    <span>{t.show}</span>
                     <select
                       value={resultsPerPage}
                       onChange={(e) => { setResultsPerPage(Number(e.target.value)); setOffset(0); }}
@@ -1332,10 +1392,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                         <option key={n} value={n}>{n}</option>
                       ))}
                     </select>
-                    <span>per page</span>
+                    <span>{t.perPage}</span>
                   </div>
-                  <Link href="/catalog" className="text-sm text-accent-rust hover:underline">
-                    Browse Full Catalog
+                  {/* /catalog has no localized twin; localePath returns it
+                      untouched, which is the honest outcome (i18n.md rule 5). */}
+                  <Link href={lp('/catalog')} className="text-sm text-accent-rust hover:underline">
+                    {t.browseFullCatalog}
                   </Link>
                 </div>
               </div>
@@ -1347,7 +1409,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!browseLoading && browseBooks.length > 0 && (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                 {browseBooks.map((book, idx) => (
-                  <CollectionBookCard key={book.id} book={book as unknown as CollectionBook} priority={idx < 5} />
+                  <CollectionBookCard key={book.id} book={book as unknown as CollectionBook} priority={idx < 5} lang={lang} />
                 ))}
               </div>
             )}
@@ -1355,13 +1417,13 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!browseLoading && browseError && (
               <div className="text-center py-16">
                 <Book className="w-16 h-16 text-border-medium mx-auto mb-4" />
-                <h2 className="text-2xl font-serif font-medium text-primary mb-2">Something went wrong</h2>
-                <p className="text-base text-muted mb-4">We couldn&apos;t load the library right now.</p>
+                <h2 className="text-2xl font-serif font-medium text-primary mb-2">{t.somethingWentWrong}</h2>
+                <p className="text-base text-muted mb-4">{t.couldNotLoadLibrary}</p>
                 <button
                   onClick={() => performBrowse()}
                   className="px-4 py-2 text-sm bg-primary text-white rounded-md hover:bg-primary/90 transition-colors"
                 >
-                  Try again
+                  {t.tryAgain}
                 </button>
               </div>
             )}
@@ -1369,8 +1431,8 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!browseLoading && !browseError && browseBooks.length === 0 && browseTotal === 0 && (
               <div className="text-center py-16">
                 <Book className="w-16 h-16 text-border-medium mx-auto mb-4" />
-                <h2 className="text-2xl font-serif font-medium text-primary mb-2">No books found</h2>
-                <p className="text-base text-muted">Try adjusting your filters.</p>
+                <h2 className="text-2xl font-serif font-medium text-primary mb-2">{t.noBooksFound}</h2>
+                <p className="text-base text-muted">{t.adjustFilters}</p>
               </div>
             )}
 
@@ -1388,7 +1450,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <span className="text-2xl shrink-0" aria-hidden>{knownEntity.icon || '📚'}</span>
             <div className="min-w-0 flex-1">
               <div className="text-xs uppercase tracking-wide text-muted">
-                {knownEntity.kind === 'reading-room' ? 'Reading room' : knownEntity.kind === 'library' ? 'Library partner' : 'Collection'}
+                {knownEntity.kind === 'reading-room' ? t.kindReadingRoom : knownEntity.kind === 'library' ? t.kindLibrary : t.kindCollection}
               </div>
               <div className="font-serif font-medium text-primary group-hover:text-accent-rust transition-colors">
                 {knownEntity.title} <span aria-hidden>→</span>
@@ -1434,21 +1496,19 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {noResults && !aiStreaming && aiResults.length === 0 && (
           <div className="text-center py-16 max-w-lg mx-auto">
             <Search className="w-16 h-16 text-border-medium mx-auto mb-4" />
-            <h2 className="text-2xl font-serif font-medium text-primary mb-2">No results found</h2>
+            <h2 className="text-2xl font-serif font-medium text-primary mb-2">{t.noResultsFound}</h2>
             {suggestion && (
               <p className="text-secondary mb-6">
-                Did you mean{' '}
+                {t.didYouMean}{' '}
                 <button
                   onClick={() => { setQuery(suggestion); setOffset(0); performSearch(suggestion, viewMode, 0); updateUrl(suggestion, viewMode, 0); }}
                   className="font-semibold text-accent-rust hover:text-accent-rust/80 underline underline-offset-2"
                 >{suggestion}</button>?
               </p>
             )}
-            <p className="text-muted mb-6">
-              Over 10,000 primary sources spanning alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit rasayana, Chinese classics, Arabic philosophy, and more.
-            </p>
+            <p className="text-muted mb-6">{t.corpusBlurb}</p>
             <div className="flex flex-wrap justify-center gap-2">
-              {['alchemy', 'Hermes', 'Paracelsus', 'Kabbalah', 'rasayana', 'Ficino'].map(term => (
+              {EXAMPLE_QUERIES[lang].map(term => (
                 <button
                   key={term}
                   onClick={() => { setQuery(term); setOffset(0); performSearch(term, viewMode, 0); updateUrl(term, viewMode, 0); }}
@@ -1461,7 +1521,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 onClick={() => { setQuery(''); setOffset(0); }}
                 className="px-3 py-1.5 bg-warm text-secondary text-sm rounded-full hover:bg-accent-rust/10 hover:text-accent-rust transition-colors"
               >
-                Browse all books
+                {t.browseAllBooks}
               </button>
             </div>
           </div>
@@ -1470,7 +1530,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {/* AI-expanded results when no main results */}
         {noResults && aiResults.length > 0 && (
           <div className="space-y-3">
-            <p className="text-sm text-muted">Related results from AI-expanded search:</p>
+            <p className="text-sm text-muted">{t.relatedFromAi}</p>
             {aiResults.map(result => (
               <RelatedResultCard key={result.id} result={result} tenant={tenant} />
             ))}
@@ -1527,7 +1587,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               {displayHint !== 'images_first' && (
                 <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-4">
                   <span className="w-1.5 h-1.5 rounded-full bg-accent-gold" />
-                  Illustrations
+                  {t.illustrations}
                 </h2>
               )}
               <div className={`grid gap-3 ${displayHint === 'images_first' ? 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4' : 'grid-cols-2 sm:grid-cols-4 md:grid-cols-6'}`}>
@@ -1537,7 +1597,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               </div>
               {imageTotal > PREVIEW_IMAGES && (
                 <button onClick={() => drillInto('images')} className="text-sm text-accent-gold-dark hover:text-accent-gold font-medium transition-colors flex items-center gap-1">
-                  See all images <ChevronRight className="w-3.5 h-3.5" />
+                  {t.seeAllImages} <ChevronRight className="w-3.5 h-3.5" />
                 </button>
               )}
             </>
@@ -1546,14 +1606,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
           const bookSection = (
             <>
               {semanticDegraded && !semanticLoading && (
-                <p className="text-xs text-muted italic mt-2">
-                  Related results couldn&apos;t be loaded just now — you may be seeing fewer matches than we hold. Try again in a moment.
-                </p>
+                <p className="text-xs text-muted italic mt-2">{t.semanticDegraded}</p>
               )}
               {hasBoth && (
                 <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-4">
                   <span className="w-1.5 h-1.5 rounded-full bg-violet-400" />
-                  Conceptual matches
+                  {t.conceptualMatches}
                 </h2>
               )}
               {uniqueSemantic.map((sem: any) => (
@@ -1562,7 +1620,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               {hasBoth && (
                 <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-4">
                   <span className="w-1.5 h-1.5 rounded-full bg-accent-rust" />
-                  Text matches
+                  {t.textMatches}
                 </h2>
               )}
               {bookResults.slice(0, PREVIEW_BOOKS).map((result, idx) => (
@@ -1570,7 +1628,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               ))}
               {bookTotal > PREVIEW_BOOKS && (
                 <button onClick={() => drillInto('books')} className="text-sm text-accent-rust hover:text-accent-rust-dark font-medium transition-colors flex items-center gap-1">
-                  See all {bookTotal} results <ChevronRight className="w-3.5 h-3.5" />
+                  {t.seeAllResults(nf(bookTotal))} <ChevronRight className="w-3.5 h-3.5" />
                 </button>
               )}
             </>
@@ -1580,12 +1638,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <>
               <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-6">
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-sage" />
-                Passages
+                {t.passages}
               </h2>
               {passageLoading ? (
                 <div className="flex items-center gap-2 text-sm text-muted py-3">
                   <Loader2 className="w-4 h-4 animate-spin" />
-                  Searching page content...
+                  {t.searchingPageContent}
                 </div>
               ) : (
                 passageResults.map((result, idx) => (
@@ -1613,17 +1671,17 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <>
               <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-6">
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-gold" />
-                Catalog matches
+                {t.catalogMatches}
                 {catalogTotal > 0 && (
                   <span className="ml-1 text-muted/70 normal-case">
-                    · {catalogTotal.toLocaleString('en-US')} {catalogTotal === 1 ? 'work' : 'works'}
+                    · {nf(catalogTotal)} {t.works(catalogTotal)}
                   </span>
                 )}
               </h2>
               {catalogLoading ? (
                 <div className="flex items-center gap-2 text-sm text-muted py-3">
                   <Loader2 className="w-4 h-4 animate-spin" />
-                  Searching catalog...
+                  {t.searchingCatalog}
                 </div>
               ) : (
                 <>
@@ -1638,10 +1696,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                   ))}
                   {catalogTotal > 5 && (
                     <Link
-                      href={`/catalog?cq=${encodeURIComponent(query)}`}
+                      href={`${lp('/catalog')}?cq=${encodeURIComponent(query)}`}
                       className="text-sm text-accent-gold-dark hover:text-accent-gold font-medium transition-colors flex items-center gap-1"
                     >
-                      Open all {catalogTotal} catalogue matches <ChevronRight className="w-3.5 h-3.5" />
+                      {t.openAllCatalogueMatches(nf(catalogTotal))} <ChevronRight className="w-3.5 h-3.5" />
                     </Link>
                   )}
                 </>
@@ -1683,15 +1741,15 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             {!loading && (
               <div className="mb-6 flex items-center justify-between flex-wrap gap-2">
                 <div className="text-muted">
-                  Found <span className="font-medium text-primary">{bookTotal}</span> books & pages for &ldquo;{query}&rdquo;
+                  {t.foundBooksAndPages(nf(bookTotal), query)}
                   {bookTotal > resultsPerPage && (
                     <span className="ml-2 text-faint">
-                      (showing {offset + 1}&ndash;{Math.min(offset + resultsPerPage, bookTotal)})
+                      {t.showingRange(offset + 1, Math.min(offset + resultsPerPage, bookTotal))}
                     </span>
                   )}
                 </div>
                 <div className="flex items-center gap-2 text-sm text-muted">
-                  <span>Show</span>
+                  <span>{t.show}</span>
                   <select
                     value={resultsPerPage}
                     onChange={(e) => { setResultsPerPage(Number(e.target.value)); setOffset(0); }}
@@ -1701,7 +1759,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       <option key={n} value={n}>{n}</option>
                     ))}
                   </select>
-                  <span>per page</span>
+                  <span>{t.perPage}</span>
                 </div>
               </div>
             )}
@@ -1720,7 +1778,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
           <>
             {!loading && (
               <div className="mb-6 text-muted">
-                Found <span className="font-medium text-primary">{indexTotal}</span> index entries for &ldquo;{query}&rdquo;
+                {t.foundIndexEntries(nf(indexTotal), query)}
               </div>
             )}
             {loading && <div className="py-4"><BookLoader size="xs" /></div>}
@@ -1735,13 +1793,21 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {/* ==================== IMAGES DRILL-DOWN ==================== */}
         {viewMode === 'images' && query.length >= 2 && (
           <>
+            {/* The gallery lane matches against English illustration
+                descriptions, so on a localized surface say so rather than let a
+                Spanish query look like an empty library (i18n.md rule 4). */}
+            {localized && t.imagesEnglishNote && (
+              <p className="mb-4 px-4 py-3 bg-warm rounded-lg border border-border-light text-sm text-secondary">
+                {t.imagesEnglishNote}
+              </p>
+            )}
             {!loading && (
               <div className="mb-6 flex items-center justify-between flex-wrap gap-2">
                 <div className="text-muted">
-                  Found <span className="font-medium text-primary">{imageTotal}</span> images for &ldquo;{query}&rdquo;
+                  {t.foundImages(nf(imageTotal), query)}
                   {imageTotal > resultsPerPage && (
                     <span className="ml-2 text-faint">
-                      (showing {offset + 1}&ndash;{Math.min(offset + resultsPerPage, imageTotal)})
+                      {t.showingRange(offset + 1, Math.min(offset + resultsPerPage, imageTotal))}
                     </span>
                   )}
                 </div>
@@ -1757,10 +1823,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
           </>
         )}
         {/* Ask the Librarian — bottom CTA */}
-        {!noResults && !loading && query.length >= 3 && viewMode === 'unified' && (
+        {!noResults && !loading && query.length >= 3 && viewMode === defaultMode && (
           <section className="mt-8 pt-6 border-t border-border-light">
             <Link
-              href={`/librarian?q=${encodeURIComponent(query)}`}
+              href={`${lp('/librarian')}?q=${encodeURIComponent(query)}`}
               className="block p-6 rounded-xl bg-gradient-to-br from-[#2c1810] to-[#1a1612] text-white hover:from-[#3a2218] hover:to-[#2c1810] transition-all group"
             >
               <div className="flex items-start gap-4">
@@ -1768,9 +1834,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                   <Quote className="w-5 h-5 text-[#c9a86c]" />
                 </div>
                 <div>
-                  <h3 className="font-serif text-lg font-medium text-white">Ask the Librarian</h3>
+                  <h3 className="font-serif text-lg font-medium text-white">{t.askLibrarian}</h3>
                   <p className="text-sm text-white/60 mt-1 font-body leading-relaxed">
-                    Want deeper analysis? The Librarian will search across {bookTotal > 0 ? `these ${bookTotal} results` : 'the collection'}, cross-reference sources, and build a research notebook you can export.
+                    {t.askLibrarianBody(bookTotal > 0 ? t.askLibrarianScopeResults(nf(bookTotal)) : t.askLibrarianScopeCollection)}
                   </p>
                 </div>
               </div>
@@ -1781,7 +1847,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {/* AI-expanded related results — shows for all searches with results */}
         {!signInRequired && !noResults && !loading && query.length >= 3 && !aiStreaming && aiResults.length > 0 && (
           <section className="mt-12 pt-8 border-t border-border-light">
-            <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">Related in the Library</h2>
+            <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">{t.relatedInLibrary}</h2>
             <div className="space-y-3">
               {aiResults.map(result => (
                 <RelatedResultCard key={result.id} result={result} tenant={tenant} />
@@ -1816,13 +1882,18 @@ function cleanSnippet(text: string): string {
 }
 
 function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: { result: SearchResult; query: string; tenant?: string; autoPassages?: boolean; mobileCompact?: boolean }) {
+  // Client children take no `lang` prop — the pathname already says which
+  // language they are in (i18n.md, "the book page: ONE page, two URLs").
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
   const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
   const text = cleanSnippet(result.snippet || result.summary || '');
   const [imgError, setImgError] = useState(false);
   const [passages, setPassages] = useState<PassageMatch[] | null>(null);
   const [passagesLoading, setPassagesLoading] = useState(false);
   const [passagesOpen, setPassagesOpen] = useState(false);
-  const bookPath = `/book/${result.slug || result.book_id}`;
+  const bookPath = lp(`/book/${result.slug || result.book_id}`);
   const autoFired = useRef(false);
 
   const fetchPassages = useCallback(async () => {
@@ -1830,7 +1901,10 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
     setPassagesLoading(true);
     setPassagesOpen(true);
     try {
-      const res = await fetch(`/api/books/${result.book_id}/search?q=${encodeURIComponent(query)}`);
+      // In-book search reads the language-keyed page store, same as the
+      // result lane above it — otherwise the card quotes English passages
+      // under a Spanish snippet.
+      const res = await fetch(`/api/books/${result.book_id}/search?q=${encodeURIComponent(query)}&lang=${lang}`);
       if (!res.ok) throw new Error('Search failed');
       const data = await res.json();
       const matches: PassageMatch[] = (data.results || [])
@@ -1850,7 +1924,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
     } finally {
       setPassagesLoading(false);
     }
-  }, [result.book_id, query, passages]);
+  }, [result.book_id, query, passages, lang]);
 
   // Auto-fetch passages for first translated book (desktop only — too tall on mobile)
   const isMobileView = typeof window !== 'undefined' && window.innerWidth < 640;
@@ -1872,9 +1946,9 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
     fetchPassages();
   }, [passages, passagesOpen, fetchPassages]);
 
-  const href = result.type === 'page'
+  const href = lp(result.type === 'page'
     ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}`
-    : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant);
+    : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant));
 
   return (
     <div className="bg-white rounded-xl border border-border-light hover:border-accent-rust/30 hover:shadow-md transition-all">
@@ -1900,13 +1974,13 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
               <div className="min-w-0">
                 <h3 className="text-lg font-medium text-primary line-clamp-2 font-serif leading-snug">
                   <HighlightedText text={result.display_title || result.title} query={query} />
-                  {result.type === 'page' && <span className="text-muted font-normal text-sm ml-2">p. {result.page_number}</span>}
+                  {result.type === 'page' && <span className="text-muted font-normal text-sm ml-2">{t.pageAbbrev(result.page_number as number)}</span>}
                 </h3>
                 <p className="text-sm text-secondary mt-0.5">
                   {(() => {
                     const byline = getEffectiveByline(result);
                     if (byline.role === 'editor') {
-                      return <>ed. <HighlightedText text={byline.editor} query={query} /></>;
+                      return <>{t.editedByAbbrev} <HighlightedText text={byline.editor} query={query} /></>;
                     }
                     return <HighlightedText text={result.author} query={query} />;
                   })()} · {result.published}
@@ -1932,7 +2006,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
             ) : null}
             <div className="mt-1.5 flex items-center gap-3 text-xs text-muted">
               {result.type === 'book' && result.page_count && (
-                <span>{result.page_count} pages{result.translated_count ? ` · ${result.translated_count} translated` : ''}</span>
+                <span>{t.pagesCount(result.page_count)}{result.translated_count ? ` · ${t.translatedCount(result.translated_count)}` : ''}</span>
               )}
               {result.type === 'book' && result.translated_count && result.translated_count > 0 && (
                 <button
@@ -1940,11 +2014,11 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
                   className="text-accent-rust hover:text-accent-rust-dark font-medium transition-colors"
                 >
                   {passagesLoading ? (
-                    <span className="flex items-center gap-1"><Loader2 className="w-3 h-3 animate-spin" /> Searching...</span>
+                    <span className="flex items-center gap-1"><Loader2 className="w-3 h-3 animate-spin" /> {t.searchingEllipsis}</span>
                   ) : passagesOpen ? (
-                    <span className="flex items-center gap-1"><ChevronDown className="w-3 h-3 rotate-180 transition-transform" /> Hide passages</span>
+                    <span className="flex items-center gap-1"><ChevronDown className="w-3 h-3 rotate-180 transition-transform" /> {t.hidePassages}</span>
                   ) : (
-                    <span className="flex items-center gap-1"><Quote className="w-3 h-3" /> Find passages</span>
+                    <span className="flex items-center gap-1"><Quote className="w-3 h-3" /> {t.findPassages}</span>
                   )}
                 </button>
               )}
@@ -1955,7 +2029,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
       {passagesOpen && (
         <div className="px-4 pb-4 -mt-1">
           {passagesLoading ? (
-            <div className="text-xs text-muted py-2">Searching pages...</div>
+            <div className="text-xs text-muted py-2">{t.searchingPages}</div>
           ) : passages && passages.length > 0 ? (
             <div className="space-y-2 border-t border-border-light pt-3">
               {passages.map((p, i) => (
@@ -1964,7 +2038,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
                   href={`${bookPath}/page-number/${p.pageNumber}`}
                   className="block text-sm py-1.5 px-3 rounded-lg hover:bg-warm transition-colors group"
                 >
-                  <span className="text-muted text-xs font-medium mr-2">p. {p.pageNumber}</span>
+                  <span className="text-muted text-xs font-medium mr-2">{t.pageAbbrev(p.pageNumber)}</span>
                   <span className="text-secondary italic font-body">
                     &ldquo;<HighlightedText text={p.snippet.slice(0, 200)} query={query} />{p.snippet.length > 200 ? '...' : ''}&rdquo;
                   </span>
@@ -1972,7 +2046,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
               ))}
             </div>
           ) : passages ? (
-            <p className="text-xs text-muted py-2 border-t border-border-light pt-3">No matching passages found in this book.</p>
+            <p className="text-xs text-muted py-2 border-t border-border-light pt-3">{t.noMatchingPassages}</p>
           ) : null}
         </div>
       )}
@@ -1981,16 +2055,19 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
 }
 
 function SearchCollectionCard({ col }: { col: { slug: string; name: string; book_count: number; hero_image?: string } }) {
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
   const [imgError, setImgError] = useState(false);
   return (
     <Link
-      href={`/collections/${col.slug}`}
+      href={lp(`/collections/${col.slug}`)}
       className="group relative block overflow-hidden rounded-lg aspect-[4/3]"
     >
       {col.hero_image && !imgError ? (
         <Image
           src={col.hero_image}
-          alt={`Illustration from ${col.name}`}
+          alt={t.illustrationFromCollection(col.name)}
           fill
           sizes="(max-width: 640px) 50vw, 33vw"
           className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
@@ -2003,7 +2080,7 @@ function SearchCollectionCard({ col }: { col: { slug: string; name: string; book
       <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
       <div className="absolute inset-0 flex flex-col justify-end p-3">
         <p className="text-white/50 text-[11px] mb-1">
-          {col.book_count.toLocaleString('en-US')} books
+          {t.collectionBooks(col.book_count.toLocaleString(t.numberLocale))}
         </p>
         <h3 className="font-serif text-sm sm:text-base text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
           {col.name}
@@ -2014,11 +2091,14 @@ function SearchCollectionCard({ col }: { col: { slug: string; name: string; book
 }
 
 function SemanticResultCard({ result, query }: { result: any; query: string }) {
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
   const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: result.thumbnail_blob });
   const [imgError, setImgError] = useState(false);
   return (
     <div className="bg-white rounded-xl border border-border-light hover:border-accent-rust/30 hover:shadow-md transition-all">
-      <Link href={`/book/${result.slug || result.book_id}`} className="block p-3 sm:p-4">
+      <Link href={lp(`/book/${result.slug || result.book_id}`)} className="block p-3 sm:p-4">
         <div className="flex items-start gap-3 sm:gap-4">
           {cover && !imgError ? (
             <Image src={cover} alt="" width={60} height={84} className="rounded shadow-sm flex-shrink-0 object-cover w-[44px] h-[62px] sm:w-[60px] sm:h-[84px]" unoptimized onError={() => setImgError(true)} />
@@ -2032,7 +2112,7 @@ function SemanticResultCard({ result, query }: { result: any; query: string }) {
             <p className="text-sm text-muted mt-0.5">
               {(() => {
                 const byline = getEffectiveByline({ author: result.author, editor: (result as { editor?: string }).editor });
-                if (byline.role === 'editor') return `ed. ${byline.editor}`;
+                if (byline.role === 'editor') return `${t.editedByAbbrev} ${byline.editor}`;
                 return result.author || '';
               })()}{result.year ? ` · ${result.year}` : ''}
               {result.language ? ` · ${result.language}` : ''}
@@ -2051,12 +2131,15 @@ function SemanticResultCard({ result, query }: { result: any; query: string }) {
 }
 
 function RelatedResultCard({ result, tenant }: { result: SearchResult; tenant?: string }) {
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
   const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
   const text = result.snippet || result.summary;
   const [imgError, setImgError] = useState(false);
   return (
     <Link
-      href={result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant)}
+      href={lp(result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant))}
       className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
     >
       {cover && !imgError ? (
@@ -2073,10 +2156,10 @@ function RelatedResultCard({ result, tenant }: { result: SearchResult; tenant?: 
         <p className="text-xs text-muted mt-0.5">
           {(() => {
             const byline = getEffectiveByline(result);
-            if (byline.role === 'editor') return `ed. ${byline.editor}`;
+            if (byline.role === 'editor') return `${t.editedByAbbrev} ${byline.editor}`;
             return result.author || '';
           })()}{result.published ? `, ${result.published}` : ''}
-          {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
+          {result.type === 'page' && result.page_number && <span> &middot; {t.pageAbbrev(result.page_number)}</span>}
         </p>
         {text && (
           <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
@@ -2087,14 +2170,20 @@ function RelatedResultCard({ result, tenant }: { result: SearchResult; tenant?: 
 }
 
 function IndexResultCard({ result, query, tenant }: { result: IndexSearchResult; query: string; tenant?: string }) {
-  const typeLabel = INDEX_TYPES.find(t => t.value === result.type)?.label || result.type;
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
+  const typeLabel = indexTypeLabel(result.type, t);
   const isQuote = result.type === 'quote';
 
-  const href = isQuote && result.quote_page
+  // `/book/<id>/guide` has no localized twin, so localePath returns those two
+  // untouched and only the bare book URL picks up the prefix. That asymmetry is
+  // the registry working (i18n.md rule 5).
+  const href = lp(isQuote && result.quote_page
     ? tenantBookUrl({ slug: result.book_slug, id: result.book_id }, tenant) + `/guide?page=${result.quote_page}`
     : result.pages && result.pages.length > 0
       ? tenantBookUrl({ slug: result.book_slug, id: result.book_id }, tenant) + `/guide?page=${result.pages[0]}`
-      : tenantBookUrl({ slug: result.book_slug, id: result.book_id }, tenant);
+      : tenantBookUrl({ slug: result.book_slug, id: result.book_id }, tenant));
 
   return (
     <Link
@@ -2183,7 +2272,10 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
   tenant?: string;
   digitizedAlsoInBooks: boolean;
 }) {
-  const title = work.title || work.full_title || work.parallel_title || work.uniform_title || '(untitled)';
+  const lang = useLocale();
+  const t = SEARCH_STRINGS[lang];
+  const lp = useLocalePath();
+  const title = work.title || work.full_title || work.parallel_title || work.uniform_title || t.untitled;
   const author = work.author || work.variant_author;
   const meta = [
     author,
@@ -2194,9 +2286,9 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
   // Manuscripts and photographs get no UBN from Memorix — `uuid` is their only
   // key, and the /catalog/[ubn] route accepts either (see BphCatalogBrowser).
   const catalogKey = work.ubn || work.uuid;
-  const href = isDigitized && work.sl_book_id
+  const href = lp(isDigitized && work.sl_book_id
     ? tenantBookUrl({ id: work.sl_book_id, slug: work.sl_book_slug || work.sl_book_id }, tenant)
-    : `/catalog/${encodeURIComponent(catalogKey || '')}`;
+    : `/catalog/${encodeURIComponent(catalogKey || '')}`);
   const [imgError, setImgError] = useState(false);
 
   // Don't double-show digitized works that already appear in book results — render
@@ -2234,7 +2326,7 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
                 ? 'bg-accent-rust/10 text-accent-rust'
                 : 'bg-cream border border-border-light text-muted'
             }`}>
-              {isDigitized ? 'Digitized' : 'Catalog only'}
+              {isDigitized ? t.digitized : t.catalogOnly}
             </span>
           </div>
           {meta && (
@@ -2258,6 +2350,7 @@ function BphCatalogResultCard({ work, query, tenant, digitizedAlsoInBooks }: {
 function Pagination({ total, offset, setOffset, loading, pageSize }: {
   total: number; offset: number; setOffset: (n: number) => void; loading: boolean; pageSize: number;
 }) {
+  const t = SEARCH_STRINGS[useLocale()];
   if (total <= pageSize || loading) return null;
 
   return (
@@ -2267,17 +2360,20 @@ function Pagination({ total, offset, setOffset, loading, pageSize }: {
         disabled={offset === 0}
         className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border border-border-medium text-secondary transition-colors disabled:opacity-40 disabled:cursor-not-allowed hover:bg-warm"
       >
-        <ChevronLeft className="w-4 h-4" /> Previous
+        <ChevronLeft className="w-4 h-4" /> {t.previous}
       </button>
       <span className="text-sm text-muted">
-        Page {Math.floor(offset / pageSize) + 1} of {Math.ceil(total / pageSize)}
+        {t.pageXofY(
+          (Math.floor(offset / pageSize) + 1).toLocaleString(t.numberLocale),
+          Math.ceil(total / pageSize).toLocaleString(t.numberLocale),
+        )}
       </span>
       <button
         onClick={() => { setOffset(offset + pageSize); window.scrollTo(0, 0); }}
         disabled={offset + pageSize >= total}
         className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border border-border-medium text-secondary transition-colors disabled:opacity-40 disabled:cursor-not-allowed hover:bg-warm"
       >
-        Next <ChevronRight className="w-4 h-4" />
+        {t.next} <ChevronRight className="w-4 h-4" />
       </button>
     </div>
   );

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -81,9 +81,9 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
               <p className="text-muted mt-2">
                 <Link href="/catalog" className="hover:text-accent-rust transition-colors">{nf(counts.totalBooks)} {t.booksLabel}</Link>
                 {' '}&middot;{' '}
-                <Link href="/search?has_translation=true" className="hover:text-accent-rust transition-colors">{nf(counts.translatedToEnglish)} {t.translationsLabel}</Link>
+                <Link href={lp('/search?has_translation=true')} className="hover:text-accent-rust transition-colors">{nf(counts.translatedToEnglish)} {t.translationsLabel}</Link>
                 {' '}&middot;{' '}
-                <Link href="/search?first_translation=true" className="hover:text-accent-rust transition-colors">{nf(counts.firstTranslationCount)} {t.firstTimeLabel}</Link>
+                <Link href={lp('/search?first_translation=true')} className="hover:text-accent-rust transition-colors">{nf(counts.firstTranslationCount)} {t.firstTimeLabel}</Link>
                 {counts.artworkCount > 0 && (
                   <>
                     {' '}&middot;{' '}
@@ -462,7 +462,7 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
           <p className="text-stone-500 text-sm mb-8">
             {t.searchStats(nf(counts.totalBooks), nf(counts.authorCount), counts.languageCount)}
           </p>
-          <form action="/search" method="get" className="relative max-w-lg mx-auto mb-6">
+          <form action={lp('/search')} method="get" className="relative max-w-lg mx-auto mb-6">
             <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -328,9 +328,9 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
 
           {/* Desktop search icon */}
           <Link
-            href="/search"
+            href={localePath('/search', locale)}
             className={`hidden lg:flex items-center justify-center w-8 h-8 rounded-lg transition-colors ${
-              pathname === '/search'
+              canonicalPath(pathname) === '/search'
                 ? (isWhiteText ? 'text-white bg-white/10' : 'text-primary bg-warm')
                 : (isWhiteText ? 'text-white/60 hover:text-white hover:bg-white/10' : 'text-secondary hover:text-primary hover:bg-warm/50')
             }`}
@@ -399,7 +399,7 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
                 })}
                 <div className="border-t border-border-light my-1.5" />
                 <Link
-                  href="/search"
+                  href={localePath('/search', locale)}
                   className="block px-4 py-2.5 text-sm text-secondary hover:text-primary hover:bg-warm/50 transition-colors"
                 >
                   {t.search}

--- a/src/components/search/UnifiedSearch.tsx
+++ b/src/components/search/UnifiedSearch.tsx
@@ -13,6 +13,7 @@ import { getBookThumbnailUrl } from '@/lib/utils';
 import { getEffectiveByline } from '@/lib/byline';
 import HighlightedText from './HighlightedText';
 import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
+import { useLocalePath, canonicalPath } from '@/lib/i18n';
 
 const TYPE_ICONS: Record<string, typeof Lightbulb> = {
   concept: Lightbulb,
@@ -96,8 +97,16 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Extract tenant prefix from pathname
-  const pathParts = pathname.split('/').filter(Boolean);
+  // Segment 0 can be a TENANT slug or a LOCALE prefix, and the two need
+  // OPPOSITE treatment: a tenant prefix is carried verbatim onto every link the
+  // component writes, while a locale prefix belongs only on the paths that
+  // actually have a twin. Deriving one prefix for both made `/es` look like a
+  // tenant, so the Spanish homepage's typeahead emitted `/es/gallery/image/…`
+  // — a 404, since the gallery has no Spanish route (measured: `/gallery` 200,
+  // `/es/gallery` 404). Strip the locale first, then re-apply it per link via
+  // the registry (i18n.md rule 5, "prefer the registry to a per-item ternary").
+  const lp = useLocalePath();
+  const pathParts = canonicalPath(pathname).split('/').filter(Boolean);
   const tenantPrefix = pathParts[0] && pathParts[0] !== 'search' ? `/${pathParts[0]}` : '';
 
   // Preload vocabulary on first focus
@@ -206,25 +215,27 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
     if (!results || !hasResults) return [];
     const items: NavigableItem[] = [];
     for (const book of results.books.results) {
-      items.push({ type: 'book', href: bookUrl(book), id: `book-${book.id}` });
+      items.push({ type: 'book', href: lp(bookUrl(book)), id: `book-${book.id}` });
     }
     for (let i = 0; i < results.index.results.length; i++) {
       const item = results.index.results[i];
       const bookPath = item.book_slug || item.book_id;
-      const href = item.pages?.[0]
+      const href = lp(item.pages?.[0]
         ? `${tenantPrefix}/book/${bookPath}/guide?page=${item.pages[0]}`
-        : `${tenantPrefix}/book/${bookPath}`;
+        : `${tenantPrefix}/book/${bookPath}`);
       items.push({ type: 'index', href, id: `index-${item.book_id}-${item.type}-${i}` });
     }
     for (const sem of semanticResults) {
-      items.push({ type: 'book', href: `${tenantPrefix}/book/${sem.book_id}`, id: `semantic-${sem.book_id}` });
+      items.push({ type: 'book', href: lp(`${tenantPrefix}/book/${sem.book_id}`), id: `semantic-${sem.book_id}` });
     }
     for (const img of galleryResults) {
-      items.push({ type: 'gallery', href: `${tenantPrefix}/gallery/image/${img.id}`, id: `gallery-${img.id}` });
+      // The gallery has no localized twin, so lp() leaves this alone — which is
+      // the point: an English gallery page beats a prefixed 404.
+      items.push({ type: 'gallery', href: lp(`${tenantPrefix}/gallery/image/${img.id}`), id: `gallery-${img.id}` });
     }
-    items.push({ type: 'full-search', href: `${tenantPrefix}/search?q=${encodeURIComponent(query)}`, id: 'full-search' });
+    items.push({ type: 'full-search', href: lp(`${tenantPrefix}/search?q=${encodeURIComponent(query)}`), id: 'full-search' });
     return items;
-  }, [results, hasResults, query, galleryResults, semanticResults, tenantPrefix]);
+  }, [results, hasResults, query, galleryResults, semanticResults, tenantPrefix, lp]);
 
   // Reset active index when results change
   useEffect(() => {
@@ -258,7 +269,7 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
         // No item selected — go to full search page
         e.preventDefault();
         setIsOpen(false);
-        router.push(`${tenantPrefix}/search?q=${encodeURIComponent(query)}`);
+        router.push(lp(`${tenantPrefix}/search?q=${encodeURIComponent(query)}`));
       }
       return;
     }
@@ -350,7 +361,7 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
                 </p>
               )}
               <Link
-                href={`/search?q=${encodeURIComponent(query)}`}
+                href={lp(`/search?q=${encodeURIComponent(query)}`)}
                 onClick={() => setIsOpen(false)}
                 className="inline-flex items-center gap-2 mt-3 text-sm text-accent-rust hover:text-accent-rust"
               >
@@ -371,7 +382,7 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
                       </span>
                       {results.books.hasMore && (
                         <Link
-                          href={`/search?q=${encodeURIComponent(query)}`}
+                          href={lp(`/search?q=${encodeURIComponent(query)}`)}
                           className="text-xs text-accent-rust hover:text-accent-rust flex items-center gap-0.5"
                           onClick={() => setIsOpen(false)}
                         >
@@ -446,7 +457,7 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
                       </span>
                       {results.index.hasMore && (
                         <Link
-                          href={`/search?q=${encodeURIComponent(query)}&mode=index`}
+                          href={lp(`/search?q=${encodeURIComponent(query)}&mode=index`)}
                           className="text-xs text-accent-rust hover:text-accent-rust flex items-center gap-0.5"
                           onClick={() => setIsOpen(false)}
                         >
@@ -620,7 +631,7 @@ export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearc
                 return (
                   <Link
                     id={`search-item-${fullSearchIndex}`}
-                    href={`/search?q=${encodeURIComponent(query)}`}
+                    href={lp(`/search?q=${encodeURIComponent(query)}`)}
                     onClick={() => setIsOpen(false)}
                     role="option"
                     aria-selected={activeIndex === fullSearchIndex}

--- a/src/lib/api-client/search.ts
+++ b/src/lib/api-client/search.ts
@@ -11,6 +11,7 @@ export const search = {
    */
   search: async (query: string, filters?: SearchFilters): Promise<SearchResponse> => {
     const params = new URLSearchParams({ q: query });
+    if (filters?.lang) params.append('lang', filters.lang);
     if (filters?.language) params.append('language', filters.language);
     if (filters?.library) params.append('library', filters.library);
     if (filters?.date_from) params.append('date_from', filters.date_from);

--- a/src/lib/api-client/types/collections.ts
+++ b/src/lib/api-client/types/collections.ts
@@ -1,3 +1,5 @@
+import type { LocalizedCollectionMap } from '@/lib/localized';
+
 /** Curated highlight entry for a book within a collection */
 export interface CuratedHighlight {
   book_id: string;
@@ -20,6 +22,14 @@ export interface CollectionImageRef {
 export interface Collection {
   slug: string;
   name: string;
+  /**
+   * Per-language copy — `{ es: { name, subtitle, description } }`. Read it
+   * through `localizedCollection()` (src/lib/localized.ts), never by indexing
+   * the map: a surface that reads `localized.es.name` will half-localize the
+   * next language (i18n.md rule 3). `/api/collections` projects nothing away,
+   * so this arrives whenever the document has it.
+   */
+  localized?: LocalizedCollectionMap | null;
   subtitle: string;
   description: string;
   expanded_description?: string;

--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -36,6 +36,14 @@ export interface SearchResult {
 }
 
 export interface SearchFilters {
+  /**
+   * TEXT language of the answer — an ISO code picking which edition of each
+   * page to search and quote back (`page_texts.lang`). Distinct from
+   * `language`, which filters by the BOOK's edition language. Anything but
+   * `en` also narrows the request to books that HAVE that edition, so every
+   * result is openable in it (#4095, invariants/search-filters-and-lanes.md).
+   */
+  lang?: string;
   language?: string;
   library?: string;
   date_from?: string;

--- a/src/lib/locale-path.ts
+++ b/src/lib/locale-path.ts
@@ -39,17 +39,17 @@ export function localeFromPathname(pathname: string | null | undefined): Locale 
 // ---------- Locale switching (sitewide EN/ES toggle, #2763) ----------
 
 // EN base paths that have a real Spanish (`/es…`) twin route. Keep this in sync
-// with the `src/app/es/**` route folders: the homepage plus the acquisition
-// funnel (`/support`, `/auth/signin`). The header toggle is shown on EVERY page,
+// with the `src/app/es/**` route folders: the homepage, the acquisition funnel
+// (`/support`, `/auth/signin`), the Librarian, and search. The header toggle is shown on EVERY page,
 // but on a page with no twin the ES link falls back to the Spanish homepage
 // (`/es`) as a front door rather than dead-ending on a 404 — the thin-i18n
 // bargain (deep pages rely on the browser's own translate).
-export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin', '/librarian']);
+export const LOCALIZED_PATHS = new Set<string>(['/', '/support', '/auth/signin', '/librarian', '/search']);
 
 // Path SHAPES with a Spanish twin. One pattern per `src/app/es/**` route —
 // deliberately exact, not a bare `/book` prefix: `/book/<id>` and
 // `/book/<id>/page/<pageId>` have twins while `/book/<id>/overview`,
-// `/guide`, `/search`, `/qa`, … do NOT, and a prefix match would send a
+// `/book/<id>/guide`, `/qa`, … do NOT, and a prefix match would send a
 // Spanish reader to `/es/book/x/overview`, which no route serves. A missing
 // pattern costs an English page; a wrong one costs a 404.
 //
@@ -113,8 +113,8 @@ export function localeHref(target: Locale, pathname: string | null | undefined):
  *
  * Rule 5 of `.claude/docs/i18n.md`: the locale is the URL prefix and it stays —
  * but only where a twin route actually exists. The registry above
- * (`LOCALIZED_PATHS` / `LOCALIZED_PREFIXES`) is the single source of truth, so
- * a path with no twin (`/gallery`, `/search`, `/author/…`) is returned
+ * (`LOCALIZED_PATHS` / `LOCALIZED_PATTERNS`) is the single source of truth, so
+ * a path with no twin (`/gallery`, `/catalog`, `/author/…`) is returned
  * UNTOUCHED rather than pointed at a 404. That asymmetry is deliberate: a
  * Spanish reader following an unprefixed link lands on an English page, which
  * is honest; following a prefixed one would land on nothing.

--- a/src/lib/search-i18n.ts
+++ b/src/lib/search-i18n.ts
@@ -1,0 +1,448 @@
+import type { Locale } from '@/lib/locale-path';
+
+/**
+ * Strings for the search page (`src/app/search/page.tsx`), which renders under
+ * both `/search` and `/es/search` taking a `lang` prop — the same "one page,
+ * two URLs" shape as the book page (#4082 phase 2, `.claude/docs/i18n.md`).
+ *
+ * There is no authored prose here: every entry is chrome. What is NOT chrome —
+ * an index term, a gallery description, a book title — stays in whatever
+ * language it was written in and is LABELLED where that could confuse
+ * (`imagesEnglishNote`), per i18n.md rule 4. Nothing is machine-translated at
+ * render time.
+ *
+ * Adding a language means adding a KEY, not a second dictionary; TypeScript
+ * will list every string you missed.
+ *
+ * ---
+ *
+ * Which LANES a locale gets is decided in the page, not here, and is worth
+ * knowing while editing these strings: `/api/search` (the Libros tab) is fully
+ * language-keyed and narrows to books that HAVE that edition, so every result
+ * is openable in the reader's language. `/api/search/unified` (the "All" tab),
+ * `/api/search/index` and `/api/search/ai-expand` are not, so they are hidden
+ * on a localized surface rather than left to return English under Spanish
+ * chrome. The gallery lane keeps its own English description index and is
+ * labelled instead of hidden, because the images themselves are the content.
+ */
+export interface SearchStrings {
+  /** BCP-47 tag for `toLocaleString` — thousands separators differ per locale. */
+  numberLocale: string;
+
+  // ---- search bar ----
+  searchPlaceholder: string;
+  searchFailed: string;
+
+  // ---- sort (query mode) ----
+  sortRelevance: string;
+  sortYearNewest: string;
+  sortYearOldest: string;
+  sortTitleAz: string;
+
+  // ---- sort (browse mode) ----
+  browseRecentTranslation: string;
+  browseRecent: string;
+  browseOldestFirst: string;
+  browseNewestFirst: string;
+  browseTitleAsc: string;
+  browseTitleDesc: string;
+
+  // ---- tabs ----
+  tabAll: string;
+  tabBooks: string;
+  tabIndex: string;
+  tabImages: string;
+
+  // ---- index-type pills ----
+  indexAllTypes: string;
+  indexConcepts: string;
+  indexPeople: string;
+  indexPlaces: string;
+  indexQuotes: string;
+  indexKeywords: string;
+  indexVocabulary: string;
+
+  // ---- filters ----
+  filters: string;
+  clear: string;
+  clearAll: string;
+  done: string;
+  filterLanguage: string;
+  filterSubject: string;
+  filterCollection: string;
+  filterLibrary: string;
+  filterPublishedAfter: string;
+  filterPublishedBefore: string;
+  allLanguages: string;
+  allCategories: string;
+  allCollections: string;
+  allLibraries: string;
+  yearFromPlaceholder: string;
+  yearToPlaceholder: string;
+  hasTranslation: string;
+  firstTranslation: string;
+  hasDoi: string;
+
+  // ---- sign-in wall ----
+  signInHeading: string;
+  signInBody: string;
+  signInCta: string;
+
+  // ---- per-page + counts ----
+  show: string;
+  perPage: string;
+  showingRange: (from: number, to: number) => string;
+  imagesCount: (n: string) => string;
+  booksCount: (n: string) => string;
+  inCollection: string;
+  browseFullCatalog: string;
+  allBooks: string;
+  andNMore: (n: number) => string;
+
+  // ---- empty / error states ----
+  noImagesFound: string;
+  noImagesBody: string;
+  somethingWentWrong: string;
+  couldNotLoadLibrary: string;
+  tryAgain: string;
+  noBooksFound: string;
+  adjustFilters: string;
+  noResultsFound: string;
+  didYouMean: string;
+  corpusBlurb: string;
+  browseAllBooks: string;
+
+  // ---- known-entity capture ----
+  kindReadingRoom: string;
+  kindLibrary: string;
+  kindCollection: string;
+
+  // ---- unified-view section headings ----
+  illustrations: string;
+  seeAllImages: string;
+  semanticDegraded: string;
+  conceptualMatches: string;
+  textMatches: string;
+  seeAllResults: (n: string) => string;
+  passages: string;
+  searchingPageContent: string;
+  catalogMatches: string;
+  works: (n: number) => string;
+  searchingCatalog: string;
+  openAllCatalogueMatches: (n: string) => string;
+  relatedFromAi: string;
+  relatedInLibrary: string;
+
+  // ---- drill-down result counts ----
+  foundBooksAndPages: (n: string, q: string) => string;
+  foundIndexEntries: (n: string, q: string) => string;
+  foundImages: (n: string, q: string) => string;
+
+  // ---- librarian CTA ----
+  askLibrarian: string;
+  askLibrarianBody: (scope: string) => string;
+  askLibrarianScopeResults: (n: string) => string;
+  askLibrarianScopeCollection: string;
+
+  // ---- result cards ----
+  editedByAbbrev: string;
+  pageAbbrev: (n: number) => string;
+  pagesCount: (n: number) => string;
+  translatedCount: (n: number) => string;
+  findPassages: string;
+  hidePassages: string;
+  searchingEllipsis: string;
+  searchingPages: string;
+  noMatchingPassages: string;
+  untitled: string;
+  digitized: string;
+  catalogOnly: string;
+  collectionBooks: (n: string) => string;
+  /** Alt text for a collection card's plate — read aloud, so it localizes. */
+  illustrationFromCollection: (name: string) => string;
+
+  // ---- pagination ----
+  previous: string;
+  next: string;
+  pageXofY: (x: string, y: string) => string;
+
+  /**
+   * Shown above gallery results on a localized surface: the illustration
+   * descriptions are an English index, so a Spanish query searches English
+   * words. Labelling beats hiding here — the images are the content, and the
+   * reader can still browse them (i18n.md rule 4).
+   */
+  imagesEnglishNote: string;
+}
+
+/**
+ * Example queries offered on the empty-results screen. Proper nouns
+ * (`Hermes`, `Paracelsus`, `Kabbalah`, `rasayana`, `Ficino`) are names and are
+ * NOT translated in any locale; only the common noun leading the row is.
+ */
+export const EXAMPLE_QUERY_PROPER_NOUNS = ['Hermes', 'Paracelsus', 'Kabbalah', 'rasayana', 'Ficino'] as const;
+
+export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
+  en: {
+    numberLocale: 'en-US',
+
+    searchPlaceholder: 'Search books, concepts, people, images...',
+    searchFailed: 'Search failed. Please try again.',
+
+    sortRelevance: 'Relevance',
+    sortYearNewest: 'Year (newest)',
+    sortYearOldest: 'Year (oldest)',
+    sortTitleAz: 'Title A-Z',
+
+    browseRecentTranslation: 'Recently translated',
+    browseRecent: 'Recently added',
+    browseOldestFirst: 'Oldest first',
+    browseNewestFirst: 'Newest first',
+    browseTitleAsc: 'Title A-Z',
+    browseTitleDesc: 'Title Z-A',
+
+    tabAll: 'All',
+    tabBooks: 'Books',
+    tabIndex: 'Index',
+    tabImages: 'Images',
+
+    indexAllTypes: 'All Types',
+    indexConcepts: 'Concepts',
+    indexPeople: 'People',
+    indexPlaces: 'Places',
+    indexQuotes: 'Quotes',
+    indexKeywords: 'Keywords',
+    indexVocabulary: 'Vocabulary',
+
+    filters: 'Filters',
+    clear: 'Clear',
+    clearAll: 'Clear all',
+    done: 'Done',
+    filterLanguage: 'Language',
+    filterSubject: 'Subject',
+    filterCollection: 'Collection',
+    filterLibrary: 'Library',
+    filterPublishedAfter: 'Published after',
+    filterPublishedBefore: 'Published before',
+    allLanguages: 'All Languages',
+    allCategories: 'All Categories',
+    allCollections: 'All Collections',
+    allLibraries: 'All Libraries',
+    yearFromPlaceholder: 'e.g., 1500',
+    yearToPlaceholder: 'e.g., 1700',
+    hasTranslation: 'Has translation',
+    firstTranslation: 'First translation',
+    hasDoi: 'Has DOI',
+
+    signInHeading: 'Sign in to keep searching',
+    signInBody: 'You’ve used your free searches for now. Sign in — it’s free — to keep exploring over 10,000 primary sources.',
+    signInCta: 'Sign in — free',
+
+    show: 'Show',
+    perPage: 'per page',
+    showingRange: (from, to) => `(showing ${from}–${to})`,
+    imagesCount: (n) => `${n} images`,
+    booksCount: (n) => `${n} books`,
+    inCollection: 'in',
+    browseFullCatalog: 'Browse Full Catalog',
+    allBooks: 'All books',
+    andNMore: (n) => `+${n} more`,
+
+    noImagesFound: 'No images found',
+    noImagesBody: 'Try searching for a subject, figure, or symbol.',
+    somethingWentWrong: 'Something went wrong',
+    couldNotLoadLibrary: 'We couldn’t load the library right now.',
+    tryAgain: 'Try again',
+    noBooksFound: 'No books found',
+    adjustFilters: 'Try adjusting your filters.',
+    noResultsFound: 'No results found',
+    didYouMean: 'Did you mean',
+    corpusBlurb: 'Over 10,000 primary sources spanning alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit rasayana, Chinese classics, Arabic philosophy, and more.',
+    browseAllBooks: 'Browse all books',
+
+    kindReadingRoom: 'Reading room',
+    kindLibrary: 'Library partner',
+    kindCollection: 'Collection',
+
+    illustrations: 'Illustrations',
+    seeAllImages: 'See all images',
+    semanticDegraded: 'Related results couldn’t be loaded just now — you may be seeing fewer matches than we hold. Try again in a moment.',
+    conceptualMatches: 'Conceptual matches',
+    textMatches: 'Text matches',
+    seeAllResults: (n) => `See all ${n} results`,
+    passages: 'Passages',
+    searchingPageContent: 'Searching page content...',
+    catalogMatches: 'Catalog matches',
+    works: (n) => (n === 1 ? 'work' : 'works'),
+    searchingCatalog: 'Searching catalog...',
+    openAllCatalogueMatches: (n) => `Open all ${n} catalogue matches`,
+    relatedFromAi: 'Related results from AI-expanded search:',
+    relatedInLibrary: 'Related in the Library',
+
+    foundBooksAndPages: (n, q) => `Found ${n} books & pages for “${q}”`,
+    foundIndexEntries: (n, q) => `Found ${n} index entries for “${q}”`,
+    foundImages: (n, q) => `Found ${n} images for “${q}”`,
+
+    askLibrarian: 'Ask the Librarian',
+    askLibrarianBody: (scope) => `Want deeper analysis? The Librarian will search across ${scope}, cross-reference sources, and build a research notebook you can export.`,
+    askLibrarianScopeResults: (n) => `these ${n} results`,
+    askLibrarianScopeCollection: 'the collection',
+
+    editedByAbbrev: 'ed.',
+    pageAbbrev: (n) => `p. ${n}`,
+    pagesCount: (n) => `${n} pages`,
+    translatedCount: (n) => `${n} translated`,
+    findPassages: 'Find passages',
+    hidePassages: 'Hide passages',
+    searchingEllipsis: 'Searching...',
+    searchingPages: 'Searching pages...',
+    noMatchingPassages: 'No matching passages found in this book.',
+    untitled: '(untitled)',
+    digitized: 'Digitized',
+    catalogOnly: 'Catalog only',
+    collectionBooks: (n) => `${n} books`,
+    illustrationFromCollection: (name) => `Illustration from ${name}`,
+
+    previous: 'Previous',
+    next: 'Next',
+    pageXofY: (x, y) => `Page ${x} of ${y}`,
+
+    imagesEnglishNote: '',
+  },
+
+  es: {
+    numberLocale: 'es-ES',
+
+    searchPlaceholder: 'Busca libros, conceptos, personas, imágenes...',
+    searchFailed: 'La búsqueda ha fallado. Vuelve a intentarlo.',
+
+    sortRelevance: 'Relevancia',
+    sortYearNewest: 'Año (más reciente)',
+    sortYearOldest: 'Año (más antiguo)',
+    sortTitleAz: 'Título A-Z',
+
+    browseRecentTranslation: 'Traducidos recientemente',
+    browseRecent: 'Añadidos recientemente',
+    browseOldestFirst: 'Más antiguos primero',
+    browseNewestFirst: 'Más recientes primero',
+    browseTitleAsc: 'Título A-Z',
+    browseTitleDesc: 'Título Z-A',
+
+    tabAll: 'Todo',
+    tabBooks: 'Libros',
+    tabIndex: 'Índice',
+    tabImages: 'Imágenes',
+
+    indexAllTypes: 'Todos los tipos',
+    indexConcepts: 'Conceptos',
+    indexPeople: 'Personas',
+    indexPlaces: 'Lugares',
+    indexQuotes: 'Citas',
+    indexKeywords: 'Palabras clave',
+    indexVocabulary: 'Vocabulario',
+
+    filters: 'Filtros',
+    clear: 'Borrar',
+    clearAll: 'Borrar todo',
+    done: 'Listo',
+    filterLanguage: 'Idioma',
+    filterSubject: 'Materia',
+    filterCollection: 'Colección',
+    filterLibrary: 'Biblioteca',
+    filterPublishedAfter: 'Publicado después de',
+    filterPublishedBefore: 'Publicado antes de',
+    allLanguages: 'Todos los idiomas',
+    allCategories: 'Todas las materias',
+    allCollections: 'Todas las colecciones',
+    allLibraries: 'Todas las bibliotecas',
+    yearFromPlaceholder: 'p. ej., 1500',
+    yearToPlaceholder: 'p. ej., 1700',
+    hasTranslation: 'Con traducción',
+    firstTranslation: 'Primera traducción',
+    hasDoi: 'Con DOI',
+
+    signInHeading: 'Inicia sesión para seguir buscando',
+    signInBody: 'Has agotado tus búsquedas gratuitas por ahora. Inicia sesión — es gratis — para seguir explorando más de 10.000 fuentes primarias.',
+    signInCta: 'Inicia sesión — es gratis',
+
+    show: 'Mostrar',
+    perPage: 'por página',
+    showingRange: (from, to) => `(mostrando ${from}–${to})`,
+    imagesCount: (n) => `${n} imágenes`,
+    booksCount: (n) => `${n} libros`,
+    inCollection: 'en',
+    browseFullCatalog: 'Ver el catálogo completo',
+    allBooks: 'Todos los libros',
+    andNMore: (n) => `+${n} más`,
+
+    noImagesFound: 'No se han encontrado imágenes',
+    noImagesBody: 'Prueba a buscar un tema, una figura o un símbolo.',
+    somethingWentWrong: 'Algo ha ido mal',
+    couldNotLoadLibrary: 'No hemos podido cargar la biblioteca en este momento.',
+    tryAgain: 'Volver a intentarlo',
+    noBooksFound: 'No se han encontrado libros',
+    adjustFilters: 'Prueba a ajustar los filtros.',
+    noResultsFound: 'No se han encontrado resultados',
+    didYouMean: '¿Quisiste decir',
+    corpusBlurb: 'Más de 10.000 fuentes primarias: alquimia, hermetismo, cábala, filosofía natural, rasayana sánscrito, clásicos chinos, filosofía árabe y mucho más.',
+    browseAllBooks: 'Ver todos los libros',
+
+    kindReadingRoom: 'Sala de lectura',
+    kindLibrary: 'Biblioteca asociada',
+    kindCollection: 'Colección',
+
+    illustrations: 'Ilustraciones',
+    seeAllImages: 'Ver todas las imágenes',
+    semanticDegraded: 'No se han podido cargar los resultados relacionados — puede que veas menos coincidencias de las que tenemos. Inténtalo de nuevo en un momento.',
+    conceptualMatches: 'Coincidencias conceptuales',
+    textMatches: 'Coincidencias en el texto',
+    seeAllResults: (n) => `Ver los ${n} resultados`,
+    passages: 'Pasajes',
+    searchingPageContent: 'Buscando en el texto de las páginas...',
+    catalogMatches: 'Coincidencias en el catálogo',
+    works: (n) => (n === 1 ? 'obra' : 'obras'),
+    searchingCatalog: 'Buscando en el catálogo...',
+    openAllCatalogueMatches: (n) => `Ver las ${n} coincidencias del catálogo`,
+    relatedFromAi: 'Resultados relacionados de la búsqueda ampliada con IA:',
+    relatedInLibrary: 'Relacionado en la biblioteca',
+
+    foundBooksAndPages: (n, q) => `${n} libros y páginas para «${q}»`,
+    foundIndexEntries: (n, q) => `${n} entradas del índice para «${q}»`,
+    foundImages: (n, q) => `${n} imágenes para «${q}»`,
+
+    askLibrarian: 'Pregunta a la fuente',
+    askLibrarianBody: (scope) => `¿Quieres un análisis más profundo? El Bibliotecario buscará en ${scope}, contrastará las fuentes y armará un cuaderno de investigación que podrás exportar.`,
+    askLibrarianScopeResults: (n) => `estos ${n} resultados`,
+    askLibrarianScopeCollection: 'la colección',
+
+    editedByAbbrev: 'ed.',
+    pageAbbrev: (n) => `p. ${n}`,
+    pagesCount: (n) => `${n} páginas`,
+    translatedCount: (n) => `${n} traducidas`,
+    findPassages: 'Buscar pasajes',
+    hidePassages: 'Ocultar pasajes',
+    searchingEllipsis: 'Buscando...',
+    searchingPages: 'Buscando en las páginas...',
+    noMatchingPassages: 'No se han encontrado pasajes coincidentes en este libro.',
+    untitled: '(sin título)',
+    digitized: 'Digitalizado',
+    catalogOnly: 'Solo en catálogo',
+    collectionBooks: (n) => `${n} libros`,
+    illustrationFromCollection: (name) => `Ilustración de ${name}`,
+
+    previous: 'Anterior',
+    next: 'Siguiente',
+    pageXofY: (x, y) => `Página ${x} de ${y}`,
+
+    imagesEnglishNote: 'Las descripciones de las ilustraciones están indexadas en inglés, así que la búsqueda de imágenes usa palabras inglesas. Las imágenes se pueden explorar en cualquier idioma.',
+  },
+};
+
+/**
+ * Example queries for the empty-results screen, per locale: the leading common
+ * noun translated, the names left alone.
+ */
+export const EXAMPLE_QUERIES: Record<Locale, string[]> = {
+  en: ['alchemy', ...EXAMPLE_QUERY_PROPER_NOUNS],
+  es: ['alquimia', ...EXAMPLE_QUERY_PROPER_NOUNS],
+};

--- a/tests/unit/reading-language-url.test.ts
+++ b/tests/unit/reading-language-url.test.ts
@@ -19,6 +19,16 @@ describe('legacyLangRedirect', () => {
       .toBe('/es/book/x');
   });
 
+  it('follows the registry when a path GAINS a twin — /search did in #4180', () => {
+    // Not a restatement of the case above: it pins that this migration reads
+    // the registry rather than a hard-coded list of families, so the day a
+    // route gets an /es twin its legacy ?lang=es links start resolving to it.
+    expect(legacyLangRedirect('/search', '?lang=es', hasLocalizedTwin))
+      .toBe('/es/search');
+    expect(legacyLangRedirect('/search', '?lang=es&q=alquimia', hasLocalizedTwin))
+      .toBe('/es/search?q=alquimia');
+  });
+
   it('preserves other query params across the migration, dropping only lang', () => {
     expect(legacyLangRedirect('/book/x/page/y', '?lang=es&v=1.2', hasLocalizedTwin))
       .toBe('/es/book/x/page/y?v=1.2');
@@ -32,7 +42,10 @@ describe('legacyLangRedirect', () => {
   it('does not redirect a page with no Spanish twin', () => {
     // `/book/<id>/overview` has no /es route; sending a reader there is a 404.
     expect(legacyLangRedirect('/book/x/overview', '?lang=es', hasLocalizedTwin)).toBeNull();
-    expect(legacyLangRedirect('/search', '?lang=es', hasLocalizedTwin)).toBeNull();
+    // `/gallery` likewise — measured 2026-08-21: /gallery 200, /es/gallery 404.
+    // This slot used to hold `/search`, which gained a twin in #4180; when an
+    // exemplar stops being an example, replace it rather than delete the case.
+    expect(legacyLangRedirect('/gallery', '?lang=es', hasLocalizedTwin)).toBeNull();
   });
 
   it('is a no-op on an already-Spanish URL, so it cannot loop', () => {


### PR DESCRIPTION
Closes #4180.

`/es` could browse collections, open a book, turn pages and search *inside* a book — all in Spanish. It could not search the library. The header's search icon pointed at `/search` and `/es/search` returned **404 on production** (measured). The data half shipped in #4095; this is the page.

## Shape

One page, two URLs. `src/app/search/page.tsx` takes `lang` and renders under both prefixes — the same shape as the book page (#4082 phase 2), not a second hand-written page. Its English chrome moves to `SEARCH_STRINGS` in a new `src/lib/search-i18n.ts`, keyed by `Locale`, so a new language adds a KEY and TypeScript lists what you missed. The six result cards and `Pagination` are client components and read `useLocale()` rather than threading a prop.

`src/app/es/search/{page,layout}.tsx` is the thin twin. Metadata and the `<Suspense>` boundary `useSearchParams` needs live in the layout, mirroring `/search`.

## The real decision: which lanes a localized surface gets

Per `.claude/docs/i18n.md` rule 4 — label or omit, never machine-translate at render time.

| lane | on `/es` | why |
|---|---|---|
| **Libros** | kept | `/api/search?lang=es` is fully language-keyed and narrows to books that HAVE the edition, so every card opens in Spanish |
| **Imágenes** | kept, **labelled** | illustration descriptions are an English index, but the images themselves are the content |
| Todo (All) | hidden | `/api/search/unified` takes no `lang` |
| Índice | hidden | `/api/search/index` entries are English-generated |
| AI narration | suppressed | `/api/search/ai-expand` answers in English and expands to English terms |
| known-entity card | suppressed | English editorial copy, no localized map |

`?mode=` is user-supplied, so the clamp lives at the state and not only in the tab list: a hand-typed `/es/search?mode=unified` resolves to the books lane rather than rendering the English one.

## Link sites, which is where a localized page actually leaks (#4164)

- The header's search icon (desktop **and** mobile) and the homepage's search **form action** plus its two stat links were hard-coded `/search`. All now route through `localePath`, with `/search` added to `LOCALIZED_PATHS`.
- The header's active-state test reads `canonicalPath(pathname)`, or the icon never highlights on `/es/search`.
- **`UnifiedSearch` had exactly the trap i18n.md warns about** ("if you add a prefix concept anywhere, check who else composes a URL from it"): it derived ONE prefix from path segment 0, so it read `es` as a tenant slug and emitted `/es/gallery/image/…` — a 404. Measured: `/gallery` → 200, `/es/gallery` → 404. It now strips the locale first and re-applies it per link via the registry, so the gallery link falls back to English (correct — no twin) and the search link keeps the prefix.
- Collection names read through `localizedCollection()` instead of `.name`; otherwise 40 English pills sit over Spanish chrome. `Collection.localized` only needed *declaring* — `/api/collections` projects nothing away.

Also: reciprocal `hreflang` on the English route (a twin's `alternates.languages` is useless one-way), both `openGraph` **and** `twitter` blocks on the twin so a `/es` link doesn't preview under the English card (#4162), and `lang` on the page wrapper — the ROOT layout still ships `<html lang="en">` on every `/es` URL, which `/es/collections` compensates for the same way.

## Out of scope, deliberately

- **#4146** — the 67 books *written* in Spanish have no `page_texts` rows, so they are visible on `/es` and still absent from these results. Store-side fix, tracked.
- **`AboutVariants` subject tags stay unprefixed.** They are hard-coded ENGLISH terms; prefixing them would land a Spanish reader on a predictably empty Spanish result page, which is worse than an English page with results. Wants localized subject tags first.
- Language/subject filter **options** and the card's language pill are English data (`books.language`) with no localized map.
- `NotFoundContent` and the cookie banner are not localized at all — broader than this PR.
- The root layout's `<html lang>`.

## Verification

Browser, not curl — as the issue asked.

- `/es/search` empty state: tabs, filter panel (Idioma / Materia / Colección / Biblioteca / Publicado después de / antes de), checkboxes, per-page, sort — all Spanish; 22.073 with a Spanish thousands separator.
- `/es/search?q=alquimia`: 9 results, Spanish snippets with the term highlighted, `p. 60` page refs. Every result href is `/es/book/…`; **zero unprefixed**. Followed one: `308 → /es/book/…/page/<id> → 200`, so the reader stays in Spanish.
- Empty-results screen: Spanish copy, and the example chips keep `Hermes / Paracelsus / Kabbalah / rasayana / Ficino` untranslated while the common noun becomes `alquimia`.
- Imágenes tab shows the English-index label.
- Pagination: `Anterior / Página 1 de 1104 / Siguiente`.
- Collection pills localize; the ones still English have no `localized.es.name` (fill-rate, correctly falling back to the original per rule 4).
- Header on `/es`: `aria-label="Buscar"`, `href="/es/search"`. Homepage form action `/es/search`.
- **English `/search` unchanged** — all four tabs, AI narration, known-entity card, `Found 42 books & pages for "alchemy" (showing 1–20)`.
- `npx tsc --noEmit` clean. `eslint` **identical to `origin/main`** — 36 problems (26 errors, 10 warnings) before and after, across every touched file; the pre-existing nested-`<a>` hydration warning is the DOI link inside the card `Link`, verbatim in `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtdzeEPvZgUZjZLPM8zHyJ
