### PR TITLE
Add a feedback panel to the reader

### DIFF
--- a/src/components/reader-v2/FeedbackPanel.tsx
+++ b/src/components/reader-v2/FeedbackPanel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * Send feedback about the page you are reading, without leaving it.
+ *
+ * The reader already had a "Send feedback" link in the site menu, but that
+ * navigates away — so the reader loses the page, and with it the one piece of
+ * context that makes a report actionable. This panel keeps the page and sends
+ * its URL along with the note, the way the on-page widget does elsewhere.
+ *
+ * Everything the panel needs is inside the panel: the form, the page it will
+ * name, the send state and the result. No modal, no navigation.
+ */
+
+import { useState } from 'react';
+import { Loader2, Check } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { useLocale } from '@/lib/i18n';
+import { getReaderStrings } from '@/lib/reader-strings';
+import { MIN_FEEDBACK_MESSAGE, MAX_FEEDBACK_MESSAGE } from '@/lib/feedback-limits';
+import type { Book, Page } from '@/lib/types';
+
+const FIELD =
+  'w-full border font-sans text-[16px] lg:text-[13px] px-2.5 py-2 outline-none transition-colors '
+  + 'focus:border-[var(--text-muted)]';
+
+export function FeedbackPanel({ page, book, url }: { page: Page; book: Book; url: string }) {
+  const t = getReaderStrings(useLocale()).feedback;
+  const { data: session } = useSession();
+  const [message, setMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signedInEmail = session?.user?.email || '';
+  const tooShort = message.trim().length < MIN_FEEDBACK_MESSAGE;
+
+  async function send() {
+    if (sending || tooShort) { setError(tooShort ? t.tooShort : null); return; }
+    setSending(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: message.trim().slice(0, MAX_FEEDBACK_MESSAGE),
+          // The page is the point. A note that says "the translation stops
+          // halfway" is unusable without knowing which page it stopped on.
+          page: url,
+          email: (email.trim() || signedInEmail) || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      setSent(true);
+    } catch {
+      // Only claim it reached us when it did.
+      setError(t.failed);
+    }
+    setSending(false);
+  }
+
+  if (sent) {
+    return (
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pt-4 pb-5" style={{ overscrollBehavior: 'contain' }}>
+        <p
+          className="font-sans text-[13px] leading-relaxed flex items-start gap-2"
+          style={{ color: 'var(--text-primary)' }}
+          role="status"
+        >
+          <Check size={15} className="shrink-0 mt-0.5" style={{ color: 'var(--accent-sage-dark)' }} />
+          {t.thanks}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto px-4 pt-3 pb-5" style={{ overscrollBehavior: 'contain' }}>
+      <p className="font-sans text-[12.5px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+        {t.blurb}
+      </p>
+
+      <label className="block mt-3">
+        <span className="sr-only">{t.placeholder}</span>
+        <textarea
+          value={message}
+          onChange={e => { setMessage(e.target.value); if (error) setError(null); }}
+          placeholder={t.placeholder}
+          rows={5}
+          maxLength={MAX_FEEDBACK_MESSAGE}
+          className={`${FIELD} resize-y leading-relaxed`}
+          style={{ borderColor: 'var(--border-medium)', background: 'var(--bg-white)', color: 'var(--text-primary)' }}
+        />
+      </label>
+
+      <label className="block mt-3">
+        <span className="block font-sans text-[11.5px] pb-1" style={{ color: 'var(--text-muted)' }}>
+          {t.emailLabel}
+        </span>
+        <input
+          type="email"
+          inputMode="email"
+          value={email || signedInEmail}
+          onChange={e => setEmail(e.target.value)}
+          placeholder={t.emailPlaceholder}
+          className={FIELD}
+          style={{ borderColor: 'var(--border-medium)', background: 'var(--bg-white)', color: 'var(--text-primary)' }}
+        />
+        <span className="block font-sans text-[11px] leading-snug pt-1" style={{ color: 'var(--text-faint)' }}>
+          {t.emailNote}
+        </span>
+      </label>
+
+      <div className="flex items-center gap-3 pt-3.5">
+        <button
+          type="button"
+          onClick={send}
+          disabled={sending || tooShort}
+          className="inline-flex items-center gap-2 h-9 px-3.5 border font-sans text-[12.5px] transition-opacity hover:opacity-85 disabled:opacity-45 disabled:cursor-default"
+          style={{ background: 'var(--text-primary)', color: 'var(--bg-cream)', borderColor: 'var(--text-primary)' }}
+        >
+          {sending && <Loader2 size={13} className="animate-spin" />}
+          {sending ? t.sending : t.send}
+        </button>
+      </div>
+
+      {error && (
+        <p className="font-sans text-[12.5px] pt-2.5" style={{ color: 'var(--status-error)' }} role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Said plainly rather than left implicit: the note carries the page,
+          and a reader should know that before they write it. */}
+      <p className="font-sans text-[11.5px] leading-snug pt-4" style={{ color: 'var(--text-faint)' }}>
+        {t.aboutPage(page.page_number ?? '—')}
+        {book.display_title || book.title ? ` ${book.display_title || book.title}` : ''}
+      </p>
+    </div>
+  );
+}

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -9,6 +9,7 @@ import { useSession, signOut } from 'next-auth/react';
 import Logo from '@/components/layout/Logo';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import DownloadButton from '@/components/ui/DownloadButton';
+import { FeedbackPanel } from './FeedbackPanel';
 import PageDeepZoomButton from '@/components/reader/PageDeepZoomButton';
 import type { DeepZoomManifest } from '@/lib/types/book';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
@@ -59,7 +60,7 @@ const PANEL_HEADER_BG = 'color-mix(in srgb, var(--bg-warm) 92%, var(--bg-dark) 5
 /** Mobile sheets that always take the full height — lists and conversations. */
 const SHEET_FILLS = new Set<Exclude<LeftPanel, null>>(['contents', 'search', 'guide', 'librarian']);
 
-type LeftPanel = 'contents' | 'search' | 'guide' | 'librarian' | 'info' | 'cite' | 'share' | 'settings' | 'views' | 'downloads' | 'history' | 'save' | 'more' | null;
+type LeftPanel = 'contents' | 'search' | 'guide' | 'librarian' | 'info' | 'cite' | 'share' | 'settings' | 'views' | 'downloads' | 'history' | 'save' | 'feedback' | 'more' | null;
 
 /**
  * Drawer titles and the one line under each — saying what the tool actually
@@ -84,7 +85,7 @@ function panelBlurb(t: ReaderStrings, panel: Exclude<LeftPanel, null>): string |
 const MORE_TOOLS = [
   'cite', 'downloads', 'info', 'history',
   'contents', 'guide', 'search', 'librarian',
-  'settings',
+  'settings', 'feedback',
 ] as const;
 
 interface Reader2CProps {
@@ -2129,6 +2130,9 @@ function PanelContent({
   if (panel === 'info') {
     return <InfoPanel page={r.currentPage} book={r.book} />;
   }
+  if (panel === 'feedback') {
+    return <FeedbackPanel page={r.currentPage} book={r.book} url={shareUrl} />;
+  }
   if (panel === 'share') {
     return <SharePanel page={r.currentPage} book={r.book} url={shareUrl} />;
   }
@@ -2883,6 +2887,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
           <span className="w-6 my-1.5 shrink-0" style={{ borderTop: `1px solid ${onInk(0.14)}` }} aria-hidden="true" />
 
           <RailButton label={t.toolbar.settings} active={leftPanel === 'settings'} onClick={() => togglePanel('settings')} icon={AaGlyph} />
+          <RailButton label={t.toolbar.feedback} active={leftPanel === 'feedback'} onClick={() => togglePanel('feedback')} icon={<MessageSquare size={17} />} />
           {/* Editing is editor-and-above only, so the affordance is gated the
               same way the current reader gates its Read/Edit toggle. */}
           <AuthCheck role="inner_circle">

--- a/src/lib/reader-strings.ts
+++ b/src/lib/reader-strings.ts
@@ -63,6 +63,7 @@ export interface ReaderStrings {
     views: string;
     pages: string;
     settings: string;
+    feedback: string;
     more: string;
     menu: string;
     readerToolsAria: string;
@@ -96,6 +97,7 @@ export interface ReaderStrings {
       views: string;
       downloads: string;
       history: string;
+      feedback: string;
       more: string;
     };
     blurbs: {
@@ -138,6 +140,8 @@ export interface ReaderStrings {
     historyBlurb: string;
     settings: string;
     settingsBlurb: string;
+    feedback: string;
+    feedbackBlurb: string;
     menu: string;
     menuBlurb: string;
   };
@@ -365,6 +369,22 @@ export interface ReaderStrings {
     wholeBook: string;
   };
 
+  /** Feedback panel — a note to us about this page or the reader itself. */
+  feedback: {
+    blurb: string;
+    placeholder: string;
+    emailLabel: string;
+    emailPlaceholder: string;
+    emailNote: string;
+    send: string;
+    sending: string;
+    thanks: string;
+    failed: string;
+    tooShort: string;
+    /** Reminds the reader which page the note will carry. */
+    aboutPage: (pageNumber: number | string) => string;
+  };
+
   /** Revision history panel (public; the Restore action itself stays
    *  editor-only/English — see the file header note). */
   history: {
@@ -472,6 +492,7 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       views: 'Views',
       pages: 'Pages',
       settings: 'Settings',
+      feedback: 'Feedback',
       more: 'More',
       menu: 'Menu',
       readerToolsAria: 'Reader tools',
@@ -502,6 +523,7 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
         views: 'Scan, text & translation',
         downloads: 'Download',
         history: 'Revision history',
+        feedback: 'Send feedback',
         more: 'More',
       },
       blurbs: {
@@ -539,6 +561,8 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       historyBlurb: 'Every recorded change to this page',
       settings: 'Reading settings',
       settingsBlurb: 'Theme, text size, typeface, notes',
+      feedback: 'Send feedback',
+      feedbackBlurb: 'Tell us about this page or the reader',
       menu: 'Menu',
       menuBlurb: 'The rest of the library, and your account',
     },
@@ -712,6 +736,19 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       downloadFailed: 'That download failed. Try again.',
       wholeBook: 'The whole book',
     },
+    feedback: {
+      blurb: 'Anything wrong, missing, or worth knowing about this page or the reader itself.',
+      placeholder: 'What did you notice?',
+      emailLabel: 'Email',
+      emailPlaceholder: 'you@example.com',
+      emailNote: 'Only if you would like a reply. We will not use it for anything else.',
+      send: 'Send',
+      sending: 'Sending…',
+      thanks: 'Thank you. This has reached us, along with the page you were on.',
+      failed: 'That did not send. Try again in a moment.',
+      tooShort: 'Tell us a little more first.',
+      aboutPage: (pageNumber) => `Your note will say you were on p. ${pageNumber}.`,
+    },
     history: {
       title: 'Revision history',
       loading: 'Loading revision history…',
@@ -800,6 +837,7 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       views: 'Vistas',
       pages: 'Páginas',
       settings: 'Ajustes',
+      feedback: 'Comentarios',
       more: 'Más',
       menu: 'Menú',
       readerToolsAria: 'Herramientas del lector',
@@ -830,6 +868,7 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
         views: 'Escaneo, texto y traducción',
         downloads: 'Descargar',
         history: 'Historial de revisiones',
+        feedback: 'Enviar comentarios',
         more: 'Más',
       },
       blurbs: {
@@ -867,6 +906,8 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       historyBlurb: 'Todos los cambios registrados en esta página',
       settings: 'Ajustes de lectura',
       settingsBlurb: 'Tema, tamaño de letra, tipografía, notas',
+      feedback: 'Enviar comentarios',
+      feedbackBlurb: 'Cuéntanos algo sobre esta página o sobre el lector',
       menu: 'Menú',
       menuBlurb: 'El resto de la biblioteca, y tu cuenta',
     },
@@ -1046,6 +1087,19 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       signInToDownload: 'Inicia sesión para descargar esta página.',
       downloadFailed: 'La descarga falló. Inténtalo de nuevo.',
       wholeBook: 'El libro entero',
+    },
+    feedback: {
+      blurb: 'Cualquier cosa que esté mal, que falte o que convenga saber sobre esta página o sobre el lector.',
+      placeholder: '¿Qué has visto?',
+      emailLabel: 'Correo electrónico',
+      emailPlaceholder: 'tu@ejemplo.com',
+      emailNote: 'Solo si quieres que te respondamos. No lo usaremos para nada más.',
+      send: 'Enviar',
+      sending: 'Enviando…',
+      thanks: 'Gracias. Nos ha llegado, junto con la página en la que estabas.',
+      failed: 'No se ha enviado. Inténtalo de nuevo en un momento.',
+      tooShort: 'Cuéntanos un poco más primero.',
+      aboutPage: (pageNumber) => `Tu mensaje indicará que estabas en la p. ${pageNumber}.`,
     },
     history: {
       title: 'Historial de revisiones',


### PR DESCRIPTION
The reader had a "Send feedback" link that navigated away, so the reader lost the page — and with it the one piece of context that makes a report actionable. A note saying "the translation stops halfway" is unusable without knowing which page it stopped on.

Behaves like every other panel: drawer on desktop, sheet on mobile, opened from the rail below Settings and above Edit, everything it needs inside it. Message, optional email for a reply (prefilled when signed in), send state and result. Posts the page URL alongside and says so above the form. Only reports success when the POST succeeded. Both languages.

`tsc` clean, `eslint` clean, build succeeds, 2,999 unit + 41 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)