### PR TITLE
fix(reader): default the OCR pane off on mobile for first-time readers

### DIFF
--- a/src/components/reader-v2/useReaderV2.ts
+++ b/src/components/reader-v2/useReaderV2.ts
@@ -254,6 +254,8 @@ export function useReaderV2(
   const viewsKey = `sl-reader-v2-views-${variant}`;
   const [views, setViews] = useState<ViewState>(defaultViews);
   useEffect(() => {
+    let hasChosen = false;
+    try { hasChosen = window.localStorage.getItem(viewsKey) !== null; } catch { /* private mode */ }
     const stored = loadStored(viewsKey, defaultViews);
     // Views are stored globally, not per book, so a reader who last turned off
     // OCR and translation arrives at an image-less book (6,743 pages, the CDLI
@@ -262,6 +264,15 @@ export function useReaderV2(
     const hasScan = !!getPageDisplayUrl(initialPage as unknown as Record<string, unknown>);
     if (!hasScan && !stored.ocr && !stored.en) {
       setViews({ ...stored, scan: false, ocr: true, en: true });
+      return;
+    }
+    // On a phone the three panes stack, and a full OCR pane pushes the
+    // translation a long scroll away — so a reader who has never chosen gets
+    // scan + translation only. Not persisted: their first explicit toggle is
+    // what writes localStorage, and this default must not follow them to
+    // desktop. (<lg, same line the stacked mobile layout uses.)
+    if (!hasChosen && hasScan && window.matchMedia('(max-width: 1023px)').matches) {
+      setViews({ ...stored, ocr: false });
       return;
     }
     setViews(stored);


### PR DESCRIPTION
Footer feedback (2026-08-26): "By default, don't show ocr on mobile view."

**In scope**
- In the views mount effect (`useReaderV2.ts`), a reader with no stored view choice on a viewport <1024px now starts with scan + translation; OCR stays one tap away in the Views sheet.
- Applies only when the page has a scan (the existing no-scan fallback still forces ocr+en on for image-less books).
- Not persisted — the default must not follow a phone reader to desktop; only explicit toggles write localStorage.

**Out of scope**
- Any change to desktop defaults or the Views UI.

Feedback-ID: 6a8f043f0271cca13b207332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Mbr77nDbD4MjWKd4tHLM