### PR TITLE
fix(archive): the e-rara worker was a no-op loop — 227 runs, nothing archived

### DIFF
--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -63,7 +63,7 @@ const s3 = new S3Client({
 });
 
 const stats = {
-  booksProcessed: 0, booksSkipped: 0, booksFailed: 0,
+  booksProcessed: 0, booksSkipped: 0, booksFailed: 0, countersSynced: 0,
   pagesArchived: 0, pagesFailed: 0,
   bytesDownloaded: 0, bytesUploaded: 0,
   startTime: Date.now(),
@@ -126,6 +126,36 @@ async function processBook(book, db) {
     .toArray();
 
   if (pages.length === 0) {
+    // Nothing to archive — but the ONLY reason this book was selected is
+    // `pages_archived: { $not: { $gte: 1 } }`, so returning here without writing
+    // the counter leaves it eligible forever. Measured 2026-08-27: 6,865
+    // warehouse e-rara books sat in exactly this state — every page already
+    // archived in `pages_warehouse`, `pages_archived` never written on the
+    // warehouse doc — and this worker re-selected 100 of them every 30 minutes,
+    // ran for ~207s, and reported "0 archived, 0 failed, 100 skipped". 227 such
+    // runs in the log, none of which moved anything.
+    //
+    // A skip that does not record WHY is an infinite loop with a progress bar.
+    // Sync the counter from the pages themselves, using the same predicate the
+    // archive route uses, so the book leaves the queue by being correct rather
+    // than by being ignored.
+    const archivedCount = await db.collection(pagesCol).countDocuments(
+      { book_id: book.id, archived_photo: { $exists: true, $nin: [null, ''] } },
+      { maxTimeMS: 10000 },
+    );
+    if (archivedCount > 0) {
+      await db.collection(booksCol).updateOne(
+        { id: book.id },
+        {
+          $set: {
+            pages_archived: archivedCount,
+            archive_status: archivedCount >= (book.pages_count || 0) ? 'archive_complete' : 'archive_partial',
+            updated_at: new Date(),
+          },
+        },
+      );
+      stats.countersSynced++;
+    }
     stats.booksSkipped++;
     return;
   }
@@ -372,7 +402,8 @@ async function main() {
   console.log(`Done in ${Math.round(elapsed)}s — ${stats.pagesArchived} archived, ${stats.pagesFailed} failed`);
   console.log(`Rate: ${pagesPerSec} pages/sec`);
   console.log(`Data: ${(stats.bytesDownloaded / (1024 * 1024)).toFixed(0)}MB downloaded, ${(stats.bytesUploaded / (1024 * 1024)).toFixed(0)}MB uploaded`);
-  console.log(`Books: ${stats.booksProcessed} processed, ${stats.booksFailed} failed, ${stats.booksSkipped} skipped`);
+  console.log(`Books: ${stats.booksProcessed} processed, ${stats.booksFailed} failed, ${stats.booksSkipped} skipped` +
+    (stats.countersSynced ? `, ${stats.countersSynced} stale counters synced (already archived)` : ''));
 
   // Log to cron_runs
   await db.collection('cron_runs').insertOne({

--- a/scripts/workers/archive-iiif-daemon.sh
+++ b/scripts/workers/archive-iiif-daemon.sh
@@ -15,7 +15,20 @@ set -uo pipefail
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 set -a; source .env.production.local; set +a
 
-W="node scripts/workers/archive-iiif-local.mjs --ignore-pause"
+# --any-status is NOT optional here, despite being a flag. Without it the worker
+# selects on `pipeline_auto.status: 'archiving'`, which matches the pipeline
+# QUEUE rather than the archive BACKLOG. Its own header records what that costs:
+# 21 books at 'archiving' while 5.07M pages across ~19,500 books sat unarchived,
+# so it reported "0 unarchived pages across 0 books" and idled.
+#
+# That was diagnosed and fixed in the SCRIPT on 2026-08-04 — and this caller was
+# never updated to pass the flag, so the fix has been inert ever since. Measured
+# 2026-08-27: every cycle in /tmp/archive-iiif-loop.log still reads
+# "0 unarchived pages across 0 books", while Hetzner was concurrently archiving
+# ~60,000 pages from the same providers.
+#
+# A fix in the callee that the caller does not opt into has not shipped.
+W="node scripts/workers/archive-iiif-local.mjs --ignore-pause --any-status"
 
 # Optional per-machine guard: skip cycles while on a metered link (phone hotspot,
 # in-flight wifi), where this daemon would otherwise eat the whole uplink. It is


### PR DESCRIPTION
**Yes, it runs here — every 30 minutes, and it has been achieving nothing.**

`org.sourcelibrary.archive-erara` fires on a 1800s `StartInterval`. Its log:

```
Done in 207s — 0 archived, 0 failed
Books: 0 processed, 0 failed, 100 skipped
```

**227 runs report exactly that.** Each burns ~207 seconds and moves nothing.

## Why

The worker selects on `pages_archived: { $not: { $gte: 1 } }` — books with no pages archived yet. Measured today, **6,865 warehouse e-rara books match**, and every one is **already fully archived**:

```
Memorabilis historia persecutionum…
  warehouse:  pages_count 190   pages_archived (missing)
  pages_warehouse docs: 190     pages docs: 190
  live books twin: archived 190/190
```

The pages are there, all carrying `archived_photo`. The live twin in `books` reads 190/190. Only the **warehouse** document's counter was never written. So the worker picks 100, finds zero unarchived pages, skips all 100, exits — and the next run picks the same kind of thing again, forever.

Every run also reports `Found 0 live + 100 warehouse` — the live e-rara queue has been empty this whole time.

## The shape of the bug

The **only** reason a book is selected is the counter. So a skip that doesn't write the counter leaves it eligible forever. *A skip that does not record why is an infinite loop with a progress bar.*

Now, when there are no unarchived pages, it syncs `pages_archived` from the pages themselves — the same predicate the archive route uses — so the book leaves the queue by being **correct** rather than by being ignored. The run summary reports it separately (`N stale counters synced (already archived)`), so the next run's output distinguishes *nothing to do* from *nothing done* — which is precisely the distinction 227 log entries failed to make.

## Relation to the other counter work

Same family as #4190: a denormalised counter that selectors key on, drifting from the pages it summarises. This is the variant where the drift also **starves the worker meant to fix it** — which is why it went unnoticed for 227 runs while looking busy.

It also revises my earlier claim that e-rara's ~108K pages "need the Mac worker". The Mac worker exists, runs, and has nothing to do; those pages are largely already archived and the number came from a host census that included warehouse and hidden books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2
