### PR TITLE
feat(gallery): --all-pages recovery mode for books invisible to every extraction gate

### DIFF
--- a/scripts/maintenance/reextract-missed-pages.mjs
+++ b/scripts/maintenance/reextract-missed-pages.mjs
@@ -37,6 +37,11 @@
  *                 blind to those pages, so they are never offered to the vision
  *                 model and read as "extracted, empty" permanently. Also skips
  *                 pages already examined.
+ *   --all-pages   Offer EVERY never-examined page (page_number > 0, no
+ *                 detected_images) to the vision model — no marker, no
+ *                 page_type needed. For books whose OCR vintage has neither
+ *                 (the worker sees "no candidates" and stamps them
+ *                 images_complete on first touch, #4241). Requires --book.
  */
 
 import { MongoClient } from 'mongodb';
@@ -71,6 +76,20 @@ const ANY_MARKER = args.includes('--any-marker');
 // Also accept pages the page-typer already called an illustration, whether or
 // not OCR left a marker behind — see pageIsWorkerCandidate() below.
 const PAGE_TYPE_CANDIDATES = args.includes('--page-type-candidates');
+// Offer EVERY never-examined page to the vision model, no marker or page_type
+// required. For books whose OCR vintage predates the <image-desc> convention
+// AND whose pages were never typed, every gate above sees zero candidates —
+// the production worker then stamps the book images_complete on first touch
+// and it exits the queue forever (the Utriusque Cosmi Vol. 2 case, #4241:
+// 700pp of plates, page_type null on every page, no markers). Requires --book:
+// this is a per-book recovery tool, not a corpus sweep — an unbounded all-pages
+// vision pass over the library would be a five-figure spend.
+const ALL_PAGES = args.includes('--all-pages');
+
+if (ALL_PAGES && !getArg('book', null)) {
+  console.error('FATAL: --all-pages requires --book=ID (per-book recovery only, never a corpus sweep)');
+  process.exit(1);
+}
 
 const MODEL = 'gemini-3-flash-preview';
 const TRIVIAL = new Set(['symbol', 'stamp', 'ornament', 'blank', 'exlibris', 'bookplate', 'decorative', "printer's mark", 'photograph', 'photographic']);
@@ -152,7 +171,7 @@ function pageIsWorkerCandidate(page) {
 }
 
 async function main() {
-  console.log(`[reextract-missed] start ${new Date().toISOString()} | apply=${APPLY} limit=${LIMIT} conc=${CONCURRENCY} anyMarker=${ANY_MARKER} pageTypeCandidates=${PAGE_TYPE_CANDIDATES} keys=${API_KEYS.length}`);
+  console.log(`[reextract-missed] start ${new Date().toISOString()} | apply=${APPLY} limit=${LIMIT} conc=${CONCURRENCY} anyMarker=${ANY_MARKER} pageTypeCandidates=${PAGE_TYPE_CANDIDATES} allPages=${ALL_PAGES} keys=${API_KEYS.length}`);
   const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 5 });
   await client.connect();
   const db = client.db('bookstore');
@@ -185,16 +204,18 @@ async function main() {
       // for --page-type-candidates: page_type alone is weaker evidence than a
       // high-significance marker, so don't spend a second vision call on a page
       // some earlier pass already looked at and found empty.
-      ...(ANY_MARKER || PAGE_TYPE_CANDIDATES ? { image_extraction_updated_at: { $exists: false } } : {}),
+      ...(ANY_MARKER || PAGE_TYPE_CANDIDATES || ALL_PAGES ? { image_extraction_updated_at: { $exists: false } } : {}),
     }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, display_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1 } }).toArray();
     for (const p of pages) {
       // Require the high-significance non-trivial OCR marker — the precise
       // "genuine miss" signal the pilot measured at ~63% recovery. (page_type
       // alone is a weaker signal and dilutes yield.) --page-type-candidates
       // trades that yield for coverage of typed pages OCR never marked up.
-      const accept = PAGE_TYPE_CANDIDATES
-        ? pageIsWorkerCandidate(p)
-        : pageHasNonTrivialHighSigMarker(p.ocr?.data);
+      const accept = ALL_PAGES
+        ? true
+        : PAGE_TYPE_CANDIDATES
+          ? pageIsWorkerCandidate(p)
+          : pageHasNonTrivialHighSigMarker(p.ocr?.data);
       if (!accept) continue;
       // Keep only the fields getPageSource() needs — drop ocr.data so a 56K-page
       // full sweep doesn't hold the entire OCR corpus in memory.


### PR DESCRIPTION
## What

Adds `--all-pages` to `scripts/maintenance/reextract-missed-pages.mjs`: offer EVERY never-examined page of one book (`--book` required) to the vision model, bypassing the marker/page_type candidate gates.

## Why

The production image-extract worker only offers a page to vision if `page_type` is an illustration class OR the OCR carries `<image-desc>` markers. A book whose OCR vintage has neither produces zero candidates — and `processBook()` then stamps it `images_complete` on first touch, removing it from the catch-up queue **forever**. Discovered on *Utriusque Cosmi Historia Vol. 2* (`6952dac977f38f6761bc6cb0`): 700pp of Fludd plates, `page_type: null` on every page, zero markers → "no candidates" → stamped complete with zero images. Full story in #4241.

## Scope guard

`--all-pages` without `--book` is a fatal error: this is a per-book recovery tool; an unbounded corpus-wide all-pages vision pass would be a five-figure spend. All existing gates and idempotency (never-examined filter via `image_extraction_updated_at`, `miss_recheck_at` stamping, resumability) apply unchanged.

## Verified

Dry-run on Vol. 2 (`--limit=3`): 3 candidates found where the worker saw zero; page 1 recovered a q=0.75 emblem (Lambach abbey ownership seal). Full `--apply` run on Vol. 2 in progress — results will be posted to #4241.

Out of scope: fixing the worker's own first-touch `images_complete` stamp (that policy question — mark-and-park vs leave-in-queue — belongs with #4241's coverage-audit work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D92AJFumf3Vu3j1iSVqS8