### PR TITLE
feat(reader): give liking a stated payoff and a route back to /favorites

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -7,6 +7,7 @@ import { resolveImprintPlace } from '@/lib/imprint';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
 import { toast } from 'sonner';
 import Logo from '@/components/layout/Logo';
+import UserMenu from '@/components/layout/UserMenu';
 import RevisionHistory from '@/components/reader/RevisionHistory';
 import {
   Loader2,
@@ -631,6 +632,10 @@ export default function TranslationEditor({
   const [transliterationLoading, setTransliterationLoading] = useState(false);
   const [showPageMetadata, setShowPageMetadata] = useState(false); // Toggle for page metadata panel
   const [showFontControls, setShowFontControls] = useState(false);
+  // Liked state of the CURRENT page, reported by the LikeButtons (#4126) so
+  // the footer line can swap "to save it to your favorites" → "Saved to your
+  // favorites". Both the toolbar and footer hearts report here.
+  const [pageLiked, setPageLiked] = useState(false);
   // Full book doc for the edition-info section of the metadata panel. The reader
   // route only ships a slim book projection, so the bibliographic fields are
   // fetched on demand — once per book, the first time the panel opens.
@@ -1345,6 +1350,17 @@ export default function TranslationEditor({
                 </span>
               )}
             </div>
+
+            {/* Account/sign-in — the reader was the one surface with no route
+                back to /favorites and no visible sign-in state (#4126). After
+                the page navigator so the highest-frequency control keeps its
+                position; on mobile this lives in row 2 instead. Never in
+                partner embeds. */}
+            {!isEmbedded && (
+              <div className="hidden sm:block shrink-0">
+                <UserMenu />
+              </div>
+            )}
           </div>
 
           {/* Row 2: Panel toggles ... Mode toggle + Like */}
@@ -1570,6 +1586,7 @@ export default function TranslationEditor({
                   bookId={book.id}
                   size="sm"
                   showCount={true}
+                  onLikedChange={setPageLiked}
                 />
                 <ShareButton
                   title={book.display_title || book.title}
@@ -1627,6 +1644,12 @@ export default function TranslationEditor({
                   tenantSlug={params?.tenant || undefined}
                   className="!p-1.5 !text-stone-500 hover:!text-stone-700 hover:!bg-stone-100 !rounded-full text-sm"
                 />
+                {/* Mobile home of the account menu — row 1 is too tight there (#4126). */}
+                {!isEmbedded && (
+                  <div className="sm:hidden ml-1">
+                    <UserMenu />
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -2340,7 +2363,13 @@ export default function TranslationEditor({
 
         {/* Footer: like + nav hint + search */}
         <div style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
-          <div className="px-4 pt-2 pb-1 flex items-center justify-center gap-3 flex-wrap text-xs">
+          {/* The like line states the payoff BEFORE the click and gives the
+              like a route back: "[♥ Like this page] to save it to your
+              favorites" → "[♥] Saved to your favorites" (#4126). The
+              /favorites link is a sibling of the button, never nested inside
+              it (nested interactives are an a11y fail and a mis-tap magnet);
+              embeds keep the bare button — there is no /favorites there. */}
+          <div className="px-4 pt-2 pb-1 flex items-center justify-center gap-1.5 flex-wrap text-xs" aria-live="polite">
             <LikeButton
               key={`footer-${page.id}`}
               targetType="page"
@@ -2348,8 +2377,21 @@ export default function TranslationEditor({
               bookId={book.id}
               size="sm"
               showCount={true}
-              label={rs.likeThisPage}
+              label={pageLiked && !isEmbedded ? undefined : rs.likeThisPage}
+              onLikedChange={setPageLiked}
             />
+            {!isEmbedded && (
+              <span style={{ color: 'var(--text-muted)' }}>
+                {pageLiked ? rs.likeSavedPrefix : rs.likeSavePrefix}{' '}
+                <a
+                  href="/favorites"
+                  className="underline underline-offset-2 hover:opacity-70 transition-opacity"
+                  style={{ color: 'var(--text-secondary)' }}
+                >
+                  {rs.likeFavoritesWord}
+                </a>
+              </span>
+            )}
           </div>
           {showNavHint && (
             <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">

--- a/src/components/ui/LikeButton.tsx
+++ b/src/components/ui/LikeButton.tsx
@@ -22,6 +22,13 @@ interface LikeButtonProps {
   showCount?: boolean;
   /** Optional text label shown next to the heart (e.g. "Like this page"). Part of the clickable button. */
   label?: string;
+  /**
+   * Fires whenever the liked state settles (cache read on mount, status
+   * fetch, toggle, error revert) — lets a parent swap surrounding copy
+   * ("to save it…" → "Saved to your favorites", #4126) without owning
+   * the like state itself.
+   */
+  onLikedChange?: (liked: boolean) => void;
   className?: string;
 }
 
@@ -59,6 +66,7 @@ export default memo(function LikeButton({
   size = 'md',
   showCount = true,
   label,
+  onLikedChange,
   className = '',
 }: LikeButtonProps) {
   // If parent explicitly passed initialCount (even 0), server provided the data
@@ -72,6 +80,12 @@ export default memo(function LikeButton({
   const promptRef = useRef<HTMLDivElement>(null);
 
   const cacheKey = `${targetType}:${targetId}`;
+
+  // Report liked-state changes without making the callback a dependency of
+  // the fetch/toggle effects (parents often pass a fresh closure per render).
+  const onLikedChangeRef = useRef(onLikedChange);
+  useEffect(() => { onLikedChangeRef.current = onLikedChange; });
+  useEffect(() => { onLikedChangeRef.current?.(liked); }, [liked]);
 
   // Close auth prompt on outside click
   useEffect(() => {

--- a/src/lib/book-i18n.ts
+++ b/src/lib/book-i18n.ts
@@ -358,6 +358,13 @@ export interface ReaderStrings {
   typeCaption: string;
   // footer + search
   likeThisPage: string;
+  // The footer like line: "[♥ Like this page] to save it to your favorites"
+  // (unliked) / "[♥] Saved to your favorites" (liked). The prefix and the
+  // linked word are separate strings because "favorites" is an <a> to
+  // /favorites rendered OUTSIDE the button (#4126).
+  likeSavePrefix: string;
+  likeSavedPrefix: string;
+  likeFavoritesWord: string;
   searchThisBook: string;
   searchWithinBook: string;
   clearSearch: string;
@@ -446,6 +453,9 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     typeCaption: 'Griffo\u2019s roman for Aldus Manutius, traced from the 1496 De Aetna.',
 
     likeThisPage: 'Like this page',
+    likeSavePrefix: 'to save it to your',
+    likeSavedPrefix: 'Saved to your',
+    likeFavoritesWord: 'favorites',
     searchThisBook: 'Search this book...',
     searchWithinBook: 'Search within this book',
     clearSearch: 'Clear search',
@@ -532,6 +542,9 @@ export const READER_STRINGS: Record<Locale, ReaderStrings> = {
     typeCaption: 'La redonda de Griffo para Aldo Manucio, calcada del De Aetna de 1496.',
 
     likeThisPage: 'Me gusta esta página',
+    likeSavePrefix: 'para guardarla en tus',
+    likeSavedPrefix: 'Guardada en tus',
+    likeFavoritesWord: 'favoritos',
     searchThisBook: 'Buscar en este libro...',
     searchWithinBook: 'Buscar dentro de este libro',
     clearSearch: 'Borrar la búsqueda',


### PR DESCRIPTION
Closes #4126 — implements the issue's spec, and completes this week's favorites arc (#4215 fixed the favorites page's dead artwork links; this gives readers a way to GET there).

**1. Footer like line states the payoff, then confirms it.** Unliked: `[♥ Like this page]` + muted "to save it to your **favorites**" (link). Liked: `[♥]` "Saved to your **favorites**". The link is a sibling of the button, not nested inside it; `aria-live="polite"` on the swapping span. Embeds keep today's bare button (no /favorites route on partner surfaces).

**2. UserMenu in the reader.** sm+: far right of header row 1, outboard of the page navigator (which keeps its position). Mobile: in the row-2 like/share/cite cluster. Gated `!isEmbedded`, same as `<Logo mini />`.

**3. LikeButton: optional `onLikedChange`** (ref-held; fires on cache mount, status fetch, toggle, error revert). Both reader hearts report to it, so toggling either keeps the footer copy truthful. No other call sites affected.

**Per the issue's notes:** landed in the read-mode return (the #3916 multiple-returns trap); new i18n strings shipped in both `en` and `es`; no API/schema change. The toolbar heart stays as the compact affordance (the issue's default). Out of scope, as the issue says: Like→Save vocabulary rename, nudge-threshold changes.

Verify on preview: reader footer shows the new line; like it → line swaps; avatar/Sign-in appears top right (sm+) and in the mobile toolbar; **absent** in `/embed/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwXZqmDxqx5pECrJo2fVyu