### PR TITLE
docs(invariants): a detector can run perfectly and still measure the wrong corpus

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -306,6 +306,19 @@ reads all three:
 - **Verify a detector by making it fail.** The only proof the wiring works is
   running it with the input removed and seeing red. A green scheduled run proves
   nothing about a detector whose failure mode is silence.
+- **And check WHAT it counted, not just that it ran.** The rule above catches a
+  detector that cannot run. It does not catch the worse case: one that runs
+  perfectly, exits `0`, and is measuring a corpus that excludes the failure.
+  `page-texts-coverage.mjs` exists to catch "an unembedded book and a book with
+  no matches return the same empty list", and it selected books by
+  `pages_translated_es > 0` — which is `0` for a book *written* in Spanish and
+  always will be. So all 68 native books sat outside its own denominator and it
+  reported clean over 19,489 unfindable pages (#4146/#4186). Making it fail
+  would have passed: break a book **in** its scope and it goes red, which proves
+  nothing about the books outside. **The tell is the scope line, not the exit
+  code** — 107 books before the fix, 175 after. Print the denominator and read
+  it. Any time a read rule widens, the detectors watching it are writers too:
+  re-run each and confirm its SCOPE moved.
 
 **Diagnostic tell for the next person:** an auto-filed issue whose fenced block is
 an *error message* rather than a *measurement*. Read the body before believing the


### PR DESCRIPTION
13 lines added to the existing detector section in `measurement-instruments.md`. CLAUDE.md unchanged at 236 lines; no new file, no new routing entry.

## The gap in the existing rule

That section covers an instrument that **cannot run** — the three-value exit contract, and *"verify a detector by making it fail."* It misses the worse case, which this session hit: a detector that runs perfectly, exits `0`, and whose **denominator excludes the failure it exists to catch**.

`page-texts-coverage.mjs` was written for exactly one purpose — catching *"an unembedded book and a book with no matches return the same empty list."* It selected books by `pages_translated_es > 0`, which is `0` for a book **written** in Spanish and always will be. So 68 books and 19,489 pages sat outside its own denominator and it reported clean over all of them (#4146, fixed #4186).

**The prescribed verification would have passed.** Break a book *inside* its scope and it goes red — which proves nothing about the books outside. The tell was never the exit code; it was the scope line: **107 books before the fix, 175 after.**

Hence the addition: print the denominator and read it, and when a read rule widens, re-run every detector watching it and confirm its **scope** moved — a detector is a writer-shaped thing, not a reader.

## Why prose and not a guard

Applying #4191's discriminator (*nameable file or symbol → check; human about to draw a conclusion → doc*), this splits cleanly and both halves are done:

- The nameable half **already shipped as a check** in #4186 — one exported `embeddableEditionFilter` imported by both the worker and its audit, with a test pinning that it is not the read-side filter. Negative control run: removing the `visible` / `pages_ocr` guards turns two tests red.
- What remains is the judgment a human makes while reading a green result. That cannot be asserted, so it is prose.

This is also an independent fourth case for #4191's argument, from a different session: a doc-shaped rule ("validate against the read path", #3293) existed, and the thing recurred anyway — in the instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MojJdMhnuk3PkZfpTPyA7k