### PR TITLE
feat(access): hidden books serve a catalog card — metadata public, content gated

### DIFF
--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -8,7 +8,7 @@ import { pruneSearchRowsForDeletedBook } from '@/lib/prune-deleted-book';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
-import { isBookReadable } from '@/lib/book-access';
+import { isBookReadable, hiddenBookMetadataCard } from '@/lib/book-access';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 
 export const preferredRegion = 'fra1';
@@ -45,10 +45,10 @@ export async function GET(
     }
     const book = result.book;
 
-    // Hidden books: same gate + indistinguishable-404 as the sibling
-    // tenant content routes (quote/download/index/…).
+    // Hidden books: catalog card only for unauthorized callers (metadata is
+    // public policy, content is not — see book-access.hiddenBookMetadataCard).
     if (!(await isBookReadable(book, request))) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      return NextResponse.json({ ...hiddenBookMetadataCard(book), pages: [] });
     }
 
     // Page projections:

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -9,7 +9,7 @@ import { withApiAuth } from '@/lib/api-auth';
 import { EDITION_COUNTER_PROJECTION } from '@/lib/page-translations';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
-import { isBookReadable } from '@/lib/book-access';
+import { isBookReadable, hiddenBookMetadataCard } from '@/lib/book-access';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
@@ -76,12 +76,13 @@ export const GET = withApiAuth(async (
     }
     const book = result.book;
 
-    // Hidden books are gated on every content route (text/quote/index/chat/…)
-    // via book-access; the base metadata route was the one surface still
-    // serving full records for hidden ids to anonymous callers. Same
-    // indistinguishable-404 contract as the sibling routes.
+    // Hidden books present their CATALOG CARD to unauthorized callers —
+    // bibliographic metadata is public policy (#4240 follow-up, 2026-08-27),
+    // content is not: no pages array, no page-image URLs (the public bucket
+    // would make that content access in one hop). Editors and CRON_SECRET
+    // callers fall through to the full record + pages as before.
     if (!(await isBookReadable(book, request))) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      return NextResponse.json({ ...hiddenBookMetadataCard(book), pages: [] });
     }
 
     // Page projections:

--- a/src/lib/book-access.ts
+++ b/src/lib/book-access.ts
@@ -69,3 +69,35 @@ export async function isBookReadable(book: BookLike | null | undefined, request:
   if (!isHiddenBook(book)) return true;
   return canReadHiddenBook(request);
 }
+
+/**
+ * The catalog card a hidden book presents to unauthorized callers.
+ *
+ * Policy (Derek, 2026-08-27): bibliographic metadata of hidden books is
+ * PUBLIC — a large visible catalog raises the library's perceived value —
+ * while CONTENT stays gated. So this card carries identity, description and
+ * counts, and deliberately omits the pages array and every per-page image
+ * URL (a page list against the public image bucket would be content access
+ * in one hop). Cover fields are included: covers are a book's public face.
+ * The text/quote/index/chat/download routes still refuse hidden books
+ * entirely via isBookReadable above.
+ */
+const METADATA_CARD_FIELDS = [
+  'id', 'slug', 'title', 'display_title', 'author', 'published', 'year',
+  'language', 'original_language', 'text_role', 'is_translation',
+  'pages_count', 'pages_translated', 'categories', 'work_id', 'doi',
+  'reading_summary', 'contains_works', 'chapters',
+  'thumbnail', 'thumbnail_blob', 'image_display', 'image_thumb',
+] as const;
+
+export function hiddenBookMetadataCard(book: BookLike): Record<string, unknown> {
+  const b = book as Record<string, unknown>;
+  const card: Record<string, unknown> = {};
+  for (const f of METADATA_CARD_FIELDS) if (b[f] !== undefined) card[f] = b[f];
+  // Per-language edition counters (pages_translated_es, …) — same public
+  // surface as the visible-book card.
+  for (const k of Object.keys(b)) if (k.startsWith('pages_translated_')) card[k] = b[k];
+  card.visible = false;
+  card.access = 'metadata_only';
+  return card;
+}


### PR DESCRIPTION
## What
Follow-up to #4240 refining the policy per Derek: unauthorized callers on `GET /api/books/[id]` (+ tenant twin) now get a hidden book's **catalog card** — id/slug/title/author/year/language/original_language/text_role, pages_count + per-language translation counters, categories, work_id, doi, reading_summary, chapters, cover fields, `visible: false`, `access: 'metadata_only'`, `pages: []` — instead of a 404.

## What stays gated
The pages array and all per-page image URLs (that list against the public image bucket is content access in one hop), and every content route (text/quote/index/chat/download/search) still refuses hidden books outright. Editors and CRON_SECRET callers are unchanged (full record + pages).

## Why
A large, visible catalog raises perceived value (the #3356 catalog-first stance: the catalog can be huge, what we hold stays deliberate). #4240's blanket 404 hid the catalog along with the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018akNMMLH8s6g9PjiBe4U4L