### PR TITLE
fix(archive): drop the 6000px master cap in archive-acquired (#3897)

### DIFF
--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -34,7 +34,8 @@ async function main() {
         const url = upgradeToFullRes(p.photo_original || p.photo);
         try {
           const buf = await rateLimitedFetch(url);
-          const jpg = await sharp(buf).rotate().resize(6000, null, { withoutEnlargement: true }).jpeg({ quality: 90, mozjpeg: true }).toBuffer();
+          // Archive at source fidelity: no resolution cap (#3897, matches archive-ia-bulk).
+          const jpg = await sharp(buf).rotate().jpeg({ quality: 90, mozjpeg: true }).toBuffer();
           const padded = String(p.page_number).padStart(4, '0');
           const blob = await storagePut(`pages/${bookId}/${padded}.jpg`, jpg, { contentType: 'image/jpeg', access: 'public' });
           const upd: any = { $set: { archived_photo: blob.url } };


### PR DESCRIPTION
## What
Removes the last resolution cap on archived masters: the IIIF/e-rara path in `archive-acquired.ts` resized to 6000px before writing to R2. Masters now store at source fidelity (`.rotate()` + q90 mozjpeg re-encode kept; display/thumb derivative tiers unchanged).

## Why
Phase 0 of #4225 (acquisition at max rate): archive full-res masters before any new wave. `archive-ia-bulk.mjs` already went uncapped in #3912 with an opt-in `--max-dim`; this brings the acquisition archiver in line. Storage is cheap; source fidelity is the product (#3897, Derek 2026-08-11).

## Scope
- In: the one remaining cap (grep confirmed `archive-images` route, `archive-ocr.mjs`, `archive-bulk.mjs`, `archive-erara.mjs` carry no resolution caps).
- Out: re-archiving the already-capped population (#3897's audit step), master key convention changes (#4194), resolver fixes (#4225 Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNMMLH8s6g9PjiBe4U4L