### PR TITLE
fix(covers): smart-cover-selection contract compliance + blank-flyleaf sweep mode (#4276)

### DIFF
--- a/scripts/maintenance/fix-digitizer-covers-4276.mjs
+++ b/scripts/maintenance/fix-digitizer-covers-4276.mjs
@@ -20,9 +20,13 @@
  *
  * Usage:
  *   node --env-file=.env.production.local scripts/maintenance/fix-digitizer-covers-4276.mjs --dry-run
- *   --dry-run       Census + preview only, no writes
- *   --limit N       Apply at most N cover changes
- *   --book-id ID    Single book (diagnostics)
+ *   --dry-run        Census + preview only, no writes
+ *   --limit N        Apply at most N cover changes
+ *   --book-id ID     Single book (diagnostics)
+ *   --include-blank  Also flag covers on blank flyleaves — but SPARE pages whose
+ *                    OCR describes a real binding (vellum/leather/"front cover"),
+ *                    and require a much stronger replacement (score ≥ 100, i.e. a
+ *                    real title page or frontispiece) than the boilerplate rule.
  *
  * After a live run: run scripts/workers/sync-books-catalog.mjs (incremental)
  * and POST the changed slugs to /api/admin/revalidate.
@@ -43,9 +47,14 @@ const BOOK_ID = (() => {
   return i !== -1 ? process.argv[i + 1] : null;
 })();
 
+const INCLUDE_BLANK = process.argv.includes('--include-blank');
+
 const SWEEP = 'digitizer-cover-sweep-4276';
 const SCAN_PAGES = 20;
 const BATCH = 50;
+/** A blank flyleaf may only be replaced by a clearly strong page — a real
+ *  title page / frontispiece — never by a marginally-better text page. */
+const BLANK_MIN_SCORE = 100;
 
 /** Digitizer/scanner boilerplate signatures, tested on the OCR head of the
  *  CURRENT cover page only. Google's insert + IA funding pages. Deliberately
@@ -63,6 +72,12 @@ const JUNK_TYPES = new Set([
   'digitizer-insert', 'scanner_metadata',
   'scanner-metadata', 'color-card', 'colorcard', 'color_card', 'target',
 ]);
+
+/** An OCR head that describes a REAL binding — an authentic cover the reader
+ *  should keep, even though the page is typed 'blank'. Checked only in
+ *  --include-blank mode. */
+const REAL_BINDING_RE =
+  /front cover|back cover|book cover|cover of (?:the|a) (?:manuscript|book|volume)|binding|vellum|leather|marbled|boards\b|spine\b|bookplate|ex.?libris/i;
 
 /** Resolve which page_number the book's current cover points at, or null. */
 function currentCoverPage(book) {
@@ -147,15 +162,23 @@ for (let i = 0; i < books.length; i += BATCH) {
     const head = coverPage?.ocr_head || '';
     const isBoilerplate =
       (coverPage && JUNK_TYPES.has(coverPage.page_type)) || BOILERPLATE_RE.test(head);
-    if (!isBoilerplate) { stats.coverClean++; continue; }
+    // Blank-flyleaf rule (opt-in): typed blank — by the field or by the OCR's
+    // own <page-type> tag — and NOT described as a real binding.
+    const typedBlank = coverPage &&
+      (coverPage.page_type === 'blank' || /<page-type>\s*blank\s*<\/page-type>/i.test(head));
+    const isBlankFlyleaf = INCLUDE_BLANK && !isBoilerplate &&
+      typedBlank && !REAL_BINDING_RE.test(head);
+    if (!isBoilerplate && !isBlankFlyleaf) { stats.coverClean++; continue; }
     stats.flagged++;
+
+    const minScore = isBoilerplate ? 30 : BLANK_MIN_SCORE;
 
     // Re-score every scanned page; scorer reads ocr_head via its fallback chain.
     const scored = bookPages
       .map(p => ({ page: p, ...scorePageForCover(p, { bookTitle: book.title }) }))
       .sort((a, b) => b.score - a.score);
     const best = scored[0];
-    if (!best || best.score < 30 || best.page.page_number === coverNum) {
+    if (!best || best.score < minScore || best.page.page_number === coverNum) {
       stats.noBetterPage++;
       skips.push({ id: book.id, slug: book.slug, why: `no better page (best p${best?.page.page_number} score ${best?.score})` });
       continue;
@@ -166,7 +189,7 @@ for (let i = 0; i < books.length; i += BATCH) {
       method: SWEEP,
       actor: 'script',
       confidence: 0.8,
-      detail: `was p${coverNum} (digitizer boilerplate) → p${best.page.page_number}: ${best.reason} (score ${best.score})`,
+      detail: `was p${coverNum} (${isBoilerplate ? 'digitizer boilerplate' : 'blank flyleaf'}) → p${best.page.page_number}: ${best.reason} (score ${best.score})`,
     });
     if (!update || !isRenderableCoverUrl(update.image_thumb)) {
       stats.notRenderable++;
@@ -175,7 +198,7 @@ for (let i = 0; i < books.length; i += BATCH) {
     }
 
     stats.fixed++;
-    changes.push({ id: book.id, slug: book.slug, title: (book.title || '').slice(0, 55), from: coverNum, to: best.page.page_number, reason: best.reason, score: best.score, thumb: update.image_thumb });
+    changes.push({ id: book.id, slug: book.slug, title: (book.title || '').slice(0, 55), rule: isBoilerplate ? 'boilerplate' : 'blank', from: coverNum, to: best.page.page_number, reason: best.reason, score: best.score, thumb: update.image_thumb });
 
     if (!DRY_RUN) {
       await db.collection('books').updateOne(

--- a/scripts/maintenance/smart-cover-selection.mjs
+++ b/scripts/maintenance/smart-cover-selection.mjs
@@ -19,7 +19,7 @@
 
 import { MongoClient } from 'mongodb';
 import { scorePageForCover } from '../lib/cover-scoring.mjs';
-import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { buildCoverUpdate } from '../lib/cover-write.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_MANUAL = process.argv.includes('--skip-manual');
@@ -50,7 +50,7 @@ const client = new MongoClient(process.env.MONGODB_URI, {
 await client.connect();
 const db = client.db('bookstore');
 
-// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
+// Cover URLs are resolved inside buildCoverUpdate (cover-write.mjs) — see top of file.
 
 // --- Main ---
 console.log(`\n=== Smart Cover Selection (OCR-based) ===`);
@@ -98,6 +98,7 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
         projection: {
           book_id: 1, page_number: 1, page_type: 1,
           photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, split_from_spread: 1,
+          enhanced_photo: 1, image_thumb: 1, thumbnail_blob: 1,
           'ocr.data': 1,
         }
       }
@@ -130,13 +131,22 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
     const best = scored[0];
     if (best.score < 30) { skipped++; continue; }
 
-    // Get the URL for the best page
-    const bestUrl = getPageImageUrl(best.page);
-    if (!bestUrl) { skipped++; continue; }
+    // Build the canonical four-field cover update (issue #4276: this script
+    // used to write only legacy `thumbnail` + nonstandard `cover_page_number`,
+    // leaving image_display/image_thumb stale — the exact partial-write class
+    // the cover-fields contract exists to prevent).
+    const update = buildCoverUpdate(best.page, {
+      source: 'smart_ocr',
+      method: 'smart-cover-selection',
+      actor: 'script',
+      confidence: 0.8,
+      detail: `${best.reason} (score ${best.score})`,
+    });
+    if (!update) { skipped++; continue; }
 
     // Check if it's different from current cover
     const currentThumb = book.thumbnail || '';
-    if (currentThumb === bestUrl) { skipped++; continue; }
+    if (currentThumb === update.image_display) { skipped++; continue; }
 
     // In non-force mode, also skip if current cover is from a later page
     // (it was likely already upgraded and might be correct)
@@ -155,14 +165,11 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
     });
 
     if (!DRY_RUN) {
+      // updated_at bump lets sync-books-catalog's incremental mode pick the
+      // book up; remember to run it (and revalidate) after a live sweep.
       await db.collection('books').updateOne(
         { id: book.id },
-        { $set: {
-          thumbnail: bestUrl,
-          thumbnail_source: 'smart_ocr',
-          cover_updated_at: new Date(),
-          cover_page_number: best.page.page_number,
-        }}
+        { $set: { ...update, updated_at: new Date() } }
       );
     }
   }


### PR DESCRIPTION
## What
1. **`smart-cover-selection.mjs` now writes the canonical cover contract.** It previously wrote only legacy `thumbnail` + nonstandard `cover_page_number`, leaving `image_display`/`image_thumb` stale — the exact partial-write class `buildCoverUpdate()` exists to prevent (cf. the 2026-05-05 BPH cover postmortem). Also bumps `updated_at` so the catalog sync picks changed books up.
2. **`fix-digitizer-covers-4276.mjs --include-blank`**: flags covers sitting on blank flyleaves (by `page_type` field or the OCR's own `<page-type>` tag), **spares** pages whose OCR describes a real binding (vellum / leather / 'front cover' / bookplate — authentic covers stay, e.g. `vat-gr-1594`'s vellum boards), and requires a much stronger replacement (score ≥ 100 — a real title page or frontispiece) than the boilerplate rule's ≥ 30.

## Already run (2026-08-27, results on #4276)
- Blank mode: 203 flagged (the binding-sparing rule cut the naive 511 to 203), **80 covers fixed**, 123 left alone for lack of a strong replacement. 12 old/new pairs eyeballed before the live run — old were genuine blanks (one a scanner color card), new are real title pages.
- The 3 boilerplate stragglers fixed by eye (Gresemund incunable → p3 incipit; Fagel → its own decorated p1 the scorer under-scored; Vinaya Pitaka III → p3 volume title). `sweep_log` method `claude-visual-pick-4276`, `thumbnail_source: manual` so future sweeps skip them.
- Catalog synced + all 83 pages revalidated.

## Out of scope
- #4276 Problem 2 (white-canvas Google scan margins) — needs a display-crop design, still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLfEqmwQa9vKyACnH4Te3R