### PR TITLE
fix(routing): redirect stale /libraries/<lib>/book/* deep links

### DIFF
--- a/src/lib/provider-prefix.ts
+++ b/src/lib/provider-prefix.ts
@@ -43,6 +43,16 @@ export function getProviderPrefixRedirect(pathname: string): string | null {
   const match = pathname.match(/^\/([a-z0-9-]+)(\/.*)?$/);
   if (!match) return null;
   const [, firstSegment, rest] = match;
+  // '/libraries/<lib>/book/foo' → '/book/foo'. The credit page owns only
+  // /libraries/<slug>; deeper content-shaped paths were never valid URL space
+  // but stale external links still carry them (not_found_reports, 2026-08:
+  // /libraries/bibliotheca-philosophica-hermetica/book/…, /libraries/bph/book/…).
+  // Any <lib> segment is stripped — known partner or not, the content slug is
+  // globally unique and the redirect target enforces its own existence.
+  if (firstSegment === 'libraries' && rest) {
+    const deep = rest.match(/^\/[a-z0-9-]+(\/(?:book|gallery|collections|author|artwork)\/.+)$/);
+    if (deep) return deep[1];
+  }
   // '/default/book/foo' → '/book/foo'. The `tenants` collection has a
   // kind:'default' row whose slug leaked into externally-built links
   // (~390 not_found_reports/3d as of 2026-07-09). No book carries

--- a/tests/unit/provider-prefix-redirect.test.ts
+++ b/tests/unit/provider-prefix-redirect.test.ts
@@ -39,6 +39,23 @@ describe('getProviderPrefixRedirect', () => {
     }
   });
 
+  it('strips a /libraries/<lib> prefix off deep content paths', () => {
+    expect(
+      getProviderPrefixRedirect('/libraries/bibliotheca-philosophica-hermetica/book/the-new-jerusalem-teellinck')
+    ).toBe('/book/the-new-jerusalem-teellinck');
+    expect(getProviderPrefixRedirect('/libraries/bph/book/foo/page/abc123')).toBe(
+      '/book/foo/page/abc123'
+    );
+    // Unknown library segments strip too — the content slug is what matters.
+    expect(getProviderPrefixRedirect('/libraries/not-a-partner/gallery/image/x-0')).toBe(
+      '/gallery/image/x-0'
+    );
+    // The credit page itself and non-content children stay untouched.
+    expect(getProviderPrefixRedirect('/libraries/internet-archive')).toBeNull();
+    expect(getProviderPrefixRedirect('/libraries')).toBeNull();
+    expect(getProviderPrefixRedirect('/libraries/bph/about')).toBeNull();
+  });
+
   it('strips the phantom default-tenant prefix', () => {
     expect(getProviderPrefixRedirect('/default/book/foo')).toBe('/book/foo');
     expect(getProviderPrefixRedirect('/default/book/foo/page/abc123')).toBe(


### PR DESCRIPTION
Fourth 404-log fix (after #4215, #4217, #4218).

`/libraries/<slug>` is a contributing-library credit page with no deeper URL space, but the 404 log shows real visitors arriving at `/libraries/bibliotheca-philosophica-hermetica/book/<slug>` and `/libraries/bph/book/<slug>` from stale external links.

Extends `getProviderPrefixRedirect` (the PR #2505 provider-prefix strip, same 308 mechanism) to strip `/libraries/<seg>/` off content-shaped deep paths (`book|gallery|collections|author|artwork`). Any `<seg>` is stripped — the content slug is globally unique and the target route enforces its own existence. Credit pages (`/libraries/<slug>`) and non-content children are untouched. Guard test extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwXZqmDxqx5pECrJo2fVyu