### PR TITLE
fix(deps): nanoid 3.3.18 — clears the last prod npm-audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3437,22 +3437,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@posthog/cli/node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@posthog/core": {
       "version": "1.39.6",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
@@ -13890,9 +13874,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Lockfile-only \`npm audit fix --package-lock-only\`: nanoid 3.3.17 → 3.3.18 (GHSA-2v37-7h3g-55p8, high, infinite-loop on zero size).
- \`npm audit --omit=dev\` now reports **0 vulnerabilities**.

## Out of scope
- Dev-only advisories (sharp vendored under @xenova/transformers, 4 high + 1 critical) need major bumps — separate PR.
- #4006 (production group bump) is blocked on a CI Node ≥22 bump for supabase-js's native-WebSocket requirement; this PR unblocks the security patch from that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)