### PR TITLE
Geometry-reel tooling: gallery sweeps, circle extraction, animated reels, print artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,13 @@ scripts/_tmp_*
 scripts/output/
 /check-*.mjs
 
+# Generated publication artifacts (EPUBs, covers, extracted plate images, manifests).
+# These are large binaries built on demand from the library — never committed.
+esoteric-geometries-out/
+kdp-out/
+**/*.epub
+.geo-*.jpg
+
 # Session coordination scratch (its own README says: never commit)
 .claude/agent-comms/
 

--- a/scripts/publication/esoteric-geometries.mjs
+++ b/scripts/publication/esoteric-geometries.mjs
@@ -1,0 +1,692 @@
+/**
+ * esoteric-geometries.mjs — build "The Source Library Guide to Esoteric Geometries".
+ *
+ * Scans the library's already-extracted illustrations (gallery_images) for
+ * geometric/diagrammatic plates from the Western esoteric traditions —
+ * Platonic/Pythagorean solids, the Monad, macrocosm–microcosm cosmograms,
+ * the Kabbalistic Tree of Life, magic squares & planetary seals, ritual magic
+ * circles, Lullian/mnemonic wheels, and alchemical–Rosicrucian emblematic
+ * geometry — classifies them into thematic chapters, curates for quality and
+ * diversity, and renders a single illustrated EPUB plus a review manifest.
+ *
+ * DATA SOURCE: the public gallery API (https://sourcelibrary.org/api/gallery),
+ * so it runs with no database credentials. Every plate is already extracted,
+ * quality-scored, and given a museum description by the image pipeline; this
+ * script only *selects and renders*.
+ *
+ * Usage:
+ *   node scripts/publication/esoteric-geometries.mjs [--out <dir>] [--base <url>]
+ *        [--max <globalCap>] [--per-book <n>] [--per-chapter <n>] [--min-quality <0-1>]
+ *        [--manifest-only]
+ *
+ * Output (in <dir>, default ./scripts/output/esoteric-geometries — git-ignored):
+ *   esoteric-geometries.epub   the illustrated guide
+ *   cover.jpg                  the cover image
+ *   manifest.json              every selected plate + its chapter (for review)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import archiver from 'archiver';
+import sharp from 'sharp';
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const a = argv.slice(2);
+  const get = (flag, def) => {
+    const i = a.indexOf(flag);
+    return i >= 0 ? a[i + 1] : def;
+  };
+  return {
+    // Default under scripts/output/ (git-ignored) so generated binaries never
+    // land in the repo even if --out is omitted. Override with --out anywhere.
+    out: resolve(get('--out', join(process.cwd(), 'scripts/output/esoteric-geometries'))),
+    base: get('--base', 'https://sourcelibrary.org'),
+    globalCap: Number(get('--max', '90')),
+    perBook: Number(get('--per-book', '3')),
+    perChapter: Number(get('--per-chapter', '14')),
+    minQuality: Number(get('--min-quality', '0.7')),
+    manifestOnly: a.includes('--manifest-only'),
+  };
+}
+
+const CFG = parseArgs(process.argv);
+
+// Image types that never belong in a geometry guide.
+const EXCLUDE_TYPES = new Set(['decorative', 'exlibris', 'bookplate', 'portrait', 'printer_device', 'ornament', 'border']);
+
+// A plate must clearly belong to a theme (score >= this) to be included.
+const MIN_SCORE = 3;
+
+// Types that carry genuine diagrammatic geometry get a small bonus so they
+// clear the threshold ahead of allegorical title pages that merely mention a
+// theme word.
+const TYPE_BONUS = { diagram: 1.5, symbol: 1.0, emblem: 0.5 };
+
+// Text that disqualifies a plate outright — off-theme subjects that keep
+// matching on stray keywords (anatomy, botany, optics, machinery, pure
+// decoration). Matched case-insensitively against the combined text.
+const BLOCK_TERMS = [
+  'phlebotomy', 'bloodletting', 'magic lantern', 'botanical illustration',
+  'unidentified plant', 'woodcut initial', "printer's device", 'title page border',
+  'title-page border', 'decorative border', 'reading wheel', 'bookwheel',
+  'anatomical', 'dissection', 'herbal',
+];
+
+const TITLE = 'The Source Library Guide to Esoteric Geometries';
+const SUBTITLE = 'Sacred, Hermetic, and Magical Diagrams from the Western Tradition';
+
+// ─── Thematic taxonomy ────────────────────────────────────────────────────
+// Each chapter has an id, display title, a short editorial intro, and a set of
+// scored keywords matched against a plate's combined text (book title +
+// description + museum description + subjects + symbols). A plate is assigned
+// to the highest-scoring chapter; unmatched plates fall to "further".
+
+const CHAPTERS = [
+  {
+    id: 'platonic',
+    title: 'The Platonic Solids and the Harmony of the Spheres',
+    intro:
+      'That the world is built on number and figure is the oldest of geometric convictions. In the five regular solids the Pythagoreans and their heirs read the elements themselves, and Kepler would later nest them inside the planetary orbits. Here are the tetrahedra, cubes, and dodecahedra by which geometry was made a theology of the cosmos.',
+    keywords: {
+      platonic: 3, tetrahed: 3, octahedron: 3, dodecahedron: 3, icosahedron: 3,
+      polyhedron: 2, polyhedra: 2, 'regular solid': 3, 'five solids': 3,
+      kepler: 2, euclid: 2, 'elements of geomet': 3, pythagor: 3, tetractys: 3,
+      quaternary: 2, 'harmony of the spheres': 3, 'perspectiva corporum': 4,
+      'geometric construction': 3, 'geometric solid': 3,
+    },
+  },
+  {
+    id: 'monad',
+    title: 'The Monad, the Point, and the Circle',
+    intro:
+      'All figure begins in the point and unfolds into the circle. From the single mark the geometer derives line, plane, and world — a procession the Hermeticists called the Monad. John Dee compressed the whole of this doctrine into one composite glyph; others sought it in the squaring of the circle and the sweep of the compass.',
+    keywords: {
+      monad: 3, 'hieroglyphic monad': 4, ' dee': 2, 'john dee': 3, unity: 1,
+      'squaring the circle': 3, compass: 1, 'point and': 2, 'the one': 1,
+    },
+  },
+  {
+    id: 'macro',
+    title: 'Macrocosm and Microcosm',
+    intro:
+      'As above, so below. The great tradition held the human being to be a small world mirroring the great one, the two bound by ratio and correspondence. In these diagrams the spheres of the elements, planets, and fixed stars are drawn about a central figure, and the structure of the cosmos is rendered as a single legible pattern.',
+    keywords: {
+      macrocosm: 4, microcosm: 4, fludd: 3, utriusque: 3, 'world soul': 3,
+      'anima mundi': 3, 'zodiac man': 4, 'homo signorum': 4, cosmolog: 2,
+      ptolemaic: 3, geocentric: 3, 'elemental spheres': 3,
+      'concentric spheres': 3, 'sphere of the': 2, armillary: 2,
+    },
+  },
+  {
+    id: 'tree',
+    title: 'The Tree of Life and the Kabbalistic Diagrams',
+    intro:
+      'The Kabbalah maps the descent of the divine into ten luminous vessels joined by twenty-two paths — the Sephirotic Tree. Around it grew a whole geometry of emanation: gates, ladders, and concentric worlds. These plates trace the figure through its Hebrew sources and its Christian-Hermetic adaptations.',
+    keywords: {
+      kabbal: 4, cabal: 3, cabbal: 3, sephir: 4, 'tree of life': 4,
+      'gates of light': 4, shaarei: 3, ilan: 3, "ain soph": 3, 'ein sof': 3,
+      'ten sefirot': 4, emanation: 2, hebrew: 1, sefira: 3,
+    },
+  },
+  {
+    id: 'squares',
+    title: 'Magic Squares, Planetary Seals, and Numerical Sigils',
+    intro:
+      'Where number becomes talisman, geometry turns operative. The planetary magic squares — each cell summing to a sacred constant — generate the seals and characters engraved on amulets and drawn in the grimoires. Agrippa and Kircher systematized them; here are the grids, kameas, and sigils in which arithmetic was made magical.',
+    keywords: {
+      'magic square': 4, kamea: 4, 'planetary seal': 4, sigil: 3, sigillum: 3,
+      arithmolog: 3, 'character of the planet': 4, 'numerical square': 3,
+      'planetary character': 4, talisman: 2, 'planetary sigil': 4,
+    },
+  },
+  {
+    id: 'circles',
+    title: 'Magic Circles and Ritual Geometry',
+    intro:
+      'The circle drawn for conjuration is geometry pressed into service as protection and boundary. Divided by crosses, inscribed with divine names, and ringed with the signs of hour and planet, the ritual figures of the Heptameron and the Goetia are among the most precisely diagrammed objects in the whole magical literature.',
+    keywords: {
+      'magic circle': 4, heptameron: 4, goetia: 3, conjuration: 3, pentacle: 3,
+      'seal of solomon': 4, hexagram: 3, invocation: 2, 'ritual circle': 4,
+      'protective circle': 3, ' ritual': 1, grimoire: 2,
+    },
+  },
+  {
+    id: 'wheels',
+    title: 'Combinatorial Wheels and the Art of Memory',
+    intro:
+      'Ramon Llull built a logic of rotating circles, and Giordano Bruno turned the same device into an engine of memory and vision. The volvelle — a wheel of paper that turns within the page — let the reader combine terms, letters, and images by hand. These revolving figures are geometry set in motion.',
+    keywords: {
+      llull: 4, lull: 3, 'ramon': 2, volvelle: 4, mnemonic: 3, combinatorial: 4,
+      ' bruno': 3, 'giordano': 3, 'art of memory': 4, revolving: 2, rotating: 2,
+      'wheel': 2, ' ars ': 2, 'porta veneris': 3, 'atrium veneris': 3,
+    },
+  },
+  {
+    id: 'cosmogram',
+    title: 'Alchemical Cosmograms and Emblematic Geometry',
+    intro:
+      'In the alchemical and Rosicrucian books, geometry becomes emblem: circles, triangles, and squares stacked into figures that encode the stages of the Work and the structure of a hidden cosmos. Boehme\u2019s spheres of the divine, the Rosicrucian secret symbols, and the plates of the Theatrum Chemicum gather here.',
+    keywords: {
+      alchem: 3, rosicrucian: 3, 'rosy cross': 3, boehme: 3, behmen: 3,
+      theosophical: 2, 'secret symbols': 4, hermetic: 2, 'prima materia': 3,
+      tincture: 2, 'squaring the circle': 4, 'alchemical diagram': 3,
+      'alchemical emblem': 3, coniunctio: 3, athanor: 2,
+    },
+  },
+];
+
+const CHAPTER_INDEX = new Map(CHAPTERS.map((c, i) => [c.id, i]));
+
+// Targeted queries designed to surface esoteric (not merely scientific)
+// geometry. Each is paginated and merged; dedupe happens on pageId-detIndex.
+const QUERIES = [
+  { semantic: true, q: 'esoteric sacred hermetic geometric diagram cosmogram' },
+  { subject: 'alchemy', type: 'diagram' },
+  { subject: 'kabbalah' },
+  { subject: 'astrology', type: 'diagram' },
+  { q: 'magic square planetary seal sigil kamea agrippa' },
+  { q: 'platonic solid polyhedron kepler euclid tetractys pythagorean' },
+  { q: 'magic circle heptameron pentacle seal of solomon hexagram' },
+  { q: 'lull llull volvelle mnemonic combinatorial wheel giordano bruno' },
+  { q: 'macrocosm microcosm fludd world soul zodiac man elemental spheres' },
+  { q: 'hieroglyphic monad john dee squaring the circle' },
+  { q: 'tree of life sephirot gates of light kabbalistic emanation' },
+  { q: 'rosicrucian secret symbols boehme theosophical cosmological diagram' },
+];
+
+// ─── Fetch + select ───────────────────────────────────────────────────────
+
+function buildUrl(query, offset, limit) {
+  const u = new URL('/api/gallery', CFG.base);
+  u.searchParams.set('minQuality', String(CFG.minQuality));
+  u.searchParams.set('limit', String(limit));
+  u.searchParams.set('offset', String(offset));
+  u.searchParams.set('maxPerBook', '6');
+  for (const [k, v] of Object.entries(query)) u.searchParams.set(k, String(v));
+  return u.toString();
+}
+
+async function fetchQuery(query, maxDepth = 200) {
+  const limit = 100;
+  const out = [];
+  for (let offset = 0; offset < maxDepth; offset += limit) {
+    let json;
+    try {
+      const r = await fetch(buildUrl(query, offset, limit));
+      if (!r.ok) break;
+      json = await r.json();
+    } catch (e) {
+      console.warn(`  ! query failed (${JSON.stringify(query)}): ${e.message}`);
+      break;
+    }
+    const items = json.items || [];
+    out.push(...items);
+    if (items.length < limit) break;
+  }
+  return out;
+}
+
+function plateKey(it) {
+  return `${it.pageId}-${it.detectionIndex}`;
+}
+
+function combinedText(it) {
+  const m = it.metadata || {};
+  return [
+    it.bookTitle,
+    it.description,
+    it.museumDescription,
+    (m.subjects || []).join(' '),
+    (m.symbols || []).join(' '),
+    (m.figures || []).join(' '),
+  ]
+    .filter(Boolean)
+    .join(' \u00b7 ')
+    .toLowerCase();
+}
+
+function classify(it) {
+  const text = combinedText(it);
+  if (BLOCK_TERMS.some(t => text.includes(t))) return null;
+
+  const typeBonus = TYPE_BONUS[it.type] ?? 0;
+  let best = null;
+  let bestScore = 0;
+  for (const ch of CHAPTERS) {
+    let score = 0;
+    for (const [kw, weight] of Object.entries(ch.keywords)) {
+      if (text.includes(kw)) score += weight;
+    }
+    if (score === 0) continue; // no thematic signal for this chapter
+    const total = score + typeBonus;
+    if (total > bestScore) {
+      bestScore = total;
+      best = ch.id;
+    }
+  }
+  return bestScore >= MIN_SCORE ? best : null;
+}
+
+async function gatherCandidates() {
+  console.log(`Scanning library for geometric plates (source: ${CFG.base})\u2026`);
+  const byKey = new Map();
+  for (const query of QUERIES) {
+    const items = await fetchQuery(query);
+    let added = 0;
+    for (const it of items) {
+      const key = plateKey(it);
+      if (byKey.has(key)) continue;
+      if (EXCLUDE_TYPES.has(it.type)) continue;
+      if ((it.galleryQuality ?? 0) < CFG.minQuality) continue;
+      if (!it.extractedUrl && !it.imageUrl) continue;
+      byKey.set(key, it);
+      added++;
+    }
+    console.log(`  ${JSON.stringify(query)} -> +${added} new (total ${byKey.size})`);
+  }
+  return [...byKey.values()];
+}
+
+// Curate: assign chapters, then cap per book (diversity), per chapter, and
+// globally, always keeping the highest-quality plates first.
+function curate(allCandidates) {
+  const candidates = [];
+  for (const it of allCandidates) {
+    const ch = classify(it);
+    if (!ch) continue; // no clear thematic home → drop (precision over recall)
+    it._chapter = ch;
+    candidates.push(it);
+  }
+  candidates.sort((a, b) => (b.galleryQuality ?? 0) - (a.galleryQuality ?? 0));
+
+  const perBook = new Map();
+  const perChapter = new Map();
+  const selected = [];
+
+  for (const it of candidates) {
+    if (selected.length >= CFG.globalCap) break;
+    const bookN = perBook.get(it.bookId) ?? 0;
+    const chapN = perChapter.get(it._chapter) ?? 0;
+    if (bookN >= CFG.perBook) continue;
+    if (chapN >= CFG.perChapter) continue;
+    perBook.set(it.bookId, bookN + 1);
+    perChapter.set(it._chapter, chapN + 1);
+    selected.push(it);
+  }
+
+  // Group by chapter in taxonomy order; within a chapter, order by year then quality.
+  const grouped = CHAPTERS.map(ch => ({
+    ...ch,
+    plates: selected
+      .filter(it => it._chapter === ch.id)
+      .sort((a, b) => (a.year ?? 9999) - (b.year ?? 9999) || (b.galleryQuality ?? 0) - (a.galleryQuality ?? 0)),
+  })).filter(ch => ch.plates.length > 0);
+
+  return { grouped, selected };
+}
+
+// ─── EPUB rendering ─────────────────────────────────────────────────────────
+
+function escapeXml(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function xhtml(title, bodyClass, body) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+  <meta charset="UTF-8"/>
+  <title>${escapeXml(title)}</title>
+  <link rel="stylesheet" type="text/css" href="styles.css"/>
+</head>
+<body class="${bodyClass}">
+${body}
+</body>
+</html>`;
+}
+
+const CSS = `
+body { font-family: Georgia, 'Times New Roman', serif; line-height: 1.5; margin: 0; padding: 1.2em; color: #1a1612; }
+h1, h2, h3 { font-family: Georgia, serif; font-weight: 700; line-height: 1.2; }
+.title-page { text-align: center; padding-top: 22%; }
+.title-page h1 { font-size: 2.1em; letter-spacing: 0.02em; margin: 0 0 0.4em; }
+.title-page .subtitle { font-style: italic; font-size: 1.15em; color: #5a5348; margin-bottom: 2em; }
+.title-page .brand { font-size: 0.85em; letter-spacing: 0.35em; text-transform: uppercase; color: #8a7a54; }
+.rule { border: 0; border-top: 1px solid #c9a86c; width: 40%; margin: 1.4em auto; opacity: 0.7; }
+.chapter-intro { font-size: 1.02em; color: #3a352c; font-style: italic; margin: 0.6em 0 1.6em; }
+.plate { margin: 0 0 2.4em; page-break-inside: avoid; }
+.plate img { display: block; max-width: 100%; max-height: 88vh; margin: 0 auto 0.5em; }
+.plate .caption { font-size: 0.9em; color: #3a352c; }
+.plate .caption .figname { font-weight: 700; }
+.plate .source { font-size: 0.8em; color: #6a6357; margin-top: 0.3em; }
+.plate .source a { color: #8a7a54; text-decoration: none; }
+.frontmatter p { margin: 0 0 0.9em; }
+.colophon { font-size: 0.9em; color: #3a352c; }
+.colophon ul { padding-left: 1.2em; }
+.colophon li { margin-bottom: 0.3em; }
+figure { margin: 0; }
+`;
+
+async function fetchAndProcessImage(url, maxPx = 1200) {
+  const r = await fetch(url, { signal: AbortSignal.timeout(60000) });
+  if (!r.ok) throw new Error(`fetch ${r.status}`);
+  const buf = Buffer.from(await r.arrayBuffer());
+  const img = sharp(buf).rotate();
+  const out = await img
+    .resize(maxPx, maxPx, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 82, mozjpeg: true })
+    .toBuffer();
+  return out;
+}
+
+// Build a themed cover: best cosmogram plate as background + gradient scrim.
+async function buildCover(coverPlate) {
+  const W = 1600;
+  const H = 2400;
+  const GOLD = '#c9a86c';
+  const DARK = '#141019';
+
+  let bg;
+  try {
+    const src = coverPlate?.imageUrl || coverPlate?.extractedUrl;
+    const buf = Buffer.from(await (await fetch(src, { signal: AbortSignal.timeout(60000) })).arrayBuffer());
+    const resized = await sharp(buf).resize(W, H, { fit: 'cover', position: 'centre' }).toBuffer();
+    const scrim = `<svg width="${W}" height="${H}" xmlns="http://www.w3.org/2000/svg">
+      <defs><linearGradient id="s" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="${DARK}" stop-opacity="0.82"/>
+        <stop offset="30%" stop-color="${DARK}" stop-opacity="0.55"/>
+        <stop offset="46%" stop-color="${DARK}" stop-opacity="0.12"/>
+        <stop offset="70%" stop-color="${DARK}" stop-opacity="0.12"/>
+        <stop offset="86%" stop-color="${DARK}" stop-opacity="0.60"/>
+        <stop offset="100%" stop-color="${DARK}" stop-opacity="0.88"/>
+      </linearGradient></defs>
+      <rect width="${W}" height="${H}" fill="url(#s)"/></svg>`;
+    bg = await sharp(resized).composite([{ input: Buffer.from(scrim), top: 0, left: 0 }]).toBuffer();
+  } catch {
+    bg = await sharp({ create: { width: W, height: H, channels: 3, background: { r: 20, g: 16, b: 25 } } }).jpeg().toBuffer();
+  }
+
+  const wrap = (t, n) => {
+    const words = t.split(' ');
+    const lines = [];
+    let cur = '';
+    for (const w of words) {
+      if ((cur + ' ' + w).trim().length > n && cur) { lines.push(cur); cur = w; }
+      else cur = (cur + ' ' + w).trim();
+    }
+    if (cur) lines.push(cur);
+    return lines;
+  };
+  const titleLines = wrap('Esoteric Geometries', 16);
+  const topY = 360;
+  const titleEls = titleLines
+    .map((l, i) => `<text x="${W / 2}" y="${topY + i * 120}" font-family="serif" font-size="104" font-weight="700" fill="${GOLD}" text-anchor="middle" letter-spacing="2">${escapeXml(l)}</text>`)
+    .join('\n');
+  const kickerY = topY - 150;
+  const subY = topY + titleLines.length * 120 + 90;
+  const svg = `<svg width="${W}" height="${H}" xmlns="http://www.w3.org/2000/svg">
+    <text x="${W / 2}" y="${kickerY}" font-family="serif" font-size="40" font-style="italic" fill="${GOLD}" text-anchor="middle" letter-spacing="3">The Source Library Guide to</text>
+    ${titleEls}
+    <line x1="${W / 2 - 260}" y1="${subY - 46}" x2="${W / 2 + 260}" y2="${subY - 46}" stroke="${GOLD}" stroke-width="2" opacity="0.6"/>
+    <text x="${W / 2}" y="${subY}" font-family="serif" font-size="34" font-style="italic" fill="#d8c9a0" text-anchor="middle">Sacred, Hermetic, and Magical Diagrams</text>
+    <text x="${W / 2}" y="${subY + 46}" font-family="serif" font-size="34" font-style="italic" fill="#d8c9a0" text-anchor="middle">from the Western Tradition</text>
+    <text x="${W / 2}" y="${H - 150}" font-family="sans-serif" font-size="30" fill="${GOLD}" text-anchor="middle" letter-spacing="7" opacity="0.85">SOURCE LIBRARY</text>
+  </svg>`;
+  return sharp(bg).composite([{ input: Buffer.from(svg), top: 0, left: 0 }]).jpeg({ quality: 90, progressive: true }).toBuffer();
+}
+
+function plateCaption(plate, figNo) {
+  const desc = plate.museumDescription || plate.description || '';
+  const cite = [plate.bookTitle, plate.author && `— ${plate.author}`, plate.year && `(${plate.year})`]
+    .filter(Boolean)
+    .join(' ');
+  const galleryId = `${plate.pageId}-${plate.detectionIndex}`;
+  const url = `${CFG.base}/gallery/image/${galleryId}`;
+  return `<figure class="plate">
+  <img src="images/plate-${figNo}.jpg" alt="${escapeXml((plate.description || 'geometric diagram').slice(0, 120))}"/>
+  <figcaption class="caption">
+    <span class="figname">Fig. ${figNo}.</span> ${escapeXml(desc)}
+    <div class="source">${escapeXml(cite)} &#183; <a href="${url}">View at Source Library</a></div>
+  </figcaption>
+</figure>`;
+}
+
+async function buildEpub(grouped, selected) {
+  // Fetch + process all plate images first (numbered globally in reading order).
+  const readingOrder = [];
+  for (const ch of grouped) for (const p of ch.plates) readingOrder.push(p);
+
+  const imageFiles = []; // { name, buffer }
+  let figNo = 0;
+  const figNoByKey = new Map();
+  console.log(`Fetching + processing ${readingOrder.length} plate images\u2026`);
+  for (const p of readingOrder) {
+    figNo++;
+    figNoByKey.set(plateKey(p), figNo);
+    try {
+      const buf = await fetchAndProcessImage(p.extractedUrl || p.imageUrl);
+      imageFiles.push({ name: `images/plate-${figNo}.jpg`, buffer: buf });
+    } catch (e) {
+      console.warn(`  ! plate ${figNo} image failed: ${e.message}`);
+      figNoByKey.delete(plateKey(p));
+      figNo--;
+    }
+  }
+
+  // Cover: prefer a high-quality, roughly square cosmogram from macro/cosmogram/tree.
+  const coverPlate =
+    selected
+      .filter(p => ['macro', 'cosmogram', 'tree'].includes(p._chapter))
+      .filter(p => (p.aspect ?? 1) >= 0.6 && (p.aspect ?? 1) <= 1.15)
+      .sort((a, b) => (b.galleryQuality ?? 0) - (a.galleryQuality ?? 0))[0] ||
+    selected.sort((a, b) => (b.galleryQuality ?? 0) - (a.galleryQuality ?? 0))[0];
+  console.log(`Building cover (from: ${coverPlate?.bookTitle})\u2026`);
+  const coverBuffer = await buildCover(coverPlate);
+
+  // Source books for the colophon.
+  const books = new Map();
+  for (const p of selected) {
+    if (!books.has(p.bookId)) books.set(p.bookId, { title: p.bookTitle, author: p.author, year: p.year });
+  }
+  const bookList = [...books.values()].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
+
+  // XHTML documents.
+  const docs = [];
+  docs.push({ id: 'cover', href: 'cover.xhtml', title: 'Cover', linear: true,
+    content: xhtml('Cover', 'cover', `<div style="text-align:center"><img src="images/cover.jpg" alt="Cover" style="max-width:100%;max-height:100vh"/></div>`) });
+
+  docs.push({ id: 'title', href: 'title.xhtml', title: 'Title Page', linear: true,
+    content: xhtml('Title', 'title-page', `<div class="title-page">
+      <p class="brand">The Source Library Guide to</p>
+      <h1>Esoteric Geometries</h1>
+      <p class="subtitle">${escapeXml(SUBTITLE)}</p>
+      <hr class="rule"/>
+      <p class="brand">Source Library</p>
+    </div>`) });
+
+  const introBody = `<h1>On the Geometry of the Invisible</h1>
+    <div class="frontmatter">
+    <p>Long before geometry was a school subject it was a way of seeing. To the traditions gathered in this book \u2014 Pythagorean and Platonic, Hermetic and Kabbalistic, alchemical and magical \u2014 line and figure were not abstractions but the very grammar of creation. A circle could hold the cosmos; a square could bind a spirit; a lattice of numbers could carry the virtue of a planet.</p>
+    <p>This guide gathers ${selected.length} such figures, drawn from ${bookList.length} works across the Source Library, and arranges them by theme. Each plate is reproduced from a digitized original and accompanied by a short description; a link returns you to the source page, where the whole book may be read. Nothing here is reconstructed or redrawn \u2014 these are the diagrams as their makers left them.</p>
+    <p>Read them not as decoration but as arguments. Each was drawn to persuade the eye of an order it could not otherwise see.</p>
+    </div>`;
+  docs.push({ id: 'intro', href: 'intro.xhtml', title: 'Introduction', linear: true,
+    content: xhtml('Introduction', 'frontmatter', introBody) });
+
+  grouped.forEach((ch, i) => {
+    const plates = ch.plates
+      .map(p => {
+        const fn = figNoByKey.get(plateKey(p));
+        return fn ? plateCaption(p, fn) : '';
+      })
+      .filter(Boolean)
+      .join('\n');
+    const body = `<h1>${escapeXml(ch.title)}</h1>
+      <p class="chapter-intro">${escapeXml(ch.intro)}</p>
+      ${plates}`;
+    docs.push({ id: `chap-${ch.id}`, href: `chap-${ch.id}.xhtml`, title: ch.title, linear: true,
+      content: xhtml(ch.title, 'chapter', body) });
+  });
+
+  const colophonBody = `<h1>Colophon</h1>
+    <div class="colophon">
+    <p>This guide was assembled by the Source Library from illustrations already extracted and described by its image-analysis pipeline. Plates were selected by theme and quality, reproduced from digitized originals, and cited to their source works. Descriptions are editorial summaries generated during cataloguing; the diagrams themselves are unaltered facsimiles.</p>
+    <p><strong>Source works (${bookList.length}):</strong></p>
+    <ul>
+    ${bookList.map(b => `<li>${escapeXml([b.title, b.author && `\u2014 ${b.author}`, b.year && `(${b.year})`].filter(Boolean).join(' '))}</li>`).join('\n')}
+    </ul>
+    <p style="margin-top:1.4em">Read the complete works at <a href="${CFG.base}">sourcelibrary.org</a>.</p>
+    </div>`;
+  docs.push({ id: 'colophon', href: 'colophon.xhtml', title: 'Colophon', linear: true,
+    content: xhtml('Colophon', 'frontmatter', colophonBody) });
+
+  // nav.xhtml (EPUB3)
+  const navItems = docs
+    .filter(d => !['cover'].includes(d.id))
+    .map(d => `<li><a href="${d.href}">${escapeXml(d.title)}</a></li>`)
+    .join('\n');
+  const navDoc = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><meta charset="UTF-8"/><title>Contents</title></head>
+<body>
+<nav epub:type="toc" id="toc"><h1>Contents</h1><ol>
+${navItems}
+</ol></nav>
+</body></html>`;
+
+  // toc.ncx (EPUB2 compat)
+  const navPoints = docs
+    .filter(d => !['cover'].includes(d.id))
+    .map((d, i) => `<navPoint id="np-${i}" playOrder="${i + 1}"><navLabel><text>${escapeXml(d.title)}</text></navLabel><content src="${d.href}"/></navPoint>`)
+    .join('\n');
+  const uid = `urn:sourcelibrary:esoteric-geometries:${new Date().toISOString().slice(0, 10)}`;
+  const ncx = `<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+<head><meta name="dtb:uid" content="${uid}"/></head>
+<docTitle><text>${escapeXml(TITLE)}</text></docTitle>
+<navMap>
+${navPoints}
+</navMap></ncx>`;
+
+  // content.opf
+  const manifestItems = [
+    `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`,
+    `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`,
+    `<item id="css" href="styles.css" media-type="text/css"/>`,
+    `<item id="cover-image" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>`,
+    ...docs.map(d => `<item id="${d.id}" href="${d.href}" media-type="application/xhtml+xml"/>`),
+    ...imageFiles.map((f, i) => `<item id="img-${i}" href="${f.name}" media-type="image/jpeg"/>`),
+  ].join('\n');
+  const spine = docs.map(d => `<itemref idref="${d.id}"${d.linear ? '' : ' linear="no"'}/>`).join('\n');
+  const opf = `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:identifier id="pub-id">${uid}</dc:identifier>
+  <dc:title>${escapeXml(TITLE)}</dc:title>
+  <dc:creator>Source Library</dc:creator>
+  <dc:language>en</dc:language>
+  <dc:description>${escapeXml(SUBTITLE)}</dc:description>
+  <dc:publisher>Source Library</dc:publisher>
+  <dc:date>${new Date().toISOString().slice(0, 10)}</dc:date>
+  <meta property="dcterms:modified">${new Date().toISOString().replace(/\.\d+Z$/, 'Z')}</meta>
+</metadata>
+<manifest>
+${manifestItems}
+</manifest>
+<spine toc="ncx">
+${spine}
+</spine>
+</package>`;
+
+  // Assemble the ZIP.
+  const zip = await new Promise((resolvePromise, reject) => {
+    const chunks = [];
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    archive.on('data', c => chunks.push(c));
+    archive.on('end', () => resolvePromise(Buffer.concat(chunks)));
+    archive.on('error', reject);
+
+    // mimetype MUST be first and stored (uncompressed).
+    archive.append('application/epub+zip', { name: 'mimetype', store: true });
+    archive.append(
+      `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+<rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+</container>`,
+      { name: 'META-INF/container.xml' }
+    );
+    archive.append(opf, { name: 'OEBPS/content.opf' });
+    archive.append(navDoc, { name: 'OEBPS/nav.xhtml' });
+    archive.append(ncx, { name: 'OEBPS/toc.ncx' });
+    archive.append(CSS, { name: 'OEBPS/styles.css' });
+    archive.append(coverBuffer, { name: 'OEBPS/images/cover.jpg' });
+    for (const d of docs) archive.append(d.content, { name: `OEBPS/${d.href}` });
+    for (const f of imageFiles) archive.append(f.buffer, { name: `OEBPS/${f.name}` });
+    archive.finalize();
+  });
+
+  return { zip, coverBuffer, figCount: figNo, bookCount: bookList.length };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const candidates = await gatherCandidates();
+  console.log(`\nGathered ${candidates.length} unique candidate plates.`);
+
+  const { grouped, selected } = curate(candidates);
+  console.log(`\nCurated ${selected.length} plates across ${grouped.length} chapters:`);
+  for (const ch of grouped) console.log(`  ${ch.plates.length.toString().padStart(3)}  ${ch.title}`);
+
+  mkdirSync(CFG.out, { recursive: true });
+  const manifest = {
+    title: TITLE,
+    generated_at: new Date().toISOString(),
+    config: CFG,
+    chapters: grouped.map(ch => ({
+      id: ch.id,
+      title: ch.title,
+      plates: ch.plates.map(p => ({
+        galleryId: plateKey(p),
+        book: p.bookTitle,
+        author: p.author,
+        year: p.year,
+        type: p.type,
+        quality: p.galleryQuality,
+        description: p.description,
+        url: `${CFG.base}/gallery/image/${plateKey(p)}`,
+      })),
+    })),
+  };
+  writeFileSync(join(CFG.out, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  console.log(`\nWrote manifest -> ${join(CFG.out, 'manifest.json')}`);
+
+  if (CFG.manifestOnly) {
+    console.log('--manifest-only: skipping EPUB build.');
+    return;
+  }
+
+  const { zip, coverBuffer, figCount, bookCount } = await buildEpub(grouped, selected);
+  const epubPath = join(CFG.out, 'esoteric-geometries.epub');
+  const coverPath = join(CFG.out, 'cover.jpg');
+  writeFileSync(epubPath, zip);
+  writeFileSync(coverPath, coverBuffer);
+
+  console.log(`\nDone. ${figCount} plates from ${bookCount} works.`);
+  console.log(`  ${epubPath} (${(zip.length / 1024 / 1024).toFixed(2)} MB)`);
+  console.log(`  ${coverPath} (${(coverBuffer.length / 1024).toFixed(0)} KB)`);
+  console.log(`\nOpen the EPUB in a reader (or Kindle Previewer) to review.`);
+}
+
+main().catch(err => {
+  console.error('Generation failed:', err);
+  process.exit(1);
+});

--- a/scripts/publication/geometry-reel/README.md
+++ b/scripts/publication/geometry-reel/README.md
@@ -1,0 +1,46 @@
+# Esoteric Geometries — reel & print tooling
+
+One-off art tooling built around `scripts/publication/esoteric-geometries.mjs`
+(the EPUB generator). These scripts scan the public gallery API for circular
+plates (alchemical cosmograms, volvelles, Tibetan mandalas, chakra plates),
+center them with a gradient-based Hough circle detector, mask them to
+transparent discs, and assemble animated reels and print artifacts.
+
+Everything writes into `esoteric-geometries-out/` at the repo root (gitignored).
+All data comes from the public sourcelibrary.org API — no DB access needed.
+Some scripts carry an absolute `ROOT` path from the original session; adjust it
+(or run from the repo root) before reuse.
+
+## Gathering (gallery API sweeps)
+
+| Script | What it collects |
+|---|---|
+| `probe-buddhist.mjs` | Sizes the pool of Buddhist imagery available |
+| `gather-buddhist.mjs` | Downloads Buddhist mandala plates + manifest |
+| `gather-eyes.mjs` | "All-seeing eye" imagery |
+| `gather-psychedelic.mjs` | Proto-psychedelic / visionary-art material |
+| `gather-spiritual-anatomy.mjs` | Subtle-body / spiritual-anatomy plates |
+| `mandala-dataset.mjs` | Nested-circle mandala dataset (multi-circle Hough + NMS, relation classification, annotations.json) |
+| `mandala-center.mjs` | Center-crops the mandala dataset to the largest detected circle |
+
+## Circle extraction & reels
+
+| Script | Output |
+|---|---|
+| `build-gif.mjs` | The main animated reel (env-driven: `MASK`, `HERO`, `CLOSER`, `INCLUDE`, `EXCLUDE`, `OUTRO`, `WARP`, `TEMPO`, …). Contains the Hough detector and the swirl-warp engine |
+| `all-circles.mjs` | Masked discs for every keyword-circular plate, for curation |
+| `chakra-reel.mjs` | The seven Leadbeater chakras ascending, as a GIF |
+| `universe-warp.mjs` | Reel → Fludd-man vortex → stripe spiral → observable universe → Boehme eye warp finale (GIF + WebP) |
+| `warp-figure.mjs` | Standalone breathing swirl-warp on a single disc |
+| `recenter.mjs` | Rim-alignment grid search to fix a disc's center (`SEED_CX`/`SEED_CY`/`SEED_R`/`SEARCH` env seeds); rewrites the print disc, sticker, and button |
+| `citations.mjs` | Provenance list (Markdown + JSON) for every image in the reel |
+
+## Print & gift artifacts
+
+| Script | Output |
+|---|---|
+| `print-portfolio.mjs` | Letter PDF, one plate per tear-out page with citation (cover + colophon + 28 plates) |
+| `flipbook.mjs` | Printable flip-book sheets from the warp reel GIF |
+| `gifts-booklet.mjs` | "Eight Circles" booklet — the eight sticker/button designs with a significance paragraph each |
+
+Sticker and button artwork lands in `esoteric-geometries-out/playa-gifts/`.

--- a/scripts/publication/geometry-reel/all-circles.mjs
+++ b/scripts/publication/geometry-reel/all-circles.mjs
@@ -1,0 +1,133 @@
+// Mask a circle out of EVERY keyword-"circular" plate (the original ~31), not
+// just the ones that passed the confidence gate. Labels each with its detected
+// confidence and whether the reel USED the detection or fell back to center,
+// so we can evaluate which dropped plates are worth recovering.
+import sharp from 'sharp';
+import { readFileSync, readdirSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIR = '/tmp/geo-out/frames/OEBPS/images';
+const MANIFEST = '/tmp/geo-out/manifest.json';
+const OUTDIR = 'esoteric-geometries-out/all-circles-pngs';
+const MONTAGE = 'esoteric-geometries-out/all-circles-montage.png';
+const SIZE = 400;
+const PAD = 1.18;
+const CONF = 0.08; // same gate the reel used
+const BG = { r: 20, g: 16, b: 25 };
+
+const CIRCLE_RE = /\b(circle|circular|concentric|wheel|volvelle|sphere|spherical|armillar|orb|annular|rota|rose window|mandala|roundel|rotating|radial|zodiac|globe|disc|disk)\b/i;
+const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
+const order = manifest.chapters.flatMap(c => c.plates);
+const files = [];
+order.forEach((p, i) => {
+  if (CIRCLE_RE.test(`${p.description || ''} ${p.type || ''}`)) {
+    files.push({ file: `plate-${i + 1}.jpg`, desc: (p.description || '').slice(0, 70) });
+  }
+});
+console.log(`Keyword-circular plates: ${files.length}`);
+
+async function detectCircle(path) {
+  const DW = 240;
+  const meta = await sharp(path).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(path).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch];
+  const gxK = [-1, 0, 1, -2, 0, 2, -1, 0, 1];
+  const gyK = [-1, -2, -1, 0, 0, 0, 1, 2, 1];
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    let sx = 0, sy = 0, k = 0;
+    for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) { const v = g((y + j) * w + (x + i)); sx += v * gxK[k]; sy += v * gyK[k]; k++; }
+    const m = Math.hypot(sx, sy); const idx = y * w + x; mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const std = Math.sqrt(s2 / cnt);
+  const thr = mean + 1.0 * std;
+  const minDim = Math.min(w, h);
+  const RSTEP = 2;
+  const rmin = Math.round(minDim * 0.15), rmax = Math.round(minDim * 0.62);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let cx = Math.round(x - nx * r), cy = Math.round(y - ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+      cx = Math.round(x + nx * r); cy = Math.round(y + ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+    }
+  }
+  let best = -1, bx = w / 2, by = h / 2, bri = Math.round(nr / 2);
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      let s = 0; for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      const score = s / norm;
+      if (score > best) { best = score; bx = x; by = y; bri = ri; }
+    }
+  }
+  const br = rmin + bri * RSTEP;
+  return { cx: bx / scale, cy: by / scale, r: br / scale, conf: best };
+}
+
+rmSync(OUTDIR, { recursive: true, force: true });
+mkdirSync(OUTDIR, { recursive: true });
+
+const tiles = [];
+let usedCount = 0;
+for (let n = 0; n < files.length; n++) {
+  const { file: f } = files[n];
+  const path = join(DIR, f);
+  const meta = await sharp(path).metadata();
+  const minOrig = Math.min(meta.width, meta.height);
+  let cx = meta.width / 2, cy = meta.height / 2, r = minOrig * 0.45, use = false, conf = 0;
+  try {
+    const det = await detectCircle(path);
+    conf = det.conf;
+    const rOk = det.r >= minOrig * 0.10 && det.r <= minOrig * 0.70;
+    use = (det.conf >= CONF && rOk) || det.conf >= 0.6;
+    if (use) { cx = det.cx; cy = det.cy; r = det.r; usedCount++; }
+  } catch (e) { /* center fallback */ }
+
+  const side = Math.max(2, Math.round(2 * r * PAD));
+  const pad = side;
+  const left = Math.round(cx - side / 2) + pad;
+  const top = Math.round(cy - side / 2) + pad;
+  const extended = await sharp(path).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+  const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+  const mask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`);
+  const buf = await sharp(extended)
+    .extract({ left, top, width: side, height: side })
+    .resize(SIZE, SIZE, { fit: 'fill' })
+    .ensureAlpha()
+    .composite([{ input: mask, blend: 'dest-in' }])
+    .png().toBuffer();
+
+  const stem = f.replace(/\.jpg$/, '');
+  const tag = use ? 'USE' : 'FALL';
+  writeFileSync(join(OUTDIR, `${String(n + 1).padStart(2, '0')}_${stem}_c${conf.toFixed(2)}_${tag}.png`), buf);
+  tiles.push({ buf, label: `${n + 1} ${stem} c=${conf.toFixed(2)} ${tag}`, use });
+  console.log(`  ${String(n + 1).padStart(2)} ${stem}  conf=${conf.toFixed(3)}  ${use ? 'USE' : 'fallback'}`);
+}
+console.log(`\nDetected & used: ${usedCount}/${files.length}  (rest are center-fallback crops)`);
+
+// Labeled montage. USE tiles get a green label bar, fallbacks red, so the
+// dropped ones are obvious at a glance.
+const TILE = 200, COLS = 6;
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const barColor = t.use ? '#1f7a3f' : '#8a2222';
+  const lbl = Buffer.from(`<svg width="${TILE}" height="20"><rect width="100%" height="100%" fill="${barColor}"/><text x="4" y="15" font-family="sans-serif" font-size="12" fill="#fff">${t.label}</text></svg>`);
+  return sharp(t.buf).resize(TILE, TILE).composite([{ input: lbl, top: TILE - 20, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 30, g: 26, b: 34 } } })
+  .composite(comps).png().toFile(MONTAGE);
+console.log('wrote montage', MONTAGE);
+console.log('wrote', tiles.length, 'masked PNGs to', OUTDIR);

--- a/scripts/publication/geometry-reel/build-gif.mjs
+++ b/scripts/publication/geometry-reel/build-gif.mjs
@@ -1,0 +1,468 @@
+import sharp from 'sharp';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIR = '/tmp/geo-out/frames/OEBPS/images';
+const MANIFEST = '/tmp/geo-out/manifest.json';
+const EXTRA_DIR = process.env.EXTRA_DIR || ''; // extra image dir (e.g. Buddhist plates); no keyword pre-filter, detection decides
+const EXTRA_CONF = Number(process.env.EXTRA_CONF || 0); // separate (usually lower) detection threshold for extra-dir images
+const EXTRA_RMIN = Number(process.env.EXTRA_RMIN || 0.10); // min detected-radius fraction for extra images (mandalas fill the plate)
+const EXTRA_MINPX = Number(process.env.EXTRA_MINPX || 0); // skip extra images smaller than this on their short side (drops tiny thumbnails)
+const GEO_SKIP = process.env.GEO_SKIP === '1'; // skip the geometry plates (extra-dir only)
+const EXCLUDE = new Set((process.env.EXCLUDE || '').split(',').map(s => s.trim()).filter(Boolean)); // drop these source files
+const INCLUDE = new Set((process.env.INCLUDE || '').split(',').map(s => s.trim()).filter(Boolean)); // force-keep these: trust detection even below the conf gate
+const OUT = process.argv[2] || '/tmp/geo-out/esoteric-geometries-circles-centered.gif';
+const SIZE = Number(process.argv[3] || 560);
+const DELAY = Number(process.argv[4] || 70);
+const TEMPO = Number(process.env.TEMPO || 1); // multiply ALL frame delays (1.4 = 40% slower)
+const T = (ms) => Math.round(ms * TEMPO);
+const COLOURS = Number(process.argv[5] || 256);
+const PAD = Number(process.argv[6] || 1.18); // frame side = detected diameter * PAD (so all circles fill SIZE/PAD)
+const CONF = Number(process.argv[7] || 0.08); // min ring-completeness to trust a detected circle
+const DETECTED_ONLY = process.env.DETECTED_ONLY === '1'; // keep only plates with a real detected circle
+const MASK = process.env.MASK === '1'; // mask to the disc only, transparent outside (implies detected-only)
+const OUTRO = process.env.OUTRO === '1'; // append a Source Library logo fade-out outro (opaque, branded)
+const WARP = process.env.WARP === '1'; // outro ends in a spinning hypnotic spiral instead of the wordmark
+const LOGO = process.env.LOGO || 'public/brand/png/logo-stacked--white-on-transparent--512h.png';
+const BG = { r: 20, g: 16, b: 25 };
+const DARK = { r: 26, g: 22, b: 18 }; // brand dark #1a1612
+
+const CIRCLE_RE = /\b(circle|circular|concentric|wheel|volvelle|sphere|spherical|armillar|orb|annular|rota|rose window|mandala|roundel|rotating|radial|zodiac|globe|disc|disk)\b/i;
+const manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'));
+const order = manifest.chapters.flatMap(c => c.plates);
+const files = [];
+order.forEach((p, i) => { if (CIRCLE_RE.test(`${p.description || ''} ${p.type || ''}`)) files.push(`plate-${i + 1}.jpg`); });
+
+// Work items: geometry plates from DIR, plus optional extra images (Buddhist).
+const entries = GEO_SKIP ? [] : files.map(f => ({ path: join(DIR, f), file: f, extra: false }));
+if (EXTRA_DIR && existsSync(EXTRA_DIR)) {
+  const extra = readdirSync(EXTRA_DIR).filter(f => /\.(jpe?g|png)$/i.test(f)).sort();
+  for (const f of extra) entries.push({ path: join(EXTRA_DIR, f), file: f, extra: true });
+  console.log(`Extra images from ${EXTRA_DIR}: +${extra.length}`);
+}
+
+// Gradient-based Hough circle detection on a downscaled grayscale copy.
+async function detectCircle(path) {
+  const DW = 240;
+  const meta = await sharp(path).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(path).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch]; // grayscale value at pixel index
+
+  const gxK = [-1, 0, 1, -2, 0, 2, -1, 0, 1];
+  const gyK = [-1, -2, -1, 0, 0, 0, 1, 2, 1];
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    let sx = 0, sy = 0, k = 0;
+    for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) { const v = g((y + j) * w + (x + i)); sx += v * gxK[k]; sy += v * gyK[k]; k++; }
+    const m = Math.hypot(sx, sy); const idx = y * w + x; mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const std = Math.sqrt(s2 / cnt);
+  const thr = mean + 1.0 * std;
+
+  const minDim = Math.min(w, h);
+  const RSTEP = 2;
+  const rmin = Math.round(minDim * 0.15), rmax = Math.round(minDim * 0.62);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  // 3D accumulator (r, y, x): every edge pixel votes for candidate centers at
+  // each radius, in both gradient directions.
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let cx = Math.round(x - nx * r), cy = Math.round(y - ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+      cx = Math.round(x + nx * r); cy = Math.round(y + ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+    }
+  }
+  // Global peak, normalized per circumference so large circles aren't favored.
+  let best = -1, bx = w / 2, by = h / 2, bri = Math.round(nr / 2);
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      // light 3x3 smoothing in the center plane
+      let s = 0; for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      const score = s / norm;
+      if (score > best) { best = score; bx = x; by = y; bri = ri; }
+    }
+  }
+  const br = rmin + bri * RSTEP;
+  // best ≈ fraction of the ring's circumference covered by detected edges.
+  return { cx: bx / scale, cy: by / scale, r: br / scale, conf: best };
+}
+
+const kept = [];
+let detected = 0;
+for (const { path, file: f, extra } of entries) {
+  if (EXCLUDE.has(f)) { if (process.env.DEBUG) console.log(`  ${f} excluded`); continue; }
+  const confThresh = extra && EXTRA_CONF > 0 ? EXTRA_CONF : CONF;
+  const meta = await sharp(path).metadata();
+  const minOrig = Math.min(meta.width, meta.height);
+  // Extra plates below a size floor are low-value thumbnails — skip (avoids
+  // spurious tiny-circle detections on near-blank scraps).
+  if (extra && EXTRA_MINPX > 0 && minOrig < EXTRA_MINPX) { if (process.env.DEBUG) console.log(`  ${f} skip (minOrig ${minOrig} < ${EXTRA_MINPX})`); continue; }
+  let cx = meta.width / 2, cy = meta.height / 2, r = minOrig * 0.45, use = false;
+  try {
+    const det = await detectCircle(path);
+    const rLo = extra ? EXTRA_RMIN : 0.10;
+    const rOk = det.r >= minOrig * rLo && det.r <= minOrig * 0.70;
+    // Trust a detection if the ring is reasonably complete and plausibly sized,
+    // or if it's a near-perfect ring regardless of size.
+    use = (det.conf >= confThresh && rOk) || det.conf >= 0.6 || (INCLUDE.has(f) && rOk);
+    if (use) { cx = det.cx; cy = det.cy; r = det.r; detected++; }
+    if (process.env.DEBUG) console.log(`  ${f} conf=${det.conf.toFixed(3)} r=${det.r.toFixed(0)} rfrac=${(det.r / minOrig).toFixed(2)} ${rOk ? '' : 'r-bad '}${use ? 'USE' : 'fallback'}`);
+  } catch (e) { if (process.env.DEBUG) console.log(`  ${f} detect error ${e.message}`); }
+
+  // DROPPED mode: keep ONLY the plates that FAILED detection (to inspect what
+  // the precision gate excluded). Otherwise, in detected-only/mask mode, drop
+  // plates with no real circle so every frame is a circle.
+  if (process.env.DROPPED === '1') { if (use) continue; }
+  else if ((DETECTED_ONLY || MASK) && !use) continue;
+
+  const side = Math.max(2, Math.round(2 * r * PAD));
+  const pad = side;
+  const left = Math.round(cx - side / 2) + pad;
+  const top = Math.round(cy - side / 2) + pad;
+  // Two-step: materialize the extended image first, THEN extract — otherwise
+  // sharp validates the extract box against the pre-extend dimensions.
+  const extended = await sharp(path).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+  let img = sharp(extended)
+    .extract({ left, top, width: side, height: side })
+    .resize(SIZE, SIZE, { fit: 'fill' });
+  let buf;
+  if (MASK && process.env.DROPPED !== '1') {
+    // Keep only the disc: circular alpha mask at the detected radius (a hair
+    // beyond, so the outermost ring stroke isn't clipped), transparent outside.
+    const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+    const mask = Buffer.from(
+      `<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`
+    );
+    buf = await img.ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png().toBuffer();
+  } else {
+    buf = await img.removeAlpha().png().toBuffer();
+  }
+  kept.push({ file: f, buf });
+}
+console.log(`Circle-centered ${detected}/${entries.length} (rest center-fallback).`);
+
+// WhatsApp/most previews show the FIRST frame as the static resting image, so
+// promote a visually striking plate to the front (default: the vivid Sacramentum
+// wheel). Override with HERO=plate-NN.jpg.
+const HERO = process.env.HERO || 'plate-55.jpg';
+const heroIdx = kept.findIndex(k => k.file === HERO);
+if (heroIdx > 0) { const [h] = kept.splice(heroIdx, 1); kept.unshift(h); }
+console.log(`Resting frame: ${kept[0]?.file}${heroIdx < 0 ? ` (HERO ${HERO} not in set; using reading order)` : ''}`);
+
+// The CLOSER is the last reel circle — it crossfades into the concentric-ring
+// logo, so it should itself read as clean concentric rings. Default: orange disc.
+const CLOSER = process.env.CLOSER || 'plate-24.jpg';
+const closerIdx = kept.findIndex(k => k.file === CLOSER);
+if (closerIdx > 0) { const [c] = kept.splice(closerIdx, 1); kept.push(c); }
+console.log(`Closing frame: ${kept[kept.length - 1]?.file}${closerIdx < 0 ? ` (CLOSER ${CLOSER} not in set; using reel order)` : ''}`);
+const frames = kept.map(k => k.buf);
+
+if (OUTRO) {
+  // Branded, opaque version. The reel's last circle resolves into the Source
+  // Library concentric-circle ICON at the same radius as the reel circles; the
+  // icon then shrinks up while the wordmark fades in beneath it.
+  const ICON = 'public/brand/png/icon-only--white-on-transparent--512h.png';
+  const WORD = 'public/brand/png/wordmark-only--white-on-transparent--512h.png';
+  const ease = (t) => t * t * (3 - 2 * t);
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const clamp01 = (x) => Math.max(0, Math.min(1, x));
+
+  const darkBase = await sharp({ create: { width: SIZE, height: SIZE, channels: 3, background: DARK } }).png().toBuffer();
+  const onDark = (buf) => sharp(darkBase).composite([{ input: buf }]).png().toBuffer();
+  // Trim transparent padding so the icon's outer ring sits at the buffer edge
+  // (then width == outer-circle diameter, matching the reel discs exactly).
+  const iconMaster = await sharp(ICON).trim().toBuffer();
+  const wordMaster = await sharp(WORD).trim().toBuffer();
+
+  async function withAlpha(buf, f) {
+    if (f >= 1) return buf;
+    const m = await sharp(buf).metadata();
+    const mask = Buffer.from(`<svg width="${m.width}" height="${m.height}"><rect width="100%" height="100%" fill="#fff" fill-opacity="${f}"/></svg>`);
+    return sharp(buf).ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png().toBuffer();
+  }
+  async function layer(src, width, cx, cy, alpha = 1) {
+    let b = await sharp(src).resize({ width: Math.max(2, Math.round(width)) }).png().toBuffer();
+    if (alpha < 1) b = await withAlpha(b, alpha);
+    const m = await sharp(b).metadata();
+    return { input: b, left: Math.round(cx - m.width / 2), top: Math.round(cy - m.height / 2) };
+  }
+  const compose = (layers) => sharp(darkBase).composite(layers).png().toBuffer();
+
+  // Geometry: icon starts matching the reel circle radius, ends small & high;
+  // wordmark settles just below it.
+  const reelR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+  const iconStartW = 2 * reelR;
+  const iconFinalW = Math.round(SIZE * 0.22);
+  const iconFinalCY = Math.round(SIZE * 0.40);
+  const wordW = Math.round(SIZE * 0.46);
+  const wordCY = Math.round(SIZE * 0.585);
+  const CX = SIZE / 2;
+
+  const mainFrames = await Promise.all(frames.map(onDark));
+  const lastDisc = frames[frames.length - 1]; // transparent disc
+
+  if (WARP) {
+    // Ending built from ONE operator — the swirl warp — so every transition
+    // shares the same visual language: the man twists into the vortex, the
+    // vortex IS twisted sunburst stripes (spinning), the vortexed eye grows out
+    // of the center, and the whole thing untwists into the clean eye.
+    const R = reelR, cx = CX, cy = CX;
+
+    // Final figure: the spiral resolves into this disc — first at full vortex
+    // twist, then untwisting into the clean figure (the Microcosmus man).
+    const FINAL = process.env.FINAL || 'plate-24.jpg';
+    const finalEntry = kept.find(k => k.file === FINAL) || kept[kept.length - 1];
+    const MAXS = Number(process.env.SWIRL || 6.5); // max twist (radians) at disc center
+    // Swirl-warp factory. `profile(u)` (u = r/R) shapes WHERE the twist lives:
+    // default is center-max/rim-zero; the eye uses a banded profile that keeps
+    // the central eye zone AND the rim stable while the middle annulus swirls.
+    async function makeSwirler(discBuf, profile = (u) => (1 - u) * (1 - u)) {
+      const { data: raw, info } = await sharp(discBuf).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+      const W2 = info.width, H2 = info.height;
+      function sampleBilinear(sx, sy, out, oi) {
+        if (sx < 0 || sy < 0 || sx > W2 - 1 || sy > H2 - 1) { out[oi + 3] = 0; return; }
+        const x0 = Math.floor(sx), y0 = Math.floor(sy);
+        const x1 = Math.min(x0 + 1, W2 - 1), y1 = Math.min(y0 + 1, H2 - 1);
+        const fx = sx - x0, fy = sy - y0;
+        const i00 = (y0 * W2 + x0) * 4, i10 = (y0 * W2 + x1) * 4;
+        const i01 = (y1 * W2 + x0) * 4, i11 = (y1 * W2 + x1) * 4;
+        for (let c = 0; c < 4; c++) {
+          const top = raw[i00 + c] * (1 - fx) + raw[i10 + c] * fx;
+          const bot = raw[i01 + c] * (1 - fx) + raw[i11 + c] * fx;
+          out[oi + c] = Math.round(top * (1 - fy) + bot * fy);
+        }
+      }
+      return async function swirl(strength, spin = 0) {
+        const out = Buffer.alloc(W2 * H2 * 4, 0);
+        const mcx = W2 / 2, mcy = H2 / 2;
+        for (let y = 0; y < H2; y++) for (let x = 0; x < W2; x++) {
+          const ddx = x - mcx, ddy = y - mcy, r = Math.hypot(ddx, ddy);
+          const oi = (y * W2 + x) * 4;
+          if (r > R) continue;
+          const theta = Math.atan2(ddy, ddx) - strength * profile(r / R) - spin;
+          sampleBilinear(mcx + r * Math.cos(theta), mcy + r * Math.sin(theta), out, oi);
+        }
+        return sharp(out, { raw: { width: W2, height: H2, channels: 4 } }).png().toBuffer();
+      };
+    }
+    const swirlMan = await makeSwirler(finalEntry.buf);
+
+    // Sunburst stripe disc: radial sectors that, once run through the same
+    // swirl warp, become the hypnotic spiral — no separate procedural pattern,
+    // so the man->spiral->eye handoffs are all the same transform.
+    const SECTORS = Number(process.env.SECTORS || 9); // white/dark stripe pairs
+    const INK = 245;
+    const sunRaw = Buffer.alloc(SIZE * SIZE * 4, 0);
+    for (let y = 0; y < SIZE; y++) for (let x = 0; x < SIZE; x++) {
+      const ddx = x - cx, ddy = y - cy, r = Math.hypot(ddx, ddy);
+      if (r > R) continue;
+      const a = (Math.atan2(ddy, ddx) / (2 * Math.PI) + 0.5) * SECTORS * 2;
+      const i = (y * SIZE + x) * 4;
+      if (Math.floor(a) % 2 === 0) { sunRaw[i] = INK; sunRaw[i + 1] = INK; sunRaw[i + 2] = INK; }
+      else { sunRaw[i] = DARK.r; sunRaw[i + 1] = DARK.g; sunRaw[i + 2] = DARK.b; }
+      sunRaw[i + 3] = 255;
+    }
+    const sunDisc = await sharp(sunRaw, { raw: { width: SIZE, height: SIZE, channels: 4 } }).png().toBuffer();
+    const swirlSun = await makeSwirler(sunDisc);
+
+    // Eye disc: engraved all-seeing eye, masked to the reel circle.
+    const EYE = process.env.EYE || '';
+    let eyeDisc = null, swirlEye = null;
+    if (EYE && existsSync(EYE)) {
+      const det = await detectCircle(EYE);
+      const side = Math.max(2, Math.round(2 * det.r * PAD));
+      const pad = side;
+      const extended = await sharp(EYE).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+      const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+      const eyeMask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`);
+      eyeDisc = await sharp(extended)
+        .extract({ left: Math.round(det.cx - side / 2) + pad, top: Math.round(det.cy - side / 2) + pad, width: side, height: side })
+        .resize(SIZE, SIZE, { fit: 'fill' })
+        .ensureAlpha().composite([{ input: eyeMask, blend: 'dest-in' }]).png().toBuffer();
+      // Banded twist profile: dead-zero under the eye itself (u < EYE_STABLE),
+      // peak twist in the middle annulus, easing back to zero at the rim — the
+      // eye stays a stable engraving while the vortex rages around it.
+      const EYE_STABLE = Number(process.env.EYE_STABLE || 0.22);
+      const smooth = (a, b, x) => { const t = clamp01((x - a) / (b - a)); return t * t * (3 - 2 * t); };
+      const band = (u) => smooth(EYE_STABLE, 0.55, u) * (1 - u) * (1 - u);
+      let peak = 0; for (let u = 0; u <= 1; u += 0.001) peak = Math.max(peak, band(u));
+      swirlEye = await makeSwirler(eyeDisc, (u) => band(u) / peak);
+      console.log(`Eye disc: ${EYE} conf=${det.conf.toFixed(2)} r=${det.r.toFixed(0)}`);
+    }
+
+    // Soft-edged radial reveal: keep only the central rr of a frame.
+    async function centerReveal(buf, rr) {
+      const m = await sharp(Buffer.from(
+        `<svg width="${SIZE}" height="${SIZE}"><circle cx="${cx}" cy="${cy}" r="${Math.max(1, rr)}" fill="#fff"/></svg>`
+      )).blur(12).png().toBuffer();
+      return sharp(buf).ensureAlpha().composite([{ input: m, blend: 'dest-in' }]).png().toBuffer();
+    }
+
+    const K1 = 14; // man twists in
+    const K2 = 4;  // vortexed man -> vortexed stripes
+    const K3 = 12; // stripes spin at full twist
+    const K4 = 10; // vortexed eye grows out of the center (stripes keep spinning)
+    const K5 = 14; // untwist into the clean eye
+    const dS = (2 * Math.PI) / 26; // spin per frame
+    let spin = 0;
+    const outro = [], outroDelays = [];
+
+    // Brief hold on the clean man before the twist grabs him.
+    outro.push(await onDark(finalEntry.buf));
+    outroDelays.push(T(700));
+    for (let i = 1; i <= K1; i++) {
+      const te = ease(i / K1);
+      outro.push(await onDark(await swirlMan(MAXS * te)));
+      outroDelays.push(T(60));
+    }
+    // Same twist, same spin state on both discs — the blend is between two
+    // near-identical vortex fields, so it reads as one continuous warp.
+    const vortexMan = await swirlMan(MAXS);
+    for (let i = 1; i <= K2; i++) {
+      const te = ease(i / K2); spin += dS;
+      outro.push(await compose([
+        await layer(vortexMan, SIZE, cx, cy, 1 - te),
+        await layer(await swirlSun(MAXS, spin), SIZE, cx, cy, te),
+      ]));
+      outroDelays.push(T(55));
+    }
+    for (let i = 0; i < K3; i++) {
+      spin += dS;
+      outro.push(await onDark(await swirlSun(MAXS, spin)));
+      outroDelays.push(T(55));
+    }
+    if (swirlEye) {
+      // The eye grows out of the spiral's center. The eye layer NEVER spins —
+      // its banded profile keeps the center rock-stable — while its middle
+      // annulus tightens slightly each frame so the vortex around the eye
+      // stays alive against the spinning stripes behind it.
+      const DRIFT = 0.30; // extra annulus twist per reveal frame (radians)
+      let A = MAXS;
+      for (let i = 1; i <= K4; i++) {
+        const te = ease(i / K4); spin += dS; A += DRIFT;
+        const base = await swirlSun(MAXS, spin);
+        const eyeV = await swirlEye(A, 0);
+        outro.push(await compose([
+          await layer(base, SIZE, cx, cy, 1),
+          await layer(await centerReveal(eyeV, te * R * 1.15), SIZE, cx, cy, 1),
+        ]));
+        outroDelays.push(T(55));
+      }
+      // Untwist: the annulus unwinds to zero around the already-stable eye.
+      for (let i = 1; i <= K5; i++) {
+        const te = ease(i / K5);
+        outro.push(await onDark(await swirlEye(A * (1 - te), 0)));
+        outroDelays.push(T(60));
+      }
+      outro.push(await onDark(eyeDisc));
+      outroDelays.push(T(2600)); // hold on the eye
+    }
+
+    const seq = [...mainFrames, ...outro];
+    const delays = [...mainFrames.map(() => T(DELAY)), ...outroDelays];
+    await sharp(seq, { join: { animated: true } }).gif({ loop: 0, delay: delays, effort: 8, colours: COLOURS }).toFile(OUT);
+    console.log('wrote', OUT, 'with', seq.length, 'frames (', mainFrames.length, 'circles + warp )');
+    const webpOut = OUT.replace(/\.gif$/, '.webp');
+    await sharp(seq, { join: { animated: true } }).webp({ loop: 0, delay: delays, effort: 6, quality: 90 }).toFile(webpOut);
+    console.log('wrote', webpOut);
+    process.exit(0);
+  }
+
+  // Crossfade: last reel circle → icon at reel radius (both centered, same size).
+  const K1 = 6, crossfade = [];
+  for (let i = 1; i <= K1; i++) {
+    const te = ease(i / K1);
+    crossfade.push(await compose([
+      await layer(lastDisc, SIZE, CX, CX, 1 - te),
+      await layer(iconMaster, iconStartW, CX, CX, te),
+    ]));
+  }
+
+  // Shrink the icon up to its final size while the wordmark fades in.
+  const K2 = 18, shrink = [];
+  for (let i = 1; i <= K2; i++) {
+    const t = i / K2, te = ease(t);
+    const iw = lerp(iconStartW, iconFinalW, te);
+    const icy = lerp(CX, iconFinalCY, te);
+    const wmOp = ease(clamp01((t - 0.25) / 0.7));
+    const layers = [await layer(iconMaster, iw, CX, icy, 1)];
+    if (wmOp > 0.01) layers.push(await layer(wordMaster, wordW, CX, wordCY, wmOp));
+    shrink.push(await compose(layers));
+  }
+
+  const hold = await compose([
+    await layer(iconMaster, iconFinalW, CX, iconFinalCY, 1),
+    await layer(wordMaster, wordW, CX, wordCY, 1),
+  ]);
+
+  const seq = [...mainFrames, ...crossfade, ...shrink, hold];
+  const delays = [
+    ...mainFrames.map(() => T(DELAY)),
+    ...crossfade.map(() => T(55)),
+    ...shrink.map(() => T(60)),
+    T(2200), // hold on the finished logo
+  ];
+
+  await sharp(seq, { join: { animated: true } })
+    .gif({ loop: 0, delay: delays, effort: 8, colours: COLOURS })
+    .toFile(OUT);
+  console.log('wrote', OUT, 'with', seq.length, 'frames (', mainFrames.length, 'circles + outro )');
+  const webpOut = OUT.replace(/\.gif$/, '.webp');
+  await sharp(seq, { join: { animated: true } })
+    .webp({ loop: 0, delay: delays, effort: 6, quality: 90 })
+    .toFile(webpOut);
+  console.log('wrote', webpOut);
+  process.exit(0);
+}
+
+await sharp(frames, { join: { animated: true } })
+  .gif({ loop: 0, delay: DELAY, effort: 8, colours: COLOURS })
+  .toFile(OUT);
+console.log('wrote', OUT, 'with', frames.length, 'frames');
+
+if (MASK) {
+  // Smooth-alpha animated version (GIF transparency is only 1-bit).
+  const webpOut = OUT.replace(/\.gif$/, '.webp');
+  await sharp(frames, { join: { animated: true } })
+    .webp({ loop: 0, delay: DELAY, effort: 6, quality: 90, alphaQuality: 100 })
+    .toFile(webpOut);
+  console.log('wrote', webpOut);
+  // Individual transparent circle PNGs for reuse.
+  const { mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+  const dir = OUT.replace(/\.gif$/, '-pngs');
+  rmSync(dir, { recursive: true, force: true }); // clear stale PNGs from prior runs
+  mkdirSync(dir, { recursive: true });
+  kept.forEach((k, i) => {
+    const stem = k.file.replace(/\.(jpe?g|png)$/i, '');
+    writeFileSync(join(dir, `circle-${String(i + 1).padStart(2, '0')}_${stem}.png`), k.buf);
+  });
+  console.log('wrote', kept.length, 'transparent PNGs to', dir);
+}
+
+// Montage for visual QA of circle alignment: a grid of all centered frames,
+// labeled with the source plate so off-center ones are easy to identify.
+const TILE = 150, COLS = 6;
+const rows = Math.ceil(frames.length / COLS);
+const tiles = await Promise.all(kept.map(async (k, i) => {
+  const stem = k.file.replace(/\.(jpe?g|png)$/i, '');
+  const lbl = Buffer.from(`<svg width="${TILE}" height="18"><rect width="100%" height="100%" fill="black" fill-opacity="0.6"/><text x="3" y="14" font-family="sans-serif" font-size="12" fill="#fff">${i + 1} ${stem}</text></svg>`);
+  return sharp(k.buf).resize(TILE, TILE).composite([{ input: lbl, top: TILE - 18, left: 0 }]).toBuffer();
+}));
+const composites = tiles.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 30, g: 26, b: 34 } } })
+  .composite(composites)
+  .png()
+  .toFile(OUT.replace(/\.gif$/, '-montage.png'));
+console.log('wrote montage', OUT.replace(/\.gif$/, '-montage.png'));

--- a/scripts/publication/geometry-reel/chakra-reel.mjs
+++ b/scripts/publication/geometry-reel/chakra-reel.mjs
@@ -1,0 +1,180 @@
+// Build the Leadbeater chakra reel: pull every circular chakra plate from
+// "The Chakras. A monograph" (1927), center+mask each to a disc (same pipeline
+// as the circles reel), montage all candidates, then assemble an animated GIF
+// ascending the spine: Root -> Spleen -> Navel -> Heart -> Throat -> Brow ->
+// Crown (held). Env PICKS overrides the auto choice per chakra:
+//   PICKS=root=69c...-0,heart=69f...-0
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const BOOK_ID = '69c86f6c6c6f3cc53c8570c0';
+const OUT = '/tmp/geo-out/chakras';
+const SIZE = 600;
+const PAD = 1.14;
+const DARK = { r: 26, g: 22, b: 18 };
+const BG = { r: 20, g: 16, b: 25 };
+
+const ORDER = ['root', 'spleen', 'navel', 'heart', 'throat', 'brow', 'crown'];
+const CHAKRA_RE = {
+  root: /root chakra|muladhara/i,
+  spleen: /spleen chakra/i,
+  navel: /navel chakra|manipura/i,
+  heart: /heart chakra|anahata/i,
+  throat: /throat chakra|vishuddha/i,
+  brow: /brow chakra|ajna/i,
+  crown: /crown chakra|sahasrara/i,
+};
+// Only circular plate renditions (skip body diagrams, buddha heads, atoms).
+const CIRCULAR_RE = /circular|circle|petal|lotus|segments/i;
+
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(join(OUT, 'discs'), { recursive: true });
+
+// ---- fetch book plates ----
+const u = new URL('/api/gallery', BASE);
+u.searchParams.set('bookId', BOOK_ID); u.searchParams.set('limit', '60');
+const items = ((await (await fetch(u)).json()).items || []);
+console.log(`Book plates: ${items.length}`);
+
+const candidates = [];
+for (const it of items) {
+  const d = it.description || '';
+  if (!CIRCULAR_RE.test(d)) continue;
+  const chakra = ORDER.find(k => CHAKRA_RE[k].test(d));
+  if (!chakra) continue;
+  candidates.push({ it, chakra });
+}
+console.log(`Circular chakra candidates: ${candidates.length}`);
+
+// ---- circle detection (single best, from the reel pipeline) ----
+async function detectCircle(buf) {
+  const DW = 240;
+  const meta = await sharp(buf).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(buf).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch];
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const i00 = (y - 1) * w + x, i10 = y * w + x, i20 = (y + 1) * w + x;
+    const sx = -g(i00 - 1) + g(i00 + 1) - 2 * g(i10 - 1) + 2 * g(i10 + 1) - g(i20 - 1) + g(i20 + 1);
+    const sy = -g(i00 - 1) - 2 * g(i00) - g(i00 + 1) + g(i20 - 1) + 2 * g(i20) + g(i20 + 1);
+    const m = Math.hypot(sx, sy); const idx = y * w + x;
+    mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const thr = mean + Math.sqrt(s2 / cnt);
+  const minDim = Math.min(w, h);
+  // Chakra plates are near-full-bleed discs: search up to 78% of the short side.
+  const RSTEP = 2, rmin = Math.round(minDim * 0.20), rmax = Math.round(minDim * 0.78);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let cx = Math.round(x - nx * r), cy = Math.round(y - ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+      cx = Math.round(x + nx * r); cy = Math.round(y + ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+    }
+  }
+  // Best candidate PER radius, then prefer the LARGEST radius whose score is
+  // close to the global best — the plate's outer rim, not an inner ring.
+  const perR = [];
+  let globalBest = -1;
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    let best = -1, bx = 0, by = 0;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      let s = 0; for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      const sc = s / norm;
+      if (sc > best) { best = sc; bx = x; by = y; }
+    }
+    perR.push({ r, cx: bx, cy: by, conf: best });
+    if (best > globalBest) globalBest = best;
+  }
+  let pick = null;
+  for (let ri = nr - 1; ri >= 0; ri--) {
+    if (perR[ri].conf >= Math.max(0.10, 0.55 * globalBest)) { pick = perR[ri]; break; }
+  }
+  if (!pick) pick = perR.reduce((a, b) => (b.conf > a.conf ? b : a));
+  return { cx: pick.cx / scale, cy: pick.cy / scale, r: pick.r / scale, conf: pick.conf };
+}
+
+// ---- download, center, mask every candidate ----
+const discs = [];
+for (const { it, chakra } of candidates) {
+  const src = it.extractedUrl || it.imageUrl;
+  const id = `${it.pageId}-${it.detectionIndex}`;
+  try {
+    const r = await fetch(src); if (!r.ok) continue;
+    const raw = Buffer.from(await r.arrayBuffer());
+    let det = await detectCircle(raw);
+    // Soft scalloped rims and black plate borders defeat the Hough vote; these
+    // plates are all centered full-bleed discs, so fall back to that geometry.
+    if (det.conf < 0.12) {
+      const m = await sharp(raw).metadata();
+      det = { cx: m.width / 2, cy: m.height / 2, r: 0.44 * Math.min(m.width, m.height), conf: det.conf };
+    }
+    const side = Math.max(2, Math.round(2 * det.r * PAD));
+    const pad = side;
+    const extended = await sharp(raw).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+    const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+    const mask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`);
+    const disc = await sharp(extended)
+      .extract({ left: Math.round(det.cx - side / 2) + pad, top: Math.round(det.cy - side / 2) + pad, width: side, height: side })
+      .resize(SIZE, SIZE, { fit: 'fill' })
+      .ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png().toBuffer();
+    const meta = await sharp(raw).metadata();
+    discs.push({ id, chakra, disc, conf: det.conf, srcMin: Math.min(meta.width, meta.height), desc: (it.description || '').slice(0, 70) });
+    writeFileSync(join(OUT, 'discs', `${chakra}_${id}.png`), disc);
+    console.log(`  ${chakra.padEnd(6)} ${id}  conf=${det.conf.toFixed(2)} src=${Math.min(meta.width, meta.height)}px`);
+  } catch (e) { console.log(`  ! ${id} ${e.message}`); }
+}
+
+// ---- candidates montage grouped by chakra ----
+const TILE = 190, COLS = 6;
+const byChakra = ORDER.map(k => discs.filter(d => d.chakra === k));
+const tiles = [];
+for (const group of byChakra) for (const d of group) tiles.push(d);
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const lbl = Buffer.from(`<svg width="${TILE}" height="18"><rect width="100%" height="100%" fill="black" fill-opacity="0.7"/><text x="4" y="14" font-family="sans-serif" font-size="11" fill="#fff">${t.chakra} c=${t.conf.toFixed(2)} ${t.srcMin}px</text></svg>`);
+  return sharp(t.disc).resize(TILE, TILE).composite([{ input: lbl, top: TILE - 18, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 30, g: 26, b: 34 } } })
+  .composite(comps).png().toFile(join(OUT, 'chakra-candidates-montage.png'));
+
+// ---- pick best per chakra (largest source, then confidence), build the reel ----
+const PICKS = Object.fromEntries((process.env.PICKS || '').split(',').filter(Boolean).map(s => s.split('=')));
+const chosen = [];
+for (const k of ORDER) {
+  const group = discs.filter(d => d.chakra === k);
+  if (!group.length) { console.log(`  !! no plate for ${k}`); continue; }
+  const pick = PICKS[k] ? group.find(d => d.id === PICKS[k]) || group[0]
+    : group.sort((a, b) => (b.conf - a.conf) || (b.srcMin - a.srcMin))[0];
+  chosen.push(pick);
+  console.log(`  pick ${k.padEnd(6)} ${pick.id} (conf=${pick.conf.toFixed(2)}, ${pick.srcMin}px)`);
+}
+
+const darkBase = await sharp({ create: { width: SIZE, height: SIZE, channels: 3, background: DARK } }).png().toBuffer();
+const frames = [];
+for (const c of chosen) frames.push(await sharp(darkBase).composite([{ input: c.disc }]).png().toBuffer());
+
+// Ascend the spine; hold the crown, then loop.
+const delays = chosen.map((c, i) => (i === chosen.length - 1 ? 2000 : 650));
+await sharp(frames, { join: { animated: true } })
+  .gif({ loop: 0, delay: delays, effort: 8, colours: 256 })
+  .toFile(join(OUT, 'chakras-ascending.gif'));
+await sharp(frames, { join: { animated: true } })
+  .webp({ loop: 0, delay: delays, effort: 6, quality: 90 })
+  .toFile(join(OUT, 'chakras-ascending.webp'));
+console.log(`wrote ${join(OUT, 'chakras-ascending.gif')} (${frames.length} chakras) + webp + candidates montage`);

--- a/scripts/publication/geometry-reel/citations.mjs
+++ b/scripts/publication/geometry-reel/citations.mjs
@@ -1,0 +1,128 @@
+// Build a citation list for every plate used in the circles reels + the eye
+// finale. Geometry plates carry full provenance in /tmp/geo-out/manifest.json;
+// Buddhist/eye plates only stored titles at download time, so re-query the
+// gallery API and match on title+description to recover author/year/links.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT_MD = 'esoteric-geometries-out/citations.md';
+const OUT_JSON = 'esoteric-geometries-out/citations.json';
+
+// Final reel order (circle-01..19 in the combined masked reel) + the eye.
+const REEL = [
+  'plate-55', 'plate-10', 'plate-19', 'plate-39', 'plate-46', 'plate-50',
+  'plate-59', 'plate-63', 'plate-66', 'plate-87', 'plate-89',
+  'bud-01', 'bud-06', 'bud-09', 'bud-12', 'bud-18', 'bud-21', 'bud-24',
+  'plate-24',
+];
+const EYE = 'eye-11';
+
+// --- geometry plates: direct from the guide manifest -----------------------
+const geo = JSON.parse(readFileSync('/tmp/geo-out/manifest.json', 'utf8'));
+const flat = geo.chapters.flatMap(c => c.plates);
+const geoByFile = new Map();
+flat.forEach((p, i) => geoByFile.set(`plate-${i + 1}`, p));
+
+// --- buddhist + eye plates: re-query gallery, match by title+description ---
+const budManifest = JSON.parse(readFileSync('/tmp/geo-out/buddhist/manifest.json', 'utf8'));
+const eyeManifest = JSON.parse(readFileSync('/tmp/geo-out/eyes/manifest.json', 'utf8'));
+
+const QUERIES = [
+  'buddhist mandala cosmology tibetan',
+  'mandala vajrayana deity circle diagram',
+  'thangka tibetan wheel of life bhavacakra',
+  'tantric yantra meditation circle',
+  'chakra lotus wheel dharma',
+  'all-seeing eye providence rays',
+  'eye of god divine emblem engraving',
+  'oculus eye symbol alchemical emblem',
+  'eye radiant triangle masonic',
+  'divine eye clouds heaven emblem',
+];
+const pool = new Map();
+for (const q of QUERIES) {
+  const u = new URL('/api/gallery', BASE);
+  u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '4');
+  u.searchParams.set('q', q);
+  try {
+    const r = await fetch(u); if (!r.ok) continue;
+    for (const it of (await r.json()).items || []) {
+      pool.set(`${it.pageId}-${it.detectionIndex}`, it);
+    }
+  } catch { /* skip */ }
+}
+console.log(`Gallery pool for matching: ${pool.size} items`);
+
+function findMatch(entry) {
+  const descPrefix = (entry.description || '').slice(0, 80);
+  for (const it of pool.values()) {
+    if ((it.bookTitle || '') === (entry.title || '') &&
+        (it.description || '').startsWith(descPrefix)) return it;
+  }
+  // fallback: title-only match
+  for (const it of pool.values()) {
+    if ((it.bookTitle || '') === (entry.title || '')) return it;
+  }
+  return null;
+}
+
+function citeFromGeo(p) {
+  return {
+    book: p.book, author: p.author, year: p.year,
+    description: p.description, url: p.url, type: p.type,
+  };
+}
+function citeFromGallery(it, fallbackTitle) {
+  if (!it) return { book: fallbackTitle || 'Unknown', author: null, year: null, description: null, url: null };
+  return {
+    book: it.bookTitle, author: it.author || null, year: it.year || null,
+    description: it.description || null,
+    url: `${BASE}/gallery/image/${it.pageId}-${it.detectionIndex}`,
+    bookUrl: it.link ? `${BASE}${it.link}` : null,
+    type: it.type || null,
+  };
+}
+
+const budByFile = new Map(budManifest.map(e => [e.file.replace(/\.jpg$/, ''), e]));
+const eyeByFile = new Map(eyeManifest.map(e => [e.file.replace(/\.jpg$/, ''), e]));
+
+const rows = [];
+for (const stem of REEL) {
+  if (stem.startsWith('plate-')) {
+    const p = geoByFile.get(stem);
+    rows.push({ frame: rows.length + 1, file: stem, ...citeFromGeo(p) });
+  } else {
+    const entry = budByFile.get(stem);
+    const it = entry ? findMatch(entry) : null;
+    if (!it) console.log(`  ! no gallery match for ${stem} (${entry?.title})`);
+    rows.push({ frame: rows.length + 1, file: stem, ...citeFromGallery(it, entry?.title) });
+  }
+}
+{
+  const entry = eyeByFile.get(EYE);
+  const it = entry ? findMatch(entry) : null;
+  if (!it) console.log(`  ! no gallery match for ${EYE} (${entry?.title})`);
+  rows.push({ frame: 'finale', file: EYE, ...citeFromGallery(it, entry?.title) });
+}
+
+writeFileSync(OUT_JSON, JSON.stringify(rows, null, 2));
+
+const md = [];
+md.push('# Esoteric Geometries reel — image citations');
+md.push('');
+md.push('All images are plates from books and artworks in the [Source Library](https://sourcelibrary.org) collection.');
+md.push('');
+for (const r of rows) {
+  const label = r.frame === 'finale' ? 'Finale (the eye)' : `Frame ${String(r.frame).padStart(2, '0')}`;
+  const author = r.author && r.author !== 'Unknown artist' ? r.author : null;
+  const bits = [];
+  bits.push(`**${r.book}**`);
+  if (author) bits.push(author);
+  if (r.year) bits.push(String(r.year));
+  md.push(`- ${label} (\`${r.file}\`): ${bits.join(', ')}.`);
+  if (r.description) md.push(`  ${r.description.length > 160 ? r.description.slice(0, 157) + '…' : r.description}`);
+  if (r.url) md.push(`  ${r.url}`);
+}
+md.push('');
+writeFileSync(OUT_MD, md.join('\n'));
+console.log(`Wrote ${rows.length} citations to ${OUT_MD} and ${OUT_JSON}`);

--- a/scripts/publication/geometry-reel/flipbook.mjs
+++ b/scripts/publication/geometry-reel/flipbook.mjs
@@ -1,0 +1,115 @@
+// Flip book of the circles→universe→eye warp reel: every GIF frame becomes a
+// business-card-sized card (8 per US-Letter sheet, cut lines included). Stack
+// in order, binder-clip the left strip, flip the right edge. Long holds in the
+// GIF (the universe beat, the final eye) are duplicated onto extra cards so the
+// pacing survives on paper. Card 1 is a title card (the resting view).
+import sharp from 'sharp';
+import PDFDocument from 'pdfkit';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = '/Users/jdietz/Documents/GitHub/dev/sourcelibrary-v2';
+const GIF = join(ROOT, 'esoteric-geometries-out/esoteric-geometries-circles-universe.gif');
+const OUT = join(ROOT, 'esoteric-geometries-out/esoteric-geometries-flipbook.pdf');
+
+// ---- pull frames + delays from the GIF ----
+const meta = await sharp(GIF, { animated: true }).metadata();
+const delays = meta.delay; // per-frame, ms
+console.log(`GIF: ${meta.pages} frames`);
+const frames = []; // { png, n } in flip order
+for (let p = 0; p < meta.pages; p++) {
+  const png = await sharp(GIF, { page: p }).png().toBuffer();
+  const dup = Math.max(1, Math.min(4, Math.round((delays[p] || 60) / 70)));
+  for (let d = 0; d < dup; d++) frames.push(png);
+}
+console.log(`Cards after hold-duplication: ${frames.length}`);
+
+// ---- geometry (points) ----
+const PAGE_W = 612, PAGE_H = 792;
+const COLS = 2, ROWS = 4;
+const CARD_W = 288, CARD_H = 189; // 4" x 2.625"
+const GRID_W = COLS * CARD_W, GRID_H = ROWS * CARD_H;
+const MX = (PAGE_W - GRID_W) / 2, MY = (PAGE_H - GRID_H) / 2;
+const IMG = CARD_H; // square image fills card height, right-aligned
+const STRIP = CARD_W - IMG; // left binding strip
+const CREAM = '#f6f1e7', INK = '#2b241c', FADED = '#9a9083', LINE = '#c9c0af';
+
+const doc = new PDFDocument({ size: 'LETTER', margin: 0, autoFirstPage: false, info: {
+  Title: 'Esoteric Geometries — Flip Book', Author: 'Source Library',
+} });
+doc.pipe(createWriteStream(OUT));
+
+// ---- instructions page ----
+{
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(CREAM);
+  doc.font('Times-Roman').fontSize(24).fillColor(INK)
+    .text('Esoteric Geometries — a flip book', 72, 90, { width: PAGE_W - 144 });
+  doc.font('Times-Roman').fontSize(12).moveDown(1).text(
+    'Nineteen circular plates from seven centuries — alchemical cosmograms, astronomical volvelles, ' +
+    'Tibetan mandalas — spin past, the Fludd Microcosmus man twists into a vortex, the vortex becomes ' +
+    'the observable universe, and the universe opens into the Eye of Providence.',
+    72, undefined, { width: PAGE_W - 144, lineGap: 3 });
+  doc.font('Times-Bold').fontSize(13).moveDown(1.5).text('To build it:', 72, undefined);
+  doc.font('Times-Roman').fontSize(12);
+  const steps = [
+    '1.  Print single-sided at actual size (no scaling).',
+    '2.  Cut along the gray lines — 8 cards per sheet.',
+    '3.  Stack in numbered order, card 1 on top.',
+    '4.  Clamp the left strip with a binder clip (or staple twice).',
+    '5.  Thumb the right edge and let it rip.',
+  ];
+  for (const s of steps) doc.moveDown(0.4).text(s, 90, undefined, { width: PAGE_W - 180 });
+  doc.font('Times-Italic').fontSize(11).moveDown(1.5)
+    .text('Every image is from a real book you can read at sourcelibrary.org — the full citation list travels with the animated version at sourcelibrary.org/gallery.', 72, undefined, { width: PAGE_W - 144, lineGap: 3 });
+  doc.font('Helvetica').fontSize(8).fillColor(FADED)
+    .text('SOURCE LIBRARY · ' + new Date().toISOString().slice(0, 10), 72, PAGE_H - 60);
+}
+
+// ---- title card image (card 1, the resting view) ----
+const S = 600;
+const titleCard = await sharp({ create: { width: S, height: S, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+  .composite([{
+    input: Buffer.from(`<svg width="${S}" height="${S}">
+      <circle cx="300" cy="252" r="150" fill="none" stroke="#f0e9da" stroke-width="3"/>
+      <circle cx="300" cy="252" r="108" fill="none" stroke="#f0e9da" stroke-width="2.2"/>
+      <circle cx="300" cy="252" r="66" fill="none" stroke="#f0e9da" stroke-width="1.6"/>
+      <text x="300" y="470" font-family="Georgia, serif" font-size="34" fill="#f0e9da" text-anchor="middle">ESOTERIC GEOMETRIES</text>
+      <text x="300" y="516" font-family="Georgia, serif" font-size="20" font-style="italic" fill="#b9ad98" text-anchor="middle">flip me</text>
+      <text x="300" y="566" font-family="Helvetica, sans-serif" font-size="15" fill="#8a7f6c" text-anchor="middle" letter-spacing="2">SOURCELIBRARY.ORG</text>
+    </svg>`),
+  }]).png().toBuffer();
+const cards = [titleCard, ...frames];
+console.log(`Total cards incl. title: ${cards.length} -> ${Math.ceil(cards.length / (COLS * ROWS))} sheets`);
+
+// ---- card sheets ----
+for (let i = 0; i < cards.length; i += COLS * ROWS) {
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill('#ffffff');
+  const batch = cards.slice(i, i + COLS * ROWS);
+  for (let j = 0; j < batch.length; j++) {
+    const col = j % COLS, row = Math.floor(j / COLS);
+    const x = MX + col * CARD_W, y = MY + row * CARD_H;
+    const n = i + j; // 0 = title card
+    // image right-aligned on the card (motion lives at the flip edge)
+    doc.image(batch[j], x + STRIP, y, { width: IMG, height: IMG });
+    // binding strip: number + wordmark, rotated
+    doc.save();
+    doc.rotate(-90, { origin: [x + STRIP / 2, y + CARD_H / 2] });
+    doc.font('Helvetica').fontSize(7).fillColor(FADED)
+      .text(n === 0 ? 'COVER' : `No. ${String(n).padStart(3, '0')}`,
+        x + STRIP / 2 - CARD_H / 2, y + CARD_H / 2 - 24, { width: CARD_H, align: 'center' });
+    doc.fontSize(5.5)
+      .text('SOURCE LIBRARY', x + STRIP / 2 - CARD_H / 2, y + CARD_H / 2 + 8, { width: CARD_H, align: 'center', characterSpacing: 1 });
+    doc.restore();
+  }
+  // cut lines across the whole grid
+  doc.lineWidth(0.4).strokeColor(LINE);
+  for (let c = 0; c <= COLS; c++) doc.moveTo(MX + c * CARD_W, MY - 8).lineTo(MX + c * CARD_W, MY + GRID_H + 8).stroke();
+  for (let r = 0; r <= ROWS; r++) doc.moveTo(MX - 8, MY + r * CARD_H).lineTo(MX + GRID_W + 8, MY + r * CARD_H).stroke();
+}
+
+doc.end();
+await new Promise(res => doc.on('end', res));
+await new Promise(res => setTimeout(res, 400));
+console.log('wrote', OUT);

--- a/scripts/publication/geometry-reel/gather-buddhist.mjs
+++ b/scripts/publication/geometry-reel/gather-buddhist.mjs
@@ -1,0 +1,62 @@
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT = process.argv[2] || '/tmp/geo-out/buddhist';
+const CAP = Number(process.argv[3] || 24);
+mkdirSync(OUT, { recursive: true });
+
+const QUERIES = [
+  { q: 'buddhist mandala cosmology tibetan' },
+  { q: 'mandala vajrayana deity circle diagram' },
+  { q: 'thangka tibetan wheel of life bhavacakra' },
+  { q: 'tantric yantra meditation circle' },
+  { q: 'chakra lotus wheel dharma' },
+];
+
+// Prefer plates whose title/description signal a DOMINANT circle (better mask hit-rate).
+const CIRCLE_HINT = /\b(mandala|bhavacakra|wheel|yantra|chakra|circular|cosmogram|disc|disk|roundel|lotus|rota|concentric)\b/i;
+
+function key(it) { return `${it.pageId}-${it.detectionIndex}`; }
+
+async function fetchQuery(query) {
+  const u = new URL('/api/gallery', BASE);
+  u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '4');
+  for (const [k, v] of Object.entries(query)) u.searchParams.set(k, String(v));
+  try { const r = await fetch(u); if (!r.ok) return []; return (await r.json()).items || []; }
+  catch { return []; }
+}
+
+const byKey = new Map();
+for (const q of QUERIES) {
+  for (const it of await fetchQuery(q)) {
+    if (byKey.has(key(it))) continue;
+    if (!it.extractedUrl && !it.imageUrl) continue;
+    const text = `${it.bookTitle || ''} ${it.description || ''} ${it.museumDescription || ''}`;
+    it._hint = CIRCLE_HINT.test(text);
+    byKey.set(key(it), it);
+  }
+}
+// Circle-hinted first, then by any quality signal.
+const ranked = [...byKey.values()].sort((a, b) => (b._hint - a._hint) || ((b.galleryQuality ?? 0) - (a.galleryQuality ?? 0)));
+console.log(`Gathered ${ranked.length} unique Buddhist plates; downloading top ${CAP}…`);
+
+const manifest = [];
+let n = 0;
+for (const it of ranked) {
+  if (n >= CAP) break;
+  const src = it.extractedUrl || it.imageUrl;
+  try {
+    const r = await fetch(src); if (!r.ok) { console.log(`  ! ${r.status} ${(it.bookTitle || '').slice(0, 40)}`); continue; }
+    const raw = Buffer.from(await r.arrayBuffer());
+    const buf = await sharp(raw).resize(1200, 1200, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 88 }).toBuffer();
+    n++;
+    const file = `bud-${String(n).padStart(2, '0')}.jpg`;
+    writeFileSync(join(OUT, file), buf);
+    manifest.push({ file, title: it.bookTitle, description: it.description, type: it.type, hint: it._hint });
+    console.log(`  ${file}  ${it._hint ? '●' : '○'} ${(it.bookTitle || '').slice(0, 50)}`);
+  } catch (e) { console.log(`  ! ${e.message} ${(it.bookTitle || '').slice(0, 40)}`); }
+}
+writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+console.log(`Wrote ${n} images + manifest to ${OUT}`);

--- a/scripts/publication/geometry-reel/gather-eyes.mjs
+++ b/scripts/publication/geometry-reel/gather-eyes.mjs
@@ -1,0 +1,71 @@
+// Hunt the public gallery for engraved eye imagery (all-seeing eye, eye of
+// providence) to close the warp reel. Downloads candidates + labeled montage.
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT = '/tmp/geo-out/eyes';
+const CAP = 20;
+mkdirSync(OUT, { recursive: true });
+
+const QUERIES = [
+  { q: 'all-seeing eye providence rays' },
+  { q: 'eye of god divine emblem engraving' },
+  { q: 'oculus eye symbol alchemical emblem' },
+  { q: 'eye radiant triangle masonic' },
+  { q: 'divine eye clouds heaven emblem' },
+];
+const EYE_HINT = /\b(eye|oculus|ocular|all-seeing|providence)\b/i;
+
+function key(it) { return `${it.pageId}-${it.detectionIndex}`; }
+async function fetchQuery(query) {
+  const u = new URL('/api/gallery', BASE);
+  u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '3');
+  for (const [k, v] of Object.entries(query)) u.searchParams.set(k, String(v));
+  try { const r = await fetch(u); if (!r.ok) return []; return (await r.json()).items || []; }
+  catch { return []; }
+}
+
+const byKey = new Map();
+for (const q of QUERIES) {
+  for (const it of await fetchQuery(q)) {
+    if (byKey.has(key(it))) continue;
+    if (!it.extractedUrl && !it.imageUrl) continue;
+    const text = `${it.bookTitle || ''} ${it.description || ''} ${it.museumDescription || ''}`;
+    it._hint = EYE_HINT.test(text);
+    byKey.set(key(it), it);
+  }
+}
+const ranked = [...byKey.values()].sort((a, b) => (b._hint - a._hint) || ((b.galleryQuality ?? 0) - (a.galleryQuality ?? 0)));
+console.log(`Gathered ${ranked.length} candidates; downloading top ${CAP} (eye-hinted first)…`);
+
+const manifest = [], tiles = [];
+let n = 0;
+for (const it of ranked) {
+  if (n >= CAP) break;
+  const src = it.extractedUrl || it.imageUrl;
+  try {
+    const r = await fetch(src); if (!r.ok) continue;
+    const raw = Buffer.from(await r.arrayBuffer());
+    const buf = await sharp(raw).resize(1200, 1200, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 88 }).toBuffer();
+    n++;
+    const file = `eye-${String(n).padStart(2, '0')}.jpg`;
+    writeFileSync(join(OUT, file), buf);
+    manifest.push({ file, title: it.bookTitle, description: (it.description || '').slice(0, 100), hint: it._hint });
+    tiles.push({ buf, label: `${file} ${it._hint ? '●' : '○'} ${(it.bookTitle || '').slice(0, 24)}` });
+    console.log(`  ${file}  ${it._hint ? '●' : '○'} ${(it.description || it.bookTitle || '').slice(0, 80)}`);
+  } catch { /* skip */ }
+}
+writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+const TILE = 200, COLS = 5;
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const lbl = Buffer.from(`<svg width="${TILE}" height="20"><rect width="100%" height="100%" fill="black" fill-opacity="0.65"/><text x="4" y="15" font-family="sans-serif" font-size="11" fill="#fff">${t.label.replace(/&/g, '&amp;').replace(/</g, '&lt;')}</text></svg>`);
+  return sharp(t.buf).resize(TILE, TILE, { fit: 'cover' }).composite([{ input: lbl, top: TILE - 20, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 30, g: 26, b: 34 } } })
+  .composite(comps).png().toFile(join(OUT, 'eyes-montage.png'));
+console.log(`Wrote ${n} images + montage to ${OUT}`);

--- a/scripts/publication/geometry-reel/gather-psychedelic.mjs
+++ b/scripts/publication/geometry-reel/gather-psychedelic.mjs
@@ -1,0 +1,83 @@
+// Sweep the gallery for proto-psychedelic / visionary-art material: Theosophical
+// thought-forms & auras, chakra plates, visionary cosmology, kaleidoscopic color
+// diagrams, radiant/prismatic emblems. Downloads candidates + labeled montage.
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT = '/tmp/geo-out/psychedelic';
+const CAP = 36;
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(OUT, { recursive: true });
+
+const QUERIES = [
+  'thought forms aura astral color plate',
+  'theosophical color radiant emanation diagram',
+  'chakra kundalini energy color plate',
+  'visionary mystical radiant cosmic vision color',
+  'kaleidoscopic prismatic rainbow diagram',
+  'psychedelic swirling vibrant pattern',
+  'aura emanation vibration color plate occult',
+  'divine light rays radiant color mystical vision',
+  'colored cosmological spheres vision heaven',
+  'op art optical pattern concentric vibrating',
+];
+
+function key(it) { return `${it.pageId}-${it.detectionIndex}`; }
+const pool = new Map();
+for (const q of QUERIES) {
+  for (let offset = 0; offset < 120; offset += 60) {
+    const u = new URL('/api/gallery', BASE);
+    u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '4');
+    u.searchParams.set('q', q);
+    if (offset) u.searchParams.set('offset', String(offset));
+    try {
+      const r = await fetch(u); if (!r.ok) break;
+      const items = (await r.json()).items || [];
+      for (const it of items) {
+        if (!it.extractedUrl && !it.imageUrl) continue;
+        if (!pool.has(key(it))) { it._q = q; pool.set(key(it), it); }
+      }
+      if (items.length < 60) break;
+    } catch { break; }
+  }
+}
+// Rank by how psychedelic the description reads + quality.
+const VIBE_RE = /\b(aura|thought.?form|astral|kaleidoscop|prismatic|rainbow|radiant|iridescent|swirl|vibrat|kundalini|chakra|emanation|vision(ary)?|halluc|spectral|luminous|technicolor|polychrome|vivid|hand.?colou?red)\b/i;
+const ranked = [...pool.values()]
+  .map(it => ({ it, score: (VIBE_RE.test(`${it.bookTitle || ''} ${it.description || ''}`) ? 1 : 0) + (it.galleryQuality ?? 0) }))
+  .sort((a, b) => b.score - a.score);
+console.log(`Pool: ${ranked.length} unique candidates`);
+
+const manifest = [], tiles = [];
+let n = 0;
+for (const { it } of ranked) {
+  if (n >= CAP) break;
+  const src = it.extractedUrl || it.imageUrl;
+  try {
+    const r = await fetch(src); if (!r.ok) continue;
+    const raw = Buffer.from(await r.arrayBuffer());
+    const meta = await sharp(raw).metadata();
+    if (Math.min(meta.width, meta.height) < 350) continue; // skip thumbnails
+    const buf = await sharp(raw).resize(1200, 1200, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 88 }).toBuffer();
+    n++;
+    const file = `psy-${String(n).padStart(2, '0')}.jpg`;
+    writeFileSync(join(OUT, file), buf);
+    manifest.push({ file, galleryId: key(it), url: `${BASE}/gallery/image/${key(it)}`, title: it.bookTitle, author: it.author, year: it.year, description: (it.description || '').slice(0, 140), query: it._q });
+    tiles.push({ buf, label: `${file} ${(it.bookTitle || '').slice(0, 26)}` });
+    console.log(`  ${file}  ${(it.year || '????')}  ${(it.bookTitle || '').slice(0, 40)}  |  ${(it.description || '').slice(0, 60)}`);
+  } catch { /* skip */ }
+}
+writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+const TILE = 210, COLS = 6;
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const lbl = Buffer.from(`<svg width="${TILE}" height="18"><rect width="100%" height="100%" fill="black" fill-opacity="0.65"/><text x="4" y="14" font-family="sans-serif" font-size="11" fill="#fff">${t.label.replace(/&/g, '&amp;').replace(/</g, '&lt;')}</text></svg>`);
+  return sharp(t.buf).resize(TILE, TILE, { fit: 'cover' }).composite([{ input: lbl, top: TILE - 18, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+  .composite(comps).png().toFile(join(OUT, 'psy-montage.png'));
+console.log(`Wrote ${n} images + montage to ${OUT}`);

--- a/scripts/publication/geometry-reel/gather-spiritual-anatomy.mjs
+++ b/scripts/publication/geometry-reel/gather-spiritual-anatomy.mjs
@@ -1,0 +1,91 @@
+// Hunt the gallery for "spiritual anatomy" — the historical ancestors of the
+// Alex Grey / Android Jones aesthetic: bodies fused with cosmos, energy
+// channels, chakras, auras, planetary organs, transparent/x-ray mystical
+// figures, wrathful deity density. Downloads candidates + labeled montage.
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT = '/tmp/geo-out/spiritual-anatomy';
+const CAP = 42;
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(OUT, { recursive: true });
+
+const QUERIES = [
+  'theosophical man spiritual anatomy planets body',
+  'astral man body planets heart divine gichtel',
+  'subtle body energy channels nadis kundalini figure',
+  'human figure chakras spine serpent energy',
+  'man microcosm zodiac organs cosmic body',
+  'transparent body soul anatomy mystical figure',
+  'aura human figure radiating colors astral',
+  'meditation figure radiant energy body deity',
+  'wrathful deity flames dense symmetrical thangka',
+  'anatomical figure alchemical symbols organs mystical',
+  'body of light glorified spiritual rebirth figure',
+  'yogi meditation cosmic diagram body universe',
+];
+
+function key(it) { return `${it.pageId}-${it.detectionIndex}`; }
+const pool = new Map();
+for (const q of QUERIES) {
+  for (let offset = 0; offset < 120; offset += 60) {
+    const u = new URL('/api/gallery', BASE);
+    u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '5');
+    u.searchParams.set('q', q);
+    if (offset) u.searchParams.set('offset', String(offset));
+    try {
+      const r = await fetch(u); if (!r.ok) break;
+      const items = (await r.json()).items || [];
+      for (const it of items) {
+        if (!it.extractedUrl && !it.imageUrl) continue;
+        if (!pool.has(key(it))) { it._q = q; pool.set(key(it), it); }
+      }
+      if (items.length < 60) break;
+    } catch { break; }
+  }
+}
+// Score: body+cosmos fusion language.
+const BODY_RE = /\b(body|man|figure|anatom|yogi|meditat|deity)\b/i;
+const COSMIC_RE = /\b(planet|zodiac|chakra|aura|astral|energy|channel|nadis?|kundalini|serpent|radiant|cosmic|divine|spiritual|subtle|flames?|halo|emanat)\b/i;
+const ranked = [...pool.values()]
+  .map(it => {
+    const text = `${it.bookTitle || ''} ${it.description || ''}`;
+    const score = (BODY_RE.test(text) ? 1 : 0) + (COSMIC_RE.test(text) ? 1 : 0) + (it.galleryQuality ?? 0);
+    return { it, score };
+  })
+  .sort((a, b) => b.score - a.score);
+console.log(`Pool: ${ranked.length} unique candidates`);
+
+const manifest = [], tiles = [];
+let n = 0;
+for (const { it } of ranked) {
+  if (n >= CAP) break;
+  const src = it.extractedUrl || it.imageUrl;
+  try {
+    const r = await fetch(src); if (!r.ok) continue;
+    const raw = Buffer.from(await r.arrayBuffer());
+    const meta = await sharp(raw).metadata();
+    if (Math.min(meta.width, meta.height) < 350) continue;
+    const buf = await sharp(raw).resize(1200, 1200, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 88 }).toBuffer();
+    n++;
+    const file = `anat-${String(n).padStart(2, '0')}.jpg`;
+    writeFileSync(join(OUT, file), buf);
+    manifest.push({ file, galleryId: key(it), url: `${BASE}/gallery/image/${key(it)}`, title: it.bookTitle, author: it.author, year: it.year, description: (it.description || '').slice(0, 140), query: it._q });
+    tiles.push({ buf, label: `${file} ${it.year || ''} ${(it.bookTitle || '').slice(0, 22)}` });
+    console.log(`  ${file}  ${(it.year || '????')}  ${(it.bookTitle || '').slice(0, 42)}  |  ${(it.description || '').slice(0, 62)}`);
+  } catch { /* skip */ }
+}
+writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+const TILE = 210, COLS = 6;
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const lbl = Buffer.from(`<svg width="${TILE}" height="18"><rect width="100%" height="100%" fill="black" fill-opacity="0.65"/><text x="4" y="14" font-family="sans-serif" font-size="11" fill="#fff">${t.label.replace(/&/g, '&amp;').replace(/</g, '&lt;')}</text></svg>`);
+  return sharp(t.buf).resize(TILE, TILE, { fit: 'cover' }).composite([{ input: lbl, top: TILE - 18, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+  .composite(comps).png().toFile(join(OUT, 'anat-montage.png'));
+console.log(`Wrote ${n} images + montage to ${OUT}`);

--- a/scripts/publication/geometry-reel/gifts-booklet.mjs
+++ b/scripts/publication/geometry-reel/gifts-booklet.mjs
@@ -1,0 +1,137 @@
+// "Eight Circles" — a PDF booklet of the eight playa-gift designs, one page
+// each: the disc, its citation, and a paragraph on why it matters. Reuses the
+// 2000px transparent discs in playa-gifts/stickers/.
+import sharp from 'sharp';
+import PDFDocument from 'pdfkit';
+import { createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = '/Users/jdietz/Documents/GitHub/dev/sourcelibrary-v2';
+const OUTDIR = join(ROOT, 'esoteric-geometries-out');
+const STICKERS = join(OUTDIR, 'playa-gifts', 'stickers');
+
+const CREAM = '#f6f1e7';
+const DARK = '#1a1612';
+const INK = '#2b241c';
+const FADED = '#7a7062';
+
+const DESIGNS = [
+  {
+    key: 'apian-volvelle-1540',
+    title: 'The Emperor\u2019s Astronomy',
+    credit: 'Peter Apian \u00b7 Ingolstadt, 1540',
+    url: 'sourcelibrary.org/gallery/image/6990688d249ce014347d6ecb-0',
+    text: 'From Peter Apian\u2019s Astronomicum Caesareum, printed for Emperor Charles V and often called the most spectacular scientific book ever produced. This circle is a volvelle: layered paper discs that actually rotated on a thread axis, letting the reader compute planetary positions, eclipses, and horoscopes by hand. It is essentially a Renaissance analog computer disguised as art \u2014 proof that before electronics, calculation itself could be a luxury object, hand-colored and crowned with a little handle.',
+  },
+  {
+    key: 'fludd-microcosmus-man-1617',
+    title: 'The Microcosmic Man',
+    credit: 'Robert Fludd, Utriusque Cosmi Historia \u00b7 Oppenheim, 1617',
+    url: 'sourcelibrary.org/gallery/image/69904dd77d19f3f2aac1d579-0',
+    text: 'The frontispiece of Fludd\u2019s \u201cHistory of Both Worlds\u201d shows a Vitruvian-style human figure spread inside nested celestial spheres. It is the single most famous image of the microcosm\u2013macrocosm doctrine: the idea that the human body is a scale model of the universe, and the universe a scaled-up body, so that studying one reveals the other. Every \u201ccosmic human\u201d image since \u2014 up through Alex Grey \u2014 is downstream of this engraving.',
+  },
+  {
+    key: 'eye-of-providence-1715',
+    title: 'The Eye of Providence',
+    credit: 'Jacob Boehme, Der Weg zu Christo \u00b7 1715',
+    url: 'sourcelibrary.org/gallery/image/69c8352e6c6f3cc53c84e7f1-0',
+    text: 'From \u201cThe Way to Christ\u201d by Jacob Boehme, the shoemaker-mystic of G\u00f6rlitz whose visions of divine light in a pewter dish reshaped Western mysticism. The all-seeing eye sits at the center of a celestial sphere, crowned by a dove and ringed by an ouroboros \u2014 the divine gaze embedded in, not above, the cosmos. This rendering predates the eye\u2019s more familiar careers on the Masonic seal and the dollar bill; here it is still pure contemplative theology.',
+  },
+  {
+    key: 'rosicrucian-seal-1785',
+    title: 'The Rosicrucian Wheel',
+    credit: 'Geheime Figuren der Rosenkreuzer \u00b7 Altona, 1785',
+    url: 'sourcelibrary.org/gallery/image/69d38fa347cb16327c2b8a34-0',
+    text: 'From the \u201cSecret Symbols of the Rosicrucians,\u201d the great late compendium of Rosicrucian cosmology. The wheel maps creation as concentric rings running from the zodiac at the rim down through Natura, Elementa, and Chaos to the hexagram medallion at the bullseye, where the word CHAOS itself is spelled around a central sun. It reads as a diagram you fall into: the entire ordered universe collapsing ring by ring toward the primordial state it emerged from.',
+  },
+  {
+    key: 'sibley-magic-wheel-1820',
+    title: 'The Pentacle of Venus',
+    credit: 'Ebenezer Sibley, Key to the Mysteries of Magic \u00b7 c. 1820',
+    url: 'sourcelibrary.org/gallery/image/69b418b72b0edf3eaa2ddbbf-0',
+    text: 'Sibley was a physician-astrologer working the seam where Enlightenment science met ceremonial magic, and this hand-colored pentacle is a working talisman design, not an illustration \u2014 concentric rings of planetary characters and celestial stars meant to concentrate Venusian influence. It captures the moment occultism went commercial and encyclopedic in England, a direct ancestor of the Golden Dawn\u2019s diagrams seventy years later.',
+  },
+  {
+    key: 'tibetan-mandala-1927',
+    title: 'The Great Mandala of the Peaceful Deities',
+    credit: 'Bardo Thodol, ed. W. Y. Evans-Wentz \u00b7 1927',
+    url: 'sourcelibrary.org/gallery/image/6953c95577f38f6761bde8e1-0',
+    text: 'From the \u201cTibetan Book of the Dead\u201d: a map of the visions a consciousness encounters in the first days after death \u2014 the forty-two peaceful deities arranged in concentric courts, to be recognized as projections of one\u2019s own mind rather than external gods. The 1927 English edition introduced this material to the West, where Jung wrote a commentary on it and, decades later, it became the template for the first psychedelic guidebooks.',
+  },
+  {
+    key: 'crown-chakra-1927',
+    title: 'Sahasrara \u2014 the Crown Chakra',
+    credit: 'C. W. Leadbeater, The Chakras \u00b7 1927',
+    url: 'sourcelibrary.org/gallery/image/69c86fb06c6f3cc53c85712f-0',
+    text: 'From the Theosophical Society book that effectively created the modern Western image of the chakra system. This plate is the sahasrara, the \u201cthousand-petaled lotus\u201d at the crown of the head, painted as a radiant color-wheel of petals. Nearly every chakra poster, yoga-studio mural, and visionary painting of energy bodies since 1927 copies its color scheme from these plates \u2014 the missing link between Tantric diagram and psychedelic art.',
+  },
+  {
+    key: 'observable-universe-2012',
+    title: 'The Observable Universe',
+    credit: 'Pablo Carlos Budassi \u00b7 2012, CC BY-SA',
+    url: 'sourcelibrary.org/gallery/image/artwork-69e5379f5917566bf878f297-0',
+    text: 'Budassi\u2019s logarithmic map compresses 93 billion light-years into a single disc: the Sun at center, then the solar system, the Milky Way, cosmic web filaments, and the cosmic microwave background at the rim, each ring representing exponentially more space. Built from Princeton logarithmic sky-map data, it is the one genuinely contemporary image in the set \u2014 and it quietly completes the sequence: the same concentric-cosmos diagram Fludd and the Rosicrucians drew, redrawn with actual data, four centuries later.',
+  },
+];
+
+const SIZE = 2000;
+async function flatten(discPath, hex) {
+  const rgb = { r: parseInt(hex.slice(1, 3), 16), g: parseInt(hex.slice(3, 5), 16), b: parseInt(hex.slice(5, 7), 16) };
+  return sharp({ create: { width: SIZE, height: SIZE, channels: 3, background: rgb } })
+    .composite([{ input: discPath }]).jpeg({ quality: 92 }).toBuffer();
+}
+
+const PAGE_W = 612, PAGE_H = 792;
+const pdfPath = join(OUTDIR, 'eight-circles.pdf');
+const doc = new PDFDocument({ size: 'LETTER', margin: 0, autoFirstPage: false, info: {
+  Title: 'Eight Circles \u2014 Source Library',
+  Author: 'Source Library',
+  Subject: 'Eight concentric cosmologies, 1540\u20132012',
+} });
+doc.pipe(createWriteStream(pdfPath));
+
+// Cover
+{
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(DARK);
+  const cover = await flatten(join(STICKERS, 'rosicrucian-seal-1785.png'), DARK);
+  const dw = 360;
+  doc.image(cover, (PAGE_W - dw) / 2, 130, { width: dw });
+  doc.font('Helvetica').fontSize(10).fillColor('#b9ad98')
+    .text('S O U R C E   L I B R A R Y', 0, 64, { width: PAGE_W, align: 'center', characterSpacing: 2 });
+  doc.font('Times-Roman').fontSize(34).fillColor('#f0e9da')
+    .text('Eight Circles', 60, 540, { width: PAGE_W - 120, align: 'center' });
+  doc.font('Times-Italic').fontSize(13).fillColor('#b9ad98')
+    .text('Eight versions of the same gesture \u2014 putting everything in nested circles \u2014\nfrom Renaissance astronomy through alchemy, occultism, and Buddhist cosmology\nto modern astrophysics. 1540\u20132012.', 60, 592, { width: PAGE_W - 120, align: 'center', lineGap: 2 });
+  doc.font('Helvetica').fontSize(9).fillColor('#8a7f6c')
+    .text('sourcelibrary.org', 0, PAGE_H - 50, { width: PAGE_W, align: 'center' });
+}
+
+// One page per design
+let n = 0;
+for (const d of DESIGNS) {
+  n++;
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(CREAM);
+  doc.font('Helvetica').fontSize(8).fillColor(FADED)
+    .text(`EIGHT CIRCLES \u00b7 ${n} OF ${DESIGNS.length}`, 0, 42, { width: PAGE_W, align: 'center', characterSpacing: 1.5 });
+  const flat = await flatten(join(STICKERS, `${d.key}.png`), CREAM);
+  const dw = 400;
+  doc.image(flat, (PAGE_W - dw) / 2, 72, { width: dw });
+  let y = 72 + dw + 24;
+  doc.font('Times-Bold').fontSize(17).fillColor(INK)
+    .text(d.title, 76, y, { width: PAGE_W - 152, align: 'center' });
+  y = doc.y + 4;
+  doc.font('Times-Italic').fontSize(11).fillColor(INK)
+    .text(d.credit, 76, y, { width: PAGE_W - 152, align: 'center' });
+  y = doc.y + 14;
+  doc.font('Times-Roman').fontSize(10.5).fillColor('#3a332a')
+    .text(d.text, 86, y, { width: PAGE_W - 172, align: 'justify', lineGap: 2.5 });
+  doc.font('Helvetica').fontSize(7.5).fillColor(FADED)
+    .text(d.url, 0, PAGE_H - 44, { width: PAGE_W, align: 'center' });
+}
+
+doc.end();
+await new Promise(res => doc.on('end', res));
+await new Promise(res => setTimeout(res, 400));
+console.log('wrote', pdfPath, `(cover + ${n} pages)`);

--- a/scripts/publication/geometry-reel/mandala-center.mjs
+++ b/scripts/publication/geometry-reel/mandala-center.mjs
@@ -1,0 +1,43 @@
+// Center-crop every dataset plate on its BIGGEST detected circle: square crop
+// of 2*r*PAD, circle center at the image center, edge-padded where the crop
+// exceeds the source. Writes centered/ + a QA montage.
+import sharp from 'sharp';
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIR = 'esoteric-geometries-out/mandala-circles-dataset';
+const PAD = 1.18;
+const BG = { r: 20, g: 16, b: 25 };
+const SIZE = 800;
+
+const ann = JSON.parse(readFileSync(join(DIR, 'annotations.json'), 'utf8'));
+const OUTDIR = join(DIR, 'centered');
+rmSync(OUTDIR, { recursive: true, force: true });
+mkdirSync(OUTDIR, { recursive: true });
+
+const tiles = [];
+for (const item of ann.items) {
+  const big = item.circles.reduce((a, b) => (b.r > a.r ? b : a));
+  const srcPath = join(DIR, 'images', `${item.id}.jpg`);
+  const side = Math.max(2, Math.round(2 * big.r * PAD));
+  const pad = side;
+  const extended = await sharp(srcPath).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+  const buf = await sharp(extended)
+    .extract({ left: Math.round(big.cx - side / 2) + pad, top: Math.round(big.cy - side / 2) + pad, width: side, height: side })
+    .resize(SIZE, SIZE, { fit: 'fill' })
+    .jpeg({ quality: 90 }).toBuffer();
+  writeFileSync(join(OUTDIR, `${item.id}.jpg`), buf);
+  tiles.push({ buf, label: `${item.id} r=${big.r} c=${big.conf}` });
+  console.log(`  ${item.id}  biggest r=${big.r} conf=${big.conf} @ (${big.cx},${big.cy})`);
+}
+
+const TILE = 220, COLS = 6;
+const rows = Math.ceil(tiles.length / COLS);
+const composed = await Promise.all(tiles.map(async (t) => {
+  const lbl = Buffer.from(`<svg width="${TILE}" height="18"><rect width="100%" height="100%" fill="black" fill-opacity="0.65"/><text x="4" y="14" font-family="sans-serif" font-size="11" fill="#fff">${t.label}</text></svg>`);
+  return sharp(t.buf).resize(TILE, TILE).composite([{ input: lbl, top: TILE - 18, left: 0 }]).png().toBuffer();
+}));
+const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+  .composite(comps).png().toFile(join(DIR, 'centered-montage.png'));
+console.log(`Wrote ${tiles.length} centered crops to ${OUTDIR} + centered-montage.png`);

--- a/scripts/publication/geometry-reel/mandala-dataset.mjs
+++ b/scripts/publication/geometry-reel/mandala-dataset.mjs
@@ -1,0 +1,266 @@
+// Build a nested-circles dataset from Buddhist mandala plates.
+//
+// 1. Gather a wide pool of Buddhist/mandala imagery from the public gallery
+//    API (with full provenance: gallery id, book, author, year, URL).
+// 2. Run a MULTI-circle Hough detector (gradient voting + non-max suppression)
+//    on each plate to find nested rings and offset sub-circles.
+// 3. Classify pairwise relations (concentric / contained / separate), keep
+//    plates with genuine nested structure, and emit:
+//      images/       source jpgs
+//      overlays/     detections drawn on the plate
+//      crops/        square crop per detected circle
+//      annotations.json  circles + relations + provenance per image
+//      overlay montage for quick QA
+//
+// Usage: node _tmp-mandala-dataset.mjs [outDir] [maxImages]
+import sharp from 'sharp';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BASE = 'https://sourcelibrary.org';
+const OUT = process.argv[2] || 'esoteric-geometries-out/mandala-circles-dataset';
+const MAX_IMAGES = Number(process.argv[3] || 60);
+const MAX_CIRCLES = 8;      // per image
+const CONF_MIN = 0.20;      // min ring completeness for a kept circle
+const DW = 280;             // detection working width
+// Restrict to Buddhist/Tibetan sources (the semantic queries also surface
+// western esoterica — tarot, alchemy — which don't belong in this dataset).
+const BUDDHIST_RE = /tibet|buddhis|thangka|vajra|lama|bardo|stupa|dharma|bhavacakra|khor|sgrub|dgongs|gonpa|monaster|rlung|gter|gshin|phur|thor bu|sa skya|avalokite|yamantaka|kalachakra|meru/i;
+
+const QUERIES = [
+  'buddhist mandala cosmology tibetan',
+  'mandala vajrayana deity circle diagram',
+  'thangka tibetan wheel of life bhavacakra',
+  'tantric yantra meditation circle',
+  'chakra lotus wheel dharma',
+  'kalachakra mandala palace',
+  'tibetan cosmological diagram mount meru',
+  'mandala concentric deity palace ritual',
+  'stupa mandala offering diagram tibetan',
+  'srid pa khor lo wheel existence',
+  // Tibetan-native terms (the collections are catalogued with these)
+  'dkyil khor mandala diagram',
+  'srung khor protective circle amulet',
+  'rlung khor wind wheel diagram',
+  'khor lo wheel ritual diagram tibetan',
+  'tsakli initiation card tibetan',
+  'astrological diagram tibetan divination sipaho',
+  'hevajra cakrasamvara guhyasamaja mandala',
+  'lotus petals deity circle tibetan ritual',
+  'seed syllable mantra circle tibetan',
+  'torma offering diagram circle',
+];
+const PER_QUERY = 240; // paginate each query this deep (offset supported)
+
+// ---------- gather ----------------------------------------------------------
+function key(it) { return `${it.pageId}-${it.detectionIndex}`; }
+const pool = new Map();
+for (const q of QUERIES) {
+  for (let offset = 0; offset < PER_QUERY; offset += 60) {
+    const u = new URL('/api/gallery', BASE);
+    u.searchParams.set('limit', '60'); u.searchParams.set('maxPerBook', '12');
+    u.searchParams.set('q', q);
+    if (offset) u.searchParams.set('offset', String(offset));
+    try {
+      const r = await fetch(u); if (!r.ok) break;
+      const items = (await r.json()).items || [];
+      for (const it of items) {
+        if (!it.extractedUrl && !it.imageUrl) continue;
+        if (!pool.has(key(it))) pool.set(key(it), it);
+      }
+      if (items.length < 60) break; // exhausted
+    } catch { break; }
+  }
+}
+// Rank: mandala-ish text first, then quality.
+const MANDALA_RE = /\b(mandala|bhavacakra|wheel|yantra|chakra|cosmogram|concentric|circular|roundel|kalachakra|khor lo)\b/i;
+const ranked = [...pool.values()]
+  .filter(it => BUDDHIST_RE.test(`${it.bookTitle || ''} ${it.author || ''} ${it.description || ''}`))
+  .map(it => ({ it, hint: MANDALA_RE.test(`${it.bookTitle || ''} ${it.description || ''}`) ? 1 : 0 }))
+  .sort((a, b) => (b.hint - a.hint) || ((b.it.galleryQuality ?? 0) - (a.it.galleryQuality ?? 0)));
+console.log(`Gallery pool: ${ranked.length} unique candidates`);
+
+// ---------- multi-circle detector -------------------------------------------
+async function detectCircles(buf) {
+  const meta = await sharp(buf).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(buf).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch];
+
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const i00 = (y - 1) * w + x, i10 = y * w + x, i20 = (y + 1) * w + x;
+    const sx = -g(i00 - 1) + g(i00 + 1) - 2 * g(i10 - 1) + 2 * g(i10 + 1) - g(i20 - 1) + g(i20 + 1);
+    const sy = -g(i00 - 1) - 2 * g(i00) - g(i00 + 1) + g(i20 - 1) + 2 * g(i20) + g(i20 + 1);
+    const m = Math.hypot(sx, sy); const idx = y * w + x;
+    mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const thr = mean + Math.sqrt(s2 / cnt);
+
+  const minDim = Math.min(w, h);
+  const RSTEP = 2;
+  const rmin = Math.max(6, Math.round(minDim * 0.06)), rmax = Math.round(minDim * 0.62);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let cx = Math.round(x - nx * r), cy = Math.round(y - ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+      cx = Math.round(x + nx * r); cy = Math.round(y + ny * r);
+      if (cx >= 0 && cx < w && cy >= 0 && cy < h) acc[base + cy * w + cx] += 1;
+    }
+  }
+  // Smoothed, circumference-normalized score volume.
+  const score = new Float32Array(nr * w * h);
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      let s = 0;
+      for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      score[base + y * w + x] = s / norm;
+    }
+  }
+  // Iterative peak extraction with suppression in (cx, cy, r).
+  const found = [];
+  for (let k = 0; k < MAX_CIRCLES; k++) {
+    let best = -1, bx = 0, by = 0, bri = 0;
+    for (let ri = 0; ri < nr; ri++) {
+      const base = ri * w * h;
+      for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+        const v = score[base + y * w + x];
+        if (v > best) { best = v; bx = x; by = y; bri = ri; }
+      }
+    }
+    if (best < CONF_MIN) break;
+    const br = rmin + bri * RSTEP;
+    found.push({ cx: bx / scale, cy: by / scale, r: br / scale, conf: best });
+    // Suppress: same center within 0.35*r AND radius within 25% -> duplicate ring.
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP;
+      if (Math.abs(r - br) > 0.25 * br + RSTEP) continue;
+      const base = ri * w * h, supp = Math.max(6, 0.35 * br);
+      const y0 = Math.max(0, Math.round(by - supp)), y1 = Math.min(h - 1, Math.round(by + supp));
+      const x0 = Math.max(0, Math.round(bx - supp)), x1 = Math.min(w - 1, Math.round(bx + supp));
+      for (let y = y0; y <= y1; y++) for (let x = x0; x <= x1; x++) {
+        if (Math.hypot(x - bx, y - by) <= supp) score[base + y * w + x] = 0;
+      }
+    }
+  }
+  return { circles: found, width: meta.width, height: meta.height };
+}
+
+// ---------- relations --------------------------------------------------------
+function classify(circles) {
+  const rels = [];
+  for (let i = 0; i < circles.length; i++) for (let j = 0; j < circles.length; j++) {
+    if (i === j) continue;
+    const A = circles[i], B = circles[j];
+    if (B.r >= A.r) continue; // only smaller-inside-bigger
+    const d = Math.hypot(A.cx - B.cx, A.cy - B.cy);
+    if (d + B.r <= A.r * 1.05) {
+      const kind = d < 0.15 * A.r ? 'concentric' : 'contained';
+      rels.push({ outer: i, inner: j, kind, centerDist: Math.round(d) });
+    }
+  }
+  return rels;
+}
+
+// ---------- main loop --------------------------------------------------------
+rmSync(OUT, { recursive: true, force: true });
+for (const d of ['images', 'overlays', 'crops']) mkdirSync(join(OUT, d), { recursive: true });
+
+const annotations = [];
+const overlayTiles = [];
+let n = 0, kept = 0;
+for (const { it } of ranked) {
+  if (n >= MAX_IMAGES) break;
+  const src = it.extractedUrl || it.imageUrl;
+  let raw;
+  try {
+    const r = await fetch(src); if (!r.ok) continue;
+    raw = await sharp(Buffer.from(await r.arrayBuffer()))
+      .resize(1400, 1400, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 90 }).toBuffer();
+  } catch { continue; }
+  n++;
+  const id = `mandala-${String(n).padStart(3, '0')}`;
+  let det;
+  try { det = await detectCircles(raw); } catch { continue; }
+  const rels = classify(det.circles);
+  const nested = rels.length > 0 && det.circles.length >= 2;
+  console.log(`  ${id}  circles=${det.circles.length} rels=${rels.length} ${nested ? 'KEEP' : 'skip'}  ${(it.bookTitle || '').slice(0, 45)}`);
+  if (!nested) continue;
+  kept++;
+
+  writeFileSync(join(OUT, 'images', `${id}.jpg`), raw);
+
+  // Overlay: outermost/global circles green, inner ones orange, centers dotted.
+  const svgCircles = det.circles.map((c, i) => {
+    const isInner = rels.some(r => r.inner === i);
+    const col = isInner ? '#ff9a3c' : '#3cff7a';
+    return `<circle cx="${c.cx}" cy="${c.cy}" r="${c.r}" fill="none" stroke="${col}" stroke-width="5" opacity="0.9"/>` +
+      `<circle cx="${c.cx}" cy="${c.cy}" r="6" fill="${col}"/>` +
+      `<text x="${c.cx + 10}" y="${c.cy - 10}" font-family="sans-serif" font-size="34" fill="${col}">${i}</text>`;
+  }).join('');
+  const overlay = await sharp(raw).composite([{
+    input: Buffer.from(`<svg width="${det.width}" height="${det.height}">${svgCircles}</svg>`), top: 0, left: 0,
+  }]).jpeg({ quality: 88 }).toBuffer();
+  writeFileSync(join(OUT, 'overlays', `${id}.jpg`), overlay);
+  overlayTiles.push({ buf: overlay, label: `${id} c${det.circles.length} r${rels.length}` });
+
+  // Crops: square crop around each circle (1.15x padding), clamped to image.
+  for (let i = 0; i < det.circles.length; i++) {
+    const c = det.circles[i];
+    const side = Math.round(2 * c.r * 1.15);
+    const left = Math.round(c.cx - side / 2), top = Math.round(c.cy - side / 2);
+    const l = Math.max(0, left), t = Math.max(0, top);
+    const wCrop = Math.min(det.width - l, side), hCrop = Math.min(det.height - t, side);
+    if (wCrop < 40 || hCrop < 40) continue;
+    try {
+      const crop = await sharp(raw).extract({ left: l, top: t, width: wCrop, height: hCrop })
+        .resize(512, 512, { fit: 'fill' }).jpeg({ quality: 88 }).toBuffer();
+      writeFileSync(join(OUT, 'crops', `${id}_c${i}.jpg`), crop);
+    } catch { /* skip bad crop */ }
+  }
+
+  annotations.push({
+    id,
+    source: {
+      galleryId: key(it),
+      galleryUrl: `${BASE}/gallery/image/${key(it)}`,
+      book: it.bookTitle || null, author: it.author || null, year: it.year || null,
+      description: it.description || null, imageUrl: src,
+    },
+    width: det.width, height: det.height,
+    circles: det.circles.map(c => ({ cx: Math.round(c.cx), cy: Math.round(c.cy), r: Math.round(c.r), conf: Number(c.conf.toFixed(3)) })),
+    relations: rels,
+  });
+}
+
+writeFileSync(join(OUT, 'annotations.json'), JSON.stringify({
+  generated_at: new Date().toISOString(),
+  detector: { workingWidth: DW, confMin: CONF_MIN, maxCircles: MAX_CIRCLES },
+  count: annotations.length,
+  items: annotations,
+}, null, 2));
+
+// QA montage of overlays.
+const TILE = 240, COLS = 6;
+const rows = Math.ceil(overlayTiles.length / COLS);
+if (overlayTiles.length) {
+  const composed = await Promise.all(overlayTiles.map(async (t) => {
+    const lbl = Buffer.from(`<svg width="${TILE}" height="20"><rect width="100%" height="100%" fill="black" fill-opacity="0.65"/><text x="4" y="15" font-family="sans-serif" font-size="12" fill="#fff">${t.label}</text></svg>`);
+    return sharp(t.buf).resize(TILE, TILE, { fit: 'cover' }).composite([{ input: lbl, top: TILE - 20, left: 0 }]).png().toBuffer();
+  }));
+  const comps = composed.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE }));
+  await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+    .composite(comps).png().toFile(join(OUT, 'overlays-montage.png'));
+}
+console.log(`\nDataset: ${kept}/${n} plates kept (nested circles) -> ${OUT}`);

--- a/scripts/publication/geometry-reel/print-portfolio.mjs
+++ b/scripts/publication/geometry-reel/print-portfolio.mjs
@@ -1,0 +1,275 @@
+// Print portfolio: "The Source Library Guide to Esoteric Geometries" as a
+// letter-size PDF where EVERY page stands alone — one plate per page with its
+// full citation and a sourcelibrary.org pointer, so individual pages can be
+// torn out and given away. Order follows the reel: geometry plates, Buddhist
+// mandalas, the Fludd man, the seven Leadbeater chakras ascending, the
+// observable universe, the Boehme eye.
+//
+// Sources: esoteric-geometries-out/citations.json (reel provenance) + chakra
+// picks + the Budassi universe map. Full-res images come from
+// /api/gallery/image/[id] (highResUrl -> imageUrl fallback), cached in
+// esoteric-geometries-out/print-src/. Each plate gets the disc treatment
+// (detect circle, center, mask) at 2000px.
+import sharp from 'sharp';
+import PDFDocument from 'pdfkit';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = '/Users/jdietz/Documents/GitHub/dev/sourcelibrary-v2';
+const OUTDIR = join(ROOT, 'esoteric-geometries-out');
+const SRC = join(OUTDIR, 'print-src');
+const DISCS = join(OUTDIR, 'print-discs');
+mkdirSync(SRC, { recursive: true });
+mkdirSync(DISCS, { recursive: true });
+
+const BASE = 'https://sourcelibrary.org';
+const SIZE = 2000, PAD = 1.12;
+const BG = { r: 20, g: 16, b: 25 };
+const CREAM = '#f6f1e7';
+const DARK = '#1a1612';
+const INK = '#2b241c';
+const FADED = '#7a7062';
+
+// ---- build the plate list ----
+const citations = JSON.parse(readFileSync(join(OUTDIR, 'citations.json'), 'utf8'));
+const gid = (u) => u.split('/gallery/image/')[1];
+const plates = citations.map((c) => ({
+  key: c.file, id: gid(c.url), book: c.book, author: c.author, year: c.year,
+  description: c.description, url: c.url,
+}));
+// Insert the chakras + universe before the eye finale.
+const eye = plates.pop();
+const CHAKRAS = [
+  ['root', 'Muladhara — the Root Chakra', '69c86fb06c6f3cc53c85712e-0'],
+  ['spleen', 'The Spleen Chakra', '69c86fb06c6f3cc53c85712d-0'],
+  ['navel', 'Manipura — the Navel Chakra', '69c86f976c6f3cc53c857101-0'],
+  ['heart', 'Anahata — the Heart Chakra', '69f658c3750fcb7f4a9f9128-0'],
+  ['throat', 'Vishuddha — the Throat Chakra', '69c8705d6c6f3cc53c857283-0'],
+  ['brow', 'Ajna — the Brow Chakra', '69c870626c6f3cc53c857297-0'],
+  ['crown', 'Sahasrara — the Crown Chakra', '69c86fb06c6f3cc53c85712f-0'],
+];
+for (const [key, label, id] of CHAKRAS) {
+  plates.push({
+    key: `chakra-${key}`, id, book: 'The Chakras. A Monograph', author: 'C. W. Leadbeater',
+    year: 1927, description: label + ', as seen clairvoyantly — from the first color atlas of the chakra system.',
+    url: `${BASE}/gallery/image/${id}`,
+  });
+}
+plates.push({
+  key: 'universe', id: 'artwork-69e5379f5917566bf878f297-0',
+  book: 'Logarithmic Map of the Observable Universe', author: 'Pablo Carlos Budassi', year: 2012,
+  description: 'The entire observable universe in a single disc: the Solar System at the center, then the Kuiper Belt, the Milky Way, neighboring galaxies, the cosmic web, and the cosmic microwave background at the rim, on a logarithmic scale.',
+  url: `${BASE}/gallery/image/artwork-69e5379f5917566bf878f297-0`,
+});
+plates.push(eye && { ...eye, id: gid(eye.url) });
+console.log(`Plates: ${plates.length}`);
+
+// ---- fetch full-res sources (cached) ----
+// These plates come out wrong from the full-page highRes re-crop (off-center
+// subject or surrounding dark page) — use the tight extraction crop instead.
+const TIGHT = new Set(['plate-50', 'eye-11', 'chakra-heart']);
+async function fetchPlate(p) {
+  const cache = join(SRC, `${p.key}.jpg`);
+  if (existsSync(cache)) return cache;
+  const meta = await (await fetch(`${BASE}/api/gallery/image/${p.id}`)).json();
+  const hi = meta.highResUrl && (meta.highResUrl.startsWith('http') ? meta.highResUrl : BASE + meta.highResUrl);
+  const tries = TIGHT.has(p.key) ? [meta.imageUrl] : [hi, meta.imageUrl].filter(Boolean);
+  for (const u of tries) {
+    try {
+      const r = await fetch(u);
+      if (!r.ok) continue;
+      const buf = Buffer.from(await r.arrayBuffer());
+      if (buf.length < 20000) continue; // reject error stubs
+      writeFileSync(cache, buf);
+      return cache;
+    } catch { /* try next */ }
+  }
+  throw new Error(`no image for ${p.key}`);
+}
+
+// ---- circle detection: outer-rim biased Hough + centered fallback ----
+async function detectCircle(path) {
+  const DW = 240;
+  const meta = await sharp(path).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(path).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch];
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const i00 = (y - 1) * w + x, i10 = y * w + x, i20 = (y + 1) * w + x;
+    const sx = -g(i00 - 1) + g(i00 + 1) - 2 * g(i10 - 1) + 2 * g(i10 + 1) - g(i20 - 1) + g(i20 + 1);
+    const sy = -g(i00 - 1) - 2 * g(i00) - g(i00 + 1) + g(i20 - 1) + 2 * g(i20) + g(i20 + 1);
+    const m = Math.hypot(sx, sy); const idx = y * w + x;
+    mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const thr = mean + Math.sqrt(s2 / cnt);
+  const minDim = Math.min(w, h);
+  const RSTEP = 2, rmin = Math.round(minDim * 0.18), rmax = Math.round(minDim * 0.78);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let px = Math.round(x - nx * r), py = Math.round(y - ny * r);
+      if (px >= 0 && px < w && py >= 0 && py < h) acc[base + py * w + px] += 1;
+      px = Math.round(x + nx * r); py = Math.round(y + ny * r);
+      if (px >= 0 && px < w && py >= 0 && py < h) acc[base + py * w + px] += 1;
+    }
+  }
+  const perR = []; let globalBest = -1;
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    let best = -1, bx = 0, by = 0;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      let s = 0; for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      const sc = s / norm;
+      if (sc > best) { best = sc; bx = x; by = y; }
+    }
+    perR.push({ r, cx: bx, cy: by, conf: best });
+    if (best > globalBest) globalBest = best;
+  }
+  let pick = null;
+  for (let ri = nr - 1; ri >= 0; ri--) if (perR[ri].conf >= Math.max(0.10, 0.55 * globalBest)) { pick = perR[ri]; break; }
+  if (!pick) pick = perR.reduce((a, b) => (b.conf > a.conf ? b : a));
+  const res = { cx: pick.cx / scale, cy: pick.cy / scale, r: pick.r / scale, conf: pick.conf };
+  if (res.conf < 0.12) {
+    return { cx: meta.width / 2, cy: meta.height / 2, r: 0.44 * Math.min(meta.width, meta.height), conf: res.conf };
+  }
+  return res;
+}
+
+async function makeDisc(srcPath, outPath) {
+  if (existsSync(outPath)) return outPath;
+  const det = await detectCircle(srcPath);
+  const side = Math.max(2, Math.round(2 * det.r * PAD));
+  const pad = side;
+  const extended = await sharp(srcPath).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BG }).toBuffer();
+  const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+  const mask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`);
+  await sharp(extended)
+    .extract({ left: Math.round(det.cx - side / 2) + pad, top: Math.round(det.cy - side / 2) + pad, width: side, height: side })
+    .resize(SIZE, SIZE, { fit: 'fill' })
+    .ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png().toFile(outPath);
+  return { out: outPath, conf: det.conf };
+}
+
+// ---- gather all discs ----
+for (const p of plates) {
+  const src = await fetchPlate(p);
+  const disc = join(DISCS, `${p.key}.png`);
+  const r = await makeDisc(src, disc);
+  p.disc = disc;
+  const m = await sharp(src).metadata();
+  console.log(`  ${p.key.padEnd(14)} src=${m.width}x${m.height}${typeof r === 'object' ? ` conf=${r.conf.toFixed(2)}` : ' (cached)'}`);
+}
+
+// ---- contact sheet for review ----
+{
+  const TILE = 220, COLS = 7;
+  const tiles = await Promise.all(plates.map(async (p, i) => {
+    const lbl = Buffer.from(`<svg width="${TILE}" height="16"><rect width="100%" height="100%" fill="black" fill-opacity="0.7"/><text x="3" y="12" font-family="sans-serif" font-size="10" fill="#fff">${i + 1} ${p.key}</text></svg>`);
+    return sharp(p.disc).resize(TILE, TILE).composite([{ input: lbl, top: TILE - 16, left: 0 }]).png().toBuffer();
+  }));
+  const rows = Math.ceil(tiles.length / COLS);
+  await sharp({ create: { width: COLS * TILE, height: rows * TILE, channels: 3, background: { r: 30, g: 26, b: 34 } } })
+    .composite(tiles.map((input, i) => ({ input, left: (i % COLS) * TILE, top: Math.floor(i / COLS) * TILE })))
+    .png().toFile(join(OUTDIR, 'portfolio-contact-sheet.png'));
+}
+
+// ---- flatten discs for the PDF (cream page bg; cover disc on dark) ----
+async function flatten(discPath, hex) {
+  const rgb = { r: parseInt(hex.slice(1, 3), 16), g: parseInt(hex.slice(3, 5), 16), b: parseInt(hex.slice(5, 7), 16) };
+  return sharp({ create: { width: SIZE, height: SIZE, channels: 3, background: rgb } })
+    .composite([{ input: discPath }]).jpeg({ quality: 92 }).toBuffer();
+}
+
+// ---- compose the PDF ----
+const PAGE_W = 612, PAGE_H = 792; // US Letter, points
+const pdfPath = join(OUTDIR, 'esoteric-geometries-portfolio.pdf');
+const doc = new PDFDocument({ size: 'LETTER', margin: 0, autoFirstPage: false, info: {
+  Title: 'The Source Library Guide to Esoteric Geometries — Print Portfolio',
+  Author: 'Source Library', Subject: 'Plates from seven centuries of sacred and scientific geometry',
+} });
+doc.pipe(createWriteStream(pdfPath));
+
+const clamp = (s, n) => {
+  if (!s || s.length <= n) return s || '';
+  const cut = s.slice(0, n);
+  const stop = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf('; '));
+  return stop > n * 0.5 ? cut.slice(0, stop + 1) : cut.replace(/\s+\S*$/, '') + '…';
+};
+
+// Cover: dark, universe disc, title.
+{
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(DARK);
+  const uni = plates.find(p => p.key === 'universe');
+  const coverDisc = await flatten(uni.disc, DARK);
+  const dw = 380;
+  doc.image(coverDisc, (PAGE_W - dw) / 2, 120, { width: dw });
+  doc.font('Helvetica').fontSize(10).fillColor('#b9ad98')
+    .text('S O U R C E   L I B R A R Y', 0, 60, { width: PAGE_W, align: 'center', characterSpacing: 2 });
+  doc.font('Times-Roman').fontSize(30).fillColor('#f0e9da')
+    .text('The Guide to Esoteric Geometries', 60, 540, { width: PAGE_W - 120, align: 'center' });
+  doc.font('Times-Italic').fontSize(13).fillColor('#b9ad98')
+    .text(`${plates.length} plates from seven centuries · a portfolio of circles`, 60, 590, { width: PAGE_W - 120, align: 'center' });
+  doc.font('Helvetica').fontSize(9).fillColor('#8a7f6c')
+    .text('sourcelibrary.org', 0, PAGE_H - 50, { width: PAGE_W, align: 'center' });
+}
+
+// Colophon / how-to-distribute page.
+{
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(CREAM);
+  doc.font('Times-Roman').fontSize(13).fillColor(INK)
+    .text('Every page in this portfolio stands alone.', 90, 140, { width: PAGE_W - 180 });
+  doc.moveDown(0.6);
+  doc.fontSize(11).text(
+    'Each plate carries its own citation — the book it came from, its author and year, and a link back to the source. ' +
+    'Tear out a page, give it away, pin it to a wall: it remains a complete object. ' +
+    'The originals are historical primary sources — alchemical cosmograms, astronomical volvelles, Tibetan mandalas, ' +
+    'Theosophical chakra plates — digitized, restored, and made readable at Source Library, a digital library of ' +
+    'esoteric and early-scientific books. Every image here links to a page where you can read the full original.',
+    90, undefined, { width: PAGE_W - 180, lineGap: 3 });
+  doc.moveDown(1.2);
+  doc.font('Times-Italic').text('The reel of these circles, animated: sourcelibrary.org/gallery', 90, undefined, { width: PAGE_W - 180 });
+  doc.font('Helvetica').fontSize(8).fillColor(FADED)
+    .text('Assembled ' + new Date().toISOString().slice(0, 10) + ' · images public domain or CC · sourcelibrary.org', 90, PAGE_H - 60, { width: PAGE_W - 180 });
+}
+
+// Plate pages.
+let n = 0;
+for (const p of plates) {
+  n++;
+  doc.addPage();
+  doc.rect(0, 0, PAGE_W, PAGE_H).fill(CREAM);
+  doc.font('Helvetica').fontSize(8).fillColor(FADED)
+    .text(`SOURCE LIBRARY · ESOTERIC GEOMETRIES · PLATE ${n} OF ${plates.length}`, 0, 42, { width: PAGE_W, align: 'center', characterSpacing: 1.5 });
+  const flat = await flatten(p.disc, CREAM);
+  const dw = 460;
+  doc.image(flat, (PAGE_W - dw) / 2, 78, { width: dw });
+  let y = 78 + dw + 26;
+  doc.font('Times-Bold').fontSize(15).fillColor(INK)
+    .text(clamp(p.book, 90), 76, y, { width: PAGE_W - 152, align: 'center' });
+  y = doc.y + 4;
+  doc.font('Times-Italic').fontSize(11).fillColor(INK)
+    .text(`${p.author}${p.year ? ` · ${p.year}` : ''}`, 76, y, { width: PAGE_W - 152, align: 'center' });
+  y = doc.y + 10;
+  doc.font('Times-Roman').fontSize(9.5).fillColor('#4a4238')
+    .text(clamp(p.description, 260), 96, y, { width: PAGE_W - 192, align: 'center', lineGap: 2 });
+  doc.font('Helvetica').fontSize(7.5).fillColor(FADED)
+    .text(p.url.replace('https://', ''), 0, PAGE_H - 46, { width: PAGE_W, align: 'center' });
+}
+
+doc.end();
+await new Promise(res => doc.on('end', res));
+// pdfkit's stream 'end' fires on the doc; give the file stream a beat.
+await new Promise(res => setTimeout(res, 500));
+console.log('wrote', pdfPath, `(cover + colophon + ${n} plates)`);

--- a/scripts/publication/geometry-reel/probe-buddhist.mjs
+++ b/scripts/publication/geometry-reel/probe-buddhist.mjs
@@ -1,0 +1,21 @@
+const BASE = 'https://sourcelibrary.org';
+const QUERIES = [
+  { q: 'buddhist mandala cosmology tibetan' },
+  { q: 'mandala vajrayana deity circle diagram' },
+  { subject: 'buddhism' },
+  { q: 'thangka tibetan wheel of life bhavacakra' },
+  { q: 'tantric yantra meditation circle' },
+  { q: 'chakra lotus wheel dharma' },
+];
+async function run(query){
+  const u = new URL('/api/gallery', BASE);
+  u.searchParams.set('minQuality','0.6'); u.searchParams.set('limit','40'); u.searchParams.set('maxPerBook','6');
+  for (const [k,v] of Object.entries(query)) u.searchParams.set(k,String(v));
+  try{
+    const r = await fetch(u); if(!r.ok){console.log(JSON.stringify(query),'HTTP',r.status);return;}
+    const j = await r.json(); const items=j.items||[];
+    console.log('\n== '+JSON.stringify(query)+' -> '+items.length+' ==');
+    for(const it of items.slice(0,8)) console.log(`  q=${(it.galleryQuality??0).toFixed(2)} type=${it.type||'?'} | ${(it.bookTitle||'').slice(0,45)} | ${(it.description||'').slice(0,55)}`);
+  }catch(e){console.log(JSON.stringify(query),'ERR',e.message);}
+}
+for(const q of QUERIES) await run(q);

--- a/scripts/publication/geometry-reel/recenter.mjs
+++ b/scripts/publication/geometry-reel/recenter.mjs
@@ -1,0 +1,79 @@
+// Re-center a plate's disc via rim-alignment refinement: fine grid search of
+// (cx, cy, r), scoring by Sobel edge magnitude sampled along the candidate rim.
+// Fixes the disc everywhere it ships: print-discs/ (portfolio), stickers/, buttons/.
+//
+//   node _tmp-recenter.mjs <plate-key> [sticker-name]
+//   e.g. node _tmp-recenter.mjs plate-89 rosicrucian-seal-1785
+//
+// Optional env: SEED_CX, SEED_CY, SEED_R as fractions of image dims (defaults
+// centered, r=0.40*min); SEARCH as +/- fraction (default 0.12).
+import sharp from 'sharp';
+import { existsSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const key = process.argv[2];
+const stickerName = process.argv[3] || '';
+if (!key) { console.error('usage: node _tmp-recenter.mjs <plate-key> [sticker-name]'); process.exit(1); }
+
+const OUTDIR = 'esoteric-geometries-out';
+const SRC = join(OUTDIR, 'print-src', `${key}.jpg`);
+if (!existsSync(SRC)) { console.error(`missing ${SRC}`); process.exit(1); }
+
+const meta = await sharp(SRC).metadata();
+const DW = 480, scale = DW / Math.max(meta.width, meta.height);
+const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+const { data, info } = await sharp(SRC).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+const ch = info.channels, g = i => data[i * ch];
+const mag = new Float32Array(w * h);
+for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+  const i00 = (y - 1) * w + x, i10 = y * w + x, i20 = (y + 1) * w + x;
+  const sx = -g(i00 - 1) + g(i00 + 1) - 2 * g(i10 - 1) + 2 * g(i10 + 1) - g(i20 - 1) + g(i20 + 1);
+  const sy = -g(i00 - 1) - 2 * g(i00) - g(i00 + 1) + g(i20 - 1) + 2 * g(i20) + g(i20 + 1);
+  mag[y * w + x] = Math.hypot(sx, sy);
+}
+
+const seed = {
+  cx: (Number(process.env.SEED_CX) || 0.5) * w,
+  cy: (Number(process.env.SEED_CY) || 0.5) * h,
+  r: (Number(process.env.SEED_R) || 0.40) * Math.min(w, h),
+};
+const SEARCH = Number(process.env.SEARCH || 0.12);
+let best = { score: -1 };
+const ANG = 180;
+for (let cy = seed.cy - h * SEARCH; cy <= seed.cy + h * SEARCH; cy += 2)
+for (let cx = seed.cx - w * SEARCH; cx <= seed.cx + w * SEARCH; cx += 2)
+for (let r = seed.r * 0.8; r <= seed.r * 1.35; r += 2) {
+  if (cx - r < 0 || cx + r >= w || cy - r < 0 || cy + r >= h) continue;
+  let s = 0;
+  for (let a = 0; a < ANG; a++) {
+    const t = 2 * Math.PI * a / ANG;
+    s += mag[Math.round(cy + r * Math.sin(t)) * w + Math.round(cx + r * Math.cos(t))];
+  }
+  if (s > best.score) best = { score: s, cx, cy, r };
+}
+const cx = best.cx / scale, cy = best.cy / scale, r = best.r / scale;
+console.log(`refined: cx=${cx.toFixed(0)} cy=${cy.toFixed(0)} r=${r.toFixed(0)} (rim score ${(best.score / ANG).toFixed(1)})`);
+
+const SIZE = 2000, PAD = 1.12, BGC = { r: 20, g: 16, b: 25 };
+const side = Math.round(2 * r * PAD), pad = side;
+const ext = await sharp(SRC).extend({ top: pad, bottom: pad, left: pad, right: pad, background: BGC }).toBuffer();
+const maskR = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+const mask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${SIZE / 2}" cy="${SIZE / 2}" r="${maskR}" fill="#fff"/></svg>`);
+const discPath = join(OUTDIR, 'print-discs', `${key}.png`);
+await sharp(ext)
+  .extract({ left: Math.round(cx - side / 2) + pad, top: Math.round(cy - side / 2) + pad, width: side, height: side })
+  .resize(SIZE, SIZE, { fit: 'fill' })
+  .ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png()
+  .toFile(discPath);
+console.log('updated', discPath);
+
+if (stickerName) {
+  const stickerPath = join(OUTDIR, 'playa-gifts/stickers', `${stickerName}.png`);
+  copyFileSync(discPath, stickerPath);
+  const S = 2400, D = Math.round(S * 0.78);
+  const disc = await sharp(discPath).resize(D, D).png().toBuffer();
+  await sharp({ create: { width: S, height: S, channels: 3, background: { r: 26, g: 22, b: 18 } } })
+    .composite([{ input: disc, left: (S - D) / 2, top: (S - D) / 2 }]).jpeg({ quality: 95 })
+    .toFile(join(OUTDIR, 'playa-gifts/buttons', `${stickerName}.jpg`));
+  console.log('updated sticker + button:', stickerName);
+}

--- a/scripts/publication/geometry-reel/universe-warp.mjs
+++ b/scripts/publication/geometry-reel/universe-warp.mjs
@@ -1,0 +1,267 @@
+// Universe-warp reel: the surviving masked reel discs (circles-masked-combined-pngs,
+// already in final order, closer last) play through, the Microcosmus man twists
+// into the vortex, the vortex becomes spinning sunburst stripes, and the
+// Logarithmic Map of the Observable Universe (Budassi, 2012) emerges from the
+// center — its Solar System core held rock-stable — then untwists and holds.
+// Ported from the WARP block of _tmp-build-gif.mjs; inputs are workspace files
+// so it survives /tmp cleanup.
+import sharp from 'sharp';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = '/Users/jdietz/Documents/GitHub/dev/sourcelibrary-v2';
+const DISC_DIR = join(ROOT, 'esoteric-geometries-out/circles-masked-combined-pngs');
+const UNIVERSE = join(ROOT, 'esoteric-geometries-out/contemporary/ctp-09.jpg');
+const EYE = join(ROOT, 'esoteric-geometries-out/eye/eye-11.jpg'); // Boehme Eye of Providence, 1715
+const OUT = join(ROOT, 'esoteric-geometries-out/esoteric-geometries-circles-universe.gif');
+
+const SIZE = 600, DELAY = 60, COLOURS = 256, PAD = 1.12;
+const TEMPO = Number(process.env.TEMPO || 1);
+const T = (ms) => Math.round(ms * TEMPO);
+const DARK = { r: 26, g: 22, b: 18 };
+const BG = { r: 20, g: 16, b: 25 };
+const MAXS = Number(process.env.SWIRL || 6.5);
+const SECTORS = Number(process.env.SECTORS || 9);
+const CORE_STABLE = Number(process.env.CORE_STABLE || 0.22);
+
+const ease = (t) => t * t * (3 - 2 * t);
+const clamp01 = (x) => Math.max(0, Math.min(1, x));
+const cx = SIZE / 2, cy = SIZE / 2;
+const R = Math.min(SIZE / 2 - 1, Math.round((SIZE / 2) * (1.03 / PAD)));
+
+// ---- reel discs (already ordered circle-01..NN, closer = last) ----
+const discFiles = readdirSync(DISC_DIR).filter(f => f.endsWith('.png')).sort();
+console.log(`Reel discs: ${discFiles.length} (closer: ${discFiles[discFiles.length - 1]})`);
+const discs = [];
+for (const f of discFiles) discs.push(await sharp(join(DISC_DIR, f)).resize(SIZE, SIZE).png().toBuffer());
+const manDisc = discs[discs.length - 1];
+
+const darkBase = await sharp({ create: { width: SIZE, height: SIZE, channels: 3, background: DARK } }).png().toBuffer();
+const onDark = (buf) => sharp(darkBase).composite([{ input: buf }]).png().toBuffer();
+async function withAlpha(buf, f) {
+  if (f >= 1) return buf;
+  const m = await sharp(buf).metadata();
+  const mask = Buffer.from(`<svg width="${m.width}" height="${m.height}"><rect width="100%" height="100%" fill="#fff" fill-opacity="${f}"/></svg>`);
+  return sharp(buf).ensureAlpha().composite([{ input: mask, blend: 'dest-in' }]).png().toBuffer();
+}
+async function layer(src, width, lx, ly, alpha = 1) {
+  let b = await sharp(src).resize({ width: Math.max(2, Math.round(width)) }).png().toBuffer();
+  if (alpha < 1) b = await withAlpha(b, alpha);
+  const m = await sharp(b).metadata();
+  return { input: b, left: Math.round(lx - m.width / 2), top: Math.round(ly - m.height / 2) };
+}
+const compose = (layers) => sharp(darkBase).composite(layers).png().toBuffer();
+
+// ---- circle detection (outer-rim-biased; from the chakra pipeline) ----
+async function detectCircle(path) {
+  const DW = 240;
+  const meta = await sharp(path).metadata();
+  const scale = DW / Math.max(meta.width, meta.height);
+  const w = Math.round(meta.width * scale), h = Math.round(meta.height * scale);
+  const { data, info } = await sharp(path).grayscale().resize(w, h, { fit: 'fill' }).raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  const g = i => data[i * ch];
+  const mag = new Float32Array(w * h), dx = new Float32Array(w * h), dy = new Float32Array(w * h);
+  let sum = 0;
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const i00 = (y - 1) * w + x, i10 = y * w + x, i20 = (y + 1) * w + x;
+    const sx = -g(i00 - 1) + g(i00 + 1) - 2 * g(i10 - 1) + 2 * g(i10 + 1) - g(i20 - 1) + g(i20 + 1);
+    const sy = -g(i00 - 1) - 2 * g(i00) - g(i00 + 1) + g(i20 - 1) + 2 * g(i20) + g(i20 + 1);
+    const m = Math.hypot(sx, sy); const idx = y * w + x;
+    mag[idx] = m; dx[idx] = sx; dy[idx] = sy; sum += m;
+  }
+  const cnt = (w - 2) * (h - 2), mean = sum / cnt;
+  let s2 = 0; for (let i = 0; i < mag.length; i++) { const d = mag[i] - mean; s2 += d * d; }
+  const thr = mean + Math.sqrt(s2 / cnt);
+  const minDim = Math.min(w, h);
+  const RSTEP = 2, rmin = Math.round(minDim * 0.20), rmax = Math.round(minDim * 0.78);
+  const nr = Math.floor((rmax - rmin) / RSTEP) + 1;
+  const acc = new Float32Array(nr * w * h);
+  for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+    const idx = y * w + x, m = mag[idx]; if (m < thr) continue;
+    const nx = dx[idx] / m, ny = dy[idx] / m;
+    for (let ri = 0; ri < nr; ri++) {
+      const r = rmin + ri * RSTEP, base = ri * w * h;
+      let px = Math.round(x - nx * r), py = Math.round(y - ny * r);
+      if (px >= 0 && px < w && py >= 0 && py < h) acc[base + py * w + px] += 1;
+      px = Math.round(x + nx * r); py = Math.round(y + ny * r);
+      if (px >= 0 && px < w && py >= 0 && py < h) acc[base + py * w + px] += 1;
+    }
+  }
+  const perR = []; let globalBest = -1;
+  for (let ri = 0; ri < nr; ri++) {
+    const r = rmin + ri * RSTEP, base = ri * w * h, norm = 2 * Math.PI * r;
+    let best = -1, bx = 0, by = 0;
+    for (let y = 1; y < h - 1; y++) for (let x = 1; x < w - 1; x++) {
+      let s = 0; for (let j = -1; j <= 1; j++) for (let i = -1; i <= 1; i++) s += acc[base + (y + j) * w + (x + i)];
+      const sc = s / norm;
+      if (sc > best) { best = sc; bx = x; by = y; }
+    }
+    perR.push({ r, cx: bx, cy: by, conf: best });
+    if (best > globalBest) globalBest = best;
+  }
+  let pick = null;
+  for (let ri = nr - 1; ri >= 0; ri--) if (perR[ri].conf >= Math.max(0.10, 0.55 * globalBest)) { pick = perR[ri]; break; }
+  if (!pick) pick = perR.reduce((a, b) => (b.conf > a.conf ? b : a));
+  return { cx: pick.cx / scale, cy: pick.cy / scale, r: pick.r / scale, conf: pick.conf };
+}
+
+// ---- universe disc: detect, center, mask to the reel radius ----
+const det = await detectCircle(UNIVERSE);
+console.log(`Universe disc: conf=${det.conf.toFixed(2)} r=${det.r.toFixed(0)}`);
+const side = Math.max(2, Math.round(2 * det.r * PAD));
+const upad = side;
+const extended = await sharp(UNIVERSE).extend({ top: upad, bottom: upad, left: upad, right: upad, background: BG }).toBuffer();
+const uMask = Buffer.from(`<svg width="${SIZE}" height="${SIZE}"><circle cx="${cx}" cy="${cy}" r="${R}" fill="#fff"/></svg>`);
+const universeDisc = await sharp(extended)
+  .extract({ left: Math.round(det.cx - side / 2) + upad, top: Math.round(det.cy - side / 2) + upad, width: side, height: side })
+  .resize(SIZE, SIZE, { fit: 'fill' })
+  .ensureAlpha().composite([{ input: uMask, blend: 'dest-in' }]).png().toBuffer();
+await sharp(universeDisc).png().toFile(join(ROOT, 'esoteric-geometries-out/universe-disc.png'));
+
+// ---- eye disc (final image): same detect + mask treatment ----
+const edet = await detectCircle(EYE);
+console.log(`Eye disc: conf=${edet.conf.toFixed(2)} r=${edet.r.toFixed(0)}`);
+const eside = Math.max(2, Math.round(2 * edet.r * PAD));
+const epad = eside;
+const eext = await sharp(EYE).extend({ top: epad, bottom: epad, left: epad, right: epad, background: BG }).toBuffer();
+const eyeDisc = await sharp(eext)
+  .extract({ left: Math.round(edet.cx - eside / 2) + epad, top: Math.round(edet.cy - eside / 2) + epad, width: eside, height: eside })
+  .resize(SIZE, SIZE, { fit: 'fill' })
+  .ensureAlpha().composite([{ input: uMask, blend: 'dest-in' }]).png().toBuffer();
+
+// ---- swirl factory (same operator everywhere) ----
+async function makeSwirler(discBuf, profile = (u) => (1 - u) * (1 - u)) {
+  const { data: raw, info } = await sharp(discBuf).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+  const W2 = info.width, H2 = info.height;
+  function sampleBilinear(sx, sy, out, oi) {
+    if (sx < 0 || sy < 0 || sx > W2 - 1 || sy > H2 - 1) { out[oi + 3] = 0; return; }
+    const x0 = Math.floor(sx), y0 = Math.floor(sy);
+    const x1 = Math.min(x0 + 1, W2 - 1), y1 = Math.min(y0 + 1, H2 - 1);
+    const fx = sx - x0, fy = sy - y0;
+    const i00 = (y0 * W2 + x0) * 4, i10 = (y0 * W2 + x1) * 4;
+    const i01 = (y1 * W2 + x0) * 4, i11 = (y1 * W2 + x1) * 4;
+    for (let c = 0; c < 4; c++) {
+      const top = raw[i00 + c] * (1 - fx) + raw[i10 + c] * fx;
+      const bot = raw[i01 + c] * (1 - fx) + raw[i11 + c] * fx;
+      out[oi + c] = Math.round(top * (1 - fy) + bot * fy);
+    }
+  }
+  return async function swirl(strength, spin = 0) {
+    const out = Buffer.alloc(W2 * H2 * 4, 0);
+    const mcx = W2 / 2, mcy = H2 / 2;
+    for (let y = 0; y < H2; y++) for (let x = 0; x < W2; x++) {
+      const ddx = x - mcx, ddy = y - mcy, r = Math.hypot(ddx, ddy);
+      const oi = (y * W2 + x) * 4;
+      if (r > R) continue;
+      const theta = Math.atan2(ddy, ddx) - strength * profile(r / R) - spin;
+      sampleBilinear(mcx + r * Math.cos(theta), mcy + r * Math.sin(theta), out, oi);
+    }
+    return sharp(out, { raw: { width: W2, height: H2, channels: 4 } }).png().toBuffer();
+  };
+}
+const swirlMan = await makeSwirler(manDisc);
+
+// Sunburst stripes -> spiral under the same warp.
+const INK = 245;
+const sunRaw = Buffer.alloc(SIZE * SIZE * 4, 0);
+for (let y = 0; y < SIZE; y++) for (let x = 0; x < SIZE; x++) {
+  const ddx = x - cx, ddy = y - cy, r = Math.hypot(ddx, ddy);
+  if (r > R) continue;
+  const a = (Math.atan2(ddy, ddx) / (2 * Math.PI) + 0.5) * SECTORS * 2;
+  const i = (y * SIZE + x) * 4;
+  if (Math.floor(a) % 2 === 0) { sunRaw[i] = INK; sunRaw[i + 1] = INK; sunRaw[i + 2] = INK; }
+  else { sunRaw[i] = DARK.r; sunRaw[i + 1] = DARK.g; sunRaw[i + 2] = DARK.b; }
+  sunRaw[i + 3] = 255;
+}
+const sunDisc = await sharp(sunRaw, { raw: { width: SIZE, height: SIZE, channels: 4 } }).png().toBuffer();
+const swirlSun = await makeSwirler(sunDisc);
+
+// Banded profile: dead-zero under the Solar System core, peak twist in the
+// middle annulus, zero again at the rim.
+const smooth = (a, b, x) => { const t = clamp01((x - a) / (b - a)); return t * t * (3 - 2 * t); };
+const band = (u) => smooth(CORE_STABLE, 0.55, u) * (1 - u) * (1 - u);
+let peak = 0; for (let u = 0; u <= 1; u += 0.001) peak = Math.max(peak, band(u));
+const swirlUniverse = await makeSwirler(universeDisc, (u) => band(u) / peak);
+const swirlEye = await makeSwirler(eyeDisc, (u) => band(u) / peak);
+
+async function centerReveal(buf, rr) {
+  const m = await sharp(Buffer.from(
+    `<svg width="${SIZE}" height="${SIZE}"><circle cx="${cx}" cy="${cy}" r="${Math.max(1, rr)}" fill="#fff"/></svg>`
+  )).blur(12).png().toBuffer();
+  return sharp(buf).ensureAlpha().composite([{ input: m, blend: 'dest-in' }]).png().toBuffer();
+}
+
+// ---- assemble ----
+const mainFrames = await Promise.all(discs.map(onDark));
+const K1 = 14, K2 = 4, K3 = 12, K4 = 10, K5 = 14;
+// Spin per frame: 2π/SPIN_DIV. The original 26 read as too fast — default halved.
+const dS = (2 * Math.PI) / Number(process.env.SPIN_DIV || 52);
+let spin = 0;
+const outro = [], outroDelays = [];
+
+outro.push(await onDark(manDisc)); outroDelays.push(T(700));
+for (let i = 1; i <= K1; i++) {
+  outro.push(await onDark(await swirlMan(MAXS * ease(i / K1))));
+  outroDelays.push(T(60));
+}
+const vortexMan = await swirlMan(MAXS);
+for (let i = 1; i <= K2; i++) {
+  const te = ease(i / K2); spin += dS;
+  outro.push(await compose([
+    await layer(vortexMan, SIZE, cx, cy, 1 - te),
+    await layer(await swirlSun(MAXS, spin), SIZE, cx, cy, te),
+  ]));
+  outroDelays.push(T(55));
+}
+for (let i = 0; i < K3; i++) {
+  spin += dS;
+  outro.push(await onDark(await swirlSun(MAXS, spin)));
+  outroDelays.push(T(55));
+}
+// The universe grows out of the spiral's center, core stable, annulus tightening.
+const DRIFT = 0.30;
+let A = MAXS;
+for (let i = 1; i <= K4; i++) {
+  const te = ease(i / K4); spin += dS; A += DRIFT;
+  const base = await swirlSun(MAXS, spin);
+  const uniV = await swirlUniverse(A, 0);
+  outro.push(await compose([
+    await layer(base, SIZE, cx, cy, 1),
+    await layer(await centerReveal(uniV, te * R * 1.15), SIZE, cx, cy, 1),
+  ]));
+  outroDelays.push(T(55));
+}
+for (let i = 1; i <= K5; i++) {
+  outro.push(await onDark(await swirlUniverse(A * (1 - ease(i / K5)), 0)));
+  outroDelays.push(T(60));
+}
+outro.push(await onDark(universeDisc));
+outroDelays.push(T(1400)); // beat on the observable universe
+
+// The eye emerges from the universe's center — same reveal treatment the
+// universe got from the stripes, but over the still cosmos.
+const K6 = 10, K7 = 14;
+let B = MAXS;
+for (let i = 1; i <= K6; i++) {
+  const te = ease(i / K6); B += DRIFT;
+  const eyeV = await swirlEye(B, 0);
+  outro.push(await compose([
+    await layer(universeDisc, SIZE, cx, cy, 1),
+    await layer(await centerReveal(eyeV, te * R * 1.15), SIZE, cx, cy, 1),
+  ]));
+  outroDelays.push(T(55));
+}
+for (let i = 1; i <= K7; i++) {
+  outro.push(await onDark(await swirlEye(B * (1 - ease(i / K7)), 0)));
+  outroDelays.push(T(60));
+}
+outro.push(await onDark(eyeDisc));
+outroDelays.push(T(2800)); // hold on the eye
+
+const seq = [...mainFrames, ...outro];
+const delays = [...mainFrames.map(() => T(DELAY)), ...outroDelays];
+await sharp(seq, { join: { animated: true } }).gif({ loop: 0, delay: delays, effort: 8, colours: COLOURS }).toFile(OUT);
+console.log('wrote', OUT, 'with', seq.length, 'frames');
+await sharp(seq, { join: { animated: true } }).webp({ loop: 0, delay: delays, effort: 6, quality: 90 }).toFile(OUT.replace(/\.gif$/, '.webp'));
+console.log('wrote', OUT.replace(/\.gif$/, '.webp'));

--- a/scripts/publication/geometry-reel/warp-figure.mjs
+++ b/scripts/publication/geometry-reel/warp-figure.mjs
@@ -1,0 +1,93 @@
+// Swirl/vortex warp of a single circular plate (the Microcosmus man).
+// Inverse-mapped twist: max at center, 0 at the rim so the round frame stays
+// intact. Breathes 0 -> MAX -> 0 for a seamless loop.
+//
+// Usage: node _tmp-warp-figure.mjs <input.png> <out.gif>
+//   env: SWIRL  max twist radians at center (default 6.5)
+//        FRAMES  number of frames (default 48)
+//        DELAY   ms per frame (default 55)
+//        DIR     swirl direction 1|-1 (default 1)
+import sharp from 'sharp';
+
+const IN = process.argv[2] || 'esoteric-geometries-out/circles-masked-combined-pngs/circle-16_plate-24.png';
+const OUT = process.argv[3] || 'esoteric-geometries-out/vitruvian-warp.gif';
+const SWIRL = Number(process.env.SWIRL || 6.5);
+const FRAMES = Number(process.env.FRAMES || 48);
+const DELAY = Number(process.env.DELAY || 55);
+const DIRN = Number(process.env.DIR || 1);
+const DARK = { r: 26, g: 22, b: 18 };
+
+const { data: src, info } = await sharp(IN).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+const W = info.width, H = info.height, CH = info.channels;
+const cx = W / 2, cy = H / 2;
+
+// Content radius = furthest opaque pixel from center (defines the rim).
+let R = 0;
+for (let y = 0; y < H; y++) {
+  for (let x = 0; x < W; x++) {
+    if (src[(y * W + x) * CH + 3] > 24) {
+      const d = Math.hypot(x - cx, y - cy);
+      if (d > R) R = d;
+    }
+  }
+}
+R = Math.max(R, 1);
+
+function sampleBilinear(sx, sy, out, oi) {
+  if (sx < 0 || sy < 0 || sx > W - 1 || sy > H - 1) {
+    out[oi] = 0; out[oi + 1] = 0; out[oi + 2] = 0; out[oi + 3] = 0;
+    return;
+  }
+  const x0 = Math.floor(sx), y0 = Math.floor(sy);
+  const x1 = Math.min(x0 + 1, W - 1), y1 = Math.min(y0 + 1, H - 1);
+  const fx = sx - x0, fy = sy - y0;
+  const i00 = (y0 * W + x0) * CH, i10 = (y0 * W + x1) * CH;
+  const i01 = (y1 * W + x0) * CH, i11 = (y1 * W + x1) * CH;
+  for (let c = 0; c < 4; c++) {
+    const top = src[i00 + c] * (1 - fx) + src[i10 + c] * fx;
+    const bot = src[i01 + c] * (1 - fx) + src[i11 + c] * fx;
+    out[oi + c] = Math.round(top * (1 - fy) + bot * fy);
+  }
+}
+
+async function warpFrame(strength) {
+  const out = Buffer.alloc(W * H * 4, 0);
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const dx = x - cx, dy = y - cy;
+      const r = Math.hypot(dx, dy);
+      const oi = (y * W + x) * 4;
+      if (r > R) { out[oi + 3] = 0; continue; }
+      // smooth falloff: max twist at center, 0 at rim
+      const f = 1 - r / R;
+      const twist = strength * f * f; // f^2 keeps the rim extra-stable
+      const theta = Math.atan2(dy, dx) - twist * DIRN;
+      const sx = cx + r * Math.cos(theta);
+      const sy = cy + r * Math.sin(theta);
+      sampleBilinear(sx, sy, out, oi);
+    }
+  }
+  // composite on brand-dark -> opaque frame
+  return sharp({ create: { width: W, height: H, channels: 3, background: DARK } })
+    .composite([{ input: await sharp(out, { raw: { width: W, height: H, channels: 4 } }).png().toBuffer() }])
+    .png().toBuffer();
+}
+
+const frames = [];
+for (let i = 0; i < FRAMES; i++) {
+  const t = i / FRAMES;
+  const s = SWIRL * (0.5 - 0.5 * Math.cos(2 * Math.PI * t)); // 0 -> MAX -> 0
+  frames.push(await warpFrame(s));
+  process.stdout.write(`\r  frame ${i + 1}/${FRAMES}`);
+}
+process.stdout.write('\n');
+
+await sharp(frames, { join: { animated: true } })
+  .gif({ loop: 0, delay: FRAMES ? new Array(FRAMES).fill(DELAY) : DELAY, effort: 8, colours: 128 })
+  .toFile(OUT);
+console.log('wrote', OUT);
+const webp = OUT.replace(/\.gif$/, '.webp');
+await sharp(frames, { join: { animated: true } })
+  .webp({ loop: 0, delay: DELAY, effort: 6, quality: 90 })
+  .toFile(webp);
+console.log('wrote', webp);


### PR DESCRIPTION
## Summary
- Promotes the working scripts behind the esoteric-geometries reel into `scripts/publication/geometry-reel/` (17 scripts + README), companions to the EPUB generator merged in #3272.
- Gallery API sweeps (Buddhist mandalas, all-seeing eyes, visionary art, spiritual anatomy), the gradient-based Hough circle detector + masked-disc pipeline, animated reel builders (main reel, Leadbeater chakra ascent, universe/eye warp finale), a rim-alignment recenter tool, citation-list generator, and print artifacts (tear-out portfolio PDF, flip book, "Eight Circles" booklet, playa sticker/button art).

## Scope
- In scope: the tooling scripts only. All of them read from the public sourcelibrary.org API and write into the gitignored `esoteric-geometries-out/` directory — no app code, DB writers, or pipeline changes.
- Out of scope: generated artifacts (GIFs, PDFs, stickers) stay untracked; some scripts keep an absolute ROOT path from the original session, documented in the README.

## Test plan
- [x] Scripts were each run end-to-end during the session that produced them (reel GIFs/WebP/MP4, portfolio + booklet + flipbook PDFs, sticker/button art)
- [x] No changes to `src/**` — nothing to type-check or deploy

Made with [Cursor](https://cursor.com)