### PR TITLE
fix(cover-picker): portal the modal to <body> so hero styles can't reach it

### DIFF
--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { BookOpen, X, Check, Loader2, Pencil } from 'lucide-react';
@@ -148,8 +149,14 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
         )}
       </AuthCheck>
 
-      {/* Picker Modal - Only rendered for authenticated users */}
-      {isOpen && (
+      {/* Picker Modal — only rendered for authenticated users. Portaled to
+          <body>: this component often mounts inside the hero cover slot, whose
+          ancestors carry `[&_img]` !important sizing overrides (which clobbered
+          every tile image to a fixed 420px height — blank-looking tiles) and a
+          filled `hero-cover-in` opacity animation (a permanent stacking context
+          that trapped the z-50 overlay UNDER later page content). The portal
+          escapes both, and any future transformed ancestor, in one move. */}
+      {isOpen && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div
             role="dialog"
@@ -232,7 +239,8 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
               )}
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );


### PR DESCRIPTION
## What
The cover-picker modal now renders through `createPortal(…, document.body)` instead of inline inside whatever slot the picker was mounted in.

## Why
Reported on https://sourcelibrary.org/book/serpentum-et-draconum-historiae-libri-duo-aldrovandi — the picker grid rendered as blank white tiles with page content ghosting through the dialog.

Two ancestor effects, both from the hero cover slot the picker mounts in (`HeroVariants.tsx`):
1. **`[&_img]` !important sizing leak** — the cover wrapper forces every descendant `img` to a fixed 420px height on desktop. Every tile image in the modal grid got clobbered, so each ~134px tile clipped to the top-left corner of its page image. On wide-margin Google scans that corner is pure white → the whole grid read as blank. (Verified: the 150px `-thumb.jpg` variants themselves are fine and show full content.)
2. **Stacking-context trap** — `hero-cover-in` (`animation-fill-mode: both`, opacity keyframes) leaves a permanent stacking context on a modal ancestor, so the overlay's `z-50` could not escape: the hero meta row and the Contents card painted OVER the 'fixed' dialog (the ghosted text/icons in the report screenshot).

The portal escapes both, plus any future transformed/filtered ancestor that would hijack `position: fixed`.

## Out of scope
- The underlying content issue on this book (Google-digitized scan: page 1 is Google's boilerplate insert, huge white scan margins) — being handled as a data fix + audit separately.
- Scoping HeroVariants' `[&_img]` selectors more tightly: with the modal portaled out they now only reach the trigger img, which is their intent; tightening them is a cosmetic refactor left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLfEqmwQa9vKyACnH4Te3R