### PR TITLE
fix(gallery): serve the actual plate to crawlers — og:image + noscript figure on image pages

### DIFF
--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -211,6 +211,7 @@ export async function generateMetadata({
   const author = page.book?.author;
   const year = page.book?.published;
   const description = detection.description || 'Historical illustration';
+  const plateUrl = (page as { enhanced_photo?: string }).enhanced_photo || page.cropped_photo || page.archived_photo || page.photo;
 
   // Short title: first sentence (up to 70 chars) for social card headline
   const firstSentence = description.split(/\.\s/)[0];
@@ -241,11 +242,19 @@ export async function generateMetadata({
       type: 'article',
       siteName: 'Source Library',
       locale: 'en_US',
+      // The actual scan, not the generated template card: a 200k-image
+      // collection was presenting the same card in every link preview and to
+      // every og-reading crawler (#4286). When no image resolves, omit the key
+      // so the file-convention opengraph-image card fills in.
+      ...(plateUrl ? { images: [{ url: plateUrl, alt: shortTitle }] } : {}),
     },
     twitter: {
       card: 'summary_large_image',
       title: ogTitle,
       description,
+      // Per the shallow-merge invariant, X reads twitter.images (the root
+      // layout's generic logo would win without this).
+      ...(plateUrl ? { images: [plateUrl] } : {}),
     },
   };
 }
@@ -284,6 +293,34 @@ export default async function ImageLayout({
         imageUrl={imageUrl}
         book={page.book}
       />
+      {/* Server-rendered content for non-JS consumers (#4286). The viewer is a
+          client component, so without this the served HTML carried nav, footer
+          and meta tags but no image, caption, or book link — crawlers and LLM
+          retrieval bots (which fetch raw HTML and do not run JS) saw an empty
+          body on the canonical citable page for every plate. noscript keeps it
+          out of the JS-rendered view; the markup itself is what raw-HTML
+          fetchers read. */}
+      <noscript>
+        <figure className="max-w-3xl mx-auto p-6 text-white">
+          {imageUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={imageUrl} alt={detection.description || 'Historical illustration'} style={{ maxWidth: '100%', height: 'auto' }} />
+          )}
+          <figcaption className="mt-4 space-y-2 text-sm">
+            <p>{detection.description}</p>
+            {detection.museum_description && <p>{detection.museum_description}</p>}
+            <p>
+              From{' '}
+              <a href={`/book/${page.book?.slug || page.book?.id || page.book_id}?page=${page.page_number}`} className="underline">
+                {page.book?.display_title || page.book?.title || 'the source volume'}
+                {page.book?.author ? ` by ${page.book.author}` : ''}
+                {page.book?.published ? ` (${page.book.published})` : ''}
+              </a>
+              , page {page.page_number}.
+            </p>
+          </figcaption>
+        </figure>
+      </noscript>
       {children}
     </div>
   );


### PR DESCRIPTION
Implements the two verified, low-risk halves of #4286 (MCP agent crawlability audit):

1. **og:image / twitter.images = the actual scan** instead of the generated template card (which was identical-in-kind across ~200k pages). Falls back to the file-convention card when no image URL resolves. `twitter.images` set explicitly per the shallow-metadata-merge invariant.
2. **noscript figure in the layout** — img + caption + museum description + book/page link. The layout already fetched all of this server-side for JSON-LD; now the raw HTML (what non-JS crawlers and LLM retrieval bots actually read) carries the content instead of an empty body.

Out of scope (rest of #4286): gallery pagination / image sitemap, thumbnail-grid SSR, bot-policy split, images.sourcelibrary.org Search Console — those need their own decisions.

Verification: `npx tsc --noEmit` clean. Post-merge: `curl -A <browser UA> https://sourcelibrary.org/gallery/image/6a19bfb49b13f9ea2b27284b-0?cb=1 | grep -o 'og:image[^>]*'` should show the archived JPEG, and the noscript block should contain an images.sourcelibrary.org img.

Refs #4286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcC7qVRrjjrt34nMu2vF92