### PR TITLE
feat(mcp): working OAuth flow (DCR + PKCE, zero-click) — fixes the directory Connect error

### DIFF
--- a/scripts/audit/mcp-directory-contract.mjs
+++ b/scripts/audit/mcp-directory-contract.mjs
@@ -46,6 +46,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { createHash, randomBytes } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..', '..');
@@ -64,15 +65,12 @@ const MCP_URL = `${BASE}/api/mcp`;
  */
 const MANIFEST = JSON.parse(readFileSync(join(__dirname, 'mcp-directory-contract.tools.json'), 'utf8'));
 
-// Advertising OAuth without enforcing it is what defect (2) was. These must NOT
-// return 200 while `initialize` is open. If the connector ever does gate per user,
-// rewrite this audit alongside — the failure mode then inverts.
-const OAUTH_PATHS = [
-  '/.well-known/oauth-protected-resource',
-  '/.well-known/oauth-authorization-server',
-  '/oauth/authorize',
-  '/oauth/token',
-];
+// Defect (2) was OAuth advertised but BROKEN (no registration endpoint, flow
+// never completable). Since the 2026-08 restore the contract inverted: the
+// directory record declares OAuth, so the flow must WORK end to end — metadata,
+// dynamic client registration, PKCE authorize, token — while `initialize` stays
+// open to anonymous callers (locking them out would break every non-OAuth
+// client). A half-working state in either direction is the de-listing shape.
 
 // A directory submission needs a reachable privacy policy and developer docs.
 // /privacy-policy is a 404 — the live path is /privacy, and that has bitten before.
@@ -122,6 +120,24 @@ const PREDICATES = {
       detail: missing.length ? `GONE: ${missing.join(', ')} — this breaks saved Claude Projects` : `${MANIFEST.tools.length} present`,
     };
   },
+
+  oauthMetadata: (meta) => {
+    // Claude's connector flow needs all three endpoints; a missing
+    // registration_endpoint is exactly the "Couldn't register with sign-in
+    // service" directory error of 2026-08.
+    const missing = ['authorization_endpoint', 'token_endpoint', 'registration_endpoint']
+      .filter((k) => typeof meta?.[k] !== 'string' || !meta[k].startsWith('http'));
+    const s256 = Array.isArray(meta?.code_challenge_methods_supported) && meta.code_challenge_methods_supported.includes('S256');
+    return {
+      ok: missing.length === 0 && s256,
+      detail: missing.length ? `missing: ${missing.join(', ')}` : s256 ? 'endpoints + S256 present' : 'S256 not offered',
+    };
+  },
+
+  oauthTokenResponse: (tok) => {
+    const ok = typeof tok?.access_token === 'string' && tok.access_token.length > 0 && /bearer/i.test(tok?.token_type || '');
+    return { ok, detail: ok ? `Bearer, expires_in ${tok.expires_in}` : `body: ${JSON.stringify(tok).slice(0, 120)}` };
+  },
 };
 
 const results = [];
@@ -166,6 +182,21 @@ function selfTest() {
     ['noToolRemoved', 'catches a renamed tool', base.map((t, i) => (i === 0 ? { ...t, name: `${t.name}_v2` } : t)), false],
     ['noToolRemoved', 'allows an added tool', [...base, goodTool('brand_new_tool', true)], true],
   ];
+
+  const goodMeta = {
+    authorization_endpoint: 'https://x/oauth/authorize',
+    token_endpoint: 'https://x/oauth/token',
+    registration_endpoint: 'https://x/oauth/register',
+    code_challenge_methods_supported: ['S256'],
+  };
+  cases.push(
+    ['oauthMetadata', 'accepts complete metadata', goodMeta, true],
+    // The exact 2026-08 directory-error shape: flow advertised, nowhere to register.
+    ['oauthMetadata', 'catches missing registration_endpoint (the 2026-08 defect)', { ...goodMeta, registration_endpoint: undefined }, false],
+    ['oauthMetadata', 'catches missing S256', { ...goodMeta, code_challenge_methods_supported: ['plain'] }, false],
+    ['oauthTokenResponse', 'accepts a bearer token', { access_token: 'sl_abc', token_type: 'Bearer', expires_in: 1 }, true],
+    ['oauthTokenResponse', 'catches an error body', { error: 'invalid_grant' }, false],
+  );
 
   for (const [key, label, fixture, expectOk] of cases) {
     const got = PREDICATES[key](fixture).ok;
@@ -248,13 +279,65 @@ async function liveAudit() {
     }
   }
 
-  for (const path of OAUTH_PATHS) {
-    const status = await statusOf(path);
+  // --- OAuth flow: must WORK end to end (the directory record declares OAuth).
+  const metaRes = await fetch(`${BASE}/.well-known/oauth-authorization-server`, { headers: { 'User-Agent': UA } });
+  const meta = metaRes.ok ? await metaRes.json().catch(() => null) : null;
+  {
+    const { ok, detail } = PREDICATES.oauthMetadata(meta);
+    record(metaRes.status === 200 && ok, 'OAuth AS metadata complete', `HTTP ${metaRes.status} — ${detail}`);
+  }
+
+  const prRes = await fetch(`${BASE}/.well-known/oauth-protected-resource`, { headers: { 'User-Agent': UA } });
+  const pr = prRes.ok ? await prRes.json().catch(() => null) : null;
+  record(
+    prRes.status === 200 && pr?.resource === MCP_URL,
+    'protected-resource metadata points at /api/mcp',
+    `HTTP ${prRes.status}, resource: ${pr?.resource ?? '?'}`
+  );
+
+  if (meta?.registration_endpoint && meta?.authorization_endpoint && meta?.token_endpoint) {
+    const cb = 'https://claude.ai/api/mcp/auth_callback';
+    const regRes = await fetch(meta.registration_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': UA },
+      body: JSON.stringify({ client_name: 'directory-contract-audit', redirect_uris: [cb], token_endpoint_auth_method: 'none' }),
+    });
+    const reg = await regRes.json().catch(() => null);
     record(
-      status !== 200,
-      `no OAuth advertisement at ${path}`,
-      `HTTP ${status}${status === 200 ? ' — advertising OAuth while initialize is open is the hybrid that de-listed us' : ''}`
+      regRes.status === 201 && typeof reg?.client_id === 'string',
+      'dynamic client registration succeeds',
+      `HTTP ${regRes.status}${reg?.client_id ? `, client_id issued` : ''}`
     );
+
+    const verifier = randomBytes(32).toString('base64url');
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+    const authUrl = `${meta.authorization_endpoint}?response_type=code&client_id=${encodeURIComponent(reg?.client_id || 'audit')}&redirect_uri=${encodeURIComponent(cb)}&state=audit&code_challenge=${challenge}&code_challenge_method=S256`;
+    const authRes = await fetch(authUrl, { headers: { 'User-Agent': UA }, redirect: 'manual' });
+    const loc = authRes.headers.get('location') || '';
+    const code = new URL(loc, cb).searchParams.get('code');
+    record(
+      authRes.status >= 300 && authRes.status < 400 && !!code && loc.startsWith(cb),
+      'authorize redirects back with a code (zero-click)',
+      `HTTP ${authRes.status}${code ? ', code present' : `, location: ${loc.slice(0, 80)}`}`
+    );
+
+    if (code) {
+      const tokRes = await fetch(meta.token_endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': UA },
+        body: new URLSearchParams({ grant_type: 'authorization_code', code, code_verifier: verifier, redirect_uri: cb }).toString(),
+      });
+      const tok = await tokRes.json().catch(() => null);
+      const { ok, detail } = PREDICATES.oauthTokenResponse(tok);
+      record(tokRes.status === 200 && ok, 'token exchange succeeds with valid PKCE', `HTTP ${tokRes.status} — ${detail}`);
+
+      const badRes = await fetch(meta.token_endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': UA },
+        body: new URLSearchParams({ grant_type: 'authorization_code', code, code_verifier: 'wrong-verifier-wrong-verifier-wrong-verifier-wrong', redirect_uri: cb }).toString(),
+      });
+      record(badRes.status === 400, 'token exchange REJECTS a wrong PKCE verifier', `HTTP ${badRes.status}`);
+    }
   }
 
   for (const path of REQUIRED_PAGES) {

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,24 @@
+// RFC 8414 — OAuth Authorization Server Metadata
+// Claude reads this to discover our register + authorize + token endpoints.
+// Origin is derived from the request host so preview deployments are
+// self-contained (a hardcoded prod origin would send the flow to endpoints
+// that don't exist on the preview branch).
+
+import { requestOrigin } from '@/lib/oauth/origin';
+
+export async function GET(req: Request) {
+  const origin = requestOrigin(req);
+  return Response.json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/oauth/token`,
+    registration_endpoint: `${origin}/oauth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+    scopes_supported: ['mcp'],
+  }, {
+    headers: { 'Access-Control-Allow-Origin': '*' },
+  });
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,15 @@
+// RFC 9728 — Protected Resource Metadata
+// Tells Claude where to find our OAuth authorization server.
+
+import { requestOrigin } from '@/lib/oauth/origin';
+
+export async function GET(req: Request) {
+  const origin = requestOrigin(req);
+  return Response.json({
+    resource: `${origin}/api/mcp`,
+    authorization_servers: [origin],
+    scopes_supported: ['mcp'],
+  }, {
+    headers: { 'Access-Control-Allow-Origin': '*' },
+  });
+}

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -1,0 +1,122 @@
+// OAuth Authorization Endpoint
+// Shows a consent page, then redirects back with a signed code.
+// The code embeds the code_challenge so the token endpoint can verify PKCE
+// without shared state (serverless-safe).
+
+import { createHmac, randomBytes } from 'crypto';
+import { isAcceptableRedirect } from '@/lib/oauth/redirects';
+
+const SECRET = process.env.OAUTH_SECRET || process.env.NEXTAUTH_SECRET || 'source-library-mcp-oauth-2026';
+
+function signCode(payload: Record<string, string>): string {
+  const data = JSON.stringify(payload);
+  const b64 = Buffer.from(data).toString('base64url');
+  const sig = createHmac('sha256', SECRET).update(b64).digest('base64url');
+  return `${b64}.${sig}`;
+}
+
+export { SECRET, signCode };
+
+function escAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const redirect_uri = url.searchParams.get('redirect_uri');
+  const state = url.searchParams.get('state') || '';
+  const code_challenge = url.searchParams.get('code_challenge') || '';
+  const code_challenge_method = url.searchParams.get('code_challenge_method') || 'S256';
+  const response_type = url.searchParams.get('response_type');
+  const client_id = url.searchParams.get('client_id') || 'claude';
+
+  if (response_type !== 'code' || !redirect_uri) {
+    return new Response('Invalid request: response_type must be "code" and redirect_uri is required', { status: 400 });
+  }
+
+  // Only redirect to https or loopback targets — anything else turns the
+  // auto-approve consent flow into an open-redirect gadget.
+  if (!isAcceptableRedirect(redirect_uri)) {
+    return new Response('Invalid redirect_uri: must be https or loopback http', { status: 400 });
+  }
+
+  // Auto-approve path (form submission)
+  if (url.searchParams.get('approve') === '1') {
+    return approve(redirect_uri, state, code_challenge);
+  }
+
+  // Show consent page
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Connect to Source Library</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f3f0; display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 20px; }
+    .card { background: white; border-radius: 16px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.06); border: 1px solid #e8e5e0; text-align: center; }
+    h1 { font-size: 22px; color: #2c2824; margin-bottom: 8px; }
+    .subtitle { color: #8a8480; font-size: 14px; margin-bottom: 24px; }
+    .perms { text-align: left; background: #faf9f7; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+    .perms h3 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: #8a8480; margin-bottom: 8px; }
+    .perms li { font-size: 14px; color: #2c2824; padding: 4px 0; list-style: none; }
+    .perms li::before { content: "\\2713 "; color: #7c6f4a; font-weight: bold; }
+    .btn { display: inline-block; width: 100%; padding: 12px; border: none; border-radius: 8px; font-size: 15px; font-weight: 600; cursor: pointer; transition: all 0.15s; }
+    .btn-allow { background: #2c2824; color: white; margin-bottom: 8px; }
+    .btn-allow:hover { background: #3d3530; }
+    .btn-cancel { background: transparent; color: #8a8480; }
+    .btn-cancel:hover { color: #2c2824; }
+    .footer { font-size: 13px; color: #b0aaa4; margin-top: 16px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Source Library</h1>
+    <p class="subtitle">wants to connect to your conversation</p>
+    <div class="perms">
+      <h3>This will allow</h3>
+      <ul>
+        <li>Search 10,000+ rare historical texts</li>
+        <li>Read full book translations</li>
+        <li>Browse 90,000+ historical illustrations</li>
+        <li>Get page citations with DOIs</li>
+      </ul>
+    </div>
+    <form method="GET" action="/oauth/authorize">
+      <input type="hidden" name="response_type" value="code">
+      <input type="hidden" name="redirect_uri" value="${escAttr(redirect_uri)}">
+      <input type="hidden" name="state" value="${escAttr(state)}">
+      <input type="hidden" name="code_challenge" value="${escAttr(code_challenge)}">
+      <input type="hidden" name="code_challenge_method" value="${escAttr(code_challenge_method)}">
+      <input type="hidden" name="client_id" value="${escAttr(client_id)}">
+      <input type="hidden" name="approve" value="1">
+      <button type="submit" class="btn btn-allow">Allow access</button>
+    </form>
+    <button class="btn btn-cancel" onclick="window.close()">Cancel</button>
+    <p class="footer">No account required. <a href="https://sourcelibrary.org/terms" style="color: #7c6f4a;">Terms</a></p>
+  </div>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html' },
+  });
+}
+
+function approve(redirect_uri: string, state: string, code_challenge: string) {
+  const nonce = randomBytes(8).toString('hex');
+  const code = signCode({
+    code_challenge,
+    redirect_uri,
+    nonce,
+    exp: String(Date.now() + 5 * 60 * 1000),
+  });
+
+  const callback = new URL(redirect_uri);
+  callback.searchParams.set('code', code);
+  if (state) callback.searchParams.set('state', state);
+
+  return Response.redirect(callback.toString(), 302);
+}

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -40,8 +40,12 @@ export async function GET(req: Request) {
     return new Response('Invalid redirect_uri: must be https or loopback http', { status: 400 });
   }
 
-  // Auto-approve path (form submission)
-  if (url.searchParams.get('approve') === '1') {
+  // Consent is auto-granted: there is no account and the token gates nothing,
+  // so a consent click would be pure ceremony. Redirect straight back with the
+  // code — the user experience is click-Connect → connected, zero clicks.
+  // Pass ?prompt=consent to see the consent card anyway (kept for debugging
+  // and as the branded fallback if a client ever renders this URL in a tab).
+  if (url.searchParams.get('prompt') !== 'consent') {
     return approve(redirect_uri, state, code_challenge);
   }
 

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -1,0 +1,56 @@
+// RFC 7591 — OAuth Dynamic Client Registration
+// Claude's connector flow registers itself here before starting authorization.
+// We are a public server with PKCE-only public clients: registration is
+// accepted for anyone, no secret is issued, and the client_id is an opaque
+// value the other endpoints never need to look up (stateless, serverless-safe).
+
+import { randomBytes } from 'crypto';
+import { isAcceptableRedirect } from '@/lib/oauth/redirects';
+
+export async function POST(req: Request) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json(
+      { error: 'invalid_client_metadata', error_description: 'Body must be JSON' },
+      { status: 400, headers: { 'Access-Control-Allow-Origin': '*' } },
+    );
+  }
+
+  const redirectUris = Array.isArray(body.redirect_uris) ? body.redirect_uris.filter((u): u is string => typeof u === 'string') : [];
+  if (redirectUris.length === 0 || !redirectUris.every(isAcceptableRedirect)) {
+    return Response.json(
+      { error: 'invalid_redirect_uri', error_description: 'redirect_uris must be https or loopback http URLs' },
+      { status: 400, headers: { 'Access-Control-Allow-Origin': '*' } },
+    );
+  }
+
+  return Response.json({
+    client_id: `slmcp_${randomBytes(16).toString('hex')}`,
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: redirectUris,
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code'],
+    response_types: ['code'],
+    client_name: typeof body.client_name === 'string' ? body.client_name : undefined,
+    scope: 'mcp',
+  }, {
+    status: 201,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -65,7 +65,10 @@ export async function POST(req: Request) {
   return Response.json({
     access_token,
     token_type: 'Bearer',
-    expires_in: 86400, // 24 hours
+    // Long-lived on purpose: the MCP endpoint serves anonymous callers too, so
+    // an expiring token buys no security and a short one makes Claude re-run
+    // the consent popup for connected users.
+    expires_in: 31536000, // 1 year
     scope: 'mcp',
   }, {
     headers: {

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -1,0 +1,87 @@
+// OAuth Token Endpoint
+// Exchanges an authorization code for a bearer token.
+// Verifies PKCE (S256) to prevent code interception.
+
+import { createHmac, createHash } from 'crypto';
+import { randomUUID } from 'crypto';
+
+const SECRET = process.env.OAUTH_SECRET || process.env.NEXTAUTH_SECRET || 'source-library-mcp-oauth-2026';
+
+function verifyCode(code: string): Record<string, string> | null {
+  const parts = code.split('.');
+  if (parts.length !== 2) return null;
+  const [b64, sig] = parts;
+  const expected = createHmac('sha256', SECRET).update(b64).digest('base64url');
+  if (sig !== expected) return null;
+  try {
+    return JSON.parse(Buffer.from(b64, 'base64url').toString());
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: Request) {
+  // Parse form-encoded body (OAuth spec requires application/x-www-form-urlencoded)
+  const body = await req.text();
+  const params = new URLSearchParams(body);
+
+  const grant_type = params.get('grant_type');
+  const code = params.get('code');
+  const code_verifier = params.get('code_verifier');
+  const redirect_uri = params.get('redirect_uri');
+
+  if (grant_type !== 'authorization_code' || !code) {
+    return Response.json({ error: 'unsupported_grant_type' }, { status: 400 });
+  }
+
+  // Verify the signed code
+  const payload = verifyCode(code);
+  if (!payload) {
+    return Response.json({ error: 'invalid_grant', error_description: 'Invalid or tampered code' }, { status: 400 });
+  }
+
+  // Check expiration
+  if (Number(payload.exp) < Date.now()) {
+    return Response.json({ error: 'invalid_grant', error_description: 'Code expired' }, { status: 400 });
+  }
+
+  // Verify redirect_uri matches
+  if (redirect_uri && redirect_uri !== payload.redirect_uri) {
+    return Response.json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' }, { status: 400 });
+  }
+
+  // Verify PKCE — S256: base64url(sha256(code_verifier)) must equal code_challenge
+  if (payload.code_challenge && code_verifier) {
+    const expected = createHash('sha256').update(code_verifier).digest('base64url');
+    if (expected !== payload.code_challenge) {
+      return Response.json({ error: 'invalid_grant', error_description: 'PKCE verification failed' }, { status: 400 });
+    }
+  }
+
+  // Issue a token — for now, a random UUID. The MCP endpoint doesn't validate it.
+  // Later: issue a JWT with user info, store in DB, etc.
+  const access_token = `sl_${randomUUID().replace(/-/g, '')}`;
+
+  return Response.json({
+    access_token,
+    token_type: 'Bearer',
+    expires_in: 86400, // 24 hours
+    scope: 'mcp',
+  }, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}

--- a/src/lib/oauth/origin.ts
+++ b/src/lib/oauth/origin.ts
@@ -1,0 +1,9 @@
+// Resolve the public origin of the current request, so OAuth metadata points
+// at the host that was actually asked (prod, preview, or localhost) instead of
+// a hardcoded production URL.
+
+export function requestOrigin(req: Request): string {
+  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || 'sourcelibrary.org';
+  const proto = req.headers.get('x-forwarded-proto') || (host.startsWith('localhost') ? 'http' : 'https');
+  return `${proto}://${host}`;
+}

--- a/src/lib/oauth/redirects.ts
+++ b/src/lib/oauth/redirects.ts
@@ -1,0 +1,12 @@
+// Shared redirect_uri policy for the OAuth endpoints: https anywhere, or
+// loopback http for local MCP clients (RFC 8252 §7.3).
+
+export function isAcceptableRedirect(uri: string): boolean {
+  try {
+    const u = new URL(uri);
+    if (u.protocol === 'https:') return true;
+    return u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1');
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

The Claude connector directory listing's "Connect to Claude" button fails for everyone with *"Couldn't register with Source Library's sign-in service"* (ref `ofid_6c896212e1e85390`). Anthropic's directory record — built from our May submission — declares OAuth with Dynamic Client Registration, but we removed all OAuth endpoints on 2026-06-20 (#2621); the June 22 correction email to mcp-review was only ever auto-acked, and the listing published 2026-08-04 with the stale auth mode. Claude therefore attempts client registration against endpoints that 404. The identical URL works as a custom connector (that flow probes the live server instead of trusting the record).

Shipping a *working* OAuth flow makes the server match Anthropic's record, fixing the button from our side. (A parallel email asks them to fix the record; either resolution ends consistent — today's mismatch is the only broken state.)

## What

- Restores the pre-#2621 OAuth routes (RFC 8414 + 9728 metadata, authorize, token w/ PKCE S256) with three changes:
  - **RFC 7591 dynamic client registration** at `/oauth/register` — the step the directory button actually dies on; the May-era implementation never had it.
  - **Zero-click consent**: authorize auto-grants and redirects straight back with the code. There are no accounts and the token gates nothing, so a consent click was pure ceremony (`?prompt=consent` still renders the branded card).
  - **Metadata origins are request-derived**, so preview deployments are self-contained OAuth servers (that's how this was tested).
- Year-long tokens (short expiry would only re-prompt users; tokens gate nothing).
- `redirect_uri` restricted to https or loopback http (the old version redirected anywhere).
- **Anonymous access is unchanged and now guarded**: `initialize` never challenges; every non-OAuth client (Claude Code, ChatGPT, stdio, API) is untouched.
- `scripts/audit/mcp-directory-contract.mjs` inverted: instead of asserting *no* OAuth advertisement, the nightly audit now walks the live flow (metadata → DCR → zero-click authorize → token → wrong-verifier rejection) and still requires unauthenticated initialize. Self-test gains negative controls incl. the exact missing-registration shape behind the directory error.

## Verified

- Full flow curl-tested against the preview: discovery → register (201) → authorize (302 with code) → token (Bearer) → authenticated MCP initialize; wrong PKCE verifier rejected with `invalid_grant`.
- `npm run audit:mcp:self-test`: 19/19.
- Cloudflare: the existing "Allow all traffic to MCP endpoint" skip rule (`26f74063`) already covers `/oauth/*` and `/.well-known/oauth*` — no WAF change needed.
- `npx tsc --noEmit` clean.

## Out of scope, deliberately

- **Real per-user OAuth** (consent backed by Source Library accounts, validated tokens, per-user rate tiers): the strategic version that feeds the api-auth signup funnel — separate feature, needs design.
- Updating Anthropic's directory record to no-auth: pursued in parallel by email; if they flip it, this flow simply goes unused by the directory (harmless).

## Risk

Re-advertising OAuth is what #2621 *guessed* caused the May de-listing — but that hybrid was broken (flow uncompletable); this one completes, and it matches what Anthropic's own record declares. Rollback is a one-commit revert to today's state (which is the already-broken button, so downside is bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJSzeB4BWMPd6yF8hFXF97
