### PR TITLE
perf(identify): bound the fallback scans that were the pipeline's tail (#4232)

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -135,7 +135,14 @@ export async function POST(request: NextRequest) {
   // streaming path (?stream=1) can deliver partial results while later stages
   // are still running; the buffered JSON path passes a no-op. Returns the same
   // assembled payload either way. (#4232)
-  const pipeline = async (emit: (e: Record<string, unknown>) => void) => {
+  const pipeline = async (emitRaw: (e: Record<string, unknown>) => void) => {
+    // Stage timing: `t` (ms since pipeline start) rides on every event, and
+    // `mark` logs internal boundaries — the streamed events alone showed an
+    // unexplained multi-second gap between identification and matches (#4232).
+    const t0 = Date.now();
+    const emit = (e: Record<string, unknown>) => emitRaw({ ...e, t: Date.now() - t0 });
+    const mark = (label: string) => console.log(`[identify] t+${Date.now() - t0}ms ${label}`);
+
     // Run Gemini vision + CLIP visual search in parallel
     const apiKey = getNextApiKey();
     const model = 'gemini-3.1-flash-lite';
@@ -206,6 +213,7 @@ export async function POST(request: NextRequest) {
 
     // Wait for initial identification + CLIP
     const [resp, clipMatches] = await Promise.all([geminiPromise, clipPromise]);
+    mark('gemini+clip resolved');
 
     if (!resp.ok) {
       const err = await resp.text();
@@ -233,6 +241,7 @@ export async function POST(request: NextRequest) {
     // First streamed stage: the reader sees the analysis while retrieval,
     // visual confirmation and web verification are still running.
     emit({ type: 'identification', data: identification });
+    mark('identification emitted');
 
     // Promise 3: Semantic artwork search (runs after initial ID, in parallel with DB search)
     // Uses the identification to find related artworks via embedding similarity
@@ -259,6 +268,7 @@ export async function POST(request: NextRequest) {
         const textQuery = [identification.subject, ...(identification.search_terms || []).slice(0, 3)]
           .filter(Boolean).join('. ');
         const textCands = await getGalleryCandidatesByText(textQuery, 10);
+        mark('rerank: text candidates');
 
         const clipCands: IdentifyCandidate[] = clipMatches.slice(0, 10).map(cm => ({
           id: cm.id,
@@ -291,8 +301,10 @@ export async function POST(request: NextRequest) {
           })
           .filter(c => c.thumbnailUrl && (!c.galleryId || c._hydrated?.book_visible !== false));
 
+        mark('rerank: candidates hydrated');
         const t0 = Date.now();
         const verdict = await rerankByVisualComparison(base64, mimeType, candidates);
+        mark('rerank: verdict');
         if (!verdict?.picked) {
           return {
             confirmed: null as ConfirmedMatch | null,
@@ -459,6 +471,12 @@ Return JSON only:
         ],
       };
 
+      // maxTimeMS is a hard latency budget, not a safety net: these unindexed
+      // regex scans short-circuit fast when terms are common (the limit fills
+      // early) but walk all ~105K books when terms are rare — measured 8.07s
+      // for one Strategy 2 scan, which was the whole pipeline's tail (#4232).
+      // The text strategies are fallback lanes behind CLIP + visual rerank, so
+      // a bounded partial beats a complete-but-slow answer here.
       const artistBooks = await books
         .find(nameQuery, {
           projection: {
@@ -467,7 +485,7 @@ Return JSON only:
             commons_full_url: 1, archived_full_url: 1,
             commons_title: 1, 'enrichment.subject': 1, 'enrichment.inscriptions': 1,
           },
-          maxTimeMS: 8000,
+          maxTimeMS: 2500,
         })
         .limit(50)
         .toArray()
@@ -517,6 +535,7 @@ Return JSON only:
       matches.push(...scored.slice(0, 10));
     }
 
+    mark('strategy1 done');
     // Strategy 2: Search terms against title/display_title (fallback if no artist or few matches)
     if (matches.length < 3 && identification.search_terms?.length) {
       const termQueries = identification.search_terms
@@ -548,7 +567,9 @@ Return JSON only:
                 published: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, resource_type: 1,
                 'enrichment.subject': 1,
               },
-              maxTimeMS: 8000,
+              // Hard latency budget — see the Strategy 1 comment: THIS scan
+              // measured 8.07s on rare terms and was the pipeline's tail.
+              maxTimeMS: 2500,
             },
           )
           .limit(20)
@@ -596,29 +617,46 @@ Return JSON only:
       .filter(w => w.length > 4)
       .slice(0, 5);
 
+    mark('strategy2 done');
     const pageMatches: { bookId: string; pageNumber: number; score: number }[] = [];
 
     if ((searchTerms.length > 0 || phrases.length > 0) && topMatches.length > 0) {
       const bookIds = topMatches.map(m => m.id);
 
-      // Strategy A: Search for distinctive phrases (strongest signal — exact multi-word match)
-      for (const phrase of phrases.slice(0, 4)) {
+      // Up to 10 book-scoped OCR regex queries. They used to run SEQUENTIALLY
+      // and this loop alone could add several seconds; the queries are
+      // independent, so fire them together and merge in a fixed order
+      // (phrases before terms) to keep scoring deterministic. (#4232 perf)
+      const phraseQueries = phrases.slice(0, 4).map(phrase => {
         const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const found = await pages
+        return pages
           .find(
-            {
-              book_id: { $in: bookIds },
-              'ocr.data': { $regex: escaped, $options: 'i' },
-            },
-            {
-              projection: { book_id: 1, page_number: 1 },
-              maxTimeMS: 5000,
-            },
+            { book_id: { $in: bookIds }, 'ocr.data': { $regex: escaped, $options: 'i' } },
+            { projection: { book_id: 1, page_number: 1 }, maxTimeMS: 2500 },
           )
           .limit(10)
           .toArray()
           .catch(() => []);
+      });
+      const termQueries2 = searchTerms.slice(0, 6).map(term => {
+        const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return pages
+          .find(
+            { book_id: { $in: bookIds }, 'ocr.data': { $regex: escaped, $options: 'i' } },
+            { projection: { book_id: 1, page_number: 1 }, maxTimeMS: 2500 },
+          )
+          .limit(20)
+          .toArray()
+          .catch(() => []);
+      });
+      const [phraseResults, termResults] = await Promise.all([
+        Promise.all(phraseQueries),
+        Promise.all(termQueries2),
+      ]);
 
+      // Phrases first (strongest signal — exact multi-word match), then words
+      // (catches pages where OCR line breaks differ from the inscriptions).
+      for (const found of phraseResults) {
         for (const p of found) {
           const existing = pageMatches.find(
             pm => pm.bookId === p.book_id && pm.pageNumber === p.page_number,
@@ -630,26 +668,7 @@ Return JSON only:
           }
         }
       }
-
-      // Strategy B: Search for individual distinctive words (more queries but catches
-      // pages where OCR line breaks differ from the inscriptions)
-      for (const term of searchTerms.slice(0, 6)) {
-        const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const found = await pages
-          .find(
-            {
-              book_id: { $in: bookIds },
-              'ocr.data': { $regex: escaped, $options: 'i' },
-            },
-            {
-              projection: { book_id: 1, page_number: 1 },
-              maxTimeMS: 3000,
-            },
-          )
-          .limit(20)
-          .toArray()
-          .catch(() => []);
-
+      for (const found of termResults) {
         for (const p of found) {
           const existing = pageMatches.find(
             pm => pm.bookId === p.book_id && pm.pageNumber === p.page_number,
@@ -689,6 +708,7 @@ Return JSON only:
       }
     }
 
+    mark('page matching done');
     // Merge CLIP visual matches into text matches
     // CLIP matches come from Supabase with book_id — merge by boosting existing or adding new
     const existingMatchIds = new Set(matches.map(m => m.id));
@@ -720,6 +740,7 @@ Return JSON only:
     // here (thumbnail/title/id), so guard against a stale visible column.
     const { filterVisibleArtworks } = await import('@/lib/artwork-visibility');
     const semanticArtworks = await filterVisibleArtworks(db, await semanticArtworkPromise);
+    mark('semantic artworks merged');
     for (const sa of semanticArtworks) {
       if (existingMatchIds.has(sa.book_id)) continue;
       const semanticScore = Math.round(sa.similarity * 30); // Scale similarity to 0-30
@@ -810,6 +831,7 @@ Return JSON only:
 
     // Second streamed stage: the provisional rail (text + visual + semantic,
     // not yet visually confirmed), so the wait for the rerank shows results.
+    mark('matches emitting');
     emit({ type: 'matches', data: shapeMatches(matches), visual_search: clipMatches.length > 0 });
 
     // Await visual confirmation (started right after identification), but never
@@ -869,10 +891,12 @@ Return JSON only:
 
     // Third streamed stage: the verdict. Carries the final (possibly reordered
     // and trimmed) rail so the client replaces the provisional one.
+    mark('confirmed emitting');
     emit({ type: 'confirmed', data: confirmed, page: pagePayload, rerank: rerankPayload, matches: shapeMatches(matches) });
 
     // Await Google Search verification (started earlier, should be done by now)
     const verification = await verifyPromise;
+    mark('verification resolved');
 
     // Merge verification corrections into identification
     if (verification) {

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -99,16 +99,20 @@ export default function IdentifyPage() {
     timers.push(setTimeout(() => setStageMessage('Comparing against 152,000 illustrations…'), 6000));
     timers.push(setTimeout(() => setStageMessage('Confirming the match…'), 14000));
 
-    // Compress large images client-side (phone cameras produce 5-10MB files)
+    // Compress large images client-side (phone cameras produce 5-10MB files).
+    // 1600px / q0.8 is still ample for reading inscriptions, and the photo is
+    // the dominant payload THREE times over: the mobile upload, the vision
+    // identification call, and the visual-rerank call all carry it — so every
+    // byte saved here is saved at each stage (#4232 perf).
     let imageFile = file;
-    if (file.size > 3 * 1024 * 1024) {
+    if (file.size > 1.5 * 1024 * 1024) {
       try {
         const bitmap = await createImageBitmap(file);
-        const scale = Math.min(1, 2000 / Math.max(bitmap.width, bitmap.height));
+        const scale = Math.min(1, 1600 / Math.max(bitmap.width, bitmap.height));
         const canvas = new OffscreenCanvas(bitmap.width * scale, bitmap.height * scale);
         const ctx = canvas.getContext('2d')!;
         ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-        const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.85 });
+        const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
         imageFile = new File([blob], 'photo.jpg', { type: 'image/jpeg' });
       } catch {
         // Fall through with original file if compression fails


### PR DESCRIPTION
Follow-up to #4233. Derek asked how to make /identify faster; instrumentation found the answer was one query.

## The measurement

Added a `t` (ms since pipeline start) field to every streamed event and `[identify]` stage marks server-side, then ran the pipeline locally with prod data. The gap between the identification event (~3.9s) and the matches/confirmed events (~12s) was **one Strategy 2 regex scan: 8.07s**. The unindexed `$or`-over-six-fields regex on `books` (~105K docs, including long `enrichment.inscriptions` text) short-circuits fast on common terms (limit 20 fills early — which is why a standalone probe with common terms measured 625ms) but walks the entire collection on rare terms like the ones a real identification produces. Everything else was already concurrent: CLIP ~2s, semantic artwork search ~0.9s, page queries ~50ms each, rerank lane pre-work ~1.5s.

## Changes

- **Strategy 1/2 book scans: `maxTimeMS` 8000 → 2500.** These are weak fallback lanes (score-5 text matches) behind CLIP + visual rerank; a bounded partial beats a complete-but-slow answer, and on timeout they degrade to `[]` exactly as before.
- **Page phrase/term OCR queries: parallel.** Up to 10 sequential awaits became one `Promise.all` batch; results merge in fixed order (phrases before terms) so scoring stays deterministic.
- **Client compression: >1.5MB → 1600px q0.8** (was >3MB → 2000px q0.85). The photo is the dominant payload three times over — the mobile upload, the vision identification call, and the visual-rerank call. 1600px remains ample for reading inscriptions.
- **Instrumentation kept**: the `t` field on stream events and the stage marks. Zero cost, and the rerank lane (now the critical path) carries marks for the next pass.

## Measured (local, prod data, clean runs)

| Event | before | after |
|---|---|---|
| identification | ~2.3–3.9s | unchanged |
| matches (rail visible) | 11.8s | **4.7–5.0s** |
| confirmed | 11.9s | 11.1s (rerank-bound) |

The remaining tail is the visual-rerank Gemini call (~5–6s of flash-preview comparing the photo against 16 thumbnails) — noted in #4232 as the target for a future pass (candidate thumbnail prefetch during the identification wait; possibly Atlas $search for the text lanes). Not touched here because that path is accuracy-benchmarked (#3193).

Also observed during testing: with the dev machine under heavy load, macOS suspends the dev-server process and Node timers freeze — a 20s AbortSignal took 6 minutes of wall time to fire. That is a local-environment artifact (the route's own 25s race didn't fire either); it cannot occur on Vercel, and the two clean measurements above are the valid ones. Will re-verify timings on prod after merge.

## Verified
- `npx tsc --noEmit` clean; unit suite 2,927 tests green.
- Local streamed run shows the new timings above; JSON fallback shape unchanged.

Refs #4232, #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrTZhp2NaTZabcUPmp7swL