### PR TITLE
fix(e2e): match the Librarian sign-in nudge by href prefix, not exact URL (#4167)

### DIFF
--- a/e2e/embassy.spec.ts
+++ b/e2e/embassy.spec.ts
@@ -69,11 +69,17 @@ test.describe('Librarian', () => {
     // conversations and come back to them later") and broke the test the next
     // morning; the behaviour under test (a soft prompt, not a hard gate) never
     // changed. What matters is that anonymous visitors get a link, not a wall.
-    // Match the composer nudge by its exact href, not by role+name: the header
-    // UserMenu also renders a "Sign in" link (bare /auth/signin), so a name
-    // locator would pass even if the nudge below the input disappeared.
+    // Match the composer nudge by an href PREFIX, not by role+name: the header
+    // UserMenu also renders a "Sign in" link, but it is a bare /auth/signin
+    // with no query, so a name locator would pass even if the nudge below the
+    // input disappeared while `?callbackUrl=` still separates the two.
+    // Not an exact href either — #4134 (Spanish librarian) routed this through
+    // `encodeURIComponent`, so the callback renders as `%2Flibrarian` rather
+    // than `/librarian` and an equality match broke the next morning. The
+    // behaviour under test (a soft prompt carrying you back here, not a wall)
+    // never changed, and both spellings are the same URL.
     await expect(
-      page.locator('a[href="/auth/signin?callbackUrl=/librarian"]')
+      page.locator('a[href^="/auth/signin?callbackUrl="]')
     ).toBeVisible();
   });
 


### PR DESCRIPTION
Fixes #4167.

## What failed

The 2026-08-21 nightly E2E run had one hard failure — `e2e/embassy.spec.ts:59 › Librarian › anonymous visitors can use the Librarian input`, failed on all three attempts:

```
Locator: locator('a[href="/auth/signin?callbackUrl=/librarian"]')
Error: element(s) not found
```

## Why

Not a product bug. #4134 (Spanish librarian, merged 2026-08-20) routed that href through `localePath` + `encodeURIComponent`:

```diff
-<Link href="/auth/signin?callbackUrl=/librarian" …>
+<Link href={`${href('/auth/signin')}?callbackUrl=${encodeURIComponent(href('/librarian'))}`} …>
```

so [LibrarianClient.tsx:1190](src/app/librarian/LibrarianClient.tsx#L1190) now renders `/auth/signin?callbackUrl=%2Flibrarian`. Same URL, different spelling; the equality locator matched nothing.

Measured on prod — the page renders exactly two sign-in anchors:

```
signin anchors: [ '/auth/signin', '/auth/signin?callbackUrl=%2Flibrarian' ]
old locator count: 0
new locator count: 1
```

## The fix

Match by href **prefix** (`a[href^="/auth/signin?callbackUrl="]`). That keeps the discrimination the exact match existed for — the header `UserMenu` link carries no query string, so it still cannot satisfy the assertion if the nudge below the composer disappears — while surviving the encoding change.

Test-only change. The source is left alone: percent-encoding a query parameter is the more correct spelling and NextAuth accepts both.

This is the third cosmetic change to break this one assertion while the behaviour under test (a soft prompt, not a hard gate) stayed intact — #3358 took the wording out of the locator, #4007 took the second wording out, this takes the encoding out. The comment above it now records all three.

## Verification

`BASE_URL=https://sourcelibrary.org npx playwright test e2e/embassy.spec.ts` — **12 passed**, including the previously-failing test.

## Out of scope

The same run also had `e2e/catalog.spec.ts:40 › Catalog › search filters results` fail once and **pass on retry #1** — a latency flake on the live-prod search response against a 5s `toBeVisible` timeout, not a broken assertion. It didn't cause the run's failure and needs a separate look at whether that budget is right; not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)