### PR TITLE
Close an open Gemini proxy on /api/pages/[id]/ask

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/ask/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/ask/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
@@ -176,18 +177,41 @@ export async function POST(
       bookTitle,
       bookAuthor,
       pageNumber,
-      customPrompt,
-      authorSearchTerms,
-      personaName
     } = body;
 
-    if (!question) {
+    if (!question || typeof question !== 'string') {
       return NextResponse.json({ error: 'Question is required' }, { status: 400 });
+    }
+    if (question.length > 2000) {
+      return NextResponse.json({ error: 'Question is too long' }, { status: 400 });
     }
 
     if (!pageText) {
       return NextResponse.json({ error: 'Page text is required' }, { status: 400 });
     }
+
+    // Every call here spends money on Gemini, and the reader offers the
+    // Librarian to anonymous visitors, so this is the one place an anonymous
+    // request can run up a bill. Bots do not get the usual bypass: the UA
+    // check is a substring match on a spoofable header, and a crawler has no
+    // reason to ask a question about a page it is only indexing.
+    const gate = await anonActionGate(request, { name: 'page-ask', limit: 10, allowBotBypass: false });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        { error: `You have reached the hourly limit for questions. Sign in (free) to keep going: ${SIGNIN_URL}`, retry_after: gate.retryAfter },
+        { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
+      );
+    }
+
+    // Caps on what a caller can put in the prompt. `question` and `pageText`
+    // are already bounded below; the conversation was not bounded at all, so a
+    // single request could carry an arbitrary number of input tokens.
+    const safeHistory: Message[] = Array.isArray(history)
+      ? history
+          .filter((m: Message) => m && typeof m.content === 'string')
+          .slice(-12)
+          .map((m: Message) => ({ role: m.role, content: m.content.slice(0, 4000) }))
+      : [];
 
     const model = getGeminiClient().getGenerativeModel({ model: DEFAULT_MODEL });
 
@@ -198,8 +222,8 @@ export async function POST(
     ].filter(Boolean).join(' ') || 'a historical text';
 
     // Build conversation history for context
-    const conversationHistory = history.length > 0
-      ? history.map((msg: Message) =>
+    const conversationHistory = safeHistory.length > 0
+      ? safeHistory.map((msg: Message) =>
           `${msg.role === 'user' ? 'Reader' : 'Assistant'}: ${msg.content}`
         ).join('\n\n') + '\n\n'
       : '';
@@ -216,8 +240,11 @@ export async function POST(
       authorSources = formatSourcesForPrompt(sources);
     }
 
-    // Use custom prompt if provided, otherwise use default
-    const promptTemplate = customPrompt || DEFAULT_PROMPT;
+    // The prompt is ours. This used to accept a caller-supplied `customPrompt`
+    // that REPLACED the template outright, which made an unauthenticated route
+    // into a general-purpose Gemini proxy on the site's API key. No caller in
+    // this repo ever sent one.
+    const promptTemplate = DEFAULT_PROMPT;
 
     // Replace variables in the prompt
     const prompt = promptTemplate

--- a/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { anonActionGate } from '@/lib/anon-gate';
 import { performTransliteration } from '@/lib/ai';
 import { resolveTenantId } from '@/lib/tenant-context';
 
@@ -62,7 +63,12 @@ export async function POST(
 
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = TRANSLITERATION_MODEL } = body;
+    const { regenerate = false } = body;
+    // The caller does not get to name the model. It used to, and the value went
+    // straight to getGenerativeModel(), so anyone inside the anonymous budget
+    // below could spend it on the most expensive model on offer instead of the
+    // cheap one this job is costed for.
+    const model = TRANSLITERATION_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id, tenantId });
@@ -94,6 +100,18 @@ export async function POST(
         script: page.transliteration.script,
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 }
       });
+    }
+
+    // Generation is a paid Gemini call — measured at ~12s plus ~5.6s per 1000
+    // OCR characters, up to nearly three minutes on a long page. Cached serves
+    // above are free and stay ungated; generation is capped per IP for
+    // anonymous callers, exactly as the alignment route caps trace mode.
+    const gate = await anonActionGate(request, { name: 'transliterate', limit: 15, allowBotBypass: false });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        { error: 'Transliteration limit reached. Sign in (free) to keep going.', retry_after: gate.retryAfter },
+        { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
+      );
     }
 
     // Perform transliteration

--- a/src/app/api/pages/[id]/ask/route.ts
+++ b/src/app/api/pages/[id]/ask/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
@@ -168,18 +169,41 @@ export async function POST(
       bookTitle,
       bookAuthor,
       pageNumber,
-      customPrompt,
-      authorSearchTerms,
-      personaName
     } = body;
 
-    if (!question) {
+    if (!question || typeof question !== 'string') {
       return NextResponse.json({ error: 'Question is required' }, { status: 400 });
+    }
+    if (question.length > 2000) {
+      return NextResponse.json({ error: 'Question is too long' }, { status: 400 });
     }
 
     if (!pageText) {
       return NextResponse.json({ error: 'Page text is required' }, { status: 400 });
     }
+
+    // Every call here spends money on Gemini, and the reader offers the
+    // Librarian to anonymous visitors, so this is the one place an anonymous
+    // request can run up a bill. Bots do not get the usual bypass: the UA
+    // check is a substring match on a spoofable header, and a crawler has no
+    // reason to ask a question about a page it is only indexing.
+    const gate = await anonActionGate(request, { name: 'page-ask', limit: 10, allowBotBypass: false });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        { error: `You have reached the hourly limit for questions. Sign in (free) to keep going: ${SIGNIN_URL}`, retry_after: gate.retryAfter },
+        { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
+      );
+    }
+
+    // Caps on what a caller can put in the prompt. `question` and `pageText`
+    // are already bounded below; the conversation was not bounded at all, so a
+    // single request could carry an arbitrary number of input tokens.
+    const safeHistory: Message[] = Array.isArray(history)
+      ? history
+          .filter((m: Message) => m && typeof m.content === 'string')
+          .slice(-12)
+          .map((m: Message) => ({ role: m.role, content: m.content.slice(0, 4000) }))
+      : [];
 
     const model = getGeminiClient().getGenerativeModel({ model: DEFAULT_MODEL });
 
@@ -190,8 +214,8 @@ export async function POST(
     ].filter(Boolean).join(' ') || 'a historical text';
 
     // Build conversation history for context
-    const conversationHistory = history.length > 0
-      ? history.map((msg: Message) =>
+    const conversationHistory = safeHistory.length > 0
+      ? safeHistory.map((msg: Message) =>
           `${msg.role === 'user' ? 'Reader' : 'Assistant'}: ${msg.content}`
         ).join('\n\n') + '\n\n'
       : '';
@@ -208,8 +232,11 @@ export async function POST(
       authorSources = formatSourcesForPrompt(sources);
     }
 
-    // Use custom prompt if provided, otherwise use default
-    const promptTemplate = customPrompt || DEFAULT_PROMPT;
+    // The prompt is ours. This used to accept a caller-supplied `customPrompt`
+    // that REPLACED the template outright, which made an unauthenticated route
+    // into a general-purpose Gemini proxy on the site's API key. No caller in
+    // this repo ever sent one.
+    const promptTemplate = DEFAULT_PROMPT;
 
     // Replace variables in the prompt
     const prompt = promptTemplate

--- a/src/app/api/pages/[id]/transliterate/route.ts
+++ b/src/app/api/pages/[id]/transliterate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { anonActionGate } from '@/lib/anon-gate';
 import { performTransliteration } from '@/lib/ai';
 const TRANSLITERATION_MODEL = 'gemini-3-flash-preview';
 import { logGeminiCall } from '@/lib/gemini-logger';
@@ -53,7 +54,12 @@ export async function POST(
     const db = await getDb();
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = TRANSLITERATION_MODEL } = body;
+    const { regenerate = false } = body;
+    // The caller does not get to name the model. It used to, and the value went
+    // straight to getGenerativeModel(), so anyone inside the anonymous budget
+    // below could spend it on the most expensive model on offer instead of the
+    // cheap one this job is costed for.
+    const model = TRANSLITERATION_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id });
@@ -85,6 +91,18 @@ export async function POST(
         script: page.transliteration.script,
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 }
       });
+    }
+
+    // Generation is a paid Gemini call — measured at ~12s plus ~5.6s per 1000
+    // OCR characters, up to nearly three minutes on a long page. Cached serves
+    // above are free and stay ungated; generation is capped per IP for
+    // anonymous callers, exactly as the alignment route caps trace mode.
+    const gate = await anonActionGate(request, { name: 'transliterate', limit: 15, allowBotBypass: false });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        { error: 'Transliteration limit reached. Sign in (free) to keep going.', retry_after: gate.retryAfter },
+        { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
+      );
     }
 
     // Perform transliteration

--- a/src/lib/anon-gate.ts
+++ b/src/lib/anon-gate.ts
@@ -66,11 +66,20 @@ async function hasSession(): Promise<boolean> {
   }
 }
 
-/** True when this request should bypass anon gating entirely. */
-async function isExempt(request: Request): Promise<boolean> {
-  if (request.headers.get('x-warm-ping')) return true; // internal cache warmers
-  if (isVerifiedBot(request)) return true;             // SEO crawlers
-  if (await hasSession()) return true;                 // signed-in users
+/**
+ * True when this request should bypass anon gating entirely.
+ *
+ * `allowBotBypass` exists because the UA check above is spoofable and its
+ * stated worst case — "a scraper getting the same access as a logged-out
+ * human" — only holds for CONTENT. For an action that spends money per call,
+ * `curl -A googlebot` would buy unlimited Gemini requests, so spend-class
+ * call sites pass false. A crawler has no business asking us to transliterate
+ * a page anyway: it indexes what is already there.
+ */
+async function isExempt(request: Request, allowBotBypass = true): Promise<boolean> {
+  if (request.headers.get('x-warm-ping')) return true;              // internal cache warmers
+  if (allowBotBypass && isVerifiedBot(request)) return true;        // SEO crawlers
+  if (await hasSession()) return true;                              // signed-in users
   return false;
 }
 
@@ -87,9 +96,9 @@ export interface GateResult {
  */
 export async function anonActionGate(
   request: Request,
-  opts: { name: string; limit: number; windowSeconds?: number },
+  opts: { name: string; limit: number; windowSeconds?: number; allowBotBypass?: boolean },
 ): Promise<GateResult> {
-  if (await isExempt(request)) return { allowed: true };
+  if (await isExempt(request, opts.allowBotBypass ?? true)) return { allowed: true };
   // Shared (cross-instance) cap — these actions are Gemini-backed, so the limit
   // has to be a real global cap, not a per-lambda soft cap. Falls back to the
   // in-memory limiter automatically if Mongo is slow/unavailable.


### PR DESCRIPTION
## The hole

`POST /api/pages/[id]/ask` accepts a `customPrompt` that **replaces the prompt template outright** and passes it straight to `model.generateContent()` — with no `auth()`, no rate limit, and no schema.

That is a free, anonymous, general-purpose Gemini proxy on the site's API key, reachable by anyone who opens the network tab. `history` is unbounded and is concatenated into the prompt, so a single request can carry an arbitrary number of input tokens at flash-preview's $0.50/M in, $3.00/M out. Each call also fans out up to 6 server-side fetches to `https://sourcelibrary.org/api`, so it amplifies.

**Open on production today.** Nothing in the UI calls it yet, which is why it went unnoticed — the reader redesign is what would put it in front of every anonymous reader, and that is where it was found.

## The fix

- `customPrompt` removed. No caller in this repo has ever sent one (`git grep customPrompt` — every hit is OCR/translation pipeline, a different parameter).
- `history` capped at 12 turns × 4k chars; `question` capped at 2k and type-checked.
- `anonActionGate({ name: 'page-ask', limit: 10 })` — the same per-IP gate the alignment route uses. Signed-in users are exempt.

## Two related holes closed while here

**The transliterate routes let the caller name the model**, and it went straight to `getGenerativeModel()`. Anyone inside the anonymous budget could spend it on the most expensive model on offer instead of the cheap one the job is costed for. Fixed server-side, and generation (not cached reads) is now capped per IP.

**`anonActionGate` exempted any user-agent containing "googlebot".** Its own comment reasons the worst case is "a scraper getting the same access as a logged-out human" — true for content, false for an action that spends money per call, where `curl -A googlebot` bought unlimited paid requests. Spend-class call sites now pass `allowBotBypass: false`. A crawler has no business asking us to transliterate a page; it indexes what is already there.

## Verification

`tsc` clean, `eslint` clean on changed files, `npm run build` succeeds, 2,994 unit + 41 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)