### PR TITLE
feat(acquisition): priority-ordered claim so reader requests jump the queue

### DIFF
--- a/scripts/catalog-coverage/acquire-gap-batch.mjs
+++ b/scripts/catalog-coverage/acquire-gap-batch.mjs
@@ -216,10 +216,12 @@ if (RETRY_FAILED) {
 
 // Self-heal: return stale 'processing' (a prior run died mid-flight) back to pending
 await queue.updateMany({ status: 'processing', claimed_at: { $lt: new Date(Date.now() - 60*60*1000) } }, { $set: { status: 'pending' } });
-// Atomically claim a batch (set status:'processing') so concurrent/overlapping runs don't collide
+// Atomically claim a batch (set status:'processing') so concurrent/overlapping runs don't collide.
+// Sort priority DESC: reader-request rows carry priority:1 and must jump the queue; rows
+// without the field sort as null (lowest), i.e. bulk seeds keep FIFO among themselves.
 const claimed = [];
 for (let i = 0; i < BATCH; i++) {
-  const r = await queue.findOneAndUpdate({ status: 'pending' }, { $set: { status: 'processing', claimed_at: new Date() } }, { returnDocument: 'after' });
+  const r = await queue.findOneAndUpdate({ status: 'pending' }, { $set: { status: 'processing', claimed_at: new Date() } }, { sort: { priority: -1, _id: 1 }, returnDocument: 'after' });
   const doc = r?.value ?? r; if (!doc) break; claimed.push(doc);
 }
 for (let i = 0; i < claimed.length; i += CONCURRENCY) {

--- a/scripts/maintenance/ensure-indexes.mjs
+++ b/scripts/maintenance/ensure-indexes.mjs
@@ -66,6 +66,7 @@ export const INDEXES = [
   // ── acquisition_queue ─────────────────────────────────────────
   { collection: 'acquisition_queue', key: { 'status': 1 }, options: { 'name': 'status_1' }, why: 'Queue-status filter. scripts/catalog-coverage/acquire-gap-batch.mjs.' },
   { collection: 'acquisition_queue', key: { 'sn': 1 }, options: { 'name': 'sn_1', 'unique': true }, why: 'Unique catalog serial-number key, prevents re-queuing the same USTC/catalog entry. scripts/catalog-coverage/acquire-gap-batch.mjs.' },
+  { collection: 'acquisition_queue', key: { 'status': 1, 'priority': -1, '_id': 1 }, options: { 'name': 'claim_priority_idx' }, why: 'Priority-ordered claim (findOneAndUpdate sort) so reader-request rows (priority:1) jump bulk seeds. scripts/catalog-coverage/acquire-gap-batch.mjs.' },
   // ── analytics_bot_access ──────────────────────────────────────
   { collection: 'analytics_bot_access', key: { 'bot': 1, 'path_prefix': 1, 'date': 1 }, options: { 'name': 'bot_daily_idx', 'background': true }, why: 'Daily bot-hit counter upsert key (bot+path_prefix+day). src/app/api/analytics/bots/route.ts creates this lazily on first write.' },
   // ── analytics_events ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The acquisition worker claimed pending rows FIFO (`findOneAndUpdate({status:'pending'})`), so the planned bulk flip of ~17.6K deterministic-false held rows (#4225 staged plan) would bury reader-request rows for days.
- Adds `sort: { priority: -1, _id: 1 }` to the claim. Reader-request rows carry `priority: 1`; every other row lacks the field and sorts as null (lowest), so bulk seeds keep FIFO among themselves.
- Adds `claim_priority_idx` (`{status, priority desc, _id}`) to `ensure-indexes.mjs`; the index is **already created on prod** (instant build, 158K rows).

## Out of scope
- The 17.6K flip itself — that's a data operation gated on the 300-row pilot now running (`flip_batch: held-pilot-2026-08-27`).

## Test plan
- [ ] Scripts-only change; Hetzner auto-pulls main. Next worker run claims priority rows first (verify via worker log order when reader-request rows are next seeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)