### PR TITLE
fix(docs): unify image-corpus counts across public surfaces

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ This content is NOT available in Common Crawl, Wikipedia, or any other training 
 - **Rich metadata**: authors, dates, subjects, provenance, DOI-backed citations
 - **MCP server** for real-time Claude/GPT integration (npm: @source-library/mcp-server)
 - **Custom datasets** for fine-tuning on esoteric, historical, and scientific knowledge domains
-- **Image corpus**: 200,000+ extracted historical illustrations, emblems, engravings, and diagrams with AI-generated metadata, plus 14,000+ catalogued artworks
+- **Image corpus**: 200,000+ extracted historical illustrations, emblems, engravings, and diagrams with AI-generated metadata, plus 24,000+ catalogued artworks
 
 ### Corporate Sponsorship
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -5,6 +5,7 @@ import { logMcpToolCall, logMcpInitialize } from '@/lib/mcp-usage';
 import { getClientIp, peekRateLimit } from '@/lib/rate-limit';
 import { editionsForBook } from '@/lib/page-translations';
 import { getShortUrl } from '@/lib/shortlinks';
+import { IMAGE_CORPUS_STATS } from '@/lib/public-stats';
 import { pageContinuity, continuityHint } from '@/lib/page-continuity';
 import { classifyApiError } from '@/lib/mcp-errors';
 import { MAX_FEEDBACK_MESSAGE, MIN_FEEDBACK_MESSAGE } from '@/lib/feedback-limits';
@@ -1064,7 +1065,7 @@ const TOOLS: Tool[] = [
   {
     name: 'search_images',
     title: 'Search Images',
-    description: 'Search 110,000+ historical illustrations, emblems, engravings, diagrams, AND 23,000+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images YOU can see. Hosts that support MCP Apps render an in-chat image gallery for this tool automatically; on other clients images may sit inside the collapsed tool-result view, so never tell the user images are "rendered above" unless the gallery appeared — describe what you see and give each image\'s url link instead. Every image_url is public and stable — an HTML page that references them directly works in any online browser. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.',
+    description: `Search ${IMAGE_CORPUS_STATS.illustrations} historical illustrations, emblems, engravings, diagrams, AND ${IMAGE_CORPUS_STATS.artworks} artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year. Results interleave two collections: illustrations extracted from book pages (each with a page number and book link) and standalone museum artworks (type: "artwork"). The first few results also return as inline images YOU can see. Hosts that support MCP Apps render an in-chat image gallery for this tool automatically; on other clients images may sit inside the collapsed tool-result view, so never tell the user images are "rendered above" unless the gallery appeared — describe what you see and give each image's url link instead. Every image_url is public and stable — an HTML page that references them directly works in any online browser. If images.length is 0, read the note field — an empty result under a book_id filter means that book has no EXTRACTED images yet, not that the physical book has no plates.`,
     annotations: { title: 'Search Images', ...READ_ONLY },
     // MCP Apps (2026-01-26): hosts that support in-chat UI fetch this ui://
     // resource and render the gallery grid in the conversation (#3978).

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 import toolManifest from '../../../scripts/audit/mcp-directory-contract.tools.json';
+import { IMAGE_CORPUS_STATS } from '@/lib/public-stats';
 
 // One row per MCP tool, in the order the table shows them. The blurbs are
 // human one-liners — the agent-facing descriptions live in
@@ -173,7 +174,7 @@ export default function DevelopersPage() {
         <h2 className="text-2xl font-semibold text-primary mb-2">MCP Server</h2>
         <p className="text-secondary mb-6 max-w-2xl">
           Gives Claude (and any MCP client) direct access to the full collection &mdash;
-          search, read, quote, and browse 150,000+ illustrations. The endpoint is plain JSON-RPC
+          search, read, quote, and browse {IMAGE_CORPUS_STATS.illustrations} illustrations. The endpoint is plain JSON-RPC
           over HTTP, so you can also call it from any HTTP client without an MCP library
           (see the snippets above). Pick whichever path fits.
         </p>
@@ -462,7 +463,7 @@ source-library search "alchemy" --json | jq .results`}
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/gallery</td>
-                  <td className="py-2.5 text-secondary">Search 150,000+ historical illustrations</td>
+                  <td className="py-2.5 text-secondary">Search {IMAGE_CORPUS_STATS.illustrations} historical illustrations</td>
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>

--- a/src/lib/public-stats.ts
+++ b/src/lib/public-stats.ts
@@ -1,0 +1,25 @@
+/**
+ * Public-facing corpus statistics — the single source for counts quoted in
+ * copy (developer docs, MCP tool descriptions, marketing surfaces).
+ *
+ * Before this file, five surfaces quoted five different image counts
+ * (110k / 150k / 200k / 215k / 222k — issue #4290), and /llms.txt (read by
+ * AI licensing partners) understated the artwork count by 10k. Import these
+ * constants instead of hand-writing a number; static files that cannot
+ * import (public/llms.txt) must be re-synced by hand when these change.
+ *
+ * Measured 2026-08-27 (re-measure before updating — they drift):
+ *   gallery_images:                       206,372
+ *   books with resource_type (artworks):   24,819
+ * One-liner to re-measure:
+ *   node --env-file=.env.production.local -e "import('mongodb').then(async({MongoClient})=>{const c=new MongoClient(process.env.MONGODB_URI);await c.connect();const db=c.db('bookstore');console.log(await db.collection('gallery_images').countDocuments({}),await db.collection('books').countDocuments({resource_type:{\$exists:true}}));await c.close()})"
+ *
+ * Keep these as conservative rounded floors ("N+"), never live counts — copy
+ * that overstates is worse than copy that lags.
+ */
+export const IMAGE_CORPUS_STATS = {
+  /** Illustrations extracted from book pages (gallery_images collection). */
+  illustrations: '200,000+',
+  /** Standalone museum artworks (books rows with resource_type). */
+  artworks: '24,000+',
+} as const;


### PR DESCRIPTION
One constant (`src/lib/public-stats.ts`) now feeds /developers and the MCP `search_images` description; `public/llms.txt` re-synced by hand (static file). Measured 2026-08-27: 206,372 gallery_images → '200,000+', 24,819 artworks → '24,000+' (llms.txt had understated artworks as 14,000+ — the surface aimed at AI licensing partners).

Out of scope: a build-time derivation for llms.txt, and the live gallery counters (already correct). Refs #4290.

Verification: `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcC7qVRrjjrt34nMu2vF92