### PR TITLE
fix(downloads): scholarly EPUB figures use extracted crops

### DIFF
--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -2163,7 +2163,11 @@ async function generateScholarlyEpubDownload(
       const illusPageUrl = illusPage
         ? ((illusPage as any).cropped_photo || (illusPage as any).archived_photo || illusPage.photo)
         : null;
-      const illusUrl = illusPageUrl || img.extracted_url || img.image_url;
+      // Prefer the extracted CROP: the figure should show the illustration itself,
+      // not the whole page scan (the figure already links back to the page). Page
+      // scan is the fallback when no crop was generated. The cover block above
+      // deliberately keeps the opposite preference — a cover wants the full page.
+      const illusUrl = img.extracted_url || illusPageUrl || img.image_url;
       if (illusUrl) {
         const illusBuffer = await fetchIllustrationImage(illusUrl);
         if (illusBuffer) {


### PR DESCRIPTION
## Summary
- In the scholarly/bilingual EPUB generator, illustration figures preferred the full page scan (`cropped_photo`/`archived_photo`/`photo`) over the detection's `extracted_url` crop — every figure duplicated the whole page instead of showing the illustration the caption describes. Filed under #4241's UX items.
- One-line preference swap: `extracted_url` first, page scan as fallback (unchanged behavior when no crop exists), `image_url` last.
- The cover block intentionally keeps the opposite preference (a cover wants the full title page) — untouched, now noted in a comment.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] NOT e2e-tested: the route is session-gated and premium-tier, so no scholarly EPUB was generated in this session. The change only reorders a URL preference among fields already fetched by `fetchIllustrationImage`; a null `extracted_url` falls through to the exact previous behavior. Suggest generating one for an illustration-rich book (e.g. Utriusque Cosmi Vol. 2, `6952dac977f38f6761bc6cb0`, 119 gallery rows) after merge.

## Out of scope
- A dedicated extracted-images download format and the book-page gallery links (both tracked in #4241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)