### PR TITLE
docs(email): memoriam is the September letter; proposed Jons Hensel paragraph

### DIFF
--- a/.claude/docs/newsletter-queue.md
+++ b/.claude/docs/newsletter-queue.md
@@ -147,10 +147,12 @@ books** (the 1472 Pimander). Text-only, no counts, no images.
 
 Carries a PROPOSED paragraph for Jons Hensel (one paragraph, no ask, no
 pivot — per the ops-repo rule: never make a death a reason to give). Gates,
-all three hard: (1) EFM + family blessing via Natalie Koch — including the
-explicit question of whether Jons's name appears at all; (2) Derek rewrites
-the copy; (3) re-verify the Pimander link on send day. The sign-off email to
-Natalie was drafted 2026-08-27 (Gmail drafts).
+all three hard: (1) EFM + family blessing — including the explicit question
+of whether Jons's name appears at all; who signs off is Derek's call, and
+the routing + contacts live in the PRIVATE ops repo
+(`~/sourcelibrary-ops/email-campaign/memorial-signoff.md` — this repo is
+public, so no names or addresses here); (2) Derek rewrites the copy;
+(3) re-verify the Pimander link on send day.
 
 The serpent letter moves to October as a plain reader's letter, farewell
 opening deleted (note in its header).

--- a/.claude/docs/newsletter-queue.md
+++ b/.claude/docs/newsletter-queue.md
@@ -135,7 +135,27 @@ is public):
 
     db.feedback.find({ wants_to_help: true }).sort({ created_at: 1 })
 
-### 3. Unwritten, worth considering
+### 3. "Joost Ritman, 1941–2026" — the SEPTEMBER letter, first week of September
+
+`scripts/email/queued/ritman-memoriam.body.html`
+
+Decided 2026-08-27: the standalone memoriam is the September send, not the
+serpent letter with a farewell opening — a two-sentence farewell as the
+on-ramp to a fish story treats the deaths as a segue, and memorials do not
+keep (Joost died 5 June, Jons Hensel late July). Ask: **read one of his
+books** (the 1472 Pimander). Text-only, no counts, no images.
+
+Carries a PROPOSED paragraph for Jons Hensel (one paragraph, no ask, no
+pivot — per the ops-repo rule: never make a death a reason to give). Gates,
+all three hard: (1) EFM + family blessing via Natalie Koch — including the
+explicit question of whether Jons's name appears at all; (2) Derek rewrites
+the copy; (3) re-verify the Pimander link on send day. The sign-off email to
+Natalie was drafted 2026-08-27 (Gmail drafts).
+
+The serpent letter moves to October as a plain reader's letter, farewell
+opening deleted (note in its header).
+
+### 4. Unwritten, worth considering
 - **What we got wrong and fixed** — the reader reports that found the leaf
   offset (#3368) and the fabricated encyclopedia citations (#3361), told
   properly. Strong material, cut from letter 1 when Derek rewrote it; it is a

--- a/scripts/email/queued/readers-letter-serpent.body.html
+++ b/scripts/email/queued/readers-letter-serpent.body.html
@@ -10,6 +10,14 @@
   to a standalone memorial letter (see queued/ritman-memoriam.body.html —
   send ONE of the two, not both).
 
+  DECIDED 2026-08-27 (Derek): the standalone memoriam WON. This letter is the
+  OCTOBER send, as a plain reader's letter. DELETE the "Before the letter, a
+  word of farewell" paragraph before sending — a two-sentence farewell as the
+  on-ramp to a fish story treats the deaths as a segue, and by October the
+  memoriam will already have said it properly. The paragraph is kept in place
+  for now only so the memoriam's fate can settle first; also re-verify the
+  "Also opened this month" P.S. in October — its items date from July.
+
   BEFORE SENDING:
     · Derek rewrites/approves the copy (feedback_dont_change_authored_copy).
     · If the Ritman opening stays: EFM sign-off first (Natalie Koch), same

--- a/scripts/email/queued/readers-letter-serpent.body.html
+++ b/scripts/email/queued/readers-letter-serpent.body.html
@@ -20,8 +20,9 @@
 
   BEFORE SENDING:
     · Derek rewrites/approves the copy (feedback_dont_change_authored_copy).
-    · If the Ritman opening stays: EFM sign-off first (Natalie Koch), same
-      gate as the standalone letter.
+    · If the Ritman opening stays: EFM + family sign-off first, same gate as
+      the standalone letter (routing in the private ops repo:
+      ~/sourcelibrary-ops/email-campaign/memorial-signoff.md).
     · Queue order: the feedback letter (item 1) is READY and should go first;
       this is a reader's letter for the STANDING newsletter audience.
     · The quote at p.861 was verified verbatim against the book in July;

--- a/scripts/email/queued/ritman-memoriam.body.html
+++ b/scripts/email/queued/ritman-memoriam.body.html
@@ -27,6 +27,24 @@
   Deliberately text-only — no plates, no screenshots. Restraint reads as
   respect here, and any image would compete with the subject.
 
+  DECIDED 2026-08-27 (Derek): THIS letter is the September send, standalone,
+  first week of September — not the serpent letter with a farewell opening.
+  A two-sentence farewell as the on-ramp to a fish story treats the deaths as
+  a segue, and memorials do not keep. The serpent letter loses its opening
+  and waits for October (note added in its header).
+
+  THE JONS HENSEL PARAGRAPH (marked PROPOSED below) — added 2026-08-27 at
+  Derek's direction. Facts verified against the ops repo (legal/README.md):
+  Jons Hensel, chairman of Stichting Het Wereldhart, died late July 2026;
+  Westerkerk memorial 3 August 2026. Derek knew him personally. The ops-repo
+  editorial rule applies (foundation-outreach-2026-07.md): "Where it belongs,
+  one sentence, no pivot — never make a death a reason to give." Hence one
+  short paragraph, no ask attached to it; the letter's single ask stays with
+  the Pimander. Whether his name appears at all is EXPLICITLY the Embassy's
+  and the family's call — the sign-off email to Natalie asks this as its own
+  question. If they decline, delete the block and the closing stays
+  "Thank you, Joost."
+
   Shell: written for the 520px shell (wrapInEmailShell) which supplies logo,
   <h1> from the subject, and the footer. Proof with:
     node scripts/email/send-test.mjs \
@@ -82,8 +100,21 @@
   spent his life making that sentence possible.
 </p>
 
+<!-- PROPOSED — Jons Hensel. Pending EFM + family blessing via Natalie.
+     If declined: delete this block and change the closing line back to
+     "Thank you, Joost." alone. -->
 <p style="margin: 0 0 20px;">
-  Thank you, Joost.
+  There is a second farewell to make. In July the Embassy also lost Jons
+  Hensel, chairman of Stichting Het Wereldhart, the foundation that carries
+  the Embassy&rsquo;s work in the world. Most of you will not have known his
+  name &mdash; that was the nature of what he did, quiet and structural,
+  holding the roof up so that books and readers could meet. Those of us who
+  worked with him felt his hand every day.
+</p>
+<!-- /PROPOSED -->
+
+<p style="margin: 0 0 20px;">
+  Thank you, Joost. Thank you, Jons.
 </p>
 
 <p style="margin: 0 0 6px;">

--- a/scripts/email/queued/ritman-memoriam.body.html
+++ b/scripts/email/queued/ritman-memoriam.body.html
@@ -6,9 +6,10 @@
   anywhere near the composer.
 
   BEFORE SENDING — both are hard gates, not suggestions:
-    1. EFM SIGN-OFF. This is their founder and their story. Clear the wording
-       with the Embassy (Natalie Koch, nkoch@efm.amsterdam) and, through them,
-       the family. Do not send on our judgment alone.
+    1. EFM + FAMILY SIGN-OFF. This is their founder and their story. Do not
+       send on our judgment alone. Who signs off is Derek's call — routing
+       and contacts live in the PRIVATE ops repo (this repo is public):
+       ~/sourcelibrary-ops/email-campaign/memorial-signoff.md
     2. Derek rewrites the copy. See feedback_dont_change_authored_copy — this
        is the inverse case: unauthored copy must not ship as if it were his.
 
@@ -34,15 +35,13 @@
   and waits for October (note added in its header).
 
   THE JONS HENSEL PARAGRAPH (marked PROPOSED below) — added 2026-08-27 at
-  Derek's direction. Facts verified against the ops repo (legal/README.md):
-  Jons Hensel, chairman of Stichting Het Wereldhart, died late July 2026;
-  Westerkerk memorial 3 August 2026. Derek knew him personally. The ops-repo
-  editorial rule applies (foundation-outreach-2026-07.md): "Where it belongs,
-  one sentence, no pivot — never make a death a reason to give." Hence one
-  short paragraph, no ask attached to it; the letter's single ask stays with
-  the Pimander. Whether his name appears at all is EXPLICITLY the Embassy's
-  and the family's call — the sign-off email to Natalie asks this as its own
-  question. If they decline, delete the block and the closing stays
+  Derek's direction. Facts verified against the private ops repo. The ops
+  editorial rule applies: "Where it belongs, one sentence, no pivot — never
+  make a death a reason to give." Hence one short paragraph, no ask attached
+  to it; the letter's single ask stays with the Pimander. Whether his name
+  appears at all is EXPLICITLY the Embassy's and the family's call — the
+  sign-off email asks this as its own question (routing in the ops note
+  above). If they decline, delete the block and the closing stays
   "Thank you, Joost."
 
   Shell: written for the 520px shell (wrapInEmailShell) which supplies logo,


### PR DESCRIPTION
## Summary
- Decision 2026-08-27: the standalone Ritman memoriam is the **September** newsletter (first week), not the serpent letter with a two-sentence farewell opening — memorials don't keep, and a farewell as the on-ramp to a fish story treats the deaths as a segue.
- The memoriam gains a **PROPOSED** paragraph remembering Jons Hensel (chairman of Stichting Het Wereldhart, d. late July 2026) — one paragraph, no ask, per the ops rule "never make a death a reason to give." Whether his name appears at all is explicitly the Embassy's and family's call; the sign-off email to Natalie Koch asks it as its own question.
- The serpent letter moves to October as a plain reader's letter; its header now says to delete the farewell opening and re-verify the "also opened this month" P.S. before sending.
- Queue doc updated to match.

## Out of scope
The letters remain CLAUDE DRAFTS gated on Derek's rewrite + EFM sign-off — nothing here is send-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)