### PR TITLE
fix(publication): state the historical-source rule the geometry guide relies on

### DIFF
--- a/scripts/publication/esoteric-geometries.mjs
+++ b/scripts/publication/esoteric-geometries.mjs
@@ -46,6 +46,7 @@ function parseArgs(argv) {
     perBook: Number(get('--per-book', '3')),
     perChapter: Number(get('--per-chapter', '14')),
     minQuality: Number(get('--min-quality', '0.7')),
+    maxYear: Number(get('--max-year', '1930')),
     manifestOnly: a.includes('--manifest-only'),
   };
 }
@@ -231,6 +232,16 @@ function plateKey(it) {
   return `${it.pageId}-${it.detectionIndex}`;
 }
 
+/**
+ * Standalone artwork records (as opposed to plates extracted from a book's
+ * pages) come back with an `artwork-`-prefixed pageId. Their dating is the
+ * artwork's, not a historical edition's, so an undated one carries no evidence
+ * that it belongs in a guide to historical geometry.
+ */
+function isArtworkRecord(it) {
+  return String(it.pageId || '').startsWith('artwork-');
+}
+
 function combinedText(it) {
   const m = it.metadata || {};
   return [
@@ -271,6 +282,8 @@ function classify(it) {
 async function gatherCandidates() {
   console.log(`Scanning library for geometric plates (source: ${CFG.base})\u2026`);
   const byKey = new Map();
+  let droppedModern = 0;
+  let droppedUndated = 0;
   for (const query of QUERIES) {
     const items = await fetchQuery(query);
     let added = 0;
@@ -279,11 +292,27 @@ async function gatherCandidates() {
       if (byKey.has(key)) continue;
       if (EXCLUDE_TYPES.has(it.type)) continue;
       if ((it.galleryQuality ?? 0) < CFG.minQuality) continue;
+      // This is a guide to HISTORICAL esoteric geometry, and the gallery now
+      // serves a second lane: standalone artwork records, many of them modern
+      // (measured 2026-08-21: a third of the hits for this script's own
+      // Platonic-solids query were artwork records dated 2008-2024). They are
+      // currently kept out only INCIDENTALLY — they carry no gallery_quality,
+      // so the threshold above drops them. That is one accidental guard, and it
+      // disappears the day the artwork lane gets quality scores. State the rule
+      // the guide actually depends on instead of relying on that.
+      if (Number.isFinite(it.year) && it.year > CFG.maxYear) { droppedModern++; continue; }
+      if (!Number.isFinite(it.year) && isArtworkRecord(it)) { droppedUndated++; continue; }
       if (!it.extractedUrl && !it.imageUrl) continue;
       byKey.set(key, it);
       added++;
     }
     console.log(`  ${JSON.stringify(query)} -> +${added} new (total ${byKey.size})`);
+  }
+  if (droppedModern > 0 || droppedUndated > 0) {
+    console.log(
+      `  (excluded ${droppedModern} plate(s) dated after ${CFG.maxYear} and ` +
+      `${droppedUndated} undated artwork record(s) — raise with --max-year)`
+    );
   }
   return [...byKey.values()];
 }


### PR DESCRIPTION
## Why

`scripts/publication/esoteric-geometries.mjs` (merged in #3272) compiles plates from the public gallery API into an illustrated guide to **historical** esoteric geometry. The gallery now serves a second lane the script predates: standalone artwork records, many of them modern. A third of the hits for the script's own Platonic-solids query are artwork records dated 2008–2024 (measured 2026-08-21).

None of them reach the output today — but only by accident. Artwork records carry no `gallery_quality`, so the existing `< minQuality` check drops them. That is a single incidental guard for a rule nobody wrote down, and it disappears the day the artwork lane gets quality scores. A 2024 render titled *"Platonic Solid Construction Principles"* would then classify happily into chapter one, be cited with its year, and be listed in the colophon as a source work.

## What

- `--max-year` (default **1930**) — drop candidates dated later.
- Drop **undated artwork-lane records** (`artwork-`-prefixed `pageId`), which carry no evidence of belonging to a historical edition. Undated *book* plates are kept: their book is historical.
- Report both counts. No silent skips.

## Measured

| | plates | ids changed | year range | artwork records |
|---|---|---|---|---|
| before | 90 | — | 1300–1920 | 0 |
| after | 90 | 0 | 1300–1920 | 0 |

**The curated output is unchanged** — this is a guard, not an editorial change. It excludes 4 candidates from the 1,731-candidate pool, none of which were ever selected.

Verified it can bite: at `--max-year 1800` it excludes 451 candidates and the output ceiling falls to 1790.

## Out of scope

- The 14 selected plates dated 1810–1920 (Lévi, Waite, Sibley, Bragdon, Spence) are **deliberately kept** — 19th-century occultists are in scope for this guide and are public domain. 1930 is the cutoff, not 1800.
- Pruning weak classifications, PDF rendering, admin wiring — all still deferred per #3272.
- `epubcheck` still has not been run on the output (no local Java), per #3272's own note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6yEsQkyt1qdzs85WnM566