### PR TITLE
feat(bph): selection basket — pick records across searches, export as CSV

### DIFF
--- a/src/app/api/catalog/bph/export/route.ts
+++ b/src/app/api/catalog/bph/export/route.ts
@@ -4,6 +4,7 @@ import { applyBphFilters, readBphFilters } from '@/lib/bph-catalog-filters';
 
 /**
  * GET /api/catalog/bph/export — the current catalogue search, as a spreadsheet.
+ * POST — a hand-picked selection of records, as the same spreadsheet.
  *
  * Asked for by José Bouman (BPH), 2026-08-12:
  *
@@ -11,10 +12,16 @@ import { applyBphFilters, readBphFilters } from '@/lib/bph-catalog-filters';
  *    books which have JRR in one of the fields.... This is an important
  *    feature, that we often! use!"
  *
- * Takes exactly the query string the browsing API takes, and runs it through
- * the SAME filter module (src/lib/bph-catalog-filters.ts) — so "export" always
- * means "the rows I am looking at", never a near-miss. Only `offset`/`limit`
- * are ignored: an export is the whole selection, not the visible page.
+ * and 2026-08-26 (#4252): "need a way to make selections from the catalog …
+ * and then export the selections to be downloaded" — that is the POST: the
+ * browser's checkbox basket submits `keys` (UBNs and, for the 2,012 records
+ * that have none, uuids) and gets back exactly those rows, in pick order.
+ *
+ * The GET takes exactly the query string the browsing API takes, and runs it
+ * through the SAME filter module (src/lib/bph-catalog-filters.ts) — so
+ * "export" always means "the rows I am looking at", never a near-miss. Only
+ * `offset`/`limit` are ignored: an export is the whole selection, not the
+ * visible page.
  *
  * Public, like the catalogue itself. The staff-only columns (internal_remarks,
  * exhibition_history) are deliberately NOT in the export — they are not public
@@ -88,6 +95,131 @@ function csvEscape(value: unknown): string {
   return s;
 }
 
+/** Shared CSV response builder for both export modes. */
+function csvResponse(
+  rows: Array<Record<string, unknown>>,
+  filenameTerm: string,
+  notes: string[],
+): NextResponse {
+  const lines = [EXPORT_COLUMNS.map((c) => csvEscape(c.header)).join(',')];
+  for (const row of rows) {
+    lines.push(EXPORT_COLUMNS.map((c) => csvEscape(row[c.key])).join(','));
+  }
+  for (const note of notes) {
+    lines.push('');
+    lines.push(csvEscape(note));
+  }
+
+  // A named, dated file: a librarian ends up with several of these in Downloads
+  // and needs to tell them apart.
+  const stamp = new Date().toISOString().slice(0, 10);
+  const term = filenameTerm.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+  const filename = `bph-catalogue${term ? `-${term}` : ''}-${stamp}.csv`;
+
+  // The BOM makes Excel read it as UTF-8; without it, every "Böhme" in the
+  // export opens as "BÃ¶hme" on a default Windows install.
+  return new NextResponse(`﻿${lines.join('\r\n')}\r\n`, {
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': `attachment; filename="${filename}"`,
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+// Same alphabet the create route allows for a UBN; uuids fit it too. Anything
+// else in a submitted key list is attacker-shaped, not librarian-shaped.
+const KEY_RE = /^[A-Za-z0-9._-]{1,64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_KEYS = 5_000;
+// Keys per `.in()` query. supabase-js sends filters in the URL, so one query
+// with thousands of keys would blow the URL limit; chunking keeps each request
+// small and bounded.
+const KEYS_PER_QUERY = 100;
+
+/**
+ * POST /api/catalog/bph/export — export a hand-picked selection.
+ *
+ * Body (form-encoded, so a plain <form> submit downloads the file):
+ *   keys=<whitespace/comma-separated UBNs and uuids>
+ *
+ * Rows come back in the order they were picked, and any key that matches no
+ * record is reported in a trailing NOTE — a shorter-than-expected export must
+ * say so, never just look complete.
+ */
+export async function POST(req: NextRequest) {
+  let raw = '';
+  try {
+    const form = await req.formData();
+    raw = String(form.get('keys') ?? '');
+  } catch {
+    return NextResponse.json({ error: 'Expected form data with a "keys" field' }, { status: 400 });
+  }
+
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const part of raw.split(/[\s,]+/)) {
+    const key = part.trim();
+    if (!key || seen.has(key)) continue;
+    if (!KEY_RE.test(key)) {
+      return NextResponse.json({ error: `Invalid record key: "${key.slice(0, 80)}"` }, { status: 400 });
+    }
+    seen.add(key);
+    keys.push(key);
+  }
+  if (keys.length === 0) {
+    return NextResponse.json({ error: 'No records selected' }, { status: 400 });
+  }
+  if (keys.length > MAX_KEYS) {
+    return NextResponse.json(
+      { error: `Selection too large (${keys.length} records; the limit is ${MAX_KEYS}). Use the search export instead.` },
+      { status: 400 },
+    );
+  }
+
+  const ubns = keys.filter((k) => !UUID_RE.test(k));
+  const uuids = keys.filter((k) => UUID_RE.test(k));
+  const columns = EXPORT_COLUMNS.map((c) => c.key).join(', ');
+
+  // key (ubn or uuid) → row. A row is registered under both its keys so the
+  // reorder below finds it whichever one the client selected by.
+  const byKey = new Map<string, Record<string, unknown>>();
+  const chunks: Array<{ column: 'ubn' | 'uuid'; values: string[] }> = [];
+  for (let i = 0; i < ubns.length; i += KEYS_PER_QUERY) {
+    chunks.push({ column: 'ubn', values: ubns.slice(i, i + KEYS_PER_QUERY) });
+  }
+  for (let i = 0; i < uuids.length; i += KEYS_PER_QUERY) {
+    chunks.push({ column: 'uuid', values: uuids.slice(i, i + KEYS_PER_QUERY) });
+  }
+  for (const chunk of chunks) {
+    const { data, error } = await supabase
+      .from('bph_works')
+      .select(columns)
+      .in(chunk.column, chunk.values);
+    if (error) {
+      console.error('[catalog/bph/export] selection query failed:', error);
+      return NextResponse.json({ error: 'Export failed — please try again' }, { status: 500 });
+    }
+    for (const row of (data ?? []) as unknown as Array<Record<string, unknown>>) {
+      if (typeof row.ubn === 'string' && row.ubn) byKey.set(row.ubn, row);
+      if (typeof row.uuid === 'string' && row.uuid) byKey.set(row.uuid.toLowerCase(), row);
+    }
+  }
+
+  const rows: Array<Record<string, unknown>> = [];
+  const missing: string[] = [];
+  for (const key of keys) {
+    const row = byKey.get(UUID_RE.test(key) ? key.toLowerCase() : key);
+    if (row) rows.push(row);
+    else missing.push(key);
+  }
+
+  const notes = missing.length
+    ? [`NOTE: ${missing.length} selected record(s) were not found and are not in this export: ${missing.slice(0, 20).join(', ')}${missing.length > 20 ? ', …' : ''}`]
+    : [];
+  return csvResponse(rows, `selection-${rows.length}`, notes);
+}
+
 export async function GET(req: NextRequest) {
   const filters = readBphFilters(req.nextUrl.searchParams);
 
@@ -115,31 +247,11 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  const lines = [EXPORT_COLUMNS.map((c) => csvEscape(c.header)).join(',')];
-  for (const row of rows) {
-    lines.push(EXPORT_COLUMNS.map((c) => csvEscape(row[c.key])).join(','));
-  }
   // Never let a cap pass for a complete answer.
-  if (truncated) {
-    lines.push('');
-    lines.push(csvEscape(`NOTE: export capped at ${MAX_ROWS} rows — narrow the search and export again.`));
-  }
-
-  // A named, dated file: a librarian ends up with several of these in Downloads
-  // and needs to tell them apart. The search term goes in the name when there
-  // is one, reduced to characters a filesystem is happy with.
-  const stamp = new Date().toISOString().slice(0, 10);
+  const notes = truncated
+    ? [`NOTE: export capped at ${MAX_ROWS} rows — narrow the search and export again.`]
+    : [];
+  // The search term goes in the filename when there is one.
   const termRaw = filters.q || filters.author || filters.title || filters.shelfMark || '';
-  const term = termRaw.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
-  const filename = `bph-catalogue${term ? `-${term}` : ''}-${stamp}.csv`;
-
-  // The BOM makes Excel read it as UTF-8; without it, every "Böhme" in the
-  // export opens as "BÃ¶hme" on a default Windows install.
-  return new NextResponse(`﻿${lines.join('\r\n')}\r\n`, {
-    headers: {
-      'content-type': 'text/csv; charset=utf-8',
-      'content-disposition': `attachment; filename="${filename}"`,
-      'cache-control': 'no-store',
-    },
-  });
+  return csvResponse(rows, termRaw, notes);
 }

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -360,6 +360,33 @@ export default function BphCatalogBrowser({
   const [showAdvanced, setShowAdvanced] = useState(defaultAdvanced || hasAnyAdv || cadvParam);
   const abortRef = useRef<AbortController | null>(null);
 
+  // Hand-picked export basket (José Bouman, 2026-08-26, #4252). Keys are
+  // ubn-or-uuid (same fallback as detailUrl), gathered across searches and
+  // pages, exported via POST /api/catalog/bph/export. Kept in sessionStorage
+  // so a reload mid-picking doesn't cost the librarian her selection —
+  // hydrated in an effect, not the useState initializer, because this
+  // component also renders on the server where sessionStorage doesn't exist
+  // (and an initializer mismatch would break hydration).
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem('bph-catalog-selection');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) setSelectedKeys(parsed.filter((k) => typeof k === 'string'));
+      }
+    } catch { /* a broken stored value is just an empty basket */ }
+  }, []);
+  const updateSelection = useCallback((next: string[]) => {
+    setSelectedKeys(next);
+    try { sessionStorage.setItem('bph-catalog-selection', JSON.stringify(next)); } catch { /* quota/private mode */ }
+  }, []);
+  const workKey = (w: { ubn?: string | null; uuid?: string | null }) => w.ubn || w.uuid || null;
+  const selectedSet = useMemo(() => new Set(selectedKeys), [selectedKeys]);
+  const toggleSelected = useCallback((key: string) => {
+    updateSelection(selectedKeys.includes(key) ? selectedKeys.filter((k) => k !== key) : [...selectedKeys, key]);
+  }, [selectedKeys, updateSelection]);
+
   const buildParams = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
     const params = new URLSearchParams();
     params.set('limit', String(PER_PAGE));
@@ -611,6 +638,18 @@ export default function BphCatalogBrowser({
   // search row.
   const hasHeaderSlot = resultsHeaderSlot !== undefined;
 
+  // Select-all applies to the visible page only — "select all 29,000" is what
+  // the search export (GET) is for.
+  const pageKeys = works.map(workKey).filter((k): k is string => !!k);
+  const allOnPageSelected = pageKeys.length > 0 && pageKeys.every((k) => selectedSet.has(k));
+  const togglePage = () => {
+    if (allOnPageSelected) {
+      updateSelection(selectedKeys.filter((k) => !pageKeys.includes(k)));
+    } else {
+      updateSelection([...selectedKeys, ...pageKeys.filter((k) => !selectedSet.has(k))]);
+    }
+  };
+
   return (
     <div>
       {/* Search / filter row — search input, subjects dropdown, optional
@@ -787,6 +826,41 @@ export default function BphCatalogBrowser({
         </div>
       )}
 
+      {/* Selection basket bar. The basket survives searches and pages (state
+          + sessionStorage), so a librarian can gather records from several
+          queries and export them as one spreadsheet. A plain form POST so the
+          browser downloads the CSV without navigating. */}
+      {selectedKeys.length > 0 && (
+        <form
+          method="POST"
+          action="/api/catalog/bph/export"
+          className="flex flex-wrap items-center gap-3 mb-3 px-4 py-2.5 bg-warm border border-border-light rounded-lg"
+        >
+          <input type="hidden" name="keys" value={selectedKeys.join(',')} />
+          <span className="text-sm text-primary">
+            <span className="font-medium">{selectedKeys.length.toLocaleString('en-US')}</span>
+            {' '}record{selectedKeys.length === 1 ? '' : 's'} selected
+            {selectedKeys.length > 0 && !works.some((w) => selectedSet.has(workKey(w) || '')) && (
+              <span className="text-muted"> (from earlier searches)</span>
+            )}
+          </span>
+          <button
+            type="submit"
+            className="inline-flex items-center gap-1.5 text-sm text-white bg-accent-rust hover:bg-accent-rust/90 rounded-md px-3 py-1.5 transition-colors"
+          >
+            <Download className="w-3.5 h-3.5" />
+            Export selection
+          </button>
+          <button
+            type="button"
+            onClick={() => updateSelection([])}
+            className="text-sm text-muted hover:text-primary transition-colors"
+          >
+            Clear
+          </button>
+        </form>
+      )}
+
       {/* Results — table for list view, covers for grid view. The chrome
           above is identical in both modes so the top of the page doesn't
           shift between displays. */}
@@ -799,6 +873,16 @@ export default function BphCatalogBrowser({
             <table className="w-full text-sm table-fixed">
               <thead>
                 <tr className="border-b border-border-light bg-warm">
+                  <th className="px-2 py-2.5 w-9">
+                    <input
+                      type="checkbox"
+                      checked={allOnPageSelected}
+                      onChange={togglePage}
+                      aria-label="Select all records on this page"
+                      title="Select all records on this page"
+                      className="rounded border-border-light text-accent-rust focus:ring-accent-rust/30 cursor-pointer"
+                    />
+                  </th>
                   <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell w-[20%]">
                     <button
                       type="button"
@@ -847,6 +931,7 @@ export default function BphCatalogBrowser({
                 {loading && works.length === 0 && (
                   Array.from({ length: 8 }, (_, i) => (
                     <tr key={`skel-${i}`} className="border-b border-border-light last:border-0">
+                      <td className="px-2 py-3 align-top" />
                       <td className="px-3 py-3 align-top hidden sm:table-cell">
                         <div className="h-4 w-1/2 bg-border-light/40 rounded animate-pulse" />
                       </td>
@@ -886,6 +971,17 @@ export default function BphCatalogBrowser({
                       key={w.ubn ?? `null-ubn-${idx}`}
                       className="border-b border-border-light last:border-0 hover:bg-cream/50 transition-colors"
                     >
+                      <td className="px-2 py-2 align-top">
+                        {workKey(w) ? (
+                          <input
+                            type="checkbox"
+                            checked={selectedSet.has(workKey(w)!)}
+                            onChange={() => toggleSelected(workKey(w)!)}
+                            aria-label={`Select ${displayTitle}`}
+                            className="rounded border-border-light text-accent-rust focus:ring-accent-rust/30 cursor-pointer"
+                          />
+                        ) : null}
+                      </td>
                       <td className="px-3 py-2 align-top text-secondary hidden sm:table-cell">
                         {displayAuthor ? hl(displayAuthor) : <span className="text-muted">—</span>}
                       </td>
@@ -956,7 +1052,7 @@ export default function BphCatalogBrowser({
                 })}
                 {!loading && works.length === 0 && (
                   <tr>
-                    <td colSpan={6} className="px-3 py-12 text-center text-muted">
+                    <td colSpan={7} className="px-3 py-12 text-center text-muted">
                       No works found matching your search.
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- Completes the last open item in #4252: José's "need a way to make selections from the catalog … and then export the selections to be downloaded."
- **Browser** (`BphCatalogBrowser`): checkbox per list row + select-all-on-page; a selection bar ("N records selected · Export selection · Clear") appears when the basket is non-empty. The basket survives searches, paging and reloads (sessionStorage), so records can be gathered from several queries into one spreadsheet. Export is a plain form POST, so the browser downloads the CSV without navigating.
- **API** (`/api/catalog/bph/export`): new POST mode taking `keys` (UBNs and, for the 2,012 UBN-less records, uuids). Returns exactly the picked rows in pick order, same columns as the search export (shared `csvResponse` helper, refactored out of GET). Keys validated against the UBN alphabet; queries chunked at 100/`.in()` (supabase URL limits); 5,000-key cap; any key matching no record is reported in a trailing NOTE rather than producing a silently short file.

## Out of scope
- The search export itself (GET) shipped 08-13 in #3985 and is unchanged in behaviour.
- Grid view gets no checkboxes — the list is the librarian's working view; the selection bar still shows in grid mode if the basket is non-empty.
- No editor gating: the export is public data, same columns as the public GET; staff-only columns stay excluded.

## Test plan
- [ ] `npx tsc --noEmit` clean (done)
- [ ] Preview: POST with mixed ubn+uuid keys returns those rows in order (curl)
- [ ] Preview: POST with an unknown key adds the trailing NOTE
- [ ] Preview: browse list shows checkboxes; selection persists across a search change and a reload; Export selection downloads

Refs #4252

🤖 Generated with [Claude Code](https://claude.com/claude-code)