### PR TITLE
fix(blog): rehost hieroglyph-ocr card image on our CDN

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -508,7 +508,7 @@ export const posts: BlogPost[] = [
     readTime: '12 min read',
     tag: 'Technical',
     tagColor: 'bg-stone-100 text-stone-600',
-    image: 'https://iiif.archive.org/iiif/egyptianreadingb00budguoft$80/full/1000,/0/default.jpg',
+    image: 'https://images.sourcelibrary.org/archived/69b52f961a04ee0f3b417b55/80.jpg',
     imageAlt: 'Page from Budge\'s Egyptian Reading Book showing hieroglyphic text and transliteration, 1896',
   },
   {


### PR DESCRIPTION
The "Can AI Read Hieroglyphs? (No.)" card on /blog pointed at iiif.archive.org, which now returns an empty 302 / times out — blank card. We hold the same Budge reading book, so the card now serves https://images.sourcelibrary.org/archived/69b52f961a04ee0f3b417b55/80.jpg (verified 200 image/jpeg) like the rest of the cards.

**Out of scope:** the three deliberately imageless posts from #4067 (`how-long-to-translate`, `the-deletion`, `confident-hallucinator`).

Feedback-ID: 6a70dfdfbc9f8b119d07074a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Mbr77nDbD4MjWKd4tHLM