### PR TITLE
feat(feedback): separate agent (MCP) feedback from human feedback

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -25,7 +25,19 @@ submitter once if they left an email (`feedback-reply-email.ts`, idempotent via
 set -a; source .env.production.local; set +a
 node scripts/analytics/feedback-triage.mjs           # all open items, grouped
 node scripts/analytics/feedback-triage.mjs --days 45 # recent only
+node scripts/analytics/feedback-triage.mjs --channel mcp   # agent-submitted only (or --channel web)
 ```
+
+**Two channels, two treatments.** The report splits HUMAN feedback (footer
+widget / translation prompt) from AGENT feedback (public MCP `submit_feedback`;
+`channel: 'mcp'`, set from the `SourceLibrary-MCP` user-agent). Humans are
+scarce, motivated, and often owed a reply — triage them first. Agent reports are
+long, high-volume, and **confidently wrong at a nontrivial rate** (one retracted
+its own recommendation to build IIIF support that already exists): never
+implement from one directly; verify each claim against live code/data, then
+route the survivors into issues with `Feedback-ID:` markers. Repeated agent
+complaints about the same tool ergonomics collapse into ONE issue. The
+`/admin/feedback` UI has the same Humans/Agents toggle and defaults to Humans.
 
 Groups: **bug · translation-request · metadata-correction · partner-cms ·
 feature-request · praise · other.** Each line shows the `_id`, date, state,

--- a/scripts/analytics/feedback-triage.mjs
+++ b/scripts/analytics/feedback-triage.mjs
@@ -8,7 +8,7 @@
 //   read       read == true && addressed != true   <- triaged but not resolved
 //   addressed  addressed == true                    <- done (auto-emailed submitter if email present)
 //
-// Run (report):   set -a; source .env.production.local; set +a; node scripts/analytics/feedback-triage.mjs [--days N] [--all]
+// Run (report):   set -a; source .env.production.local; set +a; node scripts/analytics/feedback-triage.mjs [--days N] [--all] [--channel web|mcp]
 // Mark read:      ... feedback-triage.mjs --mark-read <id,id,...> --apply
 // Mark addressed: ... feedback-triage.mjs --mark-addressed <id,id,...> --note "what was done" [--link URL] --apply
 //
@@ -42,6 +42,12 @@ function classify(r) {
   return 'other';
 }
 
+// Agent-submitted rows (public MCP submit_feedback tool) have a different
+// profile from human ones — long, high-volume, claims unverified — so the
+// report splits them out. `channel` is set at insert since 2026-08; the
+// user_agent prefix covers older rows (same rule as the backfill).
+const isAgent = (r) => r.channel === 'mcp' || (r.user_agent || '').startsWith('SourceLibrary-MCP');
+
 await withMongo(async (db) => {
   const fb = db.collection('feedback');
 
@@ -73,25 +79,43 @@ await withMongo(async (db) => {
     read_unaddressed: await fb.countDocuments({ read: true, addressed: { $ne: true } }),
     addressed: await fb.countDocuments({ addressed: true }),
   };
-  const rows = await fb.find(q).sort({ created_at: -1 }).toArray();
+  let rows = await fb.find(q).sort({ created_at: -1 }).toArray();
+  const CHANNEL = arg('--channel'); // 'web' | 'mcp' | null (both)
+  if (CHANNEL === 'mcp') rows = rows.filter(isAgent);
+  else if (CHANNEL === 'web') rows = rows.filter((r) => !isAgent(r));
 
   console.log('# Feedback triage');
   console.log(`Queue: ${counts.unread} unread · ${counts.read_unaddressed} read-but-unresolved · ${counts.addressed} addressed (done)`);
-  console.log(`Showing ${rows.length} open items${DAYS ? ` (last ${DAYS}d)` : ''}\n`);
+  console.log(`Showing ${rows.length} open items${DAYS ? ` (last ${DAYS}d)` : ''}${CHANNEL ? ` (channel: ${CHANNEL})` : ''}\n`);
 
-  const groups = {};
-  for (const r of rows) (groups[classify(r)] ??= []).push(r);
-  const order = ['bug', 'translation-request', 'metadata-correction', 'partner-cms', 'feature-request', 'praise', 'other'];
-  for (const g of order) {
-    const items = groups[g]; if (!items?.length) continue;
-    console.log(`\n## ${g}  (${items.length})`);
-    for (const r of items) {
-      const email = (r.email || '').includes('@') ? ` ✉ ${r.email}` : '';
-      const state = r.read ? '[read]' : '[unread]';
-      console.log(`- ${r._id}  ${new Date(r.created_at).toISOString().slice(0, 10)} ${state}${email}  ${r.name ? '~' + r.name : ''}`);
-      console.log(`    page: ${r.page || '?'}`);
-      console.log(`    ${(r.message || '').replace(/\s+/g, ' ').trim().slice(0, 200)}`);
+  const printGroups = (subset) => {
+    const groups = {};
+    for (const r of subset) (groups[classify(r)] ??= []).push(r);
+    const order = ['bug', 'translation-request', 'metadata-correction', 'partner-cms', 'feature-request', 'praise', 'other'];
+    for (const g of order) {
+      const items = groups[g]; if (!items?.length) continue;
+      console.log(`\n## ${g}  (${items.length})`);
+      for (const r of items) {
+        const email = (r.email || '').includes('@') ? ` ✉ ${r.email}` : '';
+        const state = r.read ? '[read]' : '[unread]';
+        console.log(`- ${r._id}  ${new Date(r.created_at).toISOString().slice(0, 10)} ${state}${email}  ${r.name ? '~' + r.name : ''}`);
+        console.log(`    page: ${r.page || '?'}`);
+        console.log(`    ${(r.message || '').replace(/\s+/g, ' ').trim().slice(0, 200)}`);
+      }
     }
+  };
+
+  // Humans first — scarce, motivated, and often owed a reply. Agent reports
+  // (MCP tool) follow in their own section; treat their claims as unverified.
+  const human = rows.filter((r) => !isAgent(r));
+  const agent = rows.filter(isAgent);
+  if (CHANNEL) {
+    printGroups(rows);
+  } else {
+    console.log(`\n═══ HUMAN feedback (${human.length}) ═══`);
+    printGroups(human);
+    console.log(`\n═══ AGENT feedback via MCP (${agent.length}) — claims unverified, triage into issues ═══`);
+    printGroups(agent);
   }
   const emailed = rows.filter((r) => (r.email || '').includes('@')).length;
   console.log(`\n— ${emailed} open items left an email (reply candidates) · ${rows.length - emailed} anonymous (bulk-resolvable)`);

--- a/scripts/maintenance/backfill-feedback-channel.mjs
+++ b/scripts/maintenance/backfill-feedback-channel.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Backfill feedback.channel ('mcp' | 'web') from the stored user_agent.
+//
+// The MCP server proxies submit_feedback to /api/feedback server-side with
+// User-Agent "SourceLibrary-MCP/<version>", so the UA prefix identifies
+// agent-submitted rows retroactively. Everything else (footer widget,
+// translation-request prompt) is 'web'. Inserts set the field since 2026-08
+// (src/app/api/feedback/route.ts); this is the one-time catch-up.
+//
+// Dry-run by default:
+//   set -a; source .env.production.local; set +a
+//   node scripts/maintenance/backfill-feedback-channel.mjs [--apply]
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const APPLY = process.argv.includes('--apply');
+
+await withMongo(async (db) => {
+  const fb = db.collection('feedback');
+  const mcpFilter = { channel: { $exists: false }, user_agent: { $regex: '^SourceLibrary-MCP' } };
+  const webFilter = { channel: { $exists: false }, $or: [{ user_agent: { $not: { $regex: '^SourceLibrary-MCP' } } }, { user_agent: null }] };
+
+  const [mcpN, webN, already] = await Promise.all([
+    fb.countDocuments(mcpFilter),
+    fb.countDocuments(webFilter),
+    fb.countDocuments({ channel: { $exists: true } }),
+  ]);
+  console.log(`${APPLY ? 'APPLYING' : 'DRY-RUN'}: ${mcpN} rows → channel:'mcp', ${webN} rows → channel:'web' (${already} already have the field)`);
+  if (!APPLY) { console.log('(add --apply to write)'); return; }
+
+  const r1 = await fb.updateMany(mcpFilter, { $set: { channel: 'mcp' } });
+  const r2 = await fb.updateMany(webFilter, { $set: { channel: 'web' } });
+  console.log(`modified: mcp=${r1.modifiedCount}, web=${r2.modifiedCount}`);
+  const remaining = await fb.countDocuments({ channel: { $exists: false } });
+  console.log(`rows still without channel: ${remaining}${remaining ? '  ⚠ investigate' : ''}`);
+}, { timeoutMs: 90000 });

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -19,9 +19,11 @@ interface FeedbackItem {
   reply_message?: string | null;
   reply_sent_at?: string | null;
   reply_recipient?: string | null;
+  channel?: 'mcp' | 'web' | null;
 }
 
 type Tab = 'unread' | 'read' | 'addressed';
+type Channel = 'web' | 'mcp' | 'all';
 
 function formatDate(s: string) {
   const d = new Date(s);
@@ -30,25 +32,31 @@ function formatDate(s: string) {
 
 export default function AdminFeedbackPage() {
   const [tab, setTab] = useState<Tab>('unread');
+  // Human submissions are scarce and motivated; agent (MCP) submissions are
+  // high-volume and would drown them in one queue — so human-first by default.
+  const [channel, setChannel] = useState<Channel>('web');
   const [items, setItems] = useState<FeedbackItem[]>([]);
   const [counts, setCounts] = useState<{ unread: number; read: number; addressed: number }>({ unread: 0, read: 0, addressed: 0 });
+  const [channelCounts, setChannelCounts] = useState<{ web: number; mcp: number }>({ web: 0, mcp: 0 });
   const [loading, setLoading] = useState(false);
   const [actionDraft, setActionDraft] = useState<Record<string, { action: string; link: string; reply: string }>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/feedback?status=${tab}&limit=200`);
+      const channelParam = channel === 'all' ? '' : `&channel=${channel}`;
+      const res = await fetch(`/api/feedback?status=${tab}&limit=200${channelParam}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setItems(data.feedback || []);
       setCounts(data.counts || { unread: 0, read: 0, addressed: 0 });
+      setChannelCounts(data.channel_counts || { web: 0, mcp: 0 });
     } catch (err) {
       console.error(err);
     } finally {
       setLoading(false);
     }
-  }, [tab]);
+  }, [tab, channel]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -117,7 +125,19 @@ export default function AdminFeedbackPage() {
   return (
     <div className="max-w-5xl mx-auto px-6 py-10">
       <h1 className="text-2xl font-semibold mb-2">Feedback</h1>
-      <p className="text-sm text-stone-500 mb-6">From the &quot;Give Feedback&quot; button in the site footer. Mark items as <em>addressed</em> once a fix ships &mdash; if the submitter left an email, they&apos;re automatically notified (once).</p>
+      <p className="text-sm text-stone-500 mb-4">From the &quot;Give Feedback&quot; button in the site footer and the public MCP <code>submit_feedback</code> tool. Mark items as <em>addressed</em> once a fix ships &mdash; if the submitter left an email, they&apos;re automatically notified (once).</p>
+
+      <div className="flex gap-1 mb-4">
+        {([['web', `Humans (${channelCounts.web})`], ['mcp', `Agents (${channelCounts.mcp})`], ['all', 'All']] as [Channel, string][]).map(([c, label]) => (
+          <button
+            key={c}
+            onClick={() => setChannel(c)}
+            className={`px-3 py-1.5 text-xs font-medium rounded-full border transition-colors ${channel === c ? 'border-accent-rust bg-accent-rust/10 text-accent-rust' : 'border-stone-200 text-stone-500 hover:text-stone-800'}`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
 
       <div className="flex gap-2 mb-6 border-b border-stone-200">
         {(['unread', 'read', 'addressed'] as Tab[]).map(t => (
@@ -144,6 +164,11 @@ export default function AdminFeedbackPage() {
                 <span>{formatDate(item.created_at)}</span>
                 {item.name && <span> · <span className="text-stone-700">{item.name}</span></span>}
                 {item.email && <span className="text-stone-400"> &lt;{item.email}&gt;</span>}
+                {item.channel === 'mcp' && (
+                  <span className="ml-2 px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-600 border border-indigo-200 text-[10px] font-medium align-middle" title="Submitted by an AI agent via the MCP submit_feedback tool — treat claims as unverified">
+                    MCP agent
+                  </span>
+                )}
               </div>
               {item.page && (
                 <a href={item.page} target="_blank" rel="noopener noreferrer" className="text-xs text-accent-rust hover:underline truncate max-w-[40ch]" title={item.page}>

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -48,13 +48,23 @@ export async function POST(request: NextRequest) {
     const trimmedEmail = email?.trim()?.toLowerCase() || null;
     const wantsHelp = wantsToHelp === true;
 
+    // The MCP server proxies submit_feedback to this route server-side with its
+    // own User-Agent, so the UA prefix is the one reliable origin signal we have.
+    // Agent-written reports have a very different profile from human submissions
+    // (long, high-volume, confidently wrong at a nontrivial rate), so the triage
+    // surfaces split on this field. Backfill for pre-existing rows:
+    // scripts/maintenance/backfill-feedback-channel.mjs
+    const userAgent = request.headers.get('user-agent') || null;
+    const channel = userAgent?.startsWith('SourceLibrary-MCP') ? 'mcp' : 'web';
+
     const doc = {
       message: message.trim(),
       page: page || null,
       name: name?.trim() || null,
       email: trimmedEmail,
       ip,
-      user_agent: request.headers.get('user-agent') || null,
+      user_agent: userAgent,
+      channel,
       created_at: new Date(),
       read: false,
       wants_to_help: wantsHelp,
@@ -101,6 +111,7 @@ export async function POST(request: NextRequest) {
 // GET /api/feedback — list feedback (admin only — contains PII: IPs, emails)
 // Query params:
 //   ?status=unread|read|addressed   filter by lifecycle state
+//   ?channel=mcp|web                filter by submission channel (mcp = agent via MCP tool)
 //   ?unread=true                    legacy, equivalent to ?status=unread
 export const GET = withAdminAuth(async (request: NextRequest) => {
   try {
@@ -109,6 +120,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
     const offset = parseInt(searchParams.get('offset') || '0');
     const unreadOnly = searchParams.get('unread') === 'true';
     const status = searchParams.get('status'); // 'unread' | 'read' | 'addressed'
+    const channel = searchParams.get('channel'); // 'mcp' | 'web'
 
     const db = await getDb();
 
@@ -121,8 +133,13 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
     } else if (status === 'addressed') {
       query.addressed = true;
     }
+    // 'web' matches rows without the field so pre-backfill data still lists as human.
+    const channelCond: Record<string, unknown> =
+      channel === 'mcp' ? { channel: 'mcp' } :
+      channel === 'web' ? { channel: { $ne: 'mcp' } } : {};
+    Object.assign(query, channelCond);
 
-    const [items, total, counts] = await Promise.all([
+    const [items, total, counts, channelCounts] = await Promise.all([
       db.collection('feedback')
         .find(query)
         .sort({ created_at: -1 })
@@ -130,14 +147,20 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
         .limit(limit)
         .toArray(),
       db.collection('feedback').countDocuments(query),
+      // Lifecycle counts within the selected channel, so the tabs stay truthful.
       Promise.all([
-        db.collection('feedback').countDocuments({ read: { $ne: true } }),
-        db.collection('feedback').countDocuments({ read: true, addressed: { $ne: true } }),
-        db.collection('feedback').countDocuments({ addressed: true }),
+        db.collection('feedback').countDocuments({ read: { $ne: true }, ...channelCond }),
+        db.collection('feedback').countDocuments({ read: true, addressed: { $ne: true }, ...channelCond }),
+        db.collection('feedback').countDocuments({ addressed: true, ...channelCond }),
       ]).then(([unread, read, addressed]) => ({ unread, read, addressed })),
+      // Open (not-addressed) totals per channel, regardless of the active filter.
+      Promise.all([
+        db.collection('feedback').countDocuments({ addressed: { $ne: true }, channel: { $ne: 'mcp' } }),
+        db.collection('feedback').countDocuments({ addressed: { $ne: true }, channel: 'mcp' }),
+      ]).then(([web, mcp]) => ({ web, mcp })),
     ]);
 
-    return NextResponse.json({ feedback: items, total, counts });
+    return NextResponse.json({ feedback: items, total, counts, channel_counts: channelCounts });
   } catch (error) {
     console.error('Feedback list error:', error);
     return NextResponse.json({ error: 'Failed to load feedback' }, { status: 500 });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1085,7 +1085,7 @@ const TOOLS: Tool[] = [
   {
     name: 'submit_feedback',
     title: 'Submit Feedback',
-    description: 'Submit feedback, bug reports, or feature requests to the Source Library team.',
+    description: 'Submit feedback, bug reports, or feature requests to the Source Library team. Before proposing NEW functionality, read https://sourcelibrary.org/llms.txt and https://sourcelibrary.org/developers — several past submissions proposed building things that already exist (IIIF manifests, Content Search, DTS), which wastes reviewer time. State in the report which docs you checked. Bug reports with record IDs and reproducing queries are the most actionable kind.',
     annotations: { title: 'Submit Feedback', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     inputSchema: {
       type: 'object' as const,


### PR DESCRIPTION
## What

Separates agent-submitted feedback (public MCP `submit_feedback` tool) from human feedback across every triage surface. The process request came independently from Derek and from an agent's own report (feedback row 6a90915d, item 10 — which also demonstrated the problem by retracting its own earlier recommendation to build IIIF support that already exists).

**Mechanism:** the MCP server proxies `submit_feedback` to `/api/feedback` server-side with `User-Agent: SourceLibrary-MCP/<v>`, so the UA prefix is a reliable origin signal, including retroactively (the UA was already stored on every row).

- `POST /api/feedback` stamps `channel: 'mcp' | 'web'` at insert
- `GET /api/feedback` takes `?channel=mcp|web`; lifecycle counts respect the filter; new `channel_counts` (open items per channel)
- `/admin/feedback` gets a **Humans / Agents / All** toggle defaulting to Humans, and an "MCP agent" badge per item
- `feedback-triage.mjs` prints HUMAN feedback first, then AGENT feedback in its own section flagged "claims unverified"; new `--channel` flag
- One-time backfill `scripts/maintenance/backfill-feedback-channel.mjs` — **already run against prod**: 70 → mcp, 356 → web, 0 unmatched
- `submit_feedback` tool description now instructs agents to check /llms.txt and /developers before proposing functionality (would have prevented the retracted IIIF submission)
- `/feedback` skill documents the two-channel treatment

## Out of scope (deliberately)

From the same process request, for later if the volume warrants: similarity-dedup of repeated agent reports before they reach a human; per-key rate limiting; auto-attaching the session's tool-call trace. The channel field is the foundation all of those would build on.

## Verification

- `npx tsc --noEmit` clean
- Backfill dry-run then apply, `rows still without channel: 0` read from output
- Triage report re-run against prod: human bug group went 11 → 1 (ten agent audits moved to the agent section); `--channel mcp` shows 20 open agent items

Feedback-ID: 6a90915d48f2e647cdc70e1c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcC7qVRrjjrt34nMu2vF92
