### PR TITLE
fix(bph): feedback button on the catalogue browse view

### DIFF
--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -19,6 +19,7 @@ import { getRequestBaseUrl } from '@/lib/shortlinks';
 import { auth } from '@/lib/auth';
 import { effectiveCatalogRole, normalizeCatalogRole, canEditCatalog } from '@/lib/catalog-role';
 import CatalogEditorNav from '@/components/catalog/CatalogEditorNav';
+import CatalogFeedbackButton from '@/components/catalog/CatalogFeedbackButton';
 
 // Cold-start with several BPH-only Supabase/Mongo loaders can exceed the
 // Vercel default function budget (10s) under Atlas load, surfacing as
@@ -293,6 +294,12 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
                 </div>
             )}
             <SharedLibraryView {...viewProps} />
+            {/* The catalogue browse view lives on this landing page (via
+                ?view=catalog), OUTSIDE /embed/[tenant]/catalog/layout.tsx which
+                mounts this button on every other catalogue page — so cataloguers
+                had nowhere to leave feedback from the browse list (José Bouman,
+                2026-08-26). Self-hides for signed-out visitors. */}
+            {isBph && <CatalogFeedbackButton />}
         </>
     );
 }


### PR DESCRIPTION
## Summary
- The catalogue browse list renders on the tenant landing page (`?view=catalog`), **outside** `/embed/[tenant]/catalog/layout.tsx` — the layout that mounts the floating `CatalogFeedbackButton` on every other catalogue page. So cataloguers had no feedback button on the page they use most; José Bouman had to open a record page to leave her note (#4252 B).
- Mounts the same self-hiding, session-gated button on the BPH landing surface.

## Out of scope (investigated, found already done — see #4252 comment)
- Click-through to worklist records: fixed 08-12/13 (RPC emits `uuid`, route resolves it) — verified live, sample uuid links return real record pages.
- UBN heuristics (manuscripts/FOT never have UBNs): already encoded in `bph_catalogue_worklist`, live.
- `ja`→`yes` shelf marks: swept 08-13 with revisions; 0 `ja` rows live; standing detector in the RPC.
- catalog→catalogue: visible UI already says catalogue everywhere; remaining "catalog" strings are URL params/props.
- Her "In:" convention: measured — 0 of the 253 currently-flagged unfindable records carry any remark, so there is nothing to encode; the shelf-marked "In:" items were already de-flagged by the category rewrite.
- Selection/export basket: real feature, stays open in #4252.

## Test plan
- [ ] `npx tsc --noEmit` clean (done locally)
- [ ] On preview: `bph` subdomain landing with `?view=catalog`, signed in → floating Feedback button bottom-left; signed out → absent

Refs #4252

🤖 Generated with [Claude Code](https://claude.com/claude-code)