### PR TITLE
fix(artwork): /artwork/<id> 404'd every artwork in My Likes

### DIFF
--- a/src/app/api/likes/mine/route.ts
+++ b/src/app/api/likes/mine/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
     if (targetType === 'book') {
       const booksData = await db.collection('books').find(
         { id: { $in: targetIds }, ...tenantFilter },
-        { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
+        { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
       ).toArray();
       const booksMap = new Map(booksData.map(b => [b.id, b]));
 
@@ -104,6 +104,10 @@ export async function GET(request: NextRequest) {
           const gallery = galleryMap.get(book.id) || [];
           return {
             id: book.id,
+            // The favorites page builds /artwork/<slug || id> hrefs from this.
+            // /popular already returns slug; without it here every artwork in
+            // "My Likes" linked to /artwork/<id>, which used to 404.
+            slug: book.slug,
             title: book.display_title || book.title,
             author: book.author,
             year: book.year,

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -19,13 +19,19 @@ interface PageProps {
 async function getArtwork(slug: string) {
   const db = await getReadDb();
 
-  // Exact slug, or the legacy `art-` prefixed twin. Fetch BOTH and choose
-  // deliberately — a single findOne over an $in returns an arbitrary match, so
-  // a hidden duplicate twin could shadow the visible canonical and 404 a live
-  // artwork (see src/lib/artwork-slug.ts).
+  // Exact slug, the legacy `art-` prefixed twin, or the record id. Fetch ALL
+  // and choose deliberately — a single findOne over an $in returns an arbitrary
+  // match, so a hidden duplicate twin could shadow the visible canonical and
+  // 404 a live artwork (see src/lib/artwork-slug.ts). Id resolution matters
+  // because /favorites and saved links address artworks by id, and /book/<id>
+  // permanently redirects those here.
   const candidates = await db.collection('books').find(
     // content_type:'book' wins: never render a textual book as artwork even via a direct /artwork/<slug> URL.
-    { slug: { $in: [slug, `art-${slug}`] }, resource_type: { $exists: true }, content_type: { $ne: 'book' } },
+    {
+      $or: [{ slug: { $in: [slug, `art-${slug}`] } }, { id: slug }],
+      resource_type: { $exists: true },
+      content_type: { $ne: 'book' },
+    },
   ).toArray();
   const artwork = pickArtworkRecord(candidates, slug);
   if (!artwork) return null;

--- a/src/lib/artwork-slug.ts
+++ b/src/lib/artwork-slug.ts
@@ -18,13 +18,16 @@
  * Precedence, most specific first:
  *   1. the exact slug asked for, if visible
  *   2. the `art-` variant, if visible
- *   3. any match at all — hidden, so the caller's visibility gate 404s it
+ *   3. the record whose id was asked for, if visible (favorites and saved
+ *      links address artworks by id — the like APIs didn't always carry slugs)
+ *   4. any match at all — hidden, so the caller's visibility gate 404s it
  *
  * Rule 3 matters: a hidden *canonical* must still 404 rather than silently
  * falling through to some other record (the hidden-book read-path gate).
  */
 
 export interface ArtworkCandidate {
+  id?: string | null;
   slug?: string | null;
   visible?: boolean | null;
 }
@@ -53,7 +56,8 @@ export function artworkRedirectSlug(book: {
   if (book.content_type === 'text' || book.content_type === 'book') return null;
   // Mirrors isVisualArt: a resource_type that is neither of the two textual kinds.
   if (!book.resource_type || book.resource_type === 'printed_book' || book.resource_type === 'manuscript') return null;
-  // /artwork resolves by slug ($in on [slug, `art-${slug}`]), never by id.
+  // /artwork also resolves by id now, but a slugless artwork keeps its /book
+  // rendering — flipping those to permanent redirects is a separate decision.
   return book.slug || null;
 }
 
@@ -65,10 +69,12 @@ export function pickArtworkRecord<T>(candidates: T[], requestedSlug: string): T 
   const as = (c: T) => c as unknown as ArtworkCandidate;
   const visible = (c: T) => as(c).visible !== false;
   const slugOf = (c: T) => as(c).slug;
+  const idOf = (c: T) => as(c).id;
 
   return (
     candidates.find((c) => slugOf(c) === requestedSlug && visible(c)) ??
     candidates.find((c) => slugOf(c) === `art-${requestedSlug}` && visible(c)) ??
+    candidates.find((c) => idOf(c) === requestedSlug && visible(c)) ??
     candidates.find((c) => slugOf(c) === requestedSlug) ??
     candidates[0]
   );

--- a/tests/unit/artwork-slug-shadow.test.ts
+++ b/tests/unit/artwork-slug-shadow.test.ts
@@ -50,4 +50,22 @@ describe('pickArtworkRecord', () => {
   it('returns null when nothing matched', () => {
     expect(pickArtworkRecord([], 'nothing-here')).toBeNull();
   });
+
+  it('resolves a visible record addressed by id (favorites link by id)', () => {
+    const byId = { id: '69e535a6ad2c589edb9e0779', slug: 'print-garden-of-love-ca-1500', visible: true };
+    expect(pickArtworkRecord([byId], '69e535a6ad2c589edb9e0779')).toBe(byId);
+  });
+
+  it('prefers a visible slug match over an id match', () => {
+    const slugMatch = { id: 'other-id', slug: 'gold', visible: true };
+    const idMatch = { id: 'gold', slug: 'something-else', visible: true };
+    for (const candidates of both(slugMatch, idMatch)) {
+      expect(pickArtworkRecord(candidates, 'gold')).toBe(slugMatch);
+    }
+  });
+
+  it('a hidden record addressed by id still reaches the caller gate (404, not fall-through)', () => {
+    const hidden = { id: 'abc123', slug: 'hidden-work', visible: false };
+    expect(pickArtworkRecord([hidden], 'abc123')).toBe(hidden);
+  });
 });


### PR DESCRIPTION
## What

A reader reported their favorites were inaccessible. Every **artwork** card on /favorites → My Likes linked to a 404.

Two compounding defects:

1. **`/api/likes/mine` returned no `slug` for book-type likes** — `/api/likes/popular` does, which is why Most Popular worked while My Likes didn't. The favorites page builds `/artwork/${slug || id}`, so every liked artwork fell back to an id href.
2. **`/artwork/[slug]` resolved by slug only** — `/artwork/<id>` 404'd even for a visible artwork. Verified on prod before the fix: `/artwork/69e535a6ad2c589edb9e0779` → 404 while the same record's `/artwork/print-garden-of-love-ca-1500` → 200. The not_found_reports log shows these id-shaped artwork 404s arriving from real internal referrers.

## Fix

- `/api/likes/mine` book branch now projects and returns `slug`.
- `getArtwork()` matches `{ id: slug }` alongside the slug/`art-` twin lookup; `pickArtworkRecord` precedence is visible slug > visible `art-` twin > visible id > hidden exact match (the hidden-book read-path gate still gets the record and 404s it — no fall-through).
- Unit tests for id resolution, slug-over-id precedence, and the hidden-by-id gate.

## Out of scope

- `artworkRedirectSlug` still keeps slugless artworks rendering at /book (flipping those to permanent redirects is a separate decision; comment updated).
- The search-result 404s (`/book/<id>?ns=1` for ids missing from `books`) are a different defect — stale ids in a search lane, not this route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwXZqmDxqx5pECrJo2fVyu