### PR TITLE
feat(audit): give the language_review queue a runnable consumer (#3958)

### DIFF
--- a/scripts/audit/language-review-triage.mjs
+++ b/scripts/audit/language-review-triage.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+/**
+ * Triage the `language_review: true` queue against page evidence (#3958).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * 1,519 live books carry `language_review: true` and nothing drains the queue.
+ * A consumer was written in June (#2534,
+ * `scripts/maintenance/classify-language-mismatch-content.mjs`) with the right
+ * shape — clear the flag, stamp provenance, bump `updated_at` — but it reads its
+ * candidate list from `/tmp/noneng-triage.json`, a temp file that is gone and was
+ * never reproducible, and it is invoked from nowhere. So the queue has a correctly
+ * shaped consumer that cannot be run.
+ *
+ * Worse, the queue has a live PRODUCER: `crontab.production:106` runs
+ * `audit-language-mismatch.mjs --flag` every Sunday at 06:30. It is not a static
+ * backlog; it refills weekly.
+ *
+ * This script is the missing input. It queries the queue from Mongo, joins it to
+ * the per-page OCR `<language>` evidence produced by
+ * `scripts/audit/detect-book-languages.mjs` (#4117), and sorts each row into a
+ * tier that says what should happen to it.
+ *
+ * THIS SCRIPT NEVER WRITES. Clearing a flag on a published book is a public
+ * metadata decision and it happens against a producer that will re-flag some of
+ * what you clear; it wants a reviewed diff, not a sweep bolted onto a report.
+ * There is deliberately no --apply.
+ *
+ * THE TWO SIGNALS
+ * ---------------
+ * PRIMARY — the per-page `<language>` tag, aggregated per book by the #4117
+ * detector. Real detection, already paid for, works on every script.
+ *
+ * FALLBACK — the stopword/script classifier in
+ * `scripts/lib/language-content-classify.mjs`, used ONLY for books the tag cannot
+ * reach (`no_tag`: OCR predates the tag; `thin`: too few tagged pages). It is
+ * blind outside Latin script + Greek + Cyrillic, so it self-limits via
+ * `RELIABLE_CATALOGUE_LANGS` — see that file's header before trusting a verdict.
+ *
+ * Do NOT read `pages.ocr.language` (the FIELD). It holds the request parameter
+ * (`null`, `"auto-detect"`); reading it as an answer measures your own input.
+ *
+ * THE TIERS
+ * ---------
+ *   clear            Page evidence corroborates the catalogue. The flag is a
+ *                    false positive and can be cleared. `add_second` lands here
+ *                    too: a missing second language is a #4117 job, not a reason
+ *                    to hold a review flag on a correctly catalogued book.
+ *   clear_tradition  `contradict`, but the pair is a cross-script scholarly
+ *                    tradition (Joseon hanmun, Tibetan Sanskrit, Japanese
+ *                    kanbun). Correctly catalogued. MUST NEVER be auto-flipped —
+ *                    see `.claude/docs/invariants/language-fields.md`.
+ *   defect_edition   The catalogued language IS on the pages but is not dominant
+ *                    — a Latin edition of a Greek author, catalogued under the
+ *                    original's language. Route to #3261/#2184; the fix is
+ *                    `language` -> the edition's, source -> `original_language`,
+ *                    and it must gate on `text_role`.
+ *   defect_record    The catalogued language is absent from its own pages
+ *                    entirely. The real mislabel queue — #2184.
+ *   unclear          Evidence is thin, contradictory, or from the classifier
+ *                    outside its reliable range. Stays flagged for a human.
+ *
+ * A tier is a ROUTING claim, never a patch. Note in particular that a
+ * contradiction being real does not make the *proposed* language right:
+ * Merezhkovsky's *Христос и Антихрист* vol. 2 is catalogued Russian, tagged
+ * French on 100% of pages, and is in fact an English translation.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/detect-book-languages.mjs            # produce the evidence first
+ *   node scripts/audit/language-review-triage.mjs
+ *   node scripts/audit/language-review-triage.mjs --no-fallback --limit=200
+ *
+ * Flags:
+ *   --detector=FILE    #4117 JSONL evidence (default scripts/output/book-languages.jsonl)
+ *   --out=FILE         JSONL output (default scripts/output/language-review-triage.jsonl)
+ *   --limit=N          stop after N queued books
+ *   --concurrency=N    parallel page samples for the fallback (default 6)
+ *   --no-fallback      skip the classifier; report tag-less books as `unclear`
+ *   --all              include hidden/unpublished books (default: live only)
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { parseLanguageField, languageFamily } from '../lib/language-normalize.mjs';
+import {
+  classifyPageSample,
+  formatDetectedLanguage,
+  toClassifierKey,
+  RELIABLE_CATALOGUE_LANGS,
+} from '../lib/language-content-classify.mjs';
+
+const arg = (name, dflt) => {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : dflt;
+};
+const flag = (name) => process.argv.includes(`--${name}`);
+
+const DETECTOR = arg('detector', 'scripts/output/book-languages.jsonl');
+const OUT = arg('out', 'scripts/output/language-review-triage.jsonl');
+const LIMIT = Number(arg('limit', '0')) || 0;
+const CONCURRENCY = Math.max(1, Number(arg('concurrency', '6')));
+const NO_FALLBACK = flag('no-fallback');
+const ALL = flag('all');
+/** Pages pulled per book for the fallback, and the fractions sampled from them. */
+const SAMPLE_LIMIT = 300;
+const SAMPLE_AT = [0.3, 0.5, 0.7];
+
+/**
+ * Catalogued -> measured pairs where the "contradiction" is the correct record.
+ *
+ * A Joseon scholarly work catalogued `Korean` whose pages are Classical Chinese
+ * is not mislabelled: provenance, tradition and readership are Korean, the script
+ * on the page is literary Chinese. Both facts are true and the record should
+ * carry both — an addition to `languages[]`, never a replacement of `language`.
+ * This class supplied 211 of the detector's ~1,015 apparent mislabels, i.e. the
+ * single largest cluster, exactly as the "suspect the vocabulary first, and
+ * hand-check the biggest cluster" rule predicts.
+ *
+ * Latin-in-vernacular-scholarship belongs to the same family of legitimate
+ * cross-script pairs, but it is NOT listed here: it is indistinguishable by page
+ * share from the source-vs-edition defect (#3261), so it routes to review rather
+ * than to auto-clear. Compared by family, so `Literary Chinese` matches too.
+ */
+export const CROSS_SCRIPT_TRADITIONS = [
+  ['Korean', 'Chinese'],
+  ['Japanese', 'Chinese'],
+  ['Vietnamese', 'Chinese'],
+  ['Tibetan', 'Sanskrit'],
+];
+
+export function isCrossScriptTradition(catalogued, measured) {
+  const measuredFams = new Set(measured.map(languageFamily));
+  return CROSS_SCRIPT_TRADITIONS.some(([cat, meas]) =>
+    catalogued.some((c) => languageFamily(c) === languageFamily(cat)) && measuredFams.has(languageFamily(meas)));
+}
+
+/** Load the #4117 evidence into a map keyed by book id. Streamed — the file is corpus-sized. */
+async function loadDetectorRows(file) {
+  if (!fs.existsSync(file)) {
+    console.error(`Detector evidence not found: ${file}`);
+    console.error('Run `node scripts/audit/detect-book-languages.mjs` first — the page <language> tag');
+    console.error('is the primary signal here, and without it this triage is only the fallback classifier.');
+    process.exit(1);
+  }
+  const rows = new Map();
+  const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
+  let bad = 0;
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      const r = JSON.parse(line);
+      if (r && r.id) rows.set(r.id, r);
+    } catch { bad++; }
+  }
+  if (bad) console.error(`warning: ${bad} unparseable line(s) in ${file}`);
+  return rows;
+}
+
+/**
+ * Decide a tier from the detector row alone. Returns null when the tag cannot
+ * answer and the fallback should be tried.
+ */
+export function tierFromTags(book, row) {
+  const catalogued = row.catalogued?.length ? row.catalogued : parseLanguageField(book.language);
+  const shares = row.shares || [];
+  const measuredAll = shares.map(([lang]) => lang);
+
+  switch (row.bucket) {
+    case 'agree':
+      return { tier: 'clear', reason: 'page tags match the catalogue', signal: 'ocr_tag' };
+    case 'add_second':
+      return {
+        tier: 'clear',
+        reason: 'catalogue is right but incomplete — second language is a #4117 job, not a review hold',
+        signal: 'ocr_tag',
+      };
+    case 'contradict': {
+      if (isCrossScriptTradition(catalogued, measuredAll)) {
+        return {
+          tier: 'clear_tradition',
+          reason: 'cross-script scholarly tradition — correctly catalogued, never auto-flip',
+          signal: 'ocr_tag',
+        };
+      }
+      // #4181's distinction: is the catalogued language on the pages AT ALL, or
+      // absent from its own book? Present-but-not-dominant is the source-vs-edition
+      // class (#3261); wholly absent is the real mislabel (#2184).
+      const cataloguedFams = new Set(catalogued.map(languageFamily));
+      const presentAtAll = shares.some(([lang, , pages]) => pages > 0 && cataloguedFams.has(languageFamily(lang)));
+      return presentAtAll
+        ? { tier: 'defect_edition', reason: 'catalogued language present but not dominant — edition vs work', signal: 'ocr_tag' }
+        : { tier: 'defect_record', reason: 'catalogued language absent from its own pages', signal: 'ocr_tag' };
+    }
+    case 'unsupported_claim':
+      return { tier: 'unclear', reason: 'catalogue names a language the pages do not show', signal: 'ocr_tag' };
+    case 'no_catalogue_value':
+      return { tier: 'unclear', reason: 'catalogue language is a placeholder', signal: 'ocr_tag' };
+    case 'error':
+      return { tier: 'unclear', reason: `detector errored: ${row.error || 'unknown'}`, signal: 'none' };
+    case 'no_tag':
+    case 'thin':
+    case 'unparsed':
+      return null; // the tag cannot answer — fall back
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fallback: read the body text. Mirrors the #2534 triage, including its
+ * reliability gate — outside Latin/Greek the classifier cannot see the body, so
+ * a low density for the catalogued language proves nothing.
+ */
+async function tierFromContent(pages, book) {
+  const pgs = await pages
+    .find({ book_id: book.id, page_number: { $gte: 0 }, 'ocr.data': { $type: 'string', $ne: '' } },
+      { projection: { 'ocr.data': 1, page_number: 1 } })
+    .sort({ page_number: 1 })
+    .limit(SAMPLE_LIMIT)
+    .maxTimeMS(30000)
+    .toArray();
+  if (pgs.length < 3) {
+    return { tier: 'unclear', reason: 'too few OCR pages to read', signal: 'none' };
+  }
+  const texts = SAMPLE_AT.map((f) => pgs[Math.floor(f * (pgs.length - 1))].ocr.data);
+  const res = classifyPageSample(texts);
+  const catalogued = parseLanguageField(book.language);
+  const key = toClassifierKey(catalogued[0] || book.language);
+  const curDens = res.dens[key] ?? 0;
+  const detail = {
+    signal: 'content_classifier',
+    dominant: formatDetectedLanguage(res.dominant),
+    dominant_score: Number(res.score.toFixed(3)),
+    catalogued_density: Number(curDens.toFixed(3)),
+    sampled_pages: texts.length,
+  };
+  if (res.dominant && toClassifierKey(formatDetectedLanguage(res.dominant)) === key) {
+    return { tier: 'clear', reason: 'body text is the catalogued language', ...detail };
+  }
+  if (RELIABLE_CATALOGUE_LANGS.has(key) && res.score >= 0.05 && curDens < 0.015) {
+    return { tier: 'defect_record', reason: 'body text is another language, catalogued one absent', ...detail };
+  }
+  return {
+    tier: 'unclear',
+    reason: RELIABLE_CATALOGUE_LANGS.has(key)
+      ? 'mixed or weak content signal'
+      : `classifier cannot read ${catalogued[0] || book.language} — verdict would be an artifact`,
+    ...detail,
+  };
+}
+
+async function main() {
+  if (flag('apply')) {
+    console.error('This script never writes. Removing --apply and continuing would be a lie; refusing instead.');
+    console.error('Clearing a review flag on a published book is a reviewed decision (#3958), not a sweep.');
+    process.exit(2);
+  }
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI not set (set -a; source .env.production.local; set +a).');
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+
+  const detector = await loadDetectorRows(DETECTOR);
+  console.error(`loaded ${detector.size} detector rows from ${DETECTOR}`);
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+
+  // Canonical live filter: `visible: true && pages_count > 0` (see /api/books/library).
+  const query = {
+    language_review: true,
+    ...(ALL ? {} : { visible: true, pages_count: { $gt: 0 } }),
+  };
+  const queue = await books
+    .find(query, {
+      projection: {
+        id: 1, title: 1, language: 1, languages: 1, language_review_detail: 1,
+        text_role: 1, pages_ocr: 1, pages_count: 1, visible: 1,
+      },
+    })
+    .limit(LIMIT || 0)
+    .maxTimeMS(60000)
+    .toArray();
+  console.error(`queue: ${queue.length} books with language_review: true${ALL ? '' : ' (live)'}`);
+
+  const sink = fs.createWriteStream(OUT, { flags: 'w' });
+  const tiers = {};
+  const signals = {};
+  let noEvidence = 0;
+  let fellBack = 0;
+
+  for (let i = 0; i < queue.length; i += CONCURRENCY) {
+    const slice = queue.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(slice.map(async (book) => {
+      const row = detector.get(book.id);
+      let verdict = row ? tierFromTags(book, row) : null;
+      if (!verdict) {
+        if (!row) noEvidence++;
+        if (NO_FALLBACK) {
+          verdict = {
+            tier: 'unclear',
+            reason: row ? `page tags cannot answer (${row.bucket})` : 'no detector evidence for this book',
+            signal: 'none',
+          };
+        } else {
+          fellBack++;
+          try {
+            verdict = await tierFromContent(pages, book);
+          } catch (e) {
+            // Recorded as a ROW, never skipped — an absent book in the output
+            // must mean "not reached", not "failed quietly".
+            verdict = { tier: 'unclear', reason: `content sample failed: ${String(e?.message || e)}`, signal: 'none' };
+          }
+        }
+      }
+      return { book, row, verdict };
+    }));
+
+    for (const { book, row, verdict } of results) {
+      tiers[verdict.tier] = (tiers[verdict.tier] || 0) + 1;
+      signals[verdict.signal] = (signals[verdict.signal] || 0) + 1;
+      sink.write(JSON.stringify({
+        id: book.id,
+        title: book.title,
+        language: book.language,
+        catalogued: row?.catalogued ?? parseLanguageField(book.language),
+        text_role: book.text_role ?? null,
+        pages_ocr: book.pages_ocr ?? null,
+        // What the weekly cron claimed when it flagged the book, so the report
+        // can be read against the producer's own reasoning.
+        flagged: book.language_review_detail
+          ? {
+            detected: book.language_review_detail.detected ?? null,
+            confidence: book.language_review_detail.confidence ?? null,
+            bucket: book.language_review_detail.bucket ?? null,
+            flagged_at: book.language_review_detail.flagged_at ?? null,
+          }
+          : null,
+        detector_bucket: row?.bucket ?? null,
+        shares: row?.shares ?? null,
+        proposed_languages: row?.proposed_languages ?? null,
+        tier: verdict.tier,
+        reason: verdict.reason,
+        signal: verdict.signal,
+        dominant: verdict.dominant ?? null,
+        dominant_score: verdict.dominant_score ?? null,
+        catalogued_density: verdict.catalogued_density ?? null,
+      }) + '\n');
+    }
+  }
+
+  await new Promise((r) => sink.end(r));
+  await client.close();
+
+  const n = queue.length || 1;
+  const pct = (k) => `${(((tiers[k] || 0) / n) * 100).toFixed(1)}%`;
+  console.error('\n--- summary (DRY RUN — nothing written to the database) ---');
+  console.error(`queued books triaged: ${queue.length} -> ${OUT}`);
+  console.error(`tiers: ${JSON.stringify(tiers, null, 1)}`);
+  console.error(`signals: ${JSON.stringify(signals, null, 1)}`);
+  console.error(`\nno detector evidence: ${noEvidence}${NO_FALLBACK ? '' : `, fell back to the content classifier: ${fellBack}`}`);
+  console.error(`\nsafe to clear:      ${(tiers.clear || 0) + (tiers.clear_tradition || 0)} (${pct('clear')} + ${pct('clear_tradition')} tradition)`);
+  console.error(`route to #3261:     ${tiers.defect_edition || 0} (edition vs work — gate on text_role)`);
+  console.error(`route to #2184:     ${tiers.defect_record || 0} (catalogued language absent from its pages)`);
+  console.error(`stays for a human:  ${tiers.unclear || 0}`);
+  console.error('\nNothing here is a patch. The write shape for the clear tiers is the one in');
+  console.error('classify-language-mismatch-content.mjs: $unset language_review + language_review_detail,');
+  console.error('$set language_verified_content + field_provenance.language + language_review_resolved,');
+  console.error('and bump updated_at only when `language` itself changes (books_catalog mirrors `language`,');
+  console.error('never the review flag). Clearing runs against a live producer — crontab.production:106');
+  console.error('re-flags every Sunday 06:30 — so land the clear and its marker together (#3958).');
+}
+
+// Run only when invoked directly — the tier helpers above are imported by
+// `tests/unit/language-review-triage.test.ts`, and an import must not open a
+// Mongo connection or walk the corpus.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/scripts/lib/language-content-classify.mjs
+++ b/scripts/lib/language-content-classify.mjs
@@ -1,0 +1,112 @@
+/**
+ * Stopword/script language classifier for OCR'd page text.
+ *
+ * Extracted verbatim from `scripts/maintenance/classify-language-mismatch-content.mjs`
+ * (#2534, 2026-06-16) so the `language_review` triage (#3958) can reuse it instead
+ * of growing a second copy. Behaviour is unchanged — the densities, the ranking
+ * and the reliability gate are the ones that script has always used.
+ *
+ * WHAT THIS IS FOR, AND WHAT IT IS NOT
+ * ------------------------------------
+ * This reads the *body text* and measures stopword density plus Greek/Cyrillic
+ * script ratio. It is the FALLBACK signal. The primary signal for a book's
+ * language mix is the per-page OCR `<language>` tag, aggregated by
+ * `scripts/audit/detect-book-languages.mjs` (#4117) — that is real per-page
+ * detection, already paid for, and it covers scripts this classifier is blind to.
+ *
+ * Use this only where the tag cannot answer: books whose OCR predates the tag
+ * (`no_tag`) or that have too few tagged pages (`thin`).
+ *
+ * THE BLIND SPOT IS THE IMPORTANT PART. `RELIABLE_CATALOGUE_LANGS` exists because
+ * this classifier can only read Latin-script bodies plus Greek and Cyrillic. For
+ * Arabic, Hebrew, Sanskrit, Chinese, Coptic or Syriac the body is *invisible* to
+ * it, so a near-zero density for the catalogued language is an artifact of the
+ * instrument, not evidence that the language is absent. Judging those would
+ * manufacture mislabels. Gate on this set before drawing any conclusion.
+ *
+ * See `.claude/docs/invariants/language-fields.md`.
+ */
+
+/** Stopword lists, one per readable language. Deliberately short and common. */
+const SW = {
+  latin: 'et in est non cum ad qui quod sed ut ex per sunt enim hoc esse si aut nam atque ab de quae quam ipse autem'.split(' '),
+  german: 'der die das und ist von zu den nicht mit auch ein eine auf im dem sich des wird werden für als aus dass nach bei'.split(' '),
+  french: 'le la les de des et que qui une dans pour est par sur plus au aux ce il ne pas nous avec son ont été cette'.split(' '),
+  italian: 'il la di che un per non con del della le si nel gli come questo sono anche più ma suo nella delle alla'.split(' '),
+  spanish: 'el la de que los las en un una por con del se su para es como más al sus este entre cuando muy sin'.split(' '),
+  dutch: 'de het een van en in is dat op te met voor niet zijn aan die ook als maar door werd wordt deze'.split(' '),
+  english: 'the and of to in is that it was as with for his by this are be or from at on which have'.split(' '),
+};
+const swSets = Object.fromEntries(Object.entries(SW).map(([k, v]) => [k, new Set(v)]));
+
+/**
+ * Catalogue languages whose *body* this classifier can actually read. Outside
+ * this set a low density means "wrong instrument", never "wrong catalogue".
+ */
+export const RELIABLE_CATALOGUE_LANGS = new Set(['latin', 'greek']);
+
+/** Classifier keys -> canonical English language names. */
+const FMT = {
+  german: 'German', french: 'French', italian: 'Italian', spanish: 'Spanish',
+  dutch: 'Dutch', english: 'English', greek: 'Greek', russian: 'Russian',
+  latin: 'Latin',
+};
+
+/** Turn a classifier key (`'german'`) into a canonical catalogue name (`'German'`). */
+export function formatDetectedLanguage(key) {
+  return FMT[key] || key;
+}
+
+/**
+ * Lowercase a catalogue language to a classifier key. Intentionally minimal —
+ * the canonical normaliser lives in `language-normalize.mjs`; this only has to
+ * agree with the keys of `SW`.
+ */
+export function toClassifierKey(raw) {
+  const s = String(raw || '').toLowerCase().trim();
+  return ({ 'ancient greek': 'greek', eng: 'english' })[s] || s;
+}
+
+/** Drop the OCR metadata block so tags never vote on the body's language. */
+export function stripOcrMetadata(t) {
+  return (t || '')
+    .replace(/<(meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+}
+
+/**
+ * Measure per-language density for one page of OCR text.
+ * Returns the dominant key, its score, the full density map, and the word count
+ * (the caller needs `words` to weight pages when aggregating across a sample).
+ */
+export function classifyLanguageContent(text) {
+  const t = stripOcrMetadata(text);
+  const greek = (t.match(/[Ͱ-Ͽἀ-῿]/g) || []).length;
+  const cyr = (t.match(/[Ѐ-ӿ]/g) || []).length;
+  const latinCh = (t.match(/[A-Za-zÀ-ÿ]/g) || []).length;
+  const words = (t.toLowerCase().match(/[a-zà-ÿ]+/g) || []);
+  const total = words.length || 1;
+  const dens = {};
+  for (const [k, set] of Object.entries(swSets)) dens[k] = words.filter((w) => set.has(w)).length / total;
+  dens.greek = greek / (greek + latinCh + cyr + 1);
+  dens.russian = cyr / (greek + latinCh + cyr + 1);
+  const ranked = Object.entries(dens).sort((a, b) => b[1] - a[1]);
+  return { dominant: ranked[0][0], score: ranked[0][1], dens, words: total };
+}
+
+/**
+ * Aggregate several pages into one verdict, weighting each page by its word
+ * count. Mirrors the sampling the #2534 script has always done.
+ */
+export function classifyPageSample(texts) {
+  const agg = {};
+  let totalWords = 0;
+  for (const text of texts) {
+    const r = classifyLanguageContent(text);
+    for (const [k, v] of Object.entries(r.dens)) agg[k] = (agg[k] || 0) + v * r.words;
+    totalWords += r.words;
+  }
+  for (const k of Object.keys(agg)) agg[k] /= (totalWords || 1);
+  const ranked = Object.entries(agg).sort((a, b) => b[1] - a[1]);
+  return { dominant: ranked[0]?.[0] ?? null, score: ranked[0]?.[1] ?? 0, dens: agg, words: totalWords };
+}

--- a/scripts/maintenance/classify-language-mismatch-content.mjs
+++ b/scripts/maintenance/classify-language-mismatch-content.mjs
@@ -11,41 +11,37 @@
  *     correct the `language` field to the dominant language. (--apply)
  *   - mixed / unclear -> leave flagged for human review.
  *
+ * SUPERSEDED AS AN ENTRY POINT (#3958). This script reads its candidate list from
+ * `/tmp/noneng-triage.json`, a temp file that no longer exists and was never
+ * reproducible, which is why it never drained the queue it was built for. The
+ * runnable entry point is now:
+ *
+ *   scripts/audit/language-review-triage.mjs
+ *
+ * which queries the `language_review` queue from Mongo, uses the per-page OCR
+ * `<language>` tag as the primary signal (#4117), and falls back to the
+ * classifier below only for books the tag cannot reach. Its classifier now lives
+ * in `scripts/lib/language-content-classify.mjs` and is shared with this file.
+ *
+ * Kept because its `--apply` block is the reference write shape: clear the flag,
+ * stamp `field_provenance.language`, bump `updated_at`.
+ *
  * Reads /tmp/noneng-triage.json (ids). Usage:
  *   node scripts/maintenance/classify-language-mismatch-content.mjs          # report
  *   node scripts/maintenance/classify-language-mismatch-content.mjs --apply  # fix clear vernacular + clear false-positive flags
  */
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+// Classifier extracted to a lib so the #3958 triage reuses it rather than
+// copying it. Behaviour here is unchanged.
+import {
+  classifyLanguageContent as classify,
+  formatDetectedLanguage,
+  toClassifierKey as norm,
+  RELIABLE_CATALOGUE_LANGS,
+} from '../lib/language-content-classify.mjs';
 
 const APPLY = process.argv.includes('--apply');
-const SW = {
-  latin: 'et in est non cum ad qui quod sed ut ex per sunt enim hoc esse si aut nam atque ab de quae quam ipse autem'.split(' '),
-  german: 'der die das und ist von zu den nicht mit auch ein eine auf im dem sich des wird werden für als aus dass nach bei'.split(' '),
-  french: 'le la les de des et que qui une dans pour est par sur plus au aux ce il ne pas nous avec son ont été cette'.split(' '),
-  italian: 'il la di che un per non con del della le si nel gli come questo sono anche più ma suo nella delle alla'.split(' '),
-  spanish: 'el la de que los las en un una por con del se su para es como más al sus este entre cuando muy sin'.split(' '),
-  dutch: 'de het een van en in is dat op te met voor niet zijn aan die ook als maar door werd wordt deze'.split(' '),
-  english: 'the and of to in is that it was as with for his by this are be or from at on which have'.split(' '),
-};
-const swSets = Object.fromEntries(Object.entries(SW).map(([k, v]) => [k, new Set(v)]));
-const norm = s => ({ 'ancient greek': 'greek', eng: 'english' }[String(s||'').toLowerCase().trim()] || String(s||'').toLowerCase().trim());
-const strip = t => (t||'').replace(/<(meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning)[^>]*>[\s\S]*?<\/\1>/gi,' ').replace(/<[^>]+>/g,' ');
-
-function classify(text) {
-  const t = strip(text);
-  const greek = (t.match(/[Ͱ-Ͽἀ-῿]/g)||[]).length;
-  const cyr = (t.match(/[Ѐ-ӿ]/g)||[]).length;
-  const latinCh = (t.match(/[A-Za-zÀ-ÿ]/g)||[]).length;
-  const words = (t.toLowerCase().match(/[a-zà-ÿ]+/g)||[]);
-  const total = words.length || 1;
-  const dens = {};
-  for (const [k, set] of Object.entries(swSets)) dens[k] = words.filter(w => set.has(w)).length / total;
-  dens.greek = greek / (greek + latinCh + cyr + 1);
-  dens.russian = cyr / (greek + latinCh + cyr + 1);
-  const ranked = Object.entries(dens).sort((a,b)=>b[1]-a[1]);
-  return { dominant: ranked[0][0], score: ranked[0][1], dens, words: total };
-}
 
 const cand = JSON.parse(fs.readFileSync('/tmp/noneng-triage.json','utf8'));
 const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
@@ -71,13 +67,13 @@ for (const c of cand) {
   // invisible to it (no stopword/script detection), so curDens≈0 is an artifact,
   // not evidence the original is absent. Only auto-judge when the catalog
   // language is one we can actually read: latin or greek.
-  const RELIABLE = new Set(['latin','greek']);
+  const RELIABLE = RELIABLE_CATALOGUE_LANGS;
   if (norm(dominant) === cur) out.falsePositive.push(rec);                          // dominant IS the catalog language → correctly tagged
   else if (RELIABLE.has(cur) && ranked[0][1] >= 0.05 && (curDens||0) < 0.015) out.vernacular.push(rec); // reliably a modern lang, classical absent
   else out.unclear.push(rec);                                                        // non-Latin/Greek script, or mixed → human review
 }
 
-const fmtLang = d => ({ german:'German', french:'French', italian:'Italian', spanish:'Spanish', dutch:'Dutch', english:'English', greek:'Greek', russian:'Russian', latin:'Latin' }[d] || d);
+const fmtLang = formatDetectedLanguage;
 console.log(`triaged ${cand.length} candidates:`);
 console.log(`  FALSE POSITIVE (original w/ apparatus — clear review flag): ${out.falsePositive.length}`);
 console.log(`  VERNACULAR (genuine modern-lang — fix language): ${out.vernacular.length}`);

--- a/tests/unit/language-review-triage.test.ts
+++ b/tests/unit/language-review-triage.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { tierFromTags, isCrossScriptTradition } from '../../scripts/audit/language-review-triage.mjs';
+import {
+  classifyLanguageContent,
+  classifyPageSample,
+  toClassifierKey,
+  formatDetectedLanguage,
+  RELIABLE_CATALOGUE_LANGS,
+} from '../../scripts/lib/language-content-classify.mjs';
+
+/**
+ * Guards for the `language_review` triage (#3958).
+ *
+ * The routing this pins is not cosmetic. Two of these rules exist because a
+ * sweep that got them wrong nearly relabelled 547 books, and a third because the
+ * largest apparent-mislabel cluster in the corpus is not a mislabel at all. A
+ * tier is a routing claim about published metadata, so the classes that must
+ * NEVER be auto-cleared or auto-flipped are pinned here rather than left to a
+ * comment.
+ */
+
+/** Minimal detector row, in the shape `detect-book-languages.mjs` writes. */
+const row = (over: Record<string, unknown> = {}) => ({
+  id: 'x', bucket: 'agree', catalogued: ['Latin'],
+  shares: [['Latin', 0.98, 200]], proposed_languages: ['Latin'], ...over,
+});
+const book = (language: string) => ({ id: 'x', title: 't', language });
+
+describe('tierFromTags — the clear tiers', () => {
+  it('clears a book whose pages match the catalogue', () => {
+    expect(tierFromTags(book('Latin'), row()).tier).toBe('clear');
+  });
+
+  it('clears `add_second` — an incomplete catalogue is a #4117 job, not a review hold', () => {
+    const v = tierFromTags(book('German'), row({
+      bucket: 'add_second', catalogued: ['German'],
+      shares: [['German', 0.61, 61], ['Latin', 0.38, 38]],
+    }));
+    expect(v.tier).toBe('clear');
+  });
+});
+
+describe('tierFromTags — the hanmun class must never be flipped', () => {
+  // 211 of the detector's ~1,015 apparent mislabels. Joseon scholarly works are
+  // written in literary Chinese; provenance and readership are Korean. Both facts
+  // are true. Auto-flipping `language` here destroys the correct record.
+  it('routes Korean -> Classical Chinese to clear_tradition, never a defect', () => {
+    const v = tierFromTags(book('Korean'), row({
+      bucket: 'contradict', catalogued: ['Korean'],
+      shares: [['Classical Chinese', 0.99, 300]],
+    }));
+    expect(v.tier).toBe('clear_tradition');
+    expect(v.tier).not.toMatch(/^defect/);
+  });
+
+  it('routes Tibetan -> Sanskrit the same way', () => {
+    const v = tierFromTags(book('Tibetan'), row({
+      bucket: 'contradict', catalogued: ['Tibetan'],
+      shares: [['Sanskrit', 0.95, 120]],
+    }));
+    expect(v.tier).toBe('clear_tradition');
+  });
+
+  it('matches by family, so plain `Chinese` and `Literary Chinese` both count', () => {
+    expect(isCrossScriptTradition(['Korean'], ['Chinese'])).toBe(true);
+    expect(isCrossScriptTradition(['Korean'], ['Literary Chinese'])).toBe(true);
+    expect(isCrossScriptTradition(['Japanese'], ['Classical Chinese'])).toBe(true);
+  });
+
+  it('does not fire on an unrelated pair', () => {
+    expect(isCrossScriptTradition(['Greek'], ['Latin'])).toBe(false);
+    expect(isCrossScriptTradition(['German'], ['French'])).toBe(false);
+  });
+
+  it('does NOT treat Latin-in-vernacular as a tradition — it is indistinguishable from #3261', () => {
+    // Deliberately absent from CROSS_SCRIPT_TRADITIONS: auto-clearing it would
+    // hide the source-vs-edition defect it looks exactly like.
+    expect(isCrossScriptTradition(['Italian'], ['Latin'])).toBe(false);
+  });
+});
+
+describe('tierFromTags — splitting `contradict` into its two defect classes', () => {
+  // #4181's distinction. Present-but-not-dominant is a Latin edition of a Greek
+  // author (#3261, fix is language -> edition, source -> original_language, gated
+  // on text_role). Wholly absent is the real mislabel (#2184).
+  it('present but not dominant -> defect_edition', () => {
+    const v = tierFromTags(book('Greek'), row({
+      bucket: 'contradict', catalogued: ['Greek'],
+      shares: [['Latin', 0.99, 330], ['Greek', 0.04, 13]],
+    }));
+    expect(v.tier).toBe('defect_edition');
+  });
+
+  it('absent from its own pages -> defect_record', () => {
+    const v = tierFromTags(book('Arabic'), row({
+      bucket: 'contradict', catalogued: ['Arabic'],
+      shares: [['Latin', 0.99, 400]],
+    }));
+    expect(v.tier).toBe('defect_record');
+  });
+
+  it('a zero-page share does not count as present', () => {
+    const v = tierFromTags(book('Greek'), row({
+      bucket: 'contradict', catalogued: ['Greek'],
+      shares: [['Latin', 0.99, 400], ['Greek', 0, 0]],
+    }));
+    expect(v.tier).toBe('defect_record');
+  });
+});
+
+describe('tierFromTags — no verdict without evidence', () => {
+  it.each(['no_tag', 'thin', 'unparsed'])('returns null for `%s` so the caller falls back', (bucket) => {
+    expect(tierFromTags(book('Latin'), row({ bucket }))).toBeNull();
+  });
+
+  it.each(['unsupported_claim', 'no_catalogue_value', 'error'])('routes `%s` to unclear', (bucket) => {
+    expect(tierFromTags(book('Latin'), row({ bucket })).tier).toBe('unclear');
+  });
+
+  it('never invents a clear tier from an unknown bucket', () => {
+    expect(tierFromTags(book('Latin'), row({ bucket: 'something_new' }))).toBeNull();
+  });
+});
+
+describe('content classifier — the fallback and its blind spot', () => {
+  it('reads a Latin body as Latin', () => {
+    const r = classifyLanguageContent('quod est in principio et non est aliud cum hoc esse per se');
+    expect(r.dominant).toBe('latin');
+  });
+
+  it('reads a German body as German', () => {
+    const r = classifyLanguageContent('der die das und ist von zu den nicht mit auch ein auf im dem');
+    expect(r.dominant).toBe('german');
+  });
+
+  it('strips the OCR metadata block so a language tag cannot vote on the body', () => {
+    const tagged = '<language>German</language>' + ' quod est in principio et non est aliud cum hoc esse';
+    expect(classifyLanguageContent(tagged).dominant).toBe('latin');
+  });
+
+  it('only trusts itself for Latin and Greek — every other script is invisible to it', () => {
+    // A near-zero density for Arabic/Hebrew/Sanskrit/Chinese is an artifact of the
+    // instrument, not evidence the language is absent. Gating on this set is what
+    // stops the fallback manufacturing mislabels.
+    expect([...RELIABLE_CATALOGUE_LANGS].sort()).toEqual(['greek', 'latin']);
+    expect(RELIABLE_CATALOGUE_LANGS.has('arabic')).toBe(false);
+    expect(RELIABLE_CATALOGUE_LANGS.has('chinese')).toBe(false);
+  });
+
+  it('weights a multi-page sample by word count', () => {
+    const r = classifyPageSample([
+      'der die das und ist von zu den nicht mit auch ein auf im dem sich des wird',
+      'der die das und ist von zu den nicht',
+    ]);
+    expect(r.dominant).toBe('german');
+    expect(r.words).toBeGreaterThan(20);
+  });
+
+  it('survives an empty sample without throwing', () => {
+    expect(() => classifyPageSample([])).not.toThrow();
+    expect(classifyPageSample([]).words).toBe(0);
+  });
+
+  it('round-trips catalogue name -> classifier key -> canonical name', () => {
+    expect(toClassifierKey('Ancient Greek')).toBe('greek');
+    expect(formatDetectedLanguage('greek')).toBe('Greek');
+    expect(toClassifierKey(formatDetectedLanguage('german'))).toBe('german');
+  });
+});


### PR DESCRIPTION
Lane 1 of the #3958 re-scope. **Report only — no writes, and `--apply` is refused.**

## Why the queue never drained

#3958 says nothing consumes `language_review`. Reading the tree, that is not quite it: a consumer has existed since **June**. `scripts/maintenance/classify-language-mismatch-content.mjs` (#2534) does all three things the issue asks for — `$unset` the flag, stamp `field_provenance.language`, bump `updated_at` — and it already uses `language_verified_content` as the "checked, catalogue was right" marker.

It never drained anything because it reads its candidate list from **`/tmp/noneng-triage.json`**, a temp file that is gone and was never reproducible, and it is invoked from nowhere (the only reference in the repo is a docs table row). The drain existed and could not be run.

Meanwhile the queue has a **live producer**: `crontab.production:106` runs `audit-language-mismatch.mjs --flag` every Sunday 06:30. This is not a static backlog of 1,519; it refills weekly.

## What this adds

`scripts/audit/language-review-triage.mjs` — the missing input. Queries the queue from Mongo (canonical live filter `visible: true && pages_count > 0`), joins it to the per-page OCR `<language>` evidence from #4117's detector, and routes each row:

| tier | meaning |
|---|---|
| `clear` | page tags corroborate the catalogue — flag is a false positive |
| `clear_tradition` | `contradict`, but a cross-script scholarly tradition. Correctly catalogued |
| `defect_edition` | catalogued language IS on the pages, not dominant → #3261, gate on `text_role` |
| `defect_record` | catalogued language absent from its own pages → #2184, the real queue |
| `unclear` | thin or contradictory evidence — stays flagged for a human |

`add_second` lands in `clear`: a missing second language is a #4117 job, not a reason to hold a review flag on a correctly catalogued book.

Two signals, in order. **Primary** is the page `<language>` tag — real detection, already paid for, works on every script. **Fallback** is the stopword/script classifier, used only for `no_tag` (OCR predates the tag) and `thin` books. `pages.ocr.language` (the field) is not read anywhere; it holds the request parameter.

## Reuse, not a second copy

The classifier moves out of the June script into `scripts/lib/language-content-classify.mjs` and both import it. The extraction is behaviour-preserving and I checked that differentially rather than by eye — old inline implementation vs new lib across 13 samples (Latin, German, French, English, Greek, Cyrillic, tag-only, empty, whitespace) plus both lookup tables: identical dominant, score, density map and word count on every one.

Its header now carries the blind spot explicitly, because that is the part a caller gets wrong: it reads Latin script + Greek + Cyrillic only. For Arabic, Hebrew, Sanskrit, Chinese, Coptic or Syriac the body is *invisible* to it, so a near-zero density for the catalogued language is an artifact of the instrument, not evidence the language is absent. `RELIABLE_CATALOGUE_LANGS` gates it, and the gate is pinned by a test.

## The two routing rules worth reviewing closely

Both are pinned by tests rather than left to a comment, because both have already cost something.

**Korean → Classical Chinese must never become a defect.** It is 211 of the detector's ~1,015 apparent mislabels — the largest single cluster, exactly as `language-fields.md`'s "hand-check the biggest cluster first" rule predicts. Joseon scholarly works are written in literary Chinese; provenance and readership are Korean. Both facts are true and the record should carry both. Routes to `clear_tradition`; same for Tibetan/Sanskrit and Japanese kanbun. Matched by *family*, so `Chinese` / `Classical Chinese` / `Literary Chinese` all count.

**`contradict` splits on whether the catalogued language is on the pages at all** — #4181's distinction, computed from the detector's per-language page counts. Present-but-not-dominant is a Latin edition of a Greek author (Hero of Alexandria ed. Commandino 1575). Absent entirely is the real mislabel. Conflating them is #2184 repeating, and that nearly relabelled 547 English translation editions to their source languages.

**Latin-in-vernacular is deliberately NOT in the tradition list.** `language-fields.md` groups it with hanmun as a legitimate cross-script pair, and it is — but by page share it is indistinguishable from the source-vs-edition defect, so auto-clearing it would hide #3261. It routes to review instead.

A tier is a routing claim, never a patch. The script's own summary says so, and reproduces the counter-example from #4181: Merezhkovsky's *Христос и Антихрист* vol. 2 is catalogued `Russian`, tagged `French` on 100% of pages, and is in fact an **English** translation. The contradiction was real; the proposed label was wrong.

## Verified

- `npx tsc --noEmit` clean; full unit suite **3023 passing / 218 files**, including 24 new.
- `--apply` refused with exit 2. Missing detector file exits 1 and names the command to run first.
- Differential check on the extraction, described above.

## NOT verified — please read before merging

**The Mongo path is unexercised.** This environment has no production credentials (`.env.production.local` absent) and no detector output on disk, so the queue query, the fallback page sampling and the JSONL join have never run against real data. What ran is the pure routing logic, the guards, and the extraction check. Someone with credentials should do a `--limit=200` shakeout before the output is used to decide anything.

## Out of scope

- **Writing anything.** Clearing the corroborated tier is a separate PR and Derek's decision. It must land together with its marker, or the Sunday cron re-flags what it cleared and it looks like the sweep failed.
- Rewiring the two existing `expandLanguages()` call sites — that changes what search returns (#4089/#3893).
- Lane 3, filing the `defect_*` rows onto #3261/#2184. Bookkeeping once this output exists.
- The `updated_at` bump on the `--flag` write. Looks like the #3956 defect, is not one: `language_review` appears nowhere in `sync-books-catalog.mjs`, so there is nothing for it to mirror. Recorded as a non-finding in the script's summary so nobody re-derives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
