### PR TITLE
feat(identify): stream results in stages, surface the page, trim the rail (#4232)

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -93,12 +93,21 @@ interface IdentifyResult {
   web_sources?: WebSource[];
 }
 
+/** Pipeline failure that maps to a specific HTTP status on the JSON path. */
+class IdentifyError extends Error {
+  constructor(message: string, public status: number, public detail?: string) {
+    super(message);
+  }
+}
+
 export async function POST(request: NextRequest) {
   const rl = checkRateLimit({ name: 'identify', limit: 10, windowSeconds: 3600 }, getClientIp(request));
   if (!rl.allowed) {
     return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } });
   }
 
+  let base64: string;
+  let mimeType: string;
   try {
     const formData = await request.formData();
     const file = formData.get('image') as File | null;
@@ -116,9 +125,17 @@ export async function POST(request: NextRequest) {
 
     // Convert to base64
     const bytes = await file.arrayBuffer();
-    const base64 = Buffer.from(bytes).toString('base64');
-    const mimeType = file.type || 'image/jpeg';
+    base64 = Buffer.from(bytes).toString('base64');
+    mimeType = file.type || 'image/jpeg';
+  } catch {
+    return NextResponse.json({ error: 'Invalid upload' }, { status: 400 });
+  }
 
+  // The identification pipeline, staged. `emit` fires at stage boundaries so the
+  // streaming path (?stream=1) can deliver partial results while later stages
+  // are still running; the buffered JSON path passes a no-op. Returns the same
+  // assembled payload either way. (#4232)
+  const pipeline = async (emit: (e: Record<string, unknown>) => void) => {
     // Run Gemini vision + CLIP visual search in parallel
     const apiKey = getNextApiKey();
     const model = 'gemini-3.1-flash-lite';
@@ -194,7 +211,7 @@ export async function POST(request: NextRequest) {
       const err = await resp.text();
       console.error('[identify] Gemini error:', resp.status, err);
       const detail = resp.status === 429 ? 'Rate limited — try again in a moment' : `Vision API error (${resp.status})`;
-      return NextResponse.json({ error: detail }, { status: 502 });
+      throw new IdentifyError(detail, 502);
     }
 
     const geminiData = await resp.json();
@@ -202,7 +219,7 @@ export async function POST(request: NextRequest) {
 
     // Parse JSON from response
     if (!text) {
-      return NextResponse.json({ error: 'Vision API returned empty response — try a different image' }, { status: 502 });
+      throw new IdentifyError('Vision API returned empty response — try a different image', 502);
     }
     const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
     const jsonStr = (jsonMatch?.[1] || text).trim();
@@ -210,8 +227,12 @@ export async function POST(request: NextRequest) {
     try {
       identification = JSON.parse(jsonStr);
     } catch {
-      return NextResponse.json({ error: 'Could not parse vision response — try a clearer image', detail: text.substring(0, 300) }, { status: 500 });
+      throw new IdentifyError('Could not parse vision response — try a clearer image', 500, text.substring(0, 300));
     }
+
+    // First streamed stage: the reader sees the analysis while retrieval,
+    // visual confirmation and web verification are still running.
+    emit({ type: 'identification', data: identification });
 
     // Promise 3: Semantic artwork search (runs after initial ID, in parallel with DB search)
     // Uses the identification to find related artworks via embedding similarity
@@ -398,7 +419,7 @@ Return JSON only:
     const db = await getDb();
     const books = db.collection('books');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const matches: any[] = [];
+    let matches: any[] = [];
 
     // Collect all names to search — from artist, publisher, and all inscription names
     const allNames: string[] = [];
@@ -762,6 +783,35 @@ Return JSON only:
     // The artwork image fields are already in the match object from Strategy 1 query
     // (commons_full_url, archived_full_url were projected but not shown — now we surface them)
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shapeMatches = (list: any[]) =>
+      list.slice(0, 10).map(({ _score, _visual_similarity, _match_source, enrichment, commons_title, english_title, ...rest }) => {
+        // Attach page match if this book has one
+        const pm = pageMatches.find(p => p.bookId === rest.id);
+        // Use page image, artwork image, or fall back to book cover
+        const pageImg = pageImageMap.get(rest.id);
+        const matchImage = pageImg?.image_url
+          || rest.commons_full_url  // artworks from Wikimedia
+          || rest.archived_full_url // artworks archived to R2
+          || rest.thumbnail_blob || rest.thumbnail;
+        // Clean up fields we don't want to expose
+        const { commons_full_url, archived_full_url, ...cleanRest } = rest;
+        return {
+          ...cleanRest,
+          match_image: matchImage,
+          score: _score,
+          visual_similarity: _visual_similarity || undefined,
+          match_source: _match_source || 'text',
+          subject: enrichment?.subject,
+          ...(pm ? { page_number: pm.pageNumber, page_score: pm.score } : {}),
+          ...(pageImg ? { page_number: pageImg.page_number } : {}),
+        };
+      });
+
+    // Second streamed stage: the provisional rail (text + visual + semantic,
+    // not yet visually confirmed), so the wait for the rerank shows results.
+    emit({ type: 'matches', data: shapeMatches(matches), visual_search: clipMatches.length > 0 });
+
     // Await visual confirmation (started right after identification), but never
     // let it hold the response — a stalled dependency degrades to "no
     // confirmation" instead of a hung request.
@@ -792,7 +842,34 @@ Return JSON only:
           _match_source: 'visual_confirmed',
         });
       }
+
+      // With a confirmed answer the rail below it is corroboration, not
+      // discovery: the semantic lane matches on description text and reliably
+      // pads the tail with unrelated works (Book of the Dead papyri after a
+      // Mesoamerican codex — #4232). Keep the visual and text lanes, capped.
+      matches = matches
+        .filter((m, i) => i === 0 || m._match_source !== 'semantic_artwork')
+        .slice(0, 5);
     }
+
+    const pagePayload = confirmed
+      ? (confirmed.page_number != null ? { book_id: confirmed.book_id, page_number: confirmed.page_number, score: 100 } : null)
+      : bestPage ? {
+        book_id: bestPage.bookId,
+        page_number: bestPage.pageNumber,
+        score: bestPage.score,
+      } : null;
+    const rerankPayload = {
+      ran: rerank.ran,
+      candidates: rerank.candidateCount,
+      sure: (rerank as { sure?: boolean }).sure ?? false,
+      ms: (rerank as { ms?: number }).ms,
+      error: (rerank as { error?: string }).error,
+    };
+
+    // Third streamed stage: the verdict. Carries the final (possibly reordered
+    // and trimmed) rail so the client replaces the provisional one.
+    emit({ type: 'confirmed', data: confirmed, page: pagePayload, rerank: rerankPayload, matches: shapeMatches(matches) });
 
     // Await Google Search verification (started earlier, should be done by now)
     const verification = await verifyPromise;
@@ -811,57 +888,71 @@ Return JSON only:
       if (verification.sources?.length) {
         identification.web_sources = verification.sources;
       }
+      // Fourth streamed stage: web-verified attribution patched into the
+      // already-rendered analysis card.
+      emit({ type: 'verification', data: identification });
     }
 
-    return NextResponse.json({
+    return {
       identification,
-      matches: matches.slice(0, 10).map(({ _score, _visual_similarity, _match_source, enrichment, commons_title, english_title, ...rest }) => {
-        // Attach page match if this book has one
-        const pm = pageMatches.find(p => p.bookId === rest.id);
-        // Use page image, artwork image, or fall back to book cover
-        const pageImg = pageImageMap.get(rest.id);
-        const matchImage = pageImg?.image_url
-          || rest.commons_full_url  // artworks from Wikimedia
-          || rest.archived_full_url // artworks archived to R2
-          || rest.thumbnail_blob || rest.thumbnail;
-        // Clean up fields we don't want to expose
-        const { commons_full_url, archived_full_url, ...cleanRest } = rest;
-        return {
-          ...cleanRest,
-          match_image: matchImage,
-          score: _score,
-          visual_similarity: _visual_similarity || undefined,
-          match_source: _match_source || 'text',
-          subject: enrichment?.subject,
-          ...(pm ? { page_number: pm.pageNumber, page_score: pm.score } : {}),
-          ...(pageImg ? { page_number: pageImg.page_number } : {}),
-        };
-      }),
+      matches: shapeMatches(matches),
       visual_search: clipMatches.length > 0,
       semantic_artwork_search: semanticArtworks.length > 0,
       verified: !!verification,
       confirmed,
-      rerank: {
-        ran: rerank.ran,
-        candidates: rerank.candidateCount,
-        sure: (rerank as { sure?: boolean }).sure ?? false,
-        ms: (rerank as { ms?: number }).ms,
-        error: (rerank as { error?: string }).error,
-      },
+      rerank: rerankPayload,
       // A visually confirmed match supersedes the text-heuristic page guess —
       // an unconfirmed guess pointing at a different book misleads (see #3193
       // benchmark: the heuristic picked the wrong book on degraded photos).
-      page: confirmed
-        ? (confirmed.page_number != null ? { book_id: confirmed.book_id, page_number: confirmed.page_number, score: 100 } : null)
-        : bestPage ? {
-          book_id: bestPage.bookId,
-          page_number: bestPage.pageNumber,
-          score: bestPage.score,
-        } : null,
-    });
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error('[identify] Error:', msg);
-    return NextResponse.json({ error: 'Identification failed', detail: msg }, { status: 500 });
+      page: pagePayload,
+    };
+  };
+
+  // Buffered JSON is the DEFAULT: scripts and the eval bench
+  // (scripts/eval/identify-bench.mjs) keep working unchanged. The page opts
+  // into streaming with ?stream=1.
+  const wantStream = new URL(request.url).searchParams.get('stream') === '1';
+
+  if (!wantStream) {
+    try {
+      return NextResponse.json(await pipeline(() => {}));
+    } catch (error) {
+      if (error instanceof IdentifyError) {
+        return NextResponse.json(
+          { error: error.message, ...(error.detail ? { detail: error.detail } : {}) },
+          { status: error.status },
+        );
+      }
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('[identify] Error:', msg);
+      return NextResponse.json({ error: 'Identification failed', detail: msg }, { status: 500 });
+    }
   }
+
+  // NDJSON stream: one JSON object per line. Every event has a `type`; the
+  // stream always ends with `done` or `error`, so a client can treat either as
+  // terminal. HTTP status is 200 regardless — by the time a stage fails, the
+  // headers are long gone.
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const emit = (e: Record<string, unknown>) => controller.enqueue(encoder.encode(JSON.stringify(e) + '\n'));
+      try {
+        emit({ type: 'status', stage: 'reading' });
+        await pipeline(emit);
+        emit({ type: 'done' });
+      } catch (error) {
+        const msg = error instanceof IdentifyError ? error.message : 'Identification failed';
+        console.error('[identify] stream error:', error instanceof Error ? error.message : String(error));
+        emit({ type: 'error', message: msg, ...(error instanceof IdentifyError && error.detail ? { detail: error.detail } : {}) });
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/x-ndjson; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
 }

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -79,6 +79,9 @@ export default function IdentifyPage() {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<Result | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // What the pipeline is doing right now — timer-driven until the first stream
+  // event arrives, event-driven after. The stages named here are real (#4232).
+  const [stageMessage, setStageMessage] = useState<string | null>(null);
   const lastFileRef = useRef<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
@@ -87,6 +90,14 @@ export default function IdentifyPage() {
     setLoading(true);
     setError(null);
     setResult(null);
+
+    // Fallback narration: if the stream is slow to open (or unsupported), the
+    // spinner still tells the truth about what is happening and when.
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const clearTimers = () => { timers.forEach(clearTimeout); timers.length = 0; };
+    setStageMessage('Reading the image…');
+    timers.push(setTimeout(() => setStageMessage('Comparing against 152,000 illustrations…'), 6000));
+    timers.push(setTimeout(() => setStageMessage('Confirming the match…'), 14000));
 
     // Compress large images client-side (phone cameras produce 5-10MB files)
     let imageFile = file;
@@ -108,22 +119,86 @@ export default function IdentifyPage() {
     formData.append('image', imageFile);
 
     try {
-      const res = await fetch('/api/identify', { method: 'POST', body: formData });
-      let data;
-      try {
-        data = await res.json();
-      } catch {
-        setError(`Server error (${res.status}) — try again`);
+      const res = await fetch('/api/identify?stream=1', { method: 'POST', body: formData });
+      const ctype = res.headers.get('content-type') || '';
+
+      // Errors (rate limit, size) and any non-streaming server are plain JSON.
+      if (!res.ok || !ctype.includes('ndjson') || !res.body) {
+        let data;
+        try {
+          data = await res.json();
+        } catch {
+          setError(`Server error (${res.status}) — try again`);
+          return;
+        }
+        if (!res.ok) {
+          setError(data.detail || data.error || `Failed to identify (${res.status})`);
+        } else {
+          setResult(data);
+        }
         return;
       }
-      if (!res.ok) {
-        setError(data.detail || data.error || `Failed to identify (${res.status})`);
-      } else {
-        setResult(data);
+
+      // NDJSON stream: one event per line, rendered as it lands. The photo is
+      // identified in ~6s; retrieval and visual confirmation follow — this is
+      // what turns a ~25s opaque wait into visible progress.
+      let sawTerminal = false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handleEvent = (evt: any) => {
+        switch (evt.type) {
+          case 'identification':
+            clearTimers();
+            setStageMessage('Searching the library…');
+            setResult({ identification: evt.data, matches: [], confirmed: null, page: null });
+            break;
+          case 'matches':
+            setStageMessage('Confirming the match visually…');
+            setResult(r => (r ? { ...r, matches: evt.data || [], visual_search: evt.visual_search } : r));
+            break;
+          case 'confirmed':
+            setStageMessage('Checking catalogues…');
+            setResult(r => (r ? { ...r, confirmed: evt.data, page: evt.page ?? null, matches: evt.matches || r.matches } : r));
+            break;
+          case 'verification':
+            setResult(r => (r ? { ...r, identification: evt.data, verified: true } : r));
+            break;
+          case 'done':
+            sawTerminal = true;
+            break;
+          case 'error':
+            sawTerminal = true;
+            setError(evt.detail || evt.message || 'Identification failed');
+            break;
+        }
+      };
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          try {
+            handleEvent(JSON.parse(line));
+          } catch {
+            // Skip a malformed line rather than killing the whole stream
+          }
+        }
+      }
+      if (!sawTerminal) {
+        setError('Connection interrupted — try again');
       }
     } catch {
       setError('Network error — check your connection and try again');
     } finally {
+      clearTimers();
+      setStageMessage(null);
       setLoading(false);
     }
   }, []);
@@ -188,8 +263,10 @@ export default function IdentifyPage() {
         className="hidden"
       />
 
-      {/* Landing: you are standing in the room */}
-      {!image && (
+      {/* Landing: you are standing in the room. Gated on submission state, not
+          just the preview — if FileReader ever fails to produce a preview, the
+          results must not render underneath the hero. */}
+      {!image && !loading && !result && !error && (
         <>
           <section className="relative bg-dark">
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -268,11 +345,11 @@ export default function IdentifyPage() {
             <div className="relative rounded-xl overflow-hidden bg-stone-100">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={image} alt="Your photo" className="w-full max-h-[50vh] object-contain" />
-              {loading && (
+              {loading && !result && (
                 <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
                   <div className="flex items-center gap-3 bg-white/90 rounded-full px-5 py-2.5">
                     <Loader2 className="w-5 h-5 animate-spin text-accent-rust" />
-                    <span className="text-sm font-medium">Identifying...</span>
+                    <span className="text-sm font-medium">{stageMessage || 'Identifying…'}</span>
                   </div>
                 </div>
               )}
@@ -306,6 +383,15 @@ export default function IdentifyPage() {
         {/* Results */}
         {result && (
           <div className="space-y-6">
+            {/* Streaming: analysis is already on screen while retrieval and
+                visual confirmation continue — say so instead of overlaying */}
+            {loading && (
+              <div className="flex items-center gap-2.5 text-sm text-secondary" role="status">
+                <Loader2 className="w-4 h-4 animate-spin text-accent-rust" />
+                <span>{stageMessage || 'Searching the library…'}</span>
+              </div>
+            )}
+
             {/* Visually confirmed match — the answer, front and center */}
             {result.confirmed && (
               <div className="rounded-xl overflow-hidden bg-white border-2 border-accent-rust/40 shadow-sm">
@@ -314,7 +400,9 @@ export default function IdentifyPage() {
                   <span className="text-[10px] text-green-700 bg-green-50 rounded px-1.5 py-0.5">confirmed by visual comparison</span>
                 </div>
                 <div className="flex gap-4 p-5">
-                  <div className="w-24 sm:w-32 flex-shrink-0 rounded overflow-hidden bg-stone-100">
+                  {/* self-start keeps the thumb box hugging the image instead of
+                      stretching to row height and leaving a gray dead zone */}
+                  <div className="w-24 sm:w-32 flex-shrink-0 self-start rounded overflow-hidden bg-stone-100">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img src={result.confirmed.image_url} alt="" className="w-full h-auto object-contain" />
                   </div>
@@ -324,8 +412,11 @@ export default function IdentifyPage() {
                     )}
                     <p className="font-display font-semibold text-primary">
                       {result.confirmed.book_title}
+                      {/* "scan page", not "page": the work's own plate numbering
+                          (e.g. the Codex Borgia's "Page 56") can differ from our
+                          scan sequence, and the Analysis card may show it */}
                       {result.confirmed.page_number != null && (
-                        <span className="text-sm font-normal text-muted ml-2">page {result.confirmed.page_number}</span>
+                        <span className="text-sm font-normal text-muted ml-2">scan page {result.confirmed.page_number}</span>
                       )}
                     </p>
                     {result.confirmed.book_author && (
@@ -557,7 +648,7 @@ export default function IdentifyPage() {
                   })}
                 </div>
               </div>
-            ) : (
+            ) : loading ? null : (
               <div className="card p-5 text-center">
                 <p className="text-secondary">Not found in Source Library</p>
                 <p className="text-sm text-muted mt-1">

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -6,8 +6,9 @@ import Link from 'next/link';
 import Image from 'next/image';
 import {
   Search, Image as ImageIcon, BookOpen, X,
-  SlidersHorizontal, Loader2, ImagePlus, AlertCircle
+  SlidersHorizontal, Loader2, ImagePlus, AlertCircle, Camera
 } from 'lucide-react';
+import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import LikeButton from '@/components/ui/LikeButton';
 import { canLoadMore } from '@/lib/gallery-pagination';
 import { useIdentity } from '@/hooks/useIdentity';
@@ -93,6 +94,9 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const identity = useIdentity();
   // The global SL header is rendered by the page shell via ConditionalSiteHeader,
   // which suppresses it on embedded/tenant surfaces (CLAUDE.md invariant #5).
+  // Same shared signal the header/footer use to drop global-only links on
+  // partner subdomains (#3364, #3367).
+  const isTenantHost = useIsEmbedded();
 
   // Path-tenants (e.g. /internet-archive/gallery) should never propagate
   // into book/page links — those URLs are canonical at /book/{id}. The
@@ -443,6 +447,22 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             <SlidersHorizontal className="w-4 h-4" />
             Filters
           </button>
+
+          {/* Entry point to /identify — the gallery is where someone who has
+              just seen one of these images in the wild lands first (#4232).
+              Hidden on tenant hosts: /identify searches the whole corpus and
+              is on the global-only list (tenant-global-paths.ts). */}
+          {!isTenantHost && (
+            <Link
+              href="/identify"
+              className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg border bg-white text-stone-600 border-stone-300 hover:bg-stone-50 transition-colors whitespace-nowrap"
+              title="Photograph an artwork to find it in the library"
+            >
+              <Camera className="w-4 h-4" />
+              <span className="hidden sm:inline">Seen it somewhere?</span>
+              <span className="sm:hidden">Identify a photo</span>
+            </Link>
+          )}
         </div>
 
         {/* Active Filters / Book Info */}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -31,6 +31,7 @@ function buildNavLinks(t: NavStrings, locale: Locale): NavLink[] {
   const links: NavLink[] = [
     { label: t.collections, href: '/collections', activePrefix: '/collections' },
     { label: t.gallery, href: '/gallery' },
+    { label: t.identify, href: '/identify' },
     {
       label: t.browse,
       href: '/browse',

--- a/src/lib/footer-nav.ts
+++ b/src/lib/footer-nav.ts
@@ -27,6 +27,7 @@ export const FOOTER_NAV_COLUMNS: ReadonlyArray<FooterNavColumn> = [
       { key: 'browseBooks', href: '/' },
       { key: 'browseAZ', href: '/browse' },
       { key: 'gallery', href: '/gallery' },
+      { key: 'identify', href: '/identify' },
       { key: 'collections', href: '/collections' },
       { key: 'search', href: '/search' },
       { key: 'podcast', href: '/podcast' },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -28,6 +28,7 @@ export function useLocalePath(): (href: string) => string {
 export interface NavStrings {
   collections: string;
   gallery: string;
+  identify: string;
   browse: string;
   catalogue: string;
   works: string;
@@ -42,6 +43,7 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
   en: {
     collections: 'Collections',
     gallery: 'Gallery',
+    identify: 'Identify',
     browse: 'Browse',
     catalogue: 'Catalogue',
     works: 'Works',
@@ -54,6 +56,7 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
   es: {
     collections: 'Colecciones',
     gallery: 'Galería',
+    identify: 'Identificar',
     browse: 'Explorar',
     catalogue: 'Catálogo',
     works: 'Obras',
@@ -81,6 +84,7 @@ export interface FooterStrings {
   browseBooks: string;
   browseAZ: string;
   gallery: string;
+  identify: string;
   collections: string;
   search: string;
   // Kept reachable here after the header nav item was retired — the podcast is
@@ -192,6 +196,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     browseBooks: 'Browse Books',
     browseAZ: 'Browse A–Z',
     gallery: 'Gallery',
+    identify: 'Identify an Artwork',
     collections: 'Collections',
     search: 'Search',
     podcast: 'Podcast',
@@ -223,6 +228,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     browseBooks: 'Explorar libros',
     browseAZ: 'Índice A–Z',
     gallery: 'Galería',
+    identify: 'Identificar una obra',
     collections: 'Colecciones',
     search: 'Buscar',
     podcast: 'Pódcast',

--- a/src/lib/tenant-global-paths.ts
+++ b/src/lib/tenant-global-paths.ts
@@ -76,6 +76,13 @@ export const GLOBAL_ONLY_TENANT_PAGE_PATHS = [
   // construction and actuating, so a partner host must refuse it outright —
   // the same reasoning as /review, with writes attached.
   '/curation',
+  // Photo identification searches the ENTIRE corpus (CLIP index over every
+  // library's images, Mongo across all books) and links to whatever it finds —
+  // on a partner host that is a machine for surfacing other institutions'
+  // holdings. Same content-leak reasoning as /encyclopedia and /review. The
+  // museum QR use case points at sourcelibrary.org/identify, not a subdomain,
+  // so nothing tenant-facing is lost. (#4232)
+  '/identify',
 ] as const;
 
 /**
@@ -115,6 +122,9 @@ export const GLOBAL_ONLY_TENANT_API_PATHS = [
   // they were served on, so blocking only the page would leave the unscoped
   // corpus reachable from a tenant subdomain.
   '/api/review',
+  // /identify posts the photo from the client, so blocking only the page would
+  // leave corpus-wide visual search callable from a tenant host.
+  '/api/identify',
 ] as const;
 
 const ALL_GLOBAL_ONLY_PATHS: readonly string[] = [


### PR DESCRIPTION
Implements #4232 — the product-surface half of the /identify feature (retrieval quality stays in #3193).

## What's in scope

**B. Streaming (the core change).** `/api/identify?stream=1` now returns NDJSON stage events: `status` → `identification` (~5s) → `matches` (provisional rail) → `confirmed` (visual verdict + final rail) → `verification` (grounded corrections) → `done`/`error`. The page reads the stream and renders each piece as it lands, with a narration line for the running stage and staged fallback copy before the first event. **Buffered JSON stays the default** — `scripts/eval/identify-bench.mjs` and any existing client are byte-for-byte unchanged (verified: same key set, same shapes). Mid-pipeline failures became typed throws (`IdentifyError`) so both paths map them correctly; the per-stage timeout guards from #3209 are untouched, and a stalled stage ends the stream with an `error` event rather than hanging it.

**A. Discoverability.** `git grep` found zero nav links to /identify. Added: header nav item (EN + ES via `NAV_STRINGS`), footer Library column link, and a "Seen it somewhere?" camera chip in the gallery toolbar. Also added `/identify` + `/api/identify` to `tenant-global-paths.ts`: identification searches the entire corpus and links to whatever it finds, which on a partner subdomain is a machine for surfacing other institutions' holdings (same reasoning as /review); the one-list design drops it from tenant nav/footer automatically. The EFM QR (ops task) points at sourcelibrary.org, so nothing tenant-facing is lost.

**C/D/E. Results screen.** With a confirmed match the rail drops the semantic text-association lane (it padded the tail with Book of the Dead papyri after a Mesoamerican codex) and caps at 5. The confirmed card now says "scan page N" so it can't read as contradicting the Analysis card's plate numbering ("Codex Borgia, Page 56" vs scan page 18 — both correct). Thumbnail gets `self-start` so it stops stretching into a gray dead zone.

## Out of scope / corrections to the issue
- E's "feedback toast overlap": misdiagnosed — FeedbackCallout is an in-flow band above the footer, not a floating toast. No change needed.
- Homepage placement and the printed EFM QR asset (ops repo).

## Verified
- `npx tsc --noEmit` clean; full unit suite 3,068 tests green.
- Live local run (dev server + real keys): stream delivered `identification` at **4.1s** vs **12.5s** total; JSON fallback returned the classic shape with the rail correctly capped (visual_confirmed + 2×visual + text only).
- Browser walkthrough at 390px: analysis card on screen ~5s with "Searching the library…" strip, then confirmed card ("scan page 18"), rail = Codex Vaticanus B + Codex Nuttall only; header/footer/gallery links all render; tenant filter untouched elsewhere.

Closes #4232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrTZhp2NaTZabcUPmp7swL