### PR TITLE
feat(archive): the MDZ master gap — 100,188 pages that serve from R2 but whose originals we don't hold

### DIFF
--- a/.github/workflows/master-copy-watch.yml
+++ b/.github/workflows/master-copy-watch.yml
@@ -1,0 +1,74 @@
+name: Master copy watch
+
+# The detector for a class every other check calls healthy.
+#
+# A page can serve entirely from our own CDN — our 1200px display variant, our
+# 150px thumbnail — while the only FULL-RESOLUTION copy of the scan sits on the
+# source institution's server. It renders, it counts toward "served from R2",
+# and no broken-image sweep touches it. If that source changes a URL scheme or
+# withdraws the item, we keep serving 1200px forever and can never regenerate
+# anything larger.
+#
+# Measured 2026-08-21: a corpus census reported 99.56% of live pages "held on R2
+# and served from R2" — true, and it missed ~100,000 pages in exactly this state.
+# Nothing we ran would have noticed, which is why this exists.
+#
+# READ-ONLY, and findings go to an issue rather than failing a build. Repair
+# fetches from the source and costs bandwidth and R2 storage, so it is a
+# decision a person makes, never something a cron does on its own.
+#
+# Weekly, not daily: it is a full scan of ~19M page documents, and the number it
+# watches moves in weeks, not hours.
+
+on:
+  schedule:
+    - cron: '0 6 * * 2'   # Tuesdays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: 'Pages above which this is a finding'
+        required: false
+        default: '0'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  master-copy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci --ignore-scripts
+      - name: Look for pages served without a master
+        id: run
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          set +e
+          node scripts/audit/pages-served-without-a-master.mjs \
+            --max=${{ github.event.inputs.threshold || '0' }} > report.txt 2>&1
+          echo "fired=$?" >> "$GITHUB_OUTPUT"
+          cat report.txt
+      - name: File findings
+        if: steps.run.outputs.fired == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Pages served from R2 with no master held — $(date -u +'%Y-%m-%d')"
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "These pages render entirely from our own CDN while the only full-resolution copy lives on the source institution's server. Repair costs bandwidth and storage and crawls a partner's infrastructure — treat this as a prompt to decide, not an instruction to run." \
+            "$(cat report.txt)")
+          gh issue create --title "$TITLE" --body "$BODY"
+      # Exit 2 means the detector never reached the database. Fail loudly: a
+      # silent green run is indistinguishable from "checked, found nothing"
+      # (#4071 — three detectors sat blind behind a missing secret).
+      - name: Fail if the detector could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::pages-served-without-a-master could not run (exit ${{ steps.run.outputs.fired }}) — no finding was measured. Check the MONGODB_URI repo secret."
+          exit 1

--- a/scripts/audit/pages-served-without-a-master.mjs
+++ b/scripts/audit/pages-served-without-a-master.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Detector: pages we SERVE from R2 whose full-resolution master we do not hold.
+ *
+ * WHY THIS CLASS IS INVISIBLE
+ * ---------------------------
+ * Every serving-side measurement reports these pages as healthy, because they
+ * are. A page can hold our 1200px `display_photo` and our 150px `image_thumb`
+ * on R2 — so it renders entirely from our own CDN, counts toward "served from
+ * R2", and shows up in no broken-image sweep — while the only full-resolution
+ * copy of the scan sits on the source institution's server:
+ *
+ *   photo           api.digitale-sammlungen.de/.../full/full/...   (MDZ master)
+ *   archived_photo  (absent)                                        <- ours: none
+ *   display_photo   images.sourcelibrary.org/.../0040.jpg           (1200px, ours)
+ *   image_thumb     images.sourcelibrary.org/.../0040-thumb.jpg     (150px, ours)
+ *
+ * Measured 2026-08-21: a corpus census reported 99.56% of live pages "held on R2
+ * and served from R2" — true, and it missed ~100,000 pages in exactly this state.
+ * If the source changes a URL scheme or withdraws an item, we keep serving 1200px
+ * forever and can never regenerate anything larger. The loss is silent and
+ * permanent, and nothing else we run would notice it.
+ *
+ * WHAT COUNTS AS A MASTER
+ * -----------------------
+ * Two eras store it differently, and checking only one is how this gap reads as
+ * a field-naming artifact rather than a real one (verified by curl before this
+ * detector was written — `…-full.jpg` was a 404 on every book sampled):
+ *   - old era: `archived_photo` -> images.sourcelibrary.org/archived/<book>/N.jpg
+ *   - new era: `photo`          -> images.sourcelibrary.org/pages/<book>/NNNN-full.jpg
+ *   - split halves: `cropped_photo` on R2 is the materialised page
+ *
+ * READ-ONLY. Finds, never fixes — repair is `archive-mdz-gap-4190.mjs` and its
+ * kin, which fetch from the source and cost bandwidth and storage.
+ *
+ * Exit codes follow the corpus-integrity-watch contract:
+ *   0  under threshold
+ *   1  finding — over threshold
+ *   2  could not reach the database (fail LOUDLY; a silent green run is
+ *      indistinguishable from "checked, found nothing" — #4071)
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/audit/pages-served-without-a-master.mjs
+ *   … --max=0        threshold above which this is a finding (default 0)
+ *   … --top=20       how many books to list
+ *   … --all          include hidden books (default: live only)
+ */
+import { MongoClient } from 'mongodb';
+
+const ARGS = process.argv.slice(2);
+const num = (n, d) => { const m = ARGS.find(a => a.startsWith(`--${n}=`)); return m ? Number(m.split('=')[1]) : d; };
+const MAX = num('max', 0);
+const TOP = num('top', 20);
+const ALL = ARGS.includes('--all');
+
+const R2 = 'images\\.sourcelibrary\\.org';
+const MASTER_NEW = `^https://${R2}/pages/[^/]+/[^/]*\\d+(-full)?\\.jpg$`;
+
+let client;
+try {
+  client = new MongoClient(process.env.MONGODB_URI, { socketTimeoutMS: 0, serverSelectionTimeoutMS: 30000, retryReads: true });
+  await client.connect();
+  await client.db('bookstore').command({ ping: 1 });
+} catch (e) {
+  console.error(`could not reach the database: ${e.message}`);
+  process.exit(2);
+}
+
+try {
+  const db = client.db('bookstore');
+  const bookFilter = ALL ? { pages_count: { $gt: 0 } } : { visible: true, pages_count: { $gt: 0 } };
+  const bookDocs = await db.collection('books')
+    .find(bookFilter, { projection: { _id: 1, title: 1, 'image_source.provider': 1 }, maxTimeMS: 600000 })
+    .toArray();
+  const meta = Object.fromEntries(bookDocs.map(b => [b._id.toString(), b]));
+
+  const rows = await db.collection('pages').aggregate([
+    {
+      $match: {
+        page_number: { $gte: 0 },
+        // Serves from us at SOME size…
+        $or: [
+          { display_photo: { $regex: R2 } },
+          { image_thumb: { $regex: R2 } },
+          { thumbnail_blob: { $regex: R2 } },
+        ],
+        // …but we hold no full-resolution copy, under either era's convention.
+        archived_photo: { $not: new RegExp(R2) },
+        photo: { $not: new RegExp(MASTER_NEW) },
+        cropped_photo: { $not: new RegExp(R2) },
+      },
+    },
+    { $group: { _id: '$book_id', pages: { $sum: 1 }, sample: { $first: '$photo' } } },
+  ], { allowDiskUse: true, maxTimeMS: 3600000 }).toArray();
+
+  const found = rows.filter(r => meta[r._id]);
+  const total = found.reduce((a, r) => a + r.pages, 0);
+
+  const byProvider = {};
+  for (const r of found) {
+    const p = meta[r._id]?.image_source?.provider || '(none)';
+    byProvider[p] = byProvider[p] || { books: 0, pages: 0 };
+    byProvider[p].books++; byProvider[p].pages += r.pages;
+  }
+
+  console.log(`pages served from R2 with NO master held: ${total.toLocaleString()} across ${found.length} ${ALL ? '' : 'live '}books\n`);
+  if (total) {
+    console.log('by source provider:');
+    for (const [p, v] of Object.entries(byProvider).sort((a, b) => b[1].pages - a[1].pages)) {
+      console.log(`  ${p.padEnd(20)} ${String(v.books).padStart(5)} books  ${v.pages.toLocaleString().padStart(9)} pages`);
+    }
+    console.log(`\nlargest ${Math.min(TOP, found.length)}:`);
+    for (const r of found.sort((a, b) => b.pages - a.pages).slice(0, TOP)) {
+      console.log(`  ${String(r.pages).padStart(6)}p  ${String(meta[r._id]?.image_source?.provider || '?').padEnd(14)} ${String(meta[r._id]?.title || r._id).slice(0, 48)}`);
+      console.log(`          source: ${String(r.sample || '(none)').slice(0, 92)}`);
+    }
+    console.log('\nRepair fetches from the source and costs bandwidth + R2 storage — it is a');
+    console.log('decision, not a cleanup. See scripts/maintenance/archive-mdz-gap-4190.mjs.');
+  }
+
+  if (total > MAX) {
+    console.log(`\nFINDING: ${total.toLocaleString()} > threshold ${MAX}`);
+    process.exit(1);
+  }
+  console.log(`\nclean (threshold ${MAX})`);
+  process.exit(0);
+} catch (e) {
+  console.error(`detector failed before producing a measurement: ${e.message}`);
+  process.exit(2);
+} finally {
+  await client.close().catch(() => {});
+}

--- a/scripts/maintenance/archive-mdz-gap-4190.mjs
+++ b/scripts/maintenance/archive-mdz-gap-4190.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Archive the MDZ-sourced page images that are still served from the provider.
+ *
+ * WHY
+ * ---
+ * 99.56% of live page images are held on R2 and served from R2. The remainder
+ * is 24,488 pages, and once you subtract what CANNOT be archived it is one
+ * tractable set:
+ *
+ *   iiif (MDZ / api.digitale-sammlungen.de)  64 books  16,434 pages  ← this script
+ *   etcsl (text-only, no page images)       373 books   5,759 pages  nothing to fetch
+ *   already archive_failed                    ~         953 pages    dead sources
+ *   gallica / e-rara (MAC_ONLY_PROVIDERS)    15 books   1,084 pages  need the Mac worker
+ *   no source url at all                       6 books     379 pages  nothing to fetch
+ *
+ * The MDZ set is fetchable from our own infrastructure (`digitale-sammlungen.de`
+ * is in the route's ARCHIVABLE_SOURCES_REGEX and is not a Mac-only provider) and
+ * carries ZERO archive_failed pages, so nothing here is a known-dead source.
+ *
+ * WHY A DRIVER RATHER THAN ONE CALL
+ * ---------------------------------
+ * `/api/books/<id>/archive-images` takes a `limit` and routinely returns a
+ * Cloudflare 524 — the edge times out at ~100s while the function keeps working
+ * to its 300s maxDuration. Its own source comments say so. **So the HTTP
+ * response is not the measurement.** This driver re-counts unarchived pages in
+ * Mongo after every call and drives from that, which also means a 524 is
+ * correctly read as "probably progressed" rather than "failed".
+ *
+ * Checkpointed per book (corpus-walk rule): an interruption costs one book.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/archive-mdz-gap-4190.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/archive-mdz-gap-4190.mjs --apply
+ *   … --limit=200            pages per API call (default 100)
+ *   … --max-books=5          stop after N books (for a cautious first run)
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ARGS = process.argv.slice(2);
+const APPLY = ARGS.includes('--apply');
+const num = (n, d) => { const m = ARGS.find(a => a.startsWith(`--${n}=`)); return m ? Number(m.split('=')[1]) : d; };
+const LIMIT = num('limit', 100);
+const MAX_BOOKS = num('max-books', 0);
+const BASE_URL = process.env.BASE_URL || 'https://sourcelibrary.org';
+const CRON_SECRET = process.env.CRON_SECRET;
+const R2 = /images\.sourcelibrary\.org/;
+const SOURCE = /digitale-sammlungen\.de/;
+const OUT_DIR = 'scripts/output';
+const CHECKPOINT = path.join(OUT_DIR, 'archive-mdz-gap.checkpoint');
+
+if (APPLY && !CRON_SECRET) { console.error('CRON_SECRET missing — cannot call the archive route.'); process.exit(1); }
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const client = new MongoClient(process.env.MONGODB_URI, { socketTimeoutMS: 0, retryReads: true });
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+const pages = db.collection('pages');
+
+/** Pages of this book with no R2 object and a fetchable MDZ source. */
+const unarchivedCount = (bookId) => pages.countDocuments({
+  book_id: bookId,
+  page_number: { $gte: 0 },
+  archived_photo: { $not: R2 },
+  photo: { $regex: SOURCE.source },
+}, { maxTimeMS: 60000 });
+
+const live = await books.find(
+  { visible: true, pages_count: { $gt: 0 }, 'image_source.provider': 'iiif' },
+  { projection: { _id: 1, title: 1, pages_count: 1 }, maxTimeMS: 300000 },
+).toArray();
+
+const done = new Set(fs.existsSync(CHECKPOINT) ? fs.readFileSync(CHECKPOINT, 'utf8').split('\n').filter(Boolean) : []);
+console.log(`iiif-provider live books: ${live.length}${done.size ? `  (${done.size} already checkpointed)` : ''}`);
+
+const targets = [];
+for (const b of live) {
+  const id = b._id.toString();
+  if (done.has(id)) continue;
+  const n = await unarchivedCount(id);
+  if (n > 0) targets.push({ id, title: b.title, pages_count: b.pages_count, missing: n });
+}
+targets.sort((a, b) => b.missing - a.missing);
+const totalMissing = targets.reduce((a, t) => a + t.missing, 0);
+console.log(`books needing MDZ archiving: ${targets.length}   pages: ${totalMissing.toLocaleString()}\n`);
+for (const t of targets.slice(0, 10)) console.log(`  ${String(t.missing).padStart(5)}p  ${String(t.title).slice(0, 58)}`);
+if (targets.length > 10) console.log(`  … and ${targets.length - 10} more`);
+
+if (!APPLY) {
+  console.log('\nDRY RUN — pass --apply to archive. Nothing fetched, nothing written.');
+  await client.close();
+  process.exit(0);
+}
+
+let booksDone = 0, pagesArchived = 0;
+for (const t of targets) {
+  if (MAX_BOOKS && booksDone >= MAX_BOOKS) break;
+  let before = t.missing;
+  let stagnant = 0;
+
+  while (before > 0) {
+    // A 524 here means the edge gave up, not that the work did. The DB decides.
+    const res = await fetch(`${BASE_URL}/api/books/${t.id}/archive-images`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${CRON_SECRET}` },
+      body: JSON.stringify({ limit: LIMIT }),
+      signal: AbortSignal.timeout(290000),
+    }).catch(e => ({ ok: false, status: 0, _err: e.message?.slice(0, 60) }));
+
+    const after = await unarchivedCount(t.id);
+    const moved = before - after;
+    pagesArchived += Math.max(0, moved);
+    console.log(`  ${t.title?.slice(0, 40).padEnd(42)} http=${res.status ?? '?'}  ${before} -> ${after}  (+${moved})`);
+
+    if (moved <= 0) {
+      if (++stagnant >= 2) { console.log(`    no progress twice — leaving ${after} pages for a look`); break; }
+    } else stagnant = 0;
+    before = after;
+  }
+
+  fs.appendFileSync(CHECKPOINT, `${t.id}\n`);
+  booksDone++;
+}
+
+console.log(`\nbooks processed: ${booksDone}   pages archived: ${pagesArchived.toLocaleString()}`);
+console.log(`checkpoint: ${CHECKPOINT}`);
+await client.close();


### PR DESCRIPTION
**Dry-run only. Nothing fetched, nothing written.** Opened as a draft because the scope question below is a decision, not a detail.

## The finding, which matters more than the script

"Is everything archived?" has **three** answers, and the middle one is invisible to the question as usually asked. Here is a real page from *Cosmographey*:

```
photo           api.digitale-sammlungen.de/.../full/full/...   (MDZ, full-res)
archived_photo  (absent)                                        ← no master
display_photo   images.sourcelibrary.org/.../0040.jpg           (1200px, ours)
image_thumb     images.sourcelibrary.org/.../0040-thumb.jpg     (150px, ours)
```

That page serves **100% from R2** — so it counts as "served from us", correctly — while the only full-resolution copy of the scan sits on Munich's server. If MDZ changes a URL scheme or withdraws an item, we keep serving 1200px forever and can never regenerate anything larger.

| state | meaning |
|---|---|
| master on R2 (`archived_photo`) | fully preserved |
| **derivatives only** | serves fine, **we do not hold the original** |
| nothing on R2 | 24,488 pages — the gap previously reported |

**So the real job is 100,188 pages across 428 books**, not the 16,434 across 64 that a "no R2 object" count reports. The middle category is ~75K pages that every serving-side measurement calls healthy.

## Why this is a decision and not a run

Measured MDZ `full/full` sizes: **185 KB, 428 KB, 582 KB, 2.56 MB** — call it ~900 KB average. 100,188 pages ≈ **90 GB**, about **+0.4%** of R2's 21.18 TB, **~$1.35/month** ongoing, plus a long crawl against a partner institution's servers. Cheap in absolute terms, but it is paid, ongoing, and outward-facing.

Three options:

1. **Masters for everything** — 100,188 pages, ~90 GB. Full preservation.
2. **Only the 24,488 with nothing on R2** — closes the serving gap; ~22 GB. Leaves ~75K pages served-but-unpreserved.
3. **The 10 largest books first** (~12,500 pages, ~11 GB) to turn the size estimate into a measurement before committing.

## The driver

- **Checkpointed per book** — corpus-walk rule. An interruption costs one book. (The thumb repointer in #4189 learned this the hard way: its single-query version died on `ECONNRESET` after ten minutes.)
- **Reads progress from Mongo after every call, never from the HTTP response.** `/api/books/<id>/archive-images` returns Cloudflare 524s while the function keeps working to its 300s `maxDuration` — its own source comments say so — so the response is not the measurement.
- Stops a book after two calls with no progress rather than looping.
- `--max-books=N` for a cautious first run.

## Follow-up worth more than this script

**A detector for "pages with derivatives but no master."** This entire class is invisible to every check we have, because every serving-side measurement reports it healthy. That is the guardrail; this is the one-off — and by the ratchet rule now in #4191, the guardrail is the thing that should outlive the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
