### PR TITLE
fix(delete): prune Supabase search rows when a book is deleted

### DIFF
--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -4,6 +4,7 @@ import { getDb, getReadDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { ObjectId } from 'mongodb';
 import { logAuditEvent } from '@/lib/audit-logger';
+import { pruneSearchRowsForDeletedBook } from '@/lib/prune-deleted-book';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
@@ -147,13 +148,19 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
       await db.collection('pages').deleteMany({ book_id: bookId, tenantId });
       await db.collection('books').deleteOne({ _id: book._id, tenantId });
 
+      // A deleted book must leave every SERVING surface, not just Mongo —
+      // stale embedding/catalog rows kept surfacing deleted books in search
+      // and 404'd on click (#4216). Best-effort: a Supabase failure never
+      // blocks the delete; the stale-embeddings sweep is the backstop.
+      const pruned = await pruneSearchRowsForDeletedBook(bookId);
+
       // Audit log (non-blocking)
       logAuditEvent({
         action: 'book_deleted',
         book_id: bookId,
         book_title: book.title,
         pages_affected: pages.length,
-        metadata: { recoverable: true },
+        metadata: { recoverable: true, search_rows_pruned: pruned.every(p => !p.error) },
       });
 
       return NextResponse.json({
@@ -161,7 +168,7 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
         message: `Archived "${book.title}" with ${pages.length} pages`,
         bookId,
         recoverable: true,
-        hint: 'POST /api/books/restore/{id} to recover'
+        hint: 'POST /api/books/restore/{id} to recover — a restored book needs re-embedding before it surfaces in semantic search'
       });
     }
 
@@ -206,6 +213,9 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
     // Book is not archived - permanent delete from active (should be rare)
     const pagesResult = await db.collection('pages').deleteMany({ book_id: bookId, tenantId });
     await db.collection('books').deleteOne({ _id: book._id, tenantId });
+
+    // Same serving-surface prune as the soft-delete path (#4216).
+    await pruneSearchRowsForDeletedBook(bookId);
 
     logAuditEvent({
       action: 'book_deleted_permanent',

--- a/src/lib/prune-deleted-book.ts
+++ b/src/lib/prune-deleted-book.ts
@@ -1,0 +1,65 @@
+/**
+ * When a book leaves `books`, it must leave every serving surface (#4216 —
+ * two deleted books kept surfacing in semantic search via stale
+ * `book_embeddings` rows and 404'd on click; same class as the
+ * takedown-is-nine-surfaces lesson).
+ *
+ * Prunes the Supabase rows that SERVE search for a book id:
+ *   - the four pure-embedding tables (recoverable by re-running the embed
+ *     workers — a restore therefore needs re-embedding, which is billed)
+ *   - the `books_catalog` listing row (rebuilt by the catalog sync)
+ *
+ * Deliberately NOT pruned: `page_translations` and `page_texts` — those hold
+ * translation/OCR TEXT, not just derived vectors; deleting them destroys
+ * content (see scripts/maintenance/delete-stale-embeddings.mjs). Their read
+ * paths must gate on book existence instead (the semantic route does since
+ * #4217).
+ *
+ * Best-effort by design: a Supabase failure must never block the Mongo
+ * delete the admin asked for. Failures are returned and logged by callers;
+ * scripts/maintenance/delete-stale-embeddings.mjs remains the backstop sweep.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase';
+
+const EMBEDDING_TABLES = [
+  'book_embeddings',
+  'artwork_embeddings',
+  'gallery_text_embeddings',
+  'clip_embeddings',
+] as const;
+
+export interface PruneResult {
+  table: string;
+  error: string | null;
+}
+
+export async function pruneSearchRowsForDeletedBook(bookId: string): Promise<PruneResult[]> {
+  if (!bookId) return [];
+  const results: PruneResult[] = [];
+
+  for (const table of EMBEDDING_TABLES) {
+    try {
+      const { error } = await supabaseAdmin.from(table).delete().eq('book_id', bookId);
+      results.push({ table, error: error?.message ?? null });
+    } catch (e) {
+      results.push({ table, error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  try {
+    const { error } = await supabaseAdmin.from('books_catalog').delete().eq('id', bookId);
+    results.push({ table: 'books_catalog', error: error?.message ?? null });
+  } catch (e) {
+    results.push({ table: 'books_catalog', error: e instanceof Error ? e.message : String(e) });
+  }
+
+  const failed = results.filter(r => r.error);
+  if (failed.length > 0) {
+    console.error(
+      `[prune-deleted-book] ${bookId}: ${failed.map(f => `${f.table}: ${f.error}`).join('; ')} — ` +
+      'run scripts/maintenance/delete-stale-embeddings.mjs to catch up',
+    );
+  }
+  return results;
+}

--- a/src/lib/prune-deleted-book.ts
+++ b/src/lib/prune-deleted-book.ts
@@ -36,11 +36,16 @@ export interface PruneResult {
 
 export async function pruneSearchRowsForDeletedBook(bookId: string): Promise<PruneResult[]> {
   if (!bookId) return [];
+  const client = supabaseAdmin;
+  if (!client) {
+    console.error(`[prune-deleted-book] ${bookId}: supabaseAdmin unavailable — run scripts/maintenance/delete-stale-embeddings.mjs to catch up`);
+    return [...EMBEDDING_TABLES, 'books_catalog'].map(table => ({ table, error: 'supabaseAdmin unavailable' }));
+  }
   const results: PruneResult[] = [];
 
   for (const table of EMBEDDING_TABLES) {
     try {
-      const { error } = await supabaseAdmin.from(table).delete().eq('book_id', bookId);
+      const { error } = await client.from(table).delete().eq('book_id', bookId);
       results.push({ table, error: error?.message ?? null });
     } catch (e) {
       results.push({ table, error: e instanceof Error ? e.message : String(e) });
@@ -48,7 +53,7 @@ export async function pruneSearchRowsForDeletedBook(bookId: string): Promise<Pru
   }
 
   try {
-    const { error } = await supabaseAdmin.from('books_catalog').delete().eq('id', bookId);
+    const { error } = await client.from('books_catalog').delete().eq('id', bookId);
     results.push({ table: 'books_catalog', error: error?.message ?? null });
   } catch (e) {
     results.push({ table: 'books_catalog', error: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
Closes #4216 — the remaining half (the read-path guard shipped in #4217, the backlog was swept the same day).

**What:** `src/lib/prune-deleted-book.ts` deletes the four pure-embedding tables' rows and the `books_catalog` listing row for a book id; the admin DELETE route calls it in both the soft-delete and permanent-from-active paths.

**Design points:**
- Best-effort: Supabase failure never blocks the Mongo delete; failures are logged with a pointer to `delete-stale-embeddings.mjs` (the standing backstop, which also covers script-side deletes like the dedup sweeps).
- `page_translations`/`page_texts` are deliberately untouched — they hold text content, not derived vectors (same boundary the sweep script draws); read paths gate on book existence instead.
- Restore hint updated: a restored book needs re-embedding (billed) before semantic search sees it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwXZqmDxqx5pECrJo2fVyu