### PR TITLE
feat(search): honest weak-match state for multi-word queries

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -14,6 +14,7 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { CLIP_URL } from '@/lib/clip';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { logSearchEvent } from '@/lib/search-event-log';
+import { assessMatchQuality } from '@/lib/search/match-quality';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
@@ -457,8 +458,22 @@ export async function GET(request: NextRequest) {
       filters: { language, category, library },
     });
 
+    // Honest-failure flag (#4281): lanes merge by rank, so a set of stray
+    // token matches renders exactly like a real answer. If no result across
+    // any lane contains ALL the query's tokens, say so instead of bluffing.
+    const matchQuality = assessMatchQuality(query, [
+      ...scopedBooks.results.map((r: any) => [r.title, r.display_title, r.author, r.summary].filter(Boolean).join(' ')),
+      ...scopedIndex.results.map((r: any) => [r.term, r.book_title].filter(Boolean).join(' ')),
+      ...scopedGallery.results.map((r: any) => [r.description, r.bookTitle].filter(Boolean).join(' ')),
+      ...filteredVisual.results.map((r: any) => [r.description, r.bookTitle].filter(Boolean).join(' ')),
+      ...scopedSemantic.results.map((r: any) => [r.title, r.author, r.summary_snippet].filter(Boolean).join(' ')),
+      ...filteredArtworks.results.map((r: any) => [r.title, r.display_title, r.author].filter(Boolean).join(' ')),
+      ...collectionsWithTenantSlug.results.map((r: any) => [r.name, r.description].filter(Boolean).join(' ')),
+    ]);
+
     return NextResponse.json({
       query,
+      match_quality: matchQuality,
       books: scopedBooks,
       index: scopedIndex,
       gallery: scopedGallery,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/lib/api-client';
 import { tenantBookUrl } from '@/lib/slugify';
 import { matchKnownEntity } from '@/lib/known-entities';
+import { assessMatchQuality } from '@/lib/search/match-quality';
 import HighlightedText from '@/components/search/HighlightedText';
 import { SEARCH_TYPE_STYLES, type SearchIndexType } from '@/lib/style-constants';
 import { BookLoader } from '@/components/ui/BookLoader';
@@ -155,6 +156,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
   // "no related results" as if it were a fact — the "looks like 1 result" bug, where
   // held editions catalogued under another name (Pimander ≈ Corpus Hermeticum) vanish.
   const [semanticDegraded, setSemanticDegraded] = useState(false);
+  // Honest-failure flag from /api/search/unified (#4281): 'weak' = results
+  // exist but none contains all the query's words. null = strong or unjudged.
+  const [matchQuality, setMatchQuality] = useState<'strong' | 'weak' | null>(null);
 
   // Page-content passage results (for quoted phrase searches)
   const [passageResults, setPassageResults] = useState<SearchResult[]>([]);
@@ -441,6 +445,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
       setCollectionResults([]);
       setImageResults([]); setImageTotal(0);
       setCatalogResults([]); setCatalogTotal(0);
+      setMatchQuality(null);
       return;
     }
     setLoading(true);
@@ -458,6 +463,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
           setIndexTotal(cached.indexTotal);
           setImageResults(cached.images);
           setImageTotal(cached.imageTotal);
+          setMatchQuality(cached.matchQuality ?? null);
           setLoading(false);
           return;
         }
@@ -558,6 +564,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
           }
           baseImagesSet.current = true;
           setCollectionResults((data as any).collections?.results || []);
+          const mq = ((data as any).match_quality === 'weak' || (data as any).match_quality === 'strong')
+            ? (data as any).match_quality : null;
+          setMatchQuality(mq);
           displayHintLocked.current = true; // lock layout once results render
 
           // Cache the result
@@ -566,6 +575,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             books, bookTotal: bTotal,
             index, indexTotal: iTotal,
             images, imageTotal: imTotal,
+            matchQuality: mq,
           });
           // Evict old cache entries
           if (searchCache.current.size > 50) {
@@ -581,6 +591,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             setBookResults([]); setBookTotal(0);
             setIndexResults([]); setIndexTotal(0);
             setImageResults([]); setImageTotal(0);
+            setMatchQuality(null);
             setCollectionResults([]); setSemanticResults([]); setSemanticDegraded(false);
             // Stop the parallel AI-expand stream so nothing leaks past the wall.
             aiAbortRef.current?.();
@@ -763,7 +774,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
   }, [router, currentPathname, tenant, defaultMode, indexType, language, category, collection, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, browseSortBy, resultsPerPage]);
 
   // Client-side search cache — avoids re-fetching on backspace/retype
-  const searchCache = useRef(new Map<string, { ts: number; books: SearchResult[]; bookTotal: number; index: IndexSearchResult[]; indexTotal: number; images: GalleryItem[]; imageTotal: number }>());
+  const searchCache = useRef(new Map<string, { ts: number; books: SearchResult[]; bookTotal: number; index: IndexSearchResult[]; indexTotal: number; images: GalleryItem[]; imageTotal: number; matchQuality?: 'strong' | 'weak' | null }>());
   const CACHE_TTL = 60_000; // 1 minute
 
   const debouncedSearch = useDebouncedCallback((value: string) => {
@@ -1707,8 +1718,26 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             </>
           );
 
+          // Honest weak-match banner (#4281): the lanes found only partial-word
+          // matches ("Rainer" alone, "Maria" alone). Say so before showing them,
+          // instead of presenting token noise as an answer. The unified flag is
+          // metadata-only, so a page-content passage that covers every word
+          // (quoted-phrase queries) overrides it — and while passages are still
+          // loading we stay quiet rather than flash a claim we may retract.
+          const passagesCover = assessMatchQuality(
+            query,
+            passageResults.map(r => [r.title, r.display_title, r.author, r.snippet].filter(Boolean).join(' ')),
+          ) === 'strong';
+          const weakMatchBanner = matchQuality === 'weak' && !passageLoading && !passagesCover && (
+            <div className="px-4 py-3 rounded-lg border border-border-light bg-warm/60">
+              <p className="text-sm font-medium text-primary">{t.weakMatchTitle(query)}</p>
+              <p className="text-sm text-secondary mt-0.5">{t.weakMatchBody}</p>
+            </div>
+          );
+
           return (
             <div className="space-y-3">
+              {weakMatchBanner}
               {passageSection}
               {collectionCards}
               {narrationBlock}

--- a/src/lib/search-i18n.ts
+++ b/src/lib/search-i18n.ts
@@ -121,6 +121,8 @@ export interface SearchStrings {
   illustrations: string;
   seeAllImages: string;
   semanticDegraded: string;
+  weakMatchTitle: (q: string) => string;
+  weakMatchBody: string;
   conceptualMatches: string;
   textMatches: string;
   seeAllResults: (n: string) => string;
@@ -267,6 +269,8 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     illustrations: 'Illustrations',
     seeAllImages: 'See all images',
     semanticDegraded: 'Related results couldn’t be loaded just now — you may be seeing fewer matches than we hold. Try again in a moment.',
+    weakMatchTitle: (q) => `No strong matches for “${q}”`,
+    weakMatchBody: 'Nothing in the library matches all of your search words. The results below match only part of your search.',
     conceptualMatches: 'Conceptual matches',
     textMatches: 'Text matches',
     seeAllResults: (n) => `See all ${n} results`,
@@ -394,6 +398,8 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     illustrations: 'Ilustraciones',
     seeAllImages: 'Ver todas las imágenes',
     semanticDegraded: 'No se han podido cargar los resultados relacionados — puede que veas menos coincidencias de las que tenemos. Inténtalo de nuevo en un momento.',
+    weakMatchTitle: (q) => `No hay coincidencias exactas para «${q}»`,
+    weakMatchBody: 'Nada en la biblioteca coincide con todas las palabras de tu búsqueda. Los resultados siguientes coinciden solo con una parte.',
     conceptualMatches: 'Coincidencias conceptuales',
     textMatches: 'Coincidencias en el texto',
     seeAllResults: (n) => `Ver los ${n} resultados`,

--- a/src/lib/search/match-quality.ts
+++ b/src/lib/search/match-quality.ts
@@ -1,0 +1,58 @@
+/**
+ * Match-quality assessment for merged search results (#4281).
+ *
+ * Search lanes are combined by rank (RRF-style), which discards absolute
+ * relevance — the API cannot tell a strong result set from scraped-together
+ * token noise. This helper answers one narrow question honestly: does ANY
+ * result contain ALL the query's tokens? If none does, the whole set is a
+ * partial-word match and the UI should say so instead of presenting it as
+ * an answer ("Rainer Maria Rilke" → a person named Rainer + Hölderlin essays).
+ *
+ * Verdicts:
+ *   'strong'  — at least one result covers every query token
+ *   'weak'    — results exist, none covers every token
+ *   null      — abstained: the check cannot judge this query
+ *
+ * Abstentions (per non-latin-text-operations.md — an empty comparable set is
+ * UNJUDGEABLE, never a negative): queries that fold to fewer than two tokens.
+ * That covers single words (presence IS coverage), contiguous CJK runs (one
+ * token regardless of word count), and anything the tokenizer erases. A null
+ * verdict must render exactly like today's behavior.
+ */
+
+// Elide marks that sit INSIDE words (ayn, hamza, apostrophes) so `Saʻdī`
+// reaches the tokenizer as `sadi`, not two fragments. Then NFD + strip
+// combining marks so café/cafe and Rilke/Rílke compare equal. Applied
+// identically to query and haystack — a fold must normalize BOTH sides.
+function fold(text: string): string {
+  return text
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[ʻʼ‘’']/g, '')
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '');
+}
+
+function tokenize(text: string): string[] {
+  return fold(text).match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+export type MatchQuality = 'strong' | 'weak' | null;
+
+/**
+ * @param query    the raw user query
+ * @param haystacks one string per result — the concatenation of that result's
+ *                  reader-visible text fields (title, author, snippet, …)
+ */
+export function assessMatchQuality(query: string, haystacks: string[]): MatchQuality {
+  const tokens = [...new Set(tokenize(query))];
+  if (tokens.length < 2) return null;
+  if (haystacks.length === 0) return null; // zero results is the empty state, not a weak one
+
+  for (const hay of haystacks) {
+    if (!hay) continue;
+    const folded = fold(hay);
+    if (tokens.every(t => folded.includes(t))) return 'strong';
+  }
+  return 'weak';
+}

--- a/tests/unit/search-match-quality.test.ts
+++ b/tests/unit/search-match-quality.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { assessMatchQuality } from '@/lib/search/match-quality';
+
+// The honest-failure flag (#4281). Search lanes merge by rank, so a set of
+// stray token matches renders exactly like a real answer — "Rainer Maria
+// Rilke" returned a person named Rainer, Hölderlin essays and palaeography
+// handbooks with full confidence. This helper is the API's one chance to say
+// "nothing here matches all of that". The abstention cases are load-bearing:
+// per non-latin-text-operations.md, a query the tokenizer cannot split into
+// two comparable tokens is UNJUDGEABLE and must return null, never 'weak'.
+
+describe('assessMatchQuality', () => {
+  it('strong when one result covers every query token', () => {
+    expect(assessMatchQuality('Rainer Maria Rilke', [
+      'A person named Rainer observed something',
+      'Beschrijving van Barabudur — preface quoting Rainer Maria Rilke, The Book of Hours',
+    ])).toBe('strong');
+  });
+
+  it('weak when every result covers only part of the query', () => {
+    expect(assessMatchQuality('Rainer Maria Rilke', [
+      'A person named Rainer observed something',
+      'On Friedrich Hölderlin and His Fate',
+      'Maria addressed in a litany',
+    ])).toBe('weak');
+  });
+
+  it('coverage may be split across fields joined into one haystack, not across results', () => {
+    // Two results each holding one token is still weak.
+    expect(assessMatchQuality('harmonia mundi', ['harmonia alone', 'mundi alone'])).toBe('weak');
+    expect(assessMatchQuality('harmonia mundi', ['Harmonia Mundi libri quinque'])).toBe('strong');
+  });
+
+  it('folds case and diacritics on both sides', () => {
+    expect(assessMatchQuality('rilke cafe', ['CAFÉ — RÍLKE'])).toBe('strong');
+    expect(assessMatchQuality('café rílke', ['cafe rilke'])).toBe('strong');
+  });
+
+  it('elides in-word marks so short transliterations survive tokenization', () => {
+    // ʻayn/apostrophe inside a name must not split it into sub-floor fragments.
+    expect(assessMatchQuality("Sa'di poems", ['the poems of Saʻdī'])).toBe('strong');
+  });
+
+  it('abstains (null) on single-token queries — presence IS coverage there', () => {
+    expect(assessMatchQuality('Rilke', ['unrelated text'])).toBeNull();
+  });
+
+  it('abstains (null) on a contiguous CJK query — one token regardless of words', () => {
+    expect(assessMatchQuality('樂律全書', ['unrelated text'])).toBeNull();
+  });
+
+  it('judges mixed CJK + Latin queries that do yield two tokens', () => {
+    expect(assessMatchQuality('樂律全書 music', ['樂律全書 complete works on music'])).toBe('strong');
+    expect(assessMatchQuality('樂律全書 music', ['a treatise on music'])).toBe('weak');
+  });
+
+  it('abstains (null) when there are no results — that is the empty state, not a weak one', () => {
+    expect(assessMatchQuality('Rainer Maria Rilke', [])).toBeNull();
+  });
+
+  it('ignores empty haystack strings rather than crashing or matching', () => {
+    expect(assessMatchQuality('two words', ['', 'two of the words here'])).toBe('strong');
+  });
+});


### PR DESCRIPTION
Implements the core of #4281 (approved by Derek): out-of-corpus person queries returned a confident laundry list — 'Rainer Maria Rilke' gave 12 results, 10 of them stray-token noise, because RRF merges lanes by rank and discards absolute relevance.

**In scope**
- `src/lib/search/match-quality.ts` — `assessMatchQuality(query, haystacks)`: 'strong' if any result contains ALL query tokens (NFKC + lowercase + diacritic fold + in-word-mark elision, both sides), 'weak' if none does, **null (abstain)** when the query folds to <2 tokens — single words and contiguous CJK runs are unjudgeable (per `non-latin-text-operations.md`), and a null renders exactly like today.
- `/api/search/unified` returns `match_quality` computed over all lanes' reader-visible text (books, index, gallery, visual, semantic, artworks, collections).
- `/search` unified view renders an honest banner on 'weak' ('No strong matches for "X" — nothing in the library matches all of your search words…'), EN + ES strings in `SEARCH_STRINGS`. Gated on the passage lane: a page-content hit that covers every token suppresses the banner, and it stays hidden while passages load.
- Unit suite `tests/unit/search-match-quality.test.ts` (10 cases) including the non-Latin abstention cases as pinned behavior.

**Out of scope** (tracked in #4281)
- Author-thesaurus check ('we don't hold works by X')
- Phrase/proximity re-ranking of the words lane
- The bare `/api/search` (Books tab / scholar catalog / MCP) — unified is the surface the complaint came from

Feedback-ID: 6a90362c9c55dc0b601648db

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Mbr77nDbD4MjWKd4tHLM