### PR TITLE
fix(audit): the master detector missed old-era masters stored in `photo`

### DIFF
--- a/scripts/audit/pages-served-without-a-master.mjs
+++ b/scripts/audit/pages-served-without-a-master.mjs
@@ -28,6 +28,9 @@
  * detector was written — `…-full.jpg` was a 404 on every book sampled):
  *   - old era: `archived_photo` -> images.sourcelibrary.org/archived/<book>/N.jpg
  *   - new era: `photo`          -> images.sourcelibrary.org/pages/<book>/NNNN-full.jpg
+ *   - and `photo` may ALSO hold the old-era /archived/ master with
+ *     `archived_photo` unset — missing that cost 116 false positives on the
+ *     first run, so both shapes are accepted in `photo` (see MASTER_IN_PHOTO)
  *   - split halves: `cropped_photo` on R2 is the materialised page
  *
  * READ-ONLY. Finds, never fixes — repair is `archive-mdz-gap-4190.mjs` and its
@@ -54,7 +57,18 @@ const TOP = num('top', 20);
 const ALL = ARGS.includes('--all');
 
 const R2 = 'images\\.sourcelibrary\\.org';
-const MASTER_NEW = `^https://${R2}/pages/[^/]+/[^/]*\\d+(-full)?\\.jpg$`;
+/**
+ * A `photo` that is itself a master on R2, under EITHER naming convention:
+ *   new era: /pages/<book>/NNNN-full.jpg  (or the bare NNNN.jpg it derives from)
+ *   old era: /archived/<book>/N.jpg
+ *
+ * The `/archived/` half was missing on the first run and cost 116 false
+ * positives — pages that DO hold a master were reported as lacking one, because
+ * the master sat in `photo` rather than `archived_photo`. The tell was
+ * `images.sourcelibrary.org` appearing in a census of "source hosts we cannot
+ * archive from", which is nonsense: we never fetch from ourselves.
+ */
+const MASTER_IN_PHOTO = `^https://${R2}/(pages/[^/]+/[^/]*\\d+(-full)?|archived/[^/]+/\\d+)\\.jpg$`;
 
 let client;
 try {
@@ -86,7 +100,7 @@ try {
         ],
         // …but we hold no full-resolution copy, under either era's convention.
         archived_photo: { $not: new RegExp(R2) },
-        photo: { $not: new RegExp(MASTER_NEW) },
+        photo: { $not: new RegExp(MASTER_IN_PHOTO) },
         cropped_photo: { $not: new RegExp(R2) },
       },
     },


### PR DESCRIPTION
116 false positives on the detector's first run.

A page whose `photo` is `images.sourcelibrary.org/archived/<book>/N.jpg`, with `archived_photo` unset, **does** hold a full-resolution master on R2. The detector only accepted the new-era `/pages/<book>/NNNN-full.jpg` shape in that field, so it reported those pages as unpreserved.

**The tell was absurd on its face:** `images.sourcelibrary.org` appeared in a census of *source hosts the archive route cannot fetch from*. We never fetch from ourselves. A detector naming your own CDN as an unreachable upstream is describing its own blind spot, not the corpus — the same shape as the vocabulary artifacts in `language-fields.md`, where the largest cluster in the findings turned out to be the instrument.

`MASTER_IN_PHOTO` now accepts both conventions. The three-way test is otherwise unchanged: `archived_photo` on R2, **or** `photo` holding a master, **or** `cropped_photo` on R2 for split halves.

Scale: 116 of 89,475, so the headline barely moves. But a detector wrong in the direction of *"there is a gap here"* spends fetches and bandwidth on pages that are already safe — and authorising exactly that spending is its whole job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JVF1LnM4Vgwh9T5HRLNY2