### PR TITLE
fix(tenant): catalogue-linked external editions 404'd in reading rooms

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -7,6 +7,7 @@ import { notFound, permanentRedirect, redirect } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { tenantCatalogReferencesBook } from '@/lib/tenant-catalog-books';
 import { resolveImprintPlace } from '@/lib/imprint';
 import { displayPublished, citationYear } from '@/lib/publication-date';
 import { isHiddenBook } from '@/lib/book-access';
@@ -213,6 +214,17 @@ async function getBookForMetadata(id: string, tenantId?: string | null, tenantSl
     'index.keyTerms': 0,
   }, tenantId);
   if (scoped) return scoped.book as unknown as Book;
+
+  // A book the tenant's own catalogue links (external-scan edition of a held
+  // work) renders in the reading room even without a tenantId assignment —
+  // mirror of the same admission in getBook(). See src/lib/tenant-catalog-books.ts.
+  if (tenantSlug && tenantSlug !== 'default') {
+    const unscopedId = ((result.book as Record<string, unknown>).id
+      || (result.book as { _id?: { toString(): string } })._id?.toString()) as string;
+    if (await tenantCatalogReferencesBook(tenantSlug, unscopedId)) {
+      return result.book as unknown as Book;
+    }
+  }
 
   // Default tenant is the global namespace. Legacy + corpus-source books
   // (ETCSL, CDLI, etc.) have no `tenantId`/`tenant_id` field at all; the
@@ -521,12 +533,25 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
       'index.concepts': 0,
       'index.keyTerms': 0,
     }, tenantId);
-    if (!scoped) return null;
-    effectiveResult = {
-      book: scoped.book as Record<string, unknown>,
-      matchedBySlug: scoped.matchedBySlug,
-      fromCatalog: false,
-    };
+    if (scoped) {
+      effectiveResult = {
+        book: scoped.book as Record<string, unknown>,
+        matchedBySlug: scoped.matchedBySlug,
+        fromCatalog: false,
+      };
+    } else {
+      // Not assigned to this tenant — but the tenant's own catalogue may link
+      // it as an external-scan edition of a work they hold (sl_external_book_id
+      // on bph_works / library_catalog_records). The catalogue row is the
+      // authorization; without it this stays a hard miss (tenant lockdown).
+      const unscopedId = (result.book.id || result.book._id?.toString()) as string;
+      const referenced = tenantSlug
+        ? await tenantCatalogReferencesBook(tenantSlug, unscopedId)
+        : false;
+      if (!referenced) return null;
+      // Fall through with the unscoped lookup result; the hidden-book gate
+      // downstream still applies to it unchanged.
+    }
   }
 
   const { book: quickBook, matchedBySlug, fromCatalog } = effectiveResult;

--- a/src/lib/tenant-catalog-books.ts
+++ b/src/lib/tenant-catalog-books.ts
@@ -1,0 +1,54 @@
+/**
+ * Does a tenant's OWN catalogue reference this Source Library book?
+ *
+ * The tenant lockdown admits a book onto a partner subdomain when it is
+ * explicitly assigned to that tenant (`books.tenantId`). But partner
+ * catalogues also link *external-scan* editions of works they hold —
+ * `sl_external_book_id` on `bph_works` (BPH) and `library_catalog_records`
+ * (unified-catalogue tenants) — and those books are global (`tenantId`
+ * null), so `/embed/<tenant>/book/<slug>` refused them and every
+ * "read online" link the catalogue rendered for them was a 404
+ * (picatrix, Greater Key of Solomon, Chymische Hochzeit… — see the
+ * not_found_reports cluster of 2026-08-23→25).
+ *
+ * The catalogue row is curated by the partner's own librarians, so it is
+ * the authorization: a book their catalogue points at may render inside
+ * their reading room. This helper answers only that membership question —
+ * visibility/hidden gating stays with the caller, and any book NOT
+ * referenced stays locked out exactly as before.
+ */
+
+import { supabase } from '@/lib/supabase';
+
+export async function tenantCatalogReferencesBook(
+  tenantSlug: string,
+  bookId: string,
+): Promise<boolean> {
+  if (!tenantSlug || !bookId) return false;
+  // bookId is URL-derived and interpolated into a PostgREST .or() filter —
+  // restrict to the id alphabet so filter syntax (commas, parens) can't be
+  // smuggled in. Real ids are 24-hex or similar opaque tokens.
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(bookId)) return false;
+  try {
+    if (tenantSlug === 'bph') {
+      const { data, error } = await supabase
+        .from('bph_works')
+        .select('ubn')
+        .or(`sl_book_id.eq.${bookId},sl_external_book_id.eq.${bookId}`)
+        .limit(1);
+      if (error) return false;
+      return (data?.length ?? 0) > 0;
+    }
+    const { data, error } = await supabase
+      .from('library_catalog_records')
+      .select('catalog_id')
+      .eq('tenant_id', tenantSlug)
+      .or(`sl_book_id.eq.${bookId},sl_external_book_id.eq.${bookId}`)
+      .limit(1);
+    if (error) return false;
+    return (data?.length ?? 0) > 0;
+  } catch {
+    // Fail closed: an unreachable catalogue admits nothing extra.
+    return false;
+  }
+}


### PR DESCRIPTION
Third of the 404-log fixes (after #4215, #4217).

**Symptom:** BPH catalogue entries render a "read online" link for an external-scan edition of a work BPH holds (`sl_external_book_id` on `bph_works`; the unified-catalogue tenants do the same via `library_catalog_records`). Those books are global (`tenantId` null), and the tenant-scoped book lookup only admits books assigned to the tenant — so every such link 404'd. `not_found_reports` 2026-08-23→25: picatrix, Greater Key of Solomon, Key of Solomon, Chymische Hochzeit, all referred from `/embed/bph/catalog/*` pages.

**Fix:** on a tenant-scoped miss, the book renders iff the tenant's **own catalogue** references it (`sl_book_id` / `sl_external_book_id`) — `src/lib/tenant-catalog-books.ts`, wired into both `getBook()` and `getBookForMetadata()`.

**Lockdown invariants held:**
- The curated catalogue row is the authorization; an unreferenced global book is refused exactly as before.
- The hidden-book gate still applies downstream (the hidden `rubaiyat` keeps 404ing).
- The check fails closed when Supabase errors or is unreachable.
- `bookId` is validated against the id alphabet before interpolation into the PostgREST `.or()` filter.

**Out of scope:** whether these works should instead get a proper `tenantId` assignment at catalogue-linking time — that would make the admission static, but the linking flow lives in the catalog editor and deserves its own change.

**Verify after deploy** (host-gated behaviour — previews can't test this, per tenant-lockdown.md): `https://bph.sourcelibrary.org/book/picatrix-the-goal-of-the-wise-al-majriti` should 200; `node scripts/audit-bph-leaks.mjs` should stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwXZqmDxqx5pECrJo2fVyu