### PR TITLE
fix(access): wire the hidden-book gate into the base metadata routes

### DIFF
--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -8,6 +8,7 @@ import { pruneSearchRowsForDeletedBook } from '@/lib/prune-deleted-book';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { isBookReadable } from '@/lib/book-access';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 
 export const preferredRegion = 'fra1';
@@ -31,8 +32,9 @@ export async function GET(
     const db = includeFull ? await getDb() : await getReadDb();
 
     // Book projection: nav mode only needs fields the reader uses
+    // (`visible` feeds the hidden-book gate below).
     const bookProjection = pagesMode === 'nav' ? {
-      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
+      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1,
       published: 1, language: 1, doi: 1,
       chapters: 1,
     } : undefined;
@@ -42,6 +44,12 @@ export async function GET(
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
     const book = result.book;
+
+    // Hidden books: same gate + indistinguishable-404 as the sibling
+    // tenant content routes (quote/download/index/…).
+    if (!(await isBookReadable(book, request))) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
 
     // Page projections:
     // - full: all fields (for admin/processing views)

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -9,6 +9,7 @@ import { withApiAuth } from '@/lib/api-auth';
 import { EDITION_COUNTER_PROJECTION } from '@/lib/page-translations';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { isBookReadable } from '@/lib/book-access';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
@@ -38,7 +39,9 @@ export const GET = withApiAuth(async (
     // categories, year) — without these, MCP returns a book card with
     // null pages and no summary.
     const bookProjection = pagesMode === 'nav' ? {
-      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
+      // `visible` feeds the hidden-book gate below — without it a hidden book
+      // in nav mode reads as public (isHiddenBook tests visible === false).
+      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1,
       published: 1, year: 1, language: 1, doi: 1,
       // The edition-vs-work language distinction (#3942). `language` is the
       // MANIFESTATION language — what is printed on these leaves — while
@@ -72,6 +75,14 @@ export const GET = withApiAuth(async (
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
     const book = result.book;
+
+    // Hidden books are gated on every content route (text/quote/index/chat/…)
+    // via book-access; the base metadata route was the one surface still
+    // serving full records for hidden ids to anonymous callers. Same
+    // indistinguishable-404 contract as the sibling routes.
+    if (!(await isBookReadable(book, request))) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
 
     // Page projections:
     // - full: all fields (for admin/processing views)


### PR DESCRIPTION
## What
`GET /api/books/[id]` and the tenant twin now call `isBookReadable` (book-access) and return the sibling routes' indistinguishable 404 for hidden books; `visible` added to the nav projections so the gate can judge there. Editor sessions and `CRON_SECRET` callers pass unchanged.

## Why
The content routes (text/quote/index/chat/download/search) were all gated when book-access closed the hidden-book leak in 2026-06 — the base metadata route was missed on both surfaces. Verified live 2026-08-27: anonymous GET on a hidden book id returned the full record while the reader page and text API correctly 404'd. With ~57K hidden books (and ~90 new reader-request imports this week), the metadata surface should match the rest of the read path.

## Consumers checked
- Editor UI / hidden-book preview: session cookie → passes.
- Pipeline workers and scripts: `Bearer CRON_SECRET` → passes.
- Anonymous MCP/API callers: hidden books now 404 — matching the posture of every other surface (search/sitemap/library API already exclude them).

## Out of scope
R2 object-level access (public serving bucket) — separate, known tradeoff tracked in ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNMMLH8s6g9PjiBe4U4L