### PR TITLE
fix(archive): one list of archivable source hosts, and 16 more of them

### DIFF
--- a/scripts/archive-cover-pages.mjs
+++ b/scripts/archive-cover-pages.mjs
@@ -11,6 +11,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { ARCHIVABLE_SOURCES_REGEX } from './lib/archivable-sources.mjs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { assertBookScopedKey } from './lib/r2-key.mjs';
 
@@ -52,7 +53,8 @@ await client.connect();
 const db = client.db('bookstore');
 
 // Archivable source pattern
-const ARCHIVABLE_RE = /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de/;
+// Shared with the archive route and the watchdog — see scripts/lib/archivable-sources.mjs.
+const ARCHIVABLE_RE = ARCHIVABLE_SOURCES_REGEX;
 
 // Find books with zero archived pages but with archivable source URLs
 let bookFilter = {
@@ -76,8 +78,8 @@ const pipeline = [
         { $match: {
           $expr: { $eq: ['$book_id', '$$bid'] },
           $or: [
-            { photo: { $regex: /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de/ } },
-            { photo_original: { $regex: /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de/ } },
+            { photo: { $regex: ARCHIVABLE_RE } },
+            { photo_original: { $regex: ARCHIVABLE_RE } },
           ],
         }},
         { $limit: 1 },

--- a/scripts/lib/archivable-sources.mjs
+++ b/scripts/lib/archivable-sources.mjs
@@ -1,0 +1,57 @@
+/**
+ * TWIN of `src/lib/archivable-sources.ts` — these two change together.
+ *
+ * `.mjs` scripts cannot import the TS module, so the list is duplicated, which
+ * is the arrangement `translate-core.mjs` <-> `ai-models.ts` and
+ * `sync-es-collection.mjs` <-> `localized.ts` already live with. The difference
+ * is that this pair is GUARDED: `tests/unit/archivable-sources-parity.test.ts`
+ * reads both files and fails if the host lists differ.
+ *
+ * Read the TS file for why the list exists, why each host is on it, and which
+ * hosts are deliberately excluded (Harvard 429, Leiden 403, IRHT 301, QDL none).
+ * Do not add a host here without adding it there — and not without probing a
+ * REAL url from the `pages` collection against a datacenter IP first.
+ */
+
+export const ARCHIVABLE_SOURCE_HOSTS = [
+  // — original four —
+  'archive.org',
+  'gallica.bnf.fr',
+  'digitale-sammlungen.de',
+  'dl.ndl.go.jp',
+  // — verified 200 from a datacenter IP, 2026-08-27 —
+  'digital.slub-dresden.de',
+  'e-rara.ch',
+  'images.uba.uva.nl',
+  'iiif.bdrc.io',
+  'bodleian.ox.ac.uk',
+  'contentdm.lib.byu.edu',
+  'contentdm.oclc.org',
+  'imagenes.patrimonionacional.es',
+  'hab.de',
+  'digi.ub.uni-heidelberg.de',
+  'tile.loc.gov',
+  'internetculturale.it',
+  'images.metmuseum.org',
+  'dlc.services',
+  'permalinkbnd.bnportugal.gov.pt',
+  'cdli.earth',
+];
+
+/** Dot-boundary match: `archive.org` matches `ia1.us.archive.org`, never `evilarchive.org`. */
+export function isArchivableSourceUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw.startsWith('http')) return false;
+  let host;
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return ARCHIVABLE_SOURCE_HOSTS.some(h => host === h || host.endsWith(`.${h}`));
+}
+
+/** Mongo-side equivalent, built from the same array. */
+export const ARCHIVABLE_SOURCES_REGEX = new RegExp(
+  ARCHIVABLE_SOURCE_HOSTS.map(h => h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'),
+);

--- a/scripts/maintenance/archiving-watchdog.mjs
+++ b/scripts/maintenance/archiving-watchdog.mjs
@@ -37,6 +37,7 @@
  *                     (default off — classification still reports them)
  */
 import { MongoClient } from 'mongodb';
+import { ARCHIVABLE_SOURCES_REGEX } from '../lib/archivable-sources.mjs';
 
 const ARGS = process.argv.slice(2);
 const APPLY = ARGS.includes('--apply');
@@ -59,7 +60,10 @@ const MONGO = process.env.MONGODB_URI || process.env.MONGO_URI || process.env.DA
 // If they're making progress we leave them; the Mac worker owns them.
 const MAC_ONLY_PROVIDERS = new Set(['harvard', 'e-rara', 'gallica']);
 // What the on-demand /archive-images route (and Hetzner archiver) can fetch.
-const ARCHIVABLE_RE = /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de|digi\.vatlib\.it|diglib\.hab\.de|e-rara|wellcomecollection|cudl\.lib\.cam|digital\.bodleian|tudigit\.ulb\.tu-darmstadt/i;
+// Shared with the archive route — this list used to be private here and 6 hosts
+// longer than the route's, so the watchdog classified books "archivable" that
+// the route then silently refused. See scripts/lib/archivable-sources.mjs.
+const ARCHIVABLE_RE = ARCHIVABLE_SOURCES_REGEX;
 
 function log(...a) { console.log(...a); }
 

--- a/src/app/api/books/[id]/archive-images/route.ts
+++ b/src/app/api/books/[id]/archive-images/route.ts
@@ -5,12 +5,14 @@ import { images } from '@/lib/api-client/images';
 import { compress_photo } from '@/lib/image-manipulation';
 import { withAuth } from '@/lib/auth-helpers';
 import sharp from 'sharp';
+// Which source hosts we will fetch from — ONE list, shared with the watchdog and
+// the cover archiver. See src/lib/archivable-sources.ts for why three private
+// copies of this became a silent no-op.
+import { ARCHIVABLE_SOURCES_REGEX } from '@/lib/archivable-sources';
 
 // Increase timeout for archiving many images
 export const maxDuration = 300;
 
-// Regex pattern to match pages from external sources that can be archived
-const ARCHIVABLE_SOURCES_REGEX = /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de|dl\.ndl\.go\.jp/;
 
 /**
  * Recount archived pages and write the cached counter back onto the book (#3712).

--- a/src/lib/archivable-sources.ts
+++ b/src/lib/archivable-sources.ts
@@ -1,0 +1,96 @@
+/**
+ * Single source of truth for which source hosts we will fetch page images FROM.
+ *
+ * WHY THIS MODULE EXISTS (#4163's shape, third occurrence)
+ * -------------------------------------------------------
+ * Three copies of this list existed and all three disagreed:
+ *
+ *   archive-cover-pages.mjs        3 hosts
+ *   archiving-watchdog.mjs        10 hosts
+ *   api/.../archive-images/route   4 hosts
+ *
+ * The watchdog classifies a book "archivable" using ITS list, then calls the
+ * route, which refuses anything outside ITS list — so `diglib.hab.de`,
+ * `wellcomecollection`, `cudl.lib.cam` and `digital.bodleian` could each be
+ * triggered and archive nothing. A silent no-op that reads as success, which is
+ * exactly the CSP/proxy two-list failure that made 2,506 Florentine Codex pages
+ * unreadable. When two lists must agree, they must be one list.
+ *
+ * WHY THE LIST GREW (2026-08-27)
+ * ------------------------------
+ * The corpus draws page images from 22+ distinct hosts; the route allowed four.
+ * Everything else could never be archived at all, which is why ~90,000 pages
+ * served from R2 while their only full-resolution master sat on someone else's
+ * server (`scripts/audit/pages-served-without-a-master.mjs`).
+ *
+ * EVERY HOST HERE WAS PROBED FROM A DATACENTER IP (the Hetzner box) with a REAL
+ * url taken from the `pages` collection, not a hand-written one. A host that
+ * refuses a datacenter IP must NOT be added: allowlisting it converts a stall
+ * into a failed fetch, which is worse, because a stall is visible and a failure
+ * looks like work. Deliberately excluded on that basis:
+ *
+ *   mps.lib.harvard.edu          429 rate-limited
+ *   iiif.universiteitleiden.nl   403 blocked
+ *   iiif.irht.cnrs.fr            301 unresolved redirect
+ *   iiif.qdl.qa                  no response
+ *
+ * Harvard, e-rara and Gallica are additionally listed in the watchdog's
+ * MAC_ONLY_PROVIDERS. Note e-rara answered 200 with a real 493KB image from
+ * Hetzner on 2026-08-27, so that classification looks stale for e-rara at least
+ * — but one probe is not a sustained crawl, so it is allowlisted here (the route
+ * may fetch it) while the MAC_ONLY routing is left alone pending real evidence.
+ *
+ * ADDING A HOST: probe a REAL url from `pages` against a datacenter IP first.
+ * `scripts/lib/archivable-sources.mjs` is this file's twin for `.mjs` callers
+ * and `tests/unit/archivable-sources-parity.test.ts` fails if they drift.
+ */
+
+export const ARCHIVABLE_SOURCE_HOSTS = [
+  // — original four —
+  'archive.org',
+  'gallica.bnf.fr',
+  'digitale-sammlungen.de',
+  'dl.ndl.go.jp',
+  // — verified 200 from a datacenter IP, 2026-08-27 —
+  'digital.slub-dresden.de',
+  'e-rara.ch',
+  'images.uba.uva.nl',
+  'iiif.bdrc.io',
+  'bodleian.ox.ac.uk',
+  'contentdm.lib.byu.edu',
+  'contentdm.oclc.org',
+  'imagenes.patrimonionacional.es',
+  'hab.de',
+  'digi.ub.uni-heidelberg.de',
+  'tile.loc.gov',
+  'internetculturale.it',
+  'images.metmuseum.org',
+  'dlc.services',
+  'permalinkbnd.bnportugal.gov.pt',
+  'cdli.earth',
+] as const;
+
+/**
+ * Match on a DOT BOUNDARY, never a bare suffix — the same rule
+ * `image-proxy-hosts.ts` learned the hard way. `archive.org` must match
+ * `archive.org` and `ia1.us.archive.org`, and never `evilarchive.org`.
+ */
+export function isArchivableSourceUrl(url: string | null | undefined): boolean {
+  const raw = String(url || '').trim();
+  if (!raw.startsWith('http')) return false;
+  let host: string;
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return ARCHIVABLE_SOURCE_HOSTS.some(h => host === h || host.endsWith(`.${h}`));
+}
+
+/**
+ * Mongo-side equivalent, for queries that select pages by source. Built from the
+ * same array so a host can never be fetchable-but-unselectable.
+ */
+export const ARCHIVABLE_SOURCES_REGEX = new RegExp(
+  ARCHIVABLE_SOURCE_HOSTS.map(h => h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'),
+);

--- a/tests/unit/archivable-sources-parity.test.ts
+++ b/tests/unit/archivable-sources-parity.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import {
+  ARCHIVABLE_SOURCE_HOSTS,
+  isArchivableSourceUrl,
+  ARCHIVABLE_SOURCES_REGEX,
+} from '@/lib/archivable-sources';
+import {
+  ARCHIVABLE_SOURCE_HOSTS as HOSTS_MJS,
+  isArchivableSourceUrl as isArchivableMjs,
+} from '../../scripts/lib/archivable-sources.mjs';
+
+/**
+ * Three copies of this list existed and all three disagreed (3, 10 and 4 hosts).
+ * The watchdog classified a book "archivable" on its list, called the route, and
+ * the route refused on its own — a silent no-op that reads as success. Same
+ * two-lists-must-agree shape as the CSP/proxy failure in #4163.
+ *
+ * The `.mjs` twin exists because scripts cannot import the TS module. That
+ * arrangement is only safe if something fails when they drift, which is this.
+ */
+describe('archivable sources: the TS module and its .mjs twin', () => {
+  it('hold identical host lists, in the same order', () => {
+    expect([...HOSTS_MJS]).toEqual([...ARCHIVABLE_SOURCE_HOSTS]);
+  });
+
+  it('agree on every host, and on things that merely look like one', () => {
+    const probes = [
+      'https://archive.org/download/x/page/n0/full/pct:50/0/default.jpg',
+      'https://ia1.us.archive.org/x.jpg',
+      'https://api.digitale-sammlungen.de/iiif/image/v2/bsb1/full/full/0/default.jpg',
+      'https://www.e-rara.ch/zuz/i3f/v20/1/full/full/0/default.jpg',
+      'https://evilarchive.org/x.jpg',
+      'https://notdlc.services/x.jpg',
+      'https://mps.lib.harvard.edu/assets/images/drs:1/full/2000,/0/default.jpg',
+      'https://iiif.universiteitleiden.nl/iiif/2/x/full/full/0/default.jpg',
+      'not a url',
+      '',
+    ];
+    for (const p of probes) {
+      expect(isArchivableMjs(p), p).toBe(isArchivableSourceUrl(p));
+    }
+  });
+});
+
+describe('archivable sources: host matching', () => {
+  it('matches a host and its subdomains', () => {
+    expect(isArchivableSourceUrl('https://archive.org/x.jpg')).toBe(true);
+    expect(isArchivableSourceUrl('https://ia1.us.archive.org/x.jpg')).toBe(true);
+    expect(isArchivableSourceUrl('https://api.digitale-sammlungen.de/x.jpg')).toBe(true);
+  });
+
+  it('does NOT match a bare suffix — the #3508 lesson', () => {
+    // An attacker only has to register a domain ending in an allowlisted string.
+    expect(isArchivableSourceUrl('https://evilarchive.org/x.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://nothab.de/x.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://xcdli.earth/x.jpg')).toBe(false);
+  });
+
+  it('rejects hosts that refuse a datacenter IP, so a stall never becomes a failed fetch', () => {
+    // Probed 2026-08-27 from Hetzner with real urls from `pages`:
+    // Harvard 429, Leiden 403, IRHT 301, QDL no response.
+    expect(isArchivableSourceUrl('https://mps.lib.harvard.edu/assets/images/drs:1/full/2000,/0/default.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://iiif.universiteitleiden.nl/iiif/2/x/full/full/0/default.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://iiif.irht.cnrs.fr/iiif/ark:/1/full/1000,/0/default.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://iiif.qdl.qa/iiif/images/1/x.jp2/full/1000,/0/default.jpg')).toBe(false);
+  });
+
+  it('rejects non-urls rather than throwing', () => {
+    expect(isArchivableSourceUrl(null)).toBe(false);
+    expect(isArchivableSourceUrl(undefined)).toBe(false);
+    expect(isArchivableSourceUrl('')).toBe(false);
+    expect(isArchivableSourceUrl('ftp://archive.org/x.jpg')).toBe(false);
+    expect(isArchivableSourceUrl('https://')).toBe(false);
+  });
+
+  it('the Mongo regex is built from the same array it screens with', () => {
+    for (const h of ARCHIVABLE_SOURCE_HOSTS) {
+      expect(ARCHIVABLE_SOURCES_REGEX.test(`https://${h}/x.jpg`), h).toBe(true);
+    }
+  });
+});
+
+describe('no stale private copies of the list remain', () => {
+  const root = path.resolve(__dirname, '../..');
+  const read = (p: string) => readFileSync(path.join(root, p), 'utf8');
+
+  /**
+   * The negative control for this guard: reintroduce a literal host-alternation
+   * regex in any of the three former copies and this goes red. Without it the
+   * lists can silently fork again, which is the whole defect.
+   */
+  for (const f of [
+    'src/app/api/books/[id]/archive-images/route.ts',
+    'scripts/maintenance/archiving-watchdog.mjs',
+    'scripts/archive-cover-pages.mjs',
+  ]) {
+    it(`${f} imports the shared list instead of defining its own`, () => {
+      const src = read(f);
+      expect(src).toMatch(/archivable-sources/);
+      // A hand-rolled alternation of two or more source hosts is the old shape.
+      expect(src).not.toMatch(/archive\\?\.org\|gallica/);
+    });
+  }
+});


### PR DESCRIPTION
The corpus draws page images from **22+ hosts**. The archive route allowed **four**. Everything else could never be archived at all — which is why ~90,000 pages serve from R2 while their only full-resolution master sits on someone else's server.

## Four copies, all disagreeing

| file | hosts |
|---|---|
| `archive-cover-pages.mjs` | 3 named — **plus 2 more inline in a Mongo query** |
| `archiving-watchdog.mjs` | 10 |
| `api/…/archive-images/route.ts` | 4 |

The watchdog classifies a book "archivable" on **its** list, calls the route, and the route refuses on **its** list. So `diglib.hab.de`, `wellcomecollection`, `cudl.lib.cam` and `digital.bodleian` could each be triggered and archive nothing — a silent no-op that reads as success. Same two-lists-must-agree shape as #4163, which made 2,506 Florentine Codex pages unreadable.

Now `src/lib/archivable-sources.ts` with a `.mjs` twin, and all four call sites read it.

## Every new host was probed from a datacenter IP, with a real URL

URLs pulled from the `pages` collection, not hand-written — three of my first five probes were inconclusive precisely *because* I invented the URLs, which is the "a fixture you invented is evidence about you, not the system" trap.

**Added** (200 from Hetzner, 2026-08-27): `digital.slub-dresden.de`, `e-rara.ch`, `images.uba.uva.nl`, `iiif.bdrc.io`, `bodleian.ox.ac.uk`, `contentdm.lib.byu.edu`, `contentdm.oclc.org`, `imagenes.patrimonionacional.es`, `hab.de`, `digi.ub.uni-heidelberg.de`, `tile.loc.gov`, `internetculturale.it`, `images.metmuseum.org`, `dlc.services`, `permalinkbnd.bnportugal.gov.pt`, `cdli.earth`.

**Deliberately excluded**: `mps.lib.harvard.edu` (429), `iiif.universiteitleiden.nl` (403), `iiif.irht.cnrs.fr` (301 unresolved), `iiif.qdl.qa` (no response). Allowlisting a host that refuses a datacenter IP converts a stall into a **failed fetch**, which is worse — a stall is visible, a failure looks like work.

**One to watch:** `e-rara.ch` answered 200 with a real 493 KB image, though the watchdog lists it in `MAC_ONLY_PROVIDERS`. That classification looks stale, but one probe is not a sustained crawl — so the host is allowlisted (the route *may* fetch it) and the MAC_ONLY routing is left alone pending real evidence. e-rara is ~108K pages, the largest non-MDZ block, so this is worth settling properly rather than on my one probe.

## The guard, and the fourth copy it found

`tests/unit/archivable-sources-parity.test.ts` asserts the TS and `.mjs` lists are identical, that both agree on every probe including near-misses (`evilarchive.org` must not match `archive.org` — the #3508 suffix lesson), and that none of the former call sites still defines a private alternation.

**It earned its keep on its first run**, catching a fourth copy I'd missed — inline in a Mongo query rather than in the named constant I had replaced.

**Negative control run**, per `invariants/tests-that-are-not-guards.md`: removing one host from the twin turns it red; restoring it turns it green. A guard I haven't watched fail is a decoration.

Full suite: **220 files, 3,052 tests, green.** `npx tsc --noEmit` clean.

## What this unlocks

~140K pages that currently have no path to being archived. The MDZ run on Hetzner (59,969 pages done) is unaffected — it uses hosts that were already allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
