### PR TITLE
docs: budget-rule twins say words, not lines (#4263 follow-up)

### DIFF
--- a/.claude/commands/gnite.md
+++ b/.claude/commands/gnite.md
@@ -93,8 +93,9 @@ the lesson lives only in the handoff and decays. Decide *which tier*:
 **Down — is anything in `CLAUDE.md` no longer earning its place?** Do not skip this
 because nothing feels wrong; it never feels wrong. Concretely:
 
-- `wc -l CLAUDE.md` — the budget is **~250 lines**. Over it, something must be demoted
-  to `invariants/` before anything is added.
+- `wc -w CLAUDE.md` — the budget is **~5,500 words** (words, not lines: the line cap was
+  gamed by joining essays into single 3,800-char lines). Over it, something must be
+  demoted to `invariants/` before anything is added.
 - Did this session read a section that turned out to be **conditional**? Demote it.
 - Did it hit a rule that **contradicts** another, or a second write-up of the same
   incident under a different aphorism? Merge them — don't append a correction beside the

--- a/.claude/docs/knowledge-layer.md
+++ b/.claude/docs/knowledge-layer.md
@@ -28,7 +28,9 @@ a "Read this when" line so an agent can bail in two seconds.
 `CLAUDE.md` grew from ~290 lines to **827** between May and August 2026 — a 157KB file
 loaded into every one of ~10 concurrent terminals, roughly 39K tokens before any work
 began — because the ratchet below only ever *added*. Adding a section now means fitting
-the ~250-line budget or demoting an existing one into `invariants/`. The test: **if you
+the budget — **~5,500 words by `wc -w`**; a line-count cap was tried first and gamed
+within a month by joining essays into single 3,800-character lines — or demoting an
+existing section into `invariants/`. The test: **if you
 can name the file or subsystem that triggers a rule, it belongs in `invariants/`; if you
 cannot, it belongs in `CLAUDE.md`.** Note that age is not the criterion — when the split
 was done, the four largest sections were all under three weeks old.

--- a/.claude/skills/lesson/SKILL.md
+++ b/.claude/skills/lesson/SKILL.md
@@ -29,8 +29,8 @@ After fixing a bug, resolving an incident, or discovering an important pattern, 
 
    **If it rises to an invariant** — a rule whose violation already cost real damage —
    pick the tier deliberately:
-   - Applies *regardless of what you're working on* → `CLAUDE.md` (budget: ~250 lines;
-     over it, demote something to `invariants/` first).
+   - Applies *regardless of what you're working on* → `CLAUDE.md` (budget: ~5,500 words
+     by `wc -w`; over it, demote something to `invariants/` first).
    - Fires only when someone touches a particular subsystem → a new or existing
      `.claude/docs/invariants/<name>.md`, **plus** a one-line trigger entry in
      `CLAUDE.md`'s routing table. If you can name the file or subsystem that triggers


### PR DESCRIPTION
## Summary
- #4263 switched the CLAUDE.md budget from ~250 lines to ~5,500 words (`wc -w`); this updates the three files that restate the rule — `.claude/commands/gnite.md`, `.claude/skills/lesson/SKILL.md`, `.claude/docs/knowledge-layer.md` — so the ratchet doesn't contradict itself.

## Test plan
- [x] `git grep "~250"` in the three files returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)