### PR TITLE
feat(identity-review): batch lanes for the work-merge and keeper queues (#4271)

### DIFF
--- a/scripts/audit/identity-stack-gates.mjs
+++ b/scripts/audit/identity-stack-gates.mjs
@@ -75,6 +75,36 @@ const bothVisible = await books.aggregate([
   { $count: 'n' },
 ]).toArray();
 
+// ── Gate 5: the REVIEW queues — is the human lane draining? (#4271) ─────────
+// Detection finished weeks before the drain did; a queue that stops moving is
+// the failure mode, and it is invisible unless the table counts it. Segment
+// the merge queue by the LLM screen's verdict: `same`/`different` are the
+// batchable slices, `unsure`/unstamped are the manual remainder.
+const mergeQueue = await db.collection('work_merge_queue').aggregate([
+  { $group: { _id: { status: '$status', verdict: { $ifNull: ['$llm.verdict', 'unscreened'] } }, n: { $sum: 1 } } },
+]).toArray();
+const mergePending = {};
+let mergeAdjudicated = 0;
+for (const r of mergeQueue) {
+  if (r._id.status === 'pending') mergePending[r._id.verdict] = (mergePending[r._id.verdict] ?? 0) + r.n;
+  else mergeAdjudicated += r.n;
+}
+const mergePendingTotal = Object.values(mergePending).reduce((a, b) => a + b, 0);
+
+const keeperQueue = await db.collection('edition_keeper_queue').aggregate([
+  { $group: { _id: { status: '$status', bucket: '$bucket', ft: { $eq: ['$ft_flag', true] } }, n: { $sum: 1 } } },
+]).toArray();
+const keeperPending = {};
+let keeperAdjudicated = 0;
+let keeperBatchable = 0; // MECHANICAL_KEEP with no FT badge at stake — the batch lane's slice
+for (const r of keeperQueue) {
+  if (r._id.status === 'pending') {
+    keeperPending[r._id.bucket] = (keeperPending[r._id.bucket] ?? 0) + r.n;
+    if (r._id.bucket === 'MECHANICAL_KEEP' && !r._id.ft) keeperBatchable += r.n;
+  } else keeperAdjudicated += r.n;
+}
+const keeperPendingTotal = Object.values(keeperPending).reduce((a, b) => a + b, 0);
+
 const gates = {
   measured_at: new Date().toISOString(),
   phase0: {
@@ -94,6 +124,22 @@ const gates = {
     dark_cluster_pointers: darkPointers[0]?.n ?? 0,
     both_visible_edition_clusters: bothVisible[0]?.n ?? 0,
   },
+  review_queues: {
+    work_merge_queue: {
+      pending: mergePendingTotal,
+      adjudicated: mergeAdjudicated,
+      pending_by_verdict: mergePending,
+      batchable: (mergePending.same ?? 0) + (mergePending.different ?? 0),
+      manual_remainder: (mergePending.unsure ?? 0) + (mergePending.unscreened ?? 0),
+    },
+    edition_keeper_queue: {
+      pending: keeperPendingTotal,
+      adjudicated: keeperAdjudicated,
+      pending_by_bucket: keeperPending,
+      batchable_mechanical_non_ft: keeperBatchable,
+    },
+    note: 'batch lanes: /curation/identity-review (#4271). A pending count that stops falling means the drain stalled again.',
+  },
 };
 
 if (JSON_OUT) {
@@ -106,6 +152,14 @@ if (JSON_OUT) {
   console.log(`  Reader:   ${gates.collocation.books_addressable} live books in multi-language work clusters (${gates.collocation.multilanguage_work_clusters} clusters)`);
   console.log(`            ${gates.collocation.full_quality_edition_sibling_books} live books with a full-quality edition sibling`);
   console.log(`  Queues:   ${gates.queues.dark_cluster_pointers} dark pointers, ${gates.queues.both_visible_edition_clusters} both-visible edition clusters`);
+  const rq = gates.review_queues;
+  const byVerdict = Object.entries(rq.work_merge_queue.pending_by_verdict).map(([k, v]) => `${v} ${k}`).join(', ') || 'none';
+  const byBucket = Object.entries(rq.edition_keeper_queue.pending_by_bucket).map(([k, v]) => `${v} ${k}`).join(', ') || 'none';
+  console.log(`  Review:   work_merge_queue ${rq.work_merge_queue.pending} pending (${byVerdict}), ${rq.work_merge_queue.adjudicated} adjudicated`);
+  console.log(`            → ${rq.work_merge_queue.batchable} batchable, ${rq.work_merge_queue.manual_remainder} need a human one at a time`);
+  console.log(`            edition_keeper_queue ${rq.edition_keeper_queue.pending} pending (${byBucket}), ${rq.edition_keeper_queue.adjudicated} adjudicated`);
+  console.log(`            → ${rq.edition_keeper_queue.batchable_mechanical_non_ft} batchable (MECHANICAL_KEEP, no FT badge at stake)`);
+  console.log(`            drain: /curation/identity-review (batch lanes, #4271)`);
 }
 
 await client.close();

--- a/scripts/lib/books-field-write-baseline.json
+++ b/scripts/lib/books-field-write-baseline.json
@@ -4,9 +4,13 @@
     "The gate fails only on entries NOT listed here, so new drift is caught while the",
     "existing backlog stays visible instead of turning the check into noise.",
     "Shrink this list; never grow it. Each entry is either a field that should be",
-    "added to the known list deliberately, or a write that should become a sweep_log row."
+    "added to the known list deliberately, or a write that should become a sweep_log row.",
+    "The identity-review-apply.ts entries are the checker's known blind spot, not drift:",
+    "reviewed_by/reviewed_at are written to work_merge_queue and edition_keeper_queue,",
+    "never to books, but the file also writes books so every $set in it gets scanned.",
+    "They replace five identical entries for the two route files the code moved out of (#4271)."
   ],
-  "count": 24,
+  "count": 21,
   "accepted": [
     "scripts/enrichment/verify-translation-claims.mjs::write",
     "scripts/enrichment/wikidata-books.mjs::wikidata_label",
@@ -24,13 +28,10 @@
     "scripts/maintenance/repair-erara-text-shift.mjs::text_shift_repair_manual",
     "scripts/maintenance/set-digitization-sponsor.mjs::digitization_adopted_at",
     "scripts/maintenance/set-digitization-sponsor.mjs::digitization_sponsor",
-    "src/app/api/admin/edition-keepers/route.ts::keeper",
-    "src/app/api/admin/edition-keepers/route.ts::reviewed_at",
-    "src/app/api/admin/edition-keepers/route.ts::reviewed_by",
     "src/app/api/admin/promote-warehouse/route.ts::demoted_at",
     "src/app/api/admin/promote-warehouse/route.ts::promoted_session",
-    "src/app/api/admin/work-merges/route.ts::reviewed_at",
-    "src/app/api/admin/work-merges/route.ts::reviewed_by",
-    "src/app/api/books/[id]/dedicate/route.ts::dedication"
+    "src/app/api/books/[id]/dedicate/route.ts::dedication",
+    "src/lib/identity-review-apply.ts::reviewed_at",
+    "src/lib/identity-review-apply.ts::reviewed_by"
   ]
 }

--- a/src/app/api/admin/edition-keepers/batch/route.ts
+++ b/src/app/api/admin/edition-keepers/batch/route.ts
@@ -1,0 +1,252 @@
+import { NextResponse } from 'next/server';
+import { withInnerCircleAuth } from '@/lib/auth-helpers';
+import { getDb } from '@/lib/mongodb';
+import {
+  applyKeeperChoice,
+  finalizeIdentityBatch,
+  type BatchMarker,
+  type KeeperResult,
+} from '@/lib/identity-review-apply';
+
+export const maxDuration = 60;
+
+/**
+ * Batch lane for `edition_keeper_queue` (#4271) — narrower than the work-merge
+ * lane on purpose.
+ *
+ * Keeping a cluster is a VISIBILITY FLIP: the other members go
+ * `hidden_reason: 'duplicate'` and stop being readable. That is a different
+ * risk class from a work merge (which only re-labels and leaves a redirect),
+ * so only ONE bucket is batchable here:
+ *
+ *   MECHANICAL_KEEP, with `ft_flag` false.
+ *
+ * MECHANICAL_KEEP is the triage bucket where one member dominates on every
+ * axis, so `keeper_suggested` is not a judgement call. `ft_flag` clusters are
+ * excluded even inside that bucket: hiding a First-Translation-badged copy
+ * changes what FT counting sees, and the single-row UI already stops for a
+ * confirm on those. TOSSUP, SUSPECT_NOT_SAME, SCORED_KEEP and every
+ * FT-flagged cluster stay per-cluster manual.
+ *
+ * Measured 2026-08-28: 89 pending MECHANICAL_KEEP clusters, of which 25 carry
+ * `ft_flag: true` — so this lane offers 64, not the 89 the issue quotes. Of
+ * those 64, ZERO have a non-keeper that is still visible: all 69 non-keepers
+ * already carry `hidden_reason: 'same_edition_duplicate'`, which is what
+ * `apply-keeper-choice-triage.mjs` writes. The script lane applied these and
+ * never marked the queue rows, so "311 pending, zero worked" overstates the
+ * outstanding work. `willHide` is therefore computed LIVE, not from the
+ * 2026-08-09 snapshot, so the number the human approves is the real one.
+ *
+ * Shape is otherwise the work-merge lane's: GET manifest (read-only,
+ * list-first), POST chunk (inline actuation through the same
+ * `applyKeeperChoice` the single-row endpoint calls), POST finalize.
+ */
+
+const BATCHABLE_BUCKET = 'MECHANICAL_KEEP';
+const CHUNK_MAX = 25;
+const SPOT_CHECK_SIZE = 20;
+const SPOT_CHECK_ABORT_RATIO = 0.2;
+const MANIFEST_MAX = 1000;
+
+/** Only clusters where the choice is mechanical AND no FT badge is at stake. */
+function batchableFilter(): Record<string, unknown> {
+  return { status: 'pending', bucket: BATCHABLE_BUCKET, ft_flag: { $ne: true } };
+}
+
+function sample<T>(arr: T[], n: number, seed: string): T[] {
+  if (arr.length <= n) return [...arr];
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+  const picked = new Set<number>();
+  const out: T[] = [];
+  let x = Math.abs(h) || 1;
+  while (out.length < n) {
+    x = (Math.imul(1103515245, x) + 12345) & 0x7fffffff;
+    const i = x % arr.length;
+    if (picked.has(i)) continue;
+    picked.add(i);
+    out.push(arr[i]);
+  }
+  return out;
+}
+
+/** GET /api/admin/edition-keepers/batch — the manifest. Read-only. */
+export const GET = withInnerCircleAuth(async () => {
+  const db = await getDb();
+  const queue = db.collection('edition_keeper_queue');
+  const filter = batchableFilter();
+
+  const [total, ftExcluded, rows] = await Promise.all([
+    queue.countDocuments(filter),
+    queue.countDocuments({ status: 'pending', bucket: BATCHABLE_BUCKET, ft_flag: true }),
+    queue.find(filter).sort({ _id: 1 }).limit(MANIFEST_MAX).toArray(),
+  ]);
+
+  // Live visibility — the triage snapshot is from 2026-08-09 and a member may
+  // already have been hidden by another lane. "Hides N" must be a live number.
+  const memberIds = [...new Set(rows.flatMap((r) => ((r.members as { id: string }[]) || []).map((m) => m.id)))];
+  const books = memberIds.length
+    ? await db.collection('books').find(
+        { id: { $in: memberIds } },
+        { projection: { _id: 0, id: 1, title: 1, author: 1, visible: 1, is_first_translation: 1, pages_count: 1 } },
+      ).toArray()
+    : [];
+  const byId = new Map(books.map((b) => [b.id as string, b]));
+
+  const manifest = rows.map((r) => {
+    const members = ((r.members as { id: string; quality?: number }[]) || []);
+    const keeper = (r.keeper_suggested as string) || '';
+    const others = members.filter((m) => m.id !== keeper);
+    const keeperLive = byId.get(keeper);
+    return {
+      editionKey: String(r._id),
+      keeper,
+      keeperTitle: (keeperLive?.title as string) || '',
+      keeperAuthor: (keeperLive?.author as string) || '',
+      keeperFound: !!keeperLive,
+      keeperVisible: keeperLive?.visible === true,
+      nMembers: members.length,
+      // Live count of members that would actually flip (already-hidden ones
+      // are a no-op, so promising "hides 2" when one is already hidden lies).
+      willHide: others.filter((m) => byId.get(m.id)?.visible === true).length,
+      // A live FT badge anywhere in the cluster that the 08-09 snapshot missed.
+      liveFtInCluster: members.some((m) => byId.get(m.id)?.is_first_translation === true),
+      pageRatio: (r.page_ratio as number) ?? null,
+      others: others.map((m) => ({
+        id: m.id,
+        title: (byId.get(m.id)?.title as string) || '',
+        visible: byId.get(m.id)?.visible === true,
+      })),
+    };
+  });
+
+  // Belt and braces: a cluster whose keeper vanished, or that grew a live FT
+  // badge since the snapshot, is not mechanical any more — flag it out of the
+  // batch rather than trusting a three-week-old classification.
+  const isBlocked = (m: (typeof manifest)[number]) => !m.keeperFound || !m.keeper || m.liveFtInCluster;
+  const blocked = manifest.filter(isBlocked);
+  const eligible = manifest.filter((m) => !isBlocked(m));
+
+  return NextResponse.json({
+    bucket: BATCHABLE_BUCKET,
+    total,
+    capped: total > MANIFEST_MAX,
+    ftExcluded,
+    manifest: eligible,
+    blocked,
+    booksHidden: eligible.reduce((s, m) => s + m.willHide, 0),
+    spotCheckIds: sample(eligible, SPOT_CHECK_SIZE, BATCHABLE_BUCKET).map((m) => m.editionKey),
+    spotCheckSize: Math.min(SPOT_CHECK_SIZE, eligible.length),
+  });
+});
+
+interface KeeperBatchBody {
+  action?: 'keep' | 'finalize';
+  editionKeys?: string[];
+  note?: string;
+  runId?: string;
+  paths?: string[];
+  spotCheck?: { reviewed?: number; flagged?: number; of?: number };
+}
+
+/**
+ * POST /api/admin/edition-keepers/batch
+ *   { action: 'keep', editionKeys: [...], runId, spotCheck }
+ *   { action: 'finalize', paths: [...] }
+ *
+ * There is deliberately no batch `dismiss`: dismissing is the "leave
+ * everything visible" outcome, which nobody needs to do 89 times, and a
+ * bulk-dismiss button would quietly empty the queue without a decision.
+ */
+export const POST = withInnerCircleAuth(async (request, session) => {
+  const body = (await request.json()) as KeeperBatchBody;
+
+  if (body.action === 'finalize') {
+    const res = await finalizeIdentityBatch(body.paths || []);
+    return NextResponse.json(res);
+  }
+  if (body.action !== 'keep') {
+    return NextResponse.json({ error: 'action must be keep|finalize' }, { status: 400 });
+  }
+
+  const keys = (body.editionKeys || []).filter((x) => typeof x === 'string' && x.length > 0);
+  if (keys.length === 0) return NextResponse.json({ error: 'editionKeys required' }, { status: 400 });
+  if (keys.length > CHUNK_MAX) {
+    return NextResponse.json({ error: `at most ${CHUNK_MAX} clusters per chunk` }, { status: 400 });
+  }
+  const runId = typeof body.runId === 'string' && body.runId ? body.runId.slice(0, 64) : null;
+  if (!runId) return NextResponse.json({ error: 'runId required' }, { status: 400 });
+
+  const sc = body.spotCheck || {};
+  const of = Number(sc.of) || 0;
+  const reviewed = Number(sc.reviewed) || 0;
+  const flagged = Number(sc.flagged) || 0;
+  if (of === 0 || reviewed < of) {
+    return NextResponse.json({ error: 'spot check incomplete — review every sampled cluster before keeping' }, { status: 400 });
+  }
+  if (flagged / of >= SPOT_CHECK_ABORT_RATIO) {
+    return NextResponse.json({
+      error: `${flagged}/${of} sampled clusters were flagged — the MECHANICAL_KEEP classification is not holding; review these by hand`,
+    }, { status: 409 });
+  }
+
+  const db = await getDb();
+  const queue = db.collection('edition_keeper_queue');
+  const reviewer = session.user?.email || 'admin';
+  const batch: BatchMarker = {
+    run_id: runId,
+    kind: 'keeper-mechanical',
+    spot_check: { reviewed, flagged, of },
+  };
+
+  // Re-read under the batchable filter: a chunk physically cannot touch a
+  // TOSSUP, a SCORED_KEEP, an FT-flagged cluster, or one another reviewer
+  // already adjudicated — even if the client sends its key.
+  const rows = await queue.find({ _id: { $in: keys as never[] }, ...batchableFilter() }).toArray();
+  const found = new Set(rows.map((r) => String(r._id)));
+
+  const results: KeeperResult[] = keys
+    .filter((k) => !found.has(k))
+    .map((k) => ({ editionKey: k, status: 'error' as const, message: 'not a pending non-FT MECHANICAL_KEEP cluster' }));
+
+  // Re-check the live FT badge at write time. The queue's `ft_flag` is a
+  // 2026-08-09 snapshot; a badge awarded since then would otherwise be hidden
+  // by a batch that believed the cluster was mechanical.
+  const memberIds = [...new Set(rows.flatMap((r) => ((r.members as { id: string }[]) || []).map((m) => m.id)))];
+  const ftLive = new Set(
+    (memberIds.length
+      ? await db.collection('books').find(
+          { id: { $in: memberIds }, is_first_translation: true },
+          { projection: { _id: 0, id: 1 } },
+        ).toArray()
+      : []
+    ).map((b) => b.id as string),
+  );
+
+  const now = new Date();
+  for (const row of rows) {
+    const key = String(row._id);
+    const members = ((row.members as { id: string }[]) || []).map((m) => m.id);
+    if (members.some((m) => ftLive.has(m))) {
+      results.push({ editionKey: key, status: 'error', message: 'a member holds a live First Translation badge — review this cluster by hand' });
+      continue;
+    }
+    const keeperId = (row.keeper_suggested as string) || '';
+    if (!keeperId || !members.includes(keeperId)) {
+      results.push({ editionKey: key, status: 'error', message: 'no suggested keeper on this cluster' });
+      continue;
+    }
+    try {
+      results.push(await applyKeeperChoice(db, row, { keeperId, note: body.note, reviewer, now, batch }));
+    } catch (err) {
+      results.push({ editionKey: key, status: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  const paths = [...new Set(results.flatMap((r) => r.paths || []))];
+  const tally = results.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] || 0) + 1;
+    return acc;
+  }, {});
+  return NextResponse.json({ results, tally, paths });
+});

--- a/src/app/api/admin/edition-keepers/route.ts
+++ b/src/app/api/admin/edition-keepers/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withInnerCircleAuth } from '@/lib/auth-helpers';
 import { getDb } from '@/lib/mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { applyKeeperChoice, dismissKeeperCluster } from '@/lib/identity-review-apply';
 
 export const maxDuration = 30;
 
@@ -28,11 +29,19 @@ export const GET = withInnerCircleAuth(async (request) => {
   const skip = Math.max(parseInt(url.searchParams.get('skip') || '0', 10) || 0, 0);
 
   const bphOnly = url.searchParams.get('bph') === '1';
+  // `ids=key1,key2` (max 50) — the batch lane's spot-check renders its sample
+  // through this same read path (see /api/admin/edition-keepers/batch).
+  const idsParam = url.searchParams.get('ids');
 
   const db = await getDb();
   const queue = db.collection('edition_keeper_queue');
 
   const filter: Record<string, unknown> = { status };
+  if (idsParam) {
+    const ids = idsParam.split(',').map((s) => s.trim()).filter(Boolean).slice(0, 50);
+    if (ids.length === 0) return NextResponse.json({ items: [], total: 0, counts: {}, buckets: {} });
+    filter._id = { $in: ids };
+  }
   if (bucket === 'human') filter.bucket = { $in: HUMAN_BUCKETS };
   else if (bucket !== 'all') filter.bucket = bucket;
   if (bphOnly) {
@@ -127,34 +136,19 @@ export const POST = withInnerCircleAuth(async (request, session) => {
     return NextResponse.json({ error: `cluster is already ${row.status}` }, { status: 409 });
   }
 
-  const now = new Date();
   const reviewer = session.user?.email || 'admin';
 
+  // Shared write path with the batch lane (#4271) — see @/lib/identity-review-apply.
   if (action === 'dismiss') {
-    await queue.updateOne({ _id: editionKey as never }, { $set: { status: 'dismissed', note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
+    const res = await dismissKeeperCluster(db, editionKey, { note, reviewer });
+    if (res.status === 'error') return NextResponse.json({ error: res.message }, { status: 409 });
     return NextResponse.json({ status: 'dismissed' });
   }
 
-  const memberIds = ((row.members as { id: string }[]) || []).map((m) => m.id);
-  if (!keeperId || !memberIds.includes(keeperId)) {
+  if (!keeperId) {
     return NextResponse.json({ error: 'keeperId must be a member of the cluster' }, { status: 400 });
   }
-  const others = memberIds.filter((m) => m !== keeperId);
-
-  const hidden = await db.collection('books').updateMany(
-    { id: { $in: others }, visible: true },
-    { $set: {
-      hidden: true, visible: false,
-      hidden_reason: 'duplicate', hidden_at: now,
-      duplicate_of: keeperId,
-      updated_at: now, // books_catalog sync keys on this — a flip without it is invisible to Supabase
-    } }
-  );
-
-  await queue.updateOne(
-    { _id: editionKey as never },
-    { $set: { status: 'kept', keeper: keeperId, note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } }
-  );
-
-  return NextResponse.json({ status: 'kept', keeper: keeperId, hidden: hidden.modifiedCount });
+  const res = await applyKeeperChoice(db, row, { keeperId, note, reviewer });
+  if (res.status === 'error') return NextResponse.json({ error: res.message }, { status: 400 });
+  return NextResponse.json(res);
 });

--- a/src/app/api/admin/work-merges/batch/route.ts
+++ b/src/app/api/admin/work-merges/batch/route.ts
@@ -1,0 +1,257 @@
+import { NextResponse } from 'next/server';
+import { withInnerCircleAuth } from '@/lib/auth-helpers';
+import { getDb } from '@/lib/mongodb';
+import {
+  applyWorkMerge,
+  finalizeIdentityBatch,
+  pickWorkWinner,
+  rejectWorkMerge,
+  type BatchMarker,
+  type WorkMergeResult,
+} from '@/lib/identity-review-apply';
+
+export const maxDuration = 60;
+
+/**
+ * Batch lane for `work_merge_queue` (#4271).
+ *
+ * The queue accumulated 1,940 pending pairs and drained at one row per click;
+ * the LLM screen (`scripts/analysis/stamp-work-merge-queue-llm.mjs`) had
+ * already sorted 980 of them into `same` and 745 into `different` weeks
+ * earlier. This route lets a human clear a verdict slice in one sitting
+ * WITHOUT changing what a single approval does:
+ *
+ *   - GET  builds the MANIFEST — every row the run would touch, with the
+ *     winner/loser it would pick and the live count of books it would move.
+ *     Nothing is written. This is the list-first-approve step (Data
+ *     Protection rule: never batch-write without showing what will be
+ *     touched), and it is the only place the full set is enumerable.
+ *   - POST executes ONE CHUNK of that manifest, calling the exact same
+ *     `applyWorkMerge` / `rejectWorkMerge` the single-row endpoint calls.
+ *     The client loops chunks so it can show progress and abort mid-run.
+ *     Actuation stays inline — no row is left for a background job to read.
+ *   - POST { action: 'finalize' } revalidates the deduped path set once at
+ *     the end instead of ~2,000 times.
+ *
+ * Measured 2026-08-28, and the reason the manifest reports `willBeStale`:
+ * 763 of the 1,588 work ids the 980 `same` rows reference are carried by NO
+ * book any more, and none of them appear in `work_id_aliases` — so they were
+ * not merged away; the `local:n:<author>:<normalized-title>` mint moved under
+ * them when a title or author was repaired. 717 of the 980 pairs are
+ * therefore unmergeable and approving them writes `stale`, not a merge. The
+ * real merge work in that slice is ~263 pairs moving ~277 books. Say so in
+ * the manifest rather than promising 980 merges.
+ *
+ * Two guards make the endpoint refuse to be a silent bulk-merge API:
+ *   1. every id in a chunk must still be `pending` AND still carry the
+ *      `verdict` the run declared — an approve-all-`same` run physically
+ *      cannot touch a `different` row, even if the client sends one;
+ *   2. `approve` requires a declared spot-check, and is refused when the
+ *      human flagged a fifth or more of the sample (that says the screen is
+ *      unreliable on this slice, not that 20 rows need skipping).
+ */
+
+const CHUNK_MAX = { approve: 25, reject: 100 } as const;
+/** How many pairs the human must eyeball before an approve-all run. */
+const SPOT_CHECK_SIZE = 20;
+/** Flagging this share of the sample means the screen is wrong, not the rows. */
+const SPOT_CHECK_ABORT_RATIO = 0.2;
+/** Ceiling on the manifest — well past the 980 `same` rows, but not unbounded. */
+const MANIFEST_MAX = 3000;
+
+const VERDICTS = ['same', 'different', 'unsure', 'none'];
+
+function verdictFilter(verdict: string): Record<string, unknown> {
+  return verdict === 'none' ? { llm: { $exists: false } } : { 'llm.verdict': verdict };
+}
+
+/** Deterministic sample so a reload shows the reviewer the same 20 pairs. */
+function sample<T>(arr: T[], n: number, seed: string): T[] {
+  if (arr.length <= n) return [...arr];
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+  const picked = new Set<number>();
+  const out: T[] = [];
+  let x = Math.abs(h) || 1;
+  while (out.length < n) {
+    x = (Math.imul(1103515245, x) + 12345) & 0x7fffffff;
+    const i = x % arr.length;
+    if (picked.has(i)) continue;
+    picked.add(i);
+    out.push(arr[i]);
+  }
+  return out;
+}
+
+/**
+ * GET /api/admin/work-merges/batch?verdict=same&bph=1
+ * The manifest. Read-only: nothing here writes.
+ */
+export const GET = withInnerCircleAuth(async (request) => {
+  const url = new URL(request.url);
+  const verdict = url.searchParams.get('verdict') || '';
+  const bphOnly = url.searchParams.get('bph') === '1';
+  if (!VERDICTS.includes(verdict)) {
+    return NextResponse.json({ error: `verdict must be one of ${VERDICTS.join('|')}` }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const filter: Record<string, unknown> = { status: 'pending', ...verdictFilter(verdict) };
+
+  if (bphOnly) {
+    const bphWids = await db.collection('books').distinct('work_id', {
+      $or: [{ held_by: 'bph' }, { 'image_source.provider': 'bph' }],
+      work_id: { $exists: true, $nin: [null, ''] },
+    });
+    filter.$or = [{ a: { $in: bphWids } }, { b: { $in: bphWids } }];
+  }
+
+  const queue = db.collection('work_merge_queue');
+  const total = await queue.countDocuments(filter);
+  const rows = await queue.find(filter).sort({ 'evidence.author': 1, _id: 1 }).limit(MANIFEST_MAX).toArray();
+
+  // Live book counts per side — the frozen `evidence` strings on the row are
+  // display-order-unstable and can go stale, and the winner depends on which
+  // side actually holds more books RIGHT NOW.
+  const workIds = [...new Set(rows.flatMap((r) => [r.a as string, r.b as string]))];
+  const counts = new Map<string, number>();
+  if (workIds.length) {
+    const agg = await db.collection('books').aggregate([
+      { $match: { work_id: { $in: workIds } } },
+      { $group: { _id: '$work_id', n: { $sum: 1 } } },
+    ]).toArray();
+    for (const c of agg) counts.set(c._id as string, c.n as number);
+  }
+
+  const manifest = rows.map((r) => {
+    const a = r.a as string;
+    const b = r.b as string;
+    const nA = counts.get(a) || 0;
+    const nB = counts.get(b) || 0;
+    const winner = pickWorkWinner(a, b, nA, nB);
+    const loser = winner === a ? b : a;
+    return {
+      id: String(r._id),
+      author: (r.evidence?.author as string) || '',
+      titleA: (r.evidence?.titleA as string) || '',
+      titleB: (r.evidence?.titleB as string) || '',
+      a, b, nA, nB,
+      winner,
+      loser,
+      // Zero on either side means the pair is already resolved; approving it
+      // marks it `stale` rather than merging. Surfaced so the count the human
+      // sees ("N books will move") is honest.
+      booksToMove: winner === a ? nB : nA,
+      willBeStale: nA === 0 || nB === 0,
+      llmReason: (r.llm?.reason as string) || '',
+    };
+  });
+
+  const actionable = manifest.filter((m) => !m.willBeStale);
+  return NextResponse.json({
+    verdict,
+    total,
+    capped: total > MANIFEST_MAX,
+    manifest,
+    booksAffected: actionable.reduce((s, m) => s + m.booksToMove, 0),
+    staleCount: manifest.length - actionable.length,
+    spotCheckIds: sample(manifest, SPOT_CHECK_SIZE, verdict).map((m) => m.id),
+    spotCheckSize: Math.min(SPOT_CHECK_SIZE, manifest.length),
+  });
+});
+
+interface BatchBody {
+  action?: 'approve' | 'reject' | 'finalize';
+  verdict?: string;
+  ids?: string[];
+  note?: string;
+  runId?: string;
+  paths?: string[];
+  spotCheck?: { reviewed?: number; flagged?: number; of?: number };
+}
+
+/**
+ * POST /api/admin/work-merges/batch
+ *   { action: 'approve'|'reject', verdict, ids: [...], runId, spotCheck }
+ *   { action: 'finalize', paths: [...] }
+ */
+export const POST = withInnerCircleAuth(async (request, session) => {
+  const body = (await request.json()) as BatchBody;
+  const { action } = body;
+
+  if (action === 'finalize') {
+    const res = await finalizeIdentityBatch(body.paths || []);
+    return NextResponse.json(res);
+  }
+
+  if (action !== 'approve' && action !== 'reject') {
+    return NextResponse.json({ error: "action must be approve|reject|finalize" }, { status: 400 });
+  }
+  const verdict = body.verdict || '';
+  if (!VERDICTS.includes(verdict)) {
+    return NextResponse.json({ error: `verdict must be one of ${VERDICTS.join('|')}` }, { status: 400 });
+  }
+  const ids = (body.ids || []).filter((x) => typeof x === 'string' && x.length > 0);
+  if (ids.length === 0) return NextResponse.json({ error: 'ids required' }, { status: 400 });
+  if (ids.length > CHUNK_MAX[action]) {
+    return NextResponse.json({ error: `at most ${CHUNK_MAX[action]} ids per ${action} chunk` }, { status: 400 });
+  }
+  const runId = typeof body.runId === 'string' && body.runId ? body.runId.slice(0, 64) : null;
+  if (!runId) return NextResponse.json({ error: 'runId required' }, { status: 400 });
+
+  // Spot-check gate. Only `approve` actuates, so only `approve` demands it.
+  const sc = body.spotCheck || {};
+  if (action === 'approve') {
+    const of = Number(sc.of) || 0;
+    const reviewed = Number(sc.reviewed) || 0;
+    const flagged = Number(sc.flagged) || 0;
+    if (of === 0 || reviewed < of) {
+      return NextResponse.json({ error: 'spot check incomplete — review every sampled pair before approving' }, { status: 400 });
+    }
+    if (of > 0 && flagged / of >= SPOT_CHECK_ABORT_RATIO) {
+      return NextResponse.json({
+        error: `${flagged}/${of} sampled pairs were flagged — the LLM screen is unreliable on this slice; review it by hand instead of batching`,
+      }, { status: 409 });
+    }
+  }
+
+  const db = await getDb();
+  const queue = db.collection('work_merge_queue');
+  const reviewer = session.user?.email || 'admin';
+  const batch: BatchMarker = {
+    run_id: runId,
+    kind: action === 'approve' ? `approve-all-${verdict}` : `reject-all-${verdict}`,
+    spot_check: action === 'approve'
+      ? { reviewed: Number(sc.reviewed) || 0, flagged: Number(sc.flagged) || 0, of: Number(sc.of) || 0 }
+      : undefined,
+  };
+
+  // Re-read under the run's declared verdict. A chunk cannot touch a row that
+  // drifted out of the slice (another reviewer took it) or that never carried
+  // the verdict this run is for.
+  const rows = await queue.find({ _id: { $in: ids as never[] }, status: 'pending', ...verdictFilter(verdict) }).toArray();
+  const found = new Set(rows.map((r) => String(r._id)));
+
+  const results: WorkMergeResult[] = ids
+    .filter((id) => !found.has(id))
+    .map((id) => ({ id, status: 'error' as const, message: 'no longer pending in this verdict slice' }));
+
+  const now = new Date();
+  for (const row of rows) {
+    try {
+      const res = action === 'approve'
+        ? await applyWorkMerge(db, row, { note: body.note, reviewer, now, batch })
+        : await rejectWorkMerge(db, String(row._id), { note: body.note, reviewer, now, batch });
+      results.push(res);
+    } catch (err) {
+      results.push({ id: String(row._id), status: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  const paths = [...new Set(results.flatMap((r) => r.paths || []))];
+  const tally = results.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] || 0) + 1;
+    return acc;
+  }, {});
+  return NextResponse.json({ results, tally, paths });
+});

--- a/src/app/api/admin/work-merges/route.ts
+++ b/src/app/api/admin/work-merges/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withInnerCircleAuth } from '@/lib/auth-helpers';
 import { getDb } from '@/lib/mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { applyWorkMerge, pickWorkWinner, rejectWorkMerge } from '@/lib/identity-review-apply';
 
 export const maxDuration = 30;
 
@@ -67,16 +68,17 @@ function summarizeSide(workId: string, books: Record<string, unknown>[]): WorkSi
 
 /** Default winner: a Wikidata QID beats a local mint; else the id holding more books. */
 function defaultWinner(a: WorkSide, b: WorkSide): string {
-  const aQ = /^Q\d/.test(a.workId);
-  const bQ = /^Q\d/.test(b.workId);
-  if (aQ !== bQ) return aQ ? a.workId : b.workId;
-  return b.nBooks > a.nBooks ? b.workId : a.workId;
+  return pickWorkWinner(a.workId, b.workId, a.nBooks, b.nBooks);
 }
 
 /**
  * GET /api/admin/work-merges?status=pending&limit=50&skip=0&verdict=unsure&author=homer
  * Lists queue rows with live book context; `verdict` filters on the optional
  * `llm` screening stamp (same|different|unsure|none).
+ *
+ * `ids=a,b,c` (max 50) fetches specific rows — the batch lane's spot-check
+ * renders its sample through this exact read path, so what the human eyeballs
+ * before a 980-row approval is the same card a single-row reviewer sees.
  */
 export const GET = withInnerCircleAuth(async (request) => {
   const url = new URL(request.url);
@@ -86,11 +88,17 @@ export const GET = withInnerCircleAuth(async (request) => {
   const verdict = url.searchParams.get('verdict');
   const author = url.searchParams.get('author');
   const bphOnly = url.searchParams.get('bph') === '1';
+  const idsParam = url.searchParams.get('ids');
 
   const db = await getDb();
   const queue = db.collection('work_merge_queue');
 
   const filter: Record<string, unknown> = { status };
+  if (idsParam) {
+    const ids = idsParam.split(',').map((s) => s.trim()).filter(Boolean).slice(0, 50);
+    if (ids.length === 0) return NextResponse.json({ items: [], total: 0, counts: {} });
+    filter._id = { $in: ids };
+  }
   if (verdict === 'none') filter['llm'] = { $exists: false };
   else if (verdict) filter['llm.verdict'] = verdict;
   if (author) filter['evidence.author'] = { $regex: author.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
@@ -178,61 +186,17 @@ export const POST = withInnerCircleAuth(async (request, session) => {
     return NextResponse.json({ error: `row is already ${row.status}` }, { status: 409 });
   }
 
-  const now = new Date();
   const reviewer = session.user?.email || 'admin';
 
+  // Both branches run the shared write path in @/lib/identity-review-apply —
+  // the same code the batch lane (#4271) calls, so one approval and one row of
+  // a 980-row batch are byte-for-byte the same write.
   if (action === 'reject') {
-    await queue.updateOne({ _id: id as never }, { $set: { status: 'rejected', note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
+    const res = await rejectWorkMerge(db, id, { note, reviewer });
+    if (res.status === 'error') return NextResponse.json({ error: res.message }, { status: 409 });
     return NextResponse.json({ status: 'rejected' });
   }
 
-  const ids = [row.a as string, row.b as string];
-  const booksCol = db.collection('books');
-  const cluster = await booksCol.find(
-    { work_id: { $in: ids } },
-    { projection: { _id: 0, id: 1, work_id: 1 } }
-  ).toArray();
-  const nA = cluster.filter((b) => b.work_id === row.a).length;
-  const nB = cluster.filter((b) => b.work_id === row.b).length;
-  if (nA === 0 || nB === 0) {
-    // One side has no books left — an earlier merge or repair already moved
-    // them. Nothing to do; mark it so it leaves the pending lane.
-    await queue.updateOne({ _id: id as never }, { $set: { status: 'stale', reviewed_by: reviewer, reviewed_at: now, updated_at: now } });
-    return NextResponse.json({ status: 'stale', message: `no books left on ${nA === 0 ? row.a : row.b}` });
-  }
-
-  const winner = winnerParam && ids.includes(winnerParam)
-    ? winnerParam
-    : (/^Q\d/.test(row.a as string) !== /^Q\d/.test(row.b as string)
-        ? (/^Q\d/.test(row.a as string) ? row.a as string : row.b as string)
-        : (nB > nA ? row.b as string : row.a as string));
-  const loser = winner === row.a ? row.b as string : row.a as string;
-
-  // Revert path: the prior work_id of every rewritten book, kept in provenance
-  // (the script keeps this in a backup file; a request handler keeps it in the doc).
-  const affected = cluster.filter((b) => b.work_id === loser).map((b) => ({ book_id: b.id as string, old_work_id: loser }));
-
-  const moved = await booksCol.updateMany(
-    { work_id: loser },
-    { $set: { work_id: winner, updated_at: now }, $addToSet: { work_id_aliases: loser } }
-  );
-  // Winner-side books carry the alias too: the redirect describes the WORK,
-  // so every edition under it must resolve the retired id.
-  await booksCol.updateMany(
-    { work_id: winner, work_id_aliases: { $ne: loser } },
-    { $set: { updated_at: now }, $addToSet: { work_id_aliases: loser } }
-  );
-
-  await db.collection('work_id_merges').insertOne({
-    winner, losers: [loser], sources: ['queue:human'],
-    books_rewritten: moved.modifiedCount, affected,
-    resolver: 'human', reviewed_by: reviewer, issue: 3846, applied_at: now,
-  });
-
-  await queue.updateOne(
-    { _id: id as never },
-    { $set: { status: 'approved', winner, note: note || null, reviewed_by: reviewer, reviewed_at: now, updated_at: now } }
-  );
-
-  return NextResponse.json({ status: 'approved', winner, loser, booksMoved: moved.modifiedCount });
+  const res = await applyWorkMerge(db, row, { winner: winnerParam, note, reviewer });
+  return NextResponse.json(res);
 });

--- a/src/app/curation/identity-review/page.tsx
+++ b/src/app/curation/identity-review/page.tsx
@@ -7,9 +7,16 @@
  * Approve/keep actuates immediately through the same write semantics as the
  * maintenance scripts, attributed to the signed-in admin — no second job
  * reads these decisions later.
+ *
+ * Batch lanes (#4271): the same decision, N at a time, in three enforced
+ * steps — see the whole affected list, eyeball a random sample, then run.
+ * The run is a client-driven loop of small chunks so it shows progress and
+ * can be aborted, and each chunk performs the merges/hides inline through the
+ * exact same server function a single click uses. Nothing is enqueued for a
+ * later job to consume.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 // ── work merges ──
 
@@ -116,6 +123,343 @@ function WorkSideCard({ side, isSuggested }: { side: WorkSide; isSuggested: bool
   );
 }
 
+// ── batch lane ──
+
+/** Server refuses a run when this share of the sample is flagged. Mirrored here so the UI can say why. */
+const SPOT_CHECK_ABORT_RATIO = 0.2;
+
+interface ManifestResponse<M> {
+  total: number;
+  capped: boolean;
+  manifest: M[];
+  spotCheckIds: string[];
+  spotCheckSize: number;
+}
+
+interface BatchLaneProps<M, S> {
+  /** Short imperative name of the run, e.g. "Approve all 980 LLM-`same` merges". */
+  title: string;
+  /** One sentence saying exactly what the writes will be. */
+  whatHappens: string;
+  manifestUrl: string;
+  postUrl: string;
+  /** Extra fields merged into every chunk POST body (verdict, action, …). */
+  bodyBase: Record<string, unknown>;
+  /** Name of the array field carrying the ids in the POST body. */
+  idsField: string;
+  chunkSize: number;
+  keyOf: (m: M) => string;
+  manifestHead: React.ReactNode;
+  renderManifestRow: (m: M) => React.ReactNode;
+  /** Headline numbers: "980 pairs · 1,842 books will move". */
+  renderSummary: (data: ManifestResponse<M>) => React.ReactNode;
+  /** Warnings the manifest surfaced (stale rows, blocked clusters). */
+  renderNotices?: (data: ManifestResponse<M>) => React.ReactNode;
+  spotCheckUrl: (ids: string[]) => string;
+  spotKeyOf: (s: S) => string;
+  renderSpotCheck: (s: S) => React.ReactNode;
+  onClose: (didWrite: boolean) => void;
+}
+
+type Step = 'manifest' | 'spot' | 'run' | 'done';
+
+/**
+ * List-first → spot-check → run. The three steps are enforced in order: the
+ * run button does not exist until every sampled row has been judged, and the
+ * server independently refuses a chunk whose declared spot-check is
+ * incomplete or mostly flagged. Flagged rows are EXCLUDED from the run and
+ * left pending for manual review — never auto-rejected.
+ */
+function BatchLane<M, S>(props: BatchLaneProps<M, S>) {
+  const [data, setData] = useState<ManifestResponse<M> | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [step, setStep] = useState<Step>('manifest');
+  const [spotItems, setSpotItems] = useState<S[] | null>(null);
+  const [judged, setJudged] = useState<Record<string, 'ok' | 'flag'>>({});
+  const [done, setDone] = useState(0);
+  const [tally, setTally] = useState<Record<string, number>>({});
+  const [errors, setErrors] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const [finalizing, setFinalizing] = useState(false);
+  const [finalized, setFinalized] = useState<{ revalidated: number; purged: boolean } | null>(null);
+  const abortRef = useRef(false);
+  const wroteRef = useRef(false);
+
+  useEffect(() => {
+    let live = true;
+    fetch(props.manifestUrl)
+      .then(async (r) => {
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error || `HTTP ${r.status}`);
+        return j;
+      })
+      .then((j) => { if (live) setData(j); })
+      .catch((e) => { if (live) setLoadError(e.message); });
+    return () => { live = false; };
+  }, [props.manifestUrl]);
+
+  const startSpotCheck = useCallback(async () => {
+    if (!data) return;
+    setStep('spot');
+    if (spotItems) return;
+    try {
+      const res = await fetch(props.spotCheckUrl(data.spotCheckIds));
+      const j = await res.json();
+      setSpotItems(j.items || []);
+    } catch {
+      setSpotItems([]);
+    }
+  }, [data, spotItems, props]);
+
+  const sampled = data?.spotCheckIds || [];
+  const reviewed = sampled.filter((id) => judged[id]).length;
+  const flagged = sampled.filter((id) => judged[id] === 'flag').length;
+  const sampleComplete = sampled.length > 0 && reviewed === sampled.length;
+  const screenUnreliable = sampled.length > 0 && flagged / sampled.length >= SPOT_CHECK_ABORT_RATIO;
+
+  const targets = (data?.manifest || [])
+    .map(props.keyOf)
+    .filter((id) => judged[id] !== 'flag');
+
+  async function run() {
+    if (!data) return;
+    abortRef.current = false;
+    setRunning(true);
+    setStep('run');
+    const runId = (globalThis.crypto?.randomUUID?.() ?? String(Date.now()));
+    const spotCheck = { reviewed, flagged, of: sampled.length };
+    const allPaths: string[] = [];
+    const localTally: Record<string, number> = {};
+    const localErrors: string[] = [];
+    let processed = 0;
+
+    for (let i = 0; i < targets.length; i += props.chunkSize) {
+      if (abortRef.current) break;
+      const slice = targets.slice(i, i + props.chunkSize);
+      try {
+        const res = await fetch(props.postUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...props.bodyBase, [props.idsField]: slice, runId, spotCheck }),
+        });
+        const j = await res.json();
+        if (!res.ok) {
+          localErrors.push(j.error || `HTTP ${res.status}`);
+          break; // a rejected chunk means the run itself is refused — stop, don't hammer
+        }
+        wroteRef.current = true;
+        for (const [k, v] of Object.entries(j.tally || {})) localTally[k] = (localTally[k] || 0) + (v as number);
+        for (const r of j.results || []) {
+          if (r.status === 'error') localErrors.push(`${r.id || r.editionKey}: ${r.message}`);
+        }
+        allPaths.push(...(j.paths || []));
+      } catch (e) {
+        localErrors.push(e instanceof Error ? e.message : String(e));
+        break;
+      }
+      processed += slice.length;
+      setDone(processed);
+      setTally({ ...localTally });
+      setErrors([...localErrors]);
+    }
+    setTally({ ...localTally });
+    setErrors([...localErrors]);
+    setRunning(false);
+    setStep('done');
+
+    // One deduped cache pass at the end instead of ~2,000 during the run.
+    if (allPaths.length) {
+      setFinalizing(true);
+      try {
+        const res = await fetch(props.postUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'finalize', paths: [...new Set(allPaths)] }),
+        });
+        setFinalized(await res.json());
+      } catch {
+        setFinalized(null);
+      } finally {
+        setFinalizing(false);
+      }
+    }
+  }
+
+  return (
+    <div className="border border-accent-rust/40 rounded-lg bg-white mb-6">
+      <header className="flex flex-wrap items-baseline gap-3 px-4 py-3 border-b border-stone-200 bg-stone-50/60 rounded-t-lg">
+        <h3 className="text-sm font-semibold text-stone-800">{props.title}</h3>
+        <span className="text-xs text-stone-500">{props.whatHappens}</span>
+        <button onClick={() => props.onClose(wroteRef.current)} disabled={running}
+          className="ml-auto text-xs px-2 py-1 text-stone-500 hover:text-stone-800 disabled:opacity-40">
+          Close
+        </button>
+      </header>
+
+      <ol className="flex items-center gap-2 px-4 py-2 text-[11px] uppercase tracking-wide text-stone-400 border-b border-stone-100">
+        {(['manifest', 'spot', 'run'] as const).map((s, i) => (
+          <li key={s} className={step === s ? 'text-accent-rust font-semibold' : ''}>
+            {i + 1}. {s === 'manifest' ? 'see the list' : s === 'spot' ? 'spot-check' : 'run'}
+            {i < 2 && <span className="ml-2 text-stone-300">→</span>}
+          </li>
+        ))}
+      </ol>
+
+      {loadError && <p className="px-4 py-3 text-sm text-rose-700">Could not build the list: {loadError}</p>}
+      {!data && !loadError && <p className="px-4 py-3 text-sm text-stone-500">Building the full list…</p>}
+
+      {data && step === 'manifest' && (
+        <div className="p-4">
+          <p className="text-sm text-stone-700 mb-1">{props.renderSummary(data)}</p>
+          {data.capped && (
+            <p className="text-xs text-amber-700 mb-2">
+              Only the first {data.manifest.length} of {data.total} are listed — run the batch again afterwards for the rest.
+            </p>
+          )}
+          {props.renderNotices?.(data)}
+          <p className="text-xs text-stone-500 mb-3">
+            This is every row the run would touch. Read it before continuing — nothing has been written yet.
+          </p>
+          <div className="max-h-96 overflow-y-auto border border-stone-200 rounded">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-stone-50 text-stone-500 text-left">{props.manifestHead}</thead>
+              <tbody>
+                {data.manifest.map((m) => (
+                  <tr key={props.keyOf(m)} className="border-t border-stone-100 align-top">
+                    {props.renderManifestRow(m)}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button onClick={startSpotCheck} disabled={data.manifest.length === 0}
+            className="mt-3 text-sm px-4 py-2 rounded bg-stone-800 text-white hover:bg-stone-900 disabled:opacity-40">
+            I&apos;ve read the list — spot-check {data.spotCheckSize} of them →
+          </button>
+        </div>
+      )}
+
+      {data && step === 'spot' && (
+        <div className="p-4">
+          <p className="text-sm text-stone-700 mb-1">
+            Judge each of these {sampled.length} at random. <strong>{reviewed}/{sampled.length}</strong> reviewed
+            {flagged > 0 && <span className="text-rose-700"> · {flagged} flagged</span>}.
+          </p>
+          <p className="text-xs text-stone-500 mb-3">
+            Flagged rows are left pending for manual review — they are excluded from the run, never auto-rejected.
+          </p>
+          {!spotItems && <p className="text-sm text-stone-500">Loading the sample…</p>}
+          <div className="space-y-3">
+            {(spotItems || []).map((s) => {
+              const k = props.spotKeyOf(s);
+              const v = judged[k];
+              return (
+                <div key={k} className={`border rounded-lg p-3 ${v === 'ok' ? 'border-emerald-300 bg-emerald-50/30' : v === 'flag' ? 'border-rose-300 bg-rose-50/30' : 'border-stone-200'}`}>
+                  {props.renderSpotCheck(s)}
+                  <div className="flex gap-2 mt-2">
+                    <button onClick={() => setJudged((j) => ({ ...j, [k]: 'ok' }))}
+                      className={`text-xs px-3 py-1.5 rounded border ${v === 'ok' ? 'bg-emerald-600 text-white border-emerald-600' : 'border-stone-200 text-stone-600 hover:border-emerald-400'}`}>
+                      Looks right
+                    </button>
+                    <button onClick={() => setJudged((j) => ({ ...j, [k]: 'flag' }))}
+                      className={`text-xs px-3 py-1.5 rounded border ${v === 'flag' ? 'bg-rose-600 text-white border-rose-600' : 'border-stone-200 text-stone-600 hover:border-rose-400'}`}>
+                      Flag — don&apos;t include
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button onClick={() => setStep('manifest')} className="text-sm px-3 py-2 rounded border border-stone-200 text-stone-600">← Back to the list</button>
+            {screenUnreliable ? (
+              <p className="text-sm text-rose-700">
+                {flagged} of {sampled.length} sampled rows were wrong. That is a bad screen, not bad rows — review this
+                slice one at a time instead of batching it.
+              </p>
+            ) : (
+              <button onClick={() => { if (confirm(`${props.title}\n\n${targets.length} rows. ${props.whatHappens}\n\nThis writes immediately. Continue?`)) run(); }}
+                disabled={!sampleComplete || targets.length === 0}
+                className="text-sm px-4 py-2 rounded bg-accent-rust text-white hover:opacity-90 disabled:opacity-40">
+                Run on {targets.length} rows
+              </button>
+            )}
+            {!sampleComplete && !screenUnreliable && (
+              <span className="text-xs text-stone-500">Judge all {sampled.length} before the run unlocks.</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {data && (step === 'run' || step === 'done') && (
+        <div className="p-4">
+          <div className="h-2 w-full bg-stone-100 rounded overflow-hidden mb-2">
+            <div className="h-full bg-accent-rust transition-all" style={{ width: `${targets.length ? (done / targets.length) * 100 : 0}%` }} />
+          </div>
+          <p className="text-sm text-stone-700">
+            {done} of {targets.length} processed
+            {Object.entries(tally).map(([k, v]) => <span key={k} className="text-stone-500"> · {v} {k}</span>)}
+          </p>
+          {running && (
+            <button onClick={() => { abortRef.current = true; }}
+              className="mt-3 text-sm px-4 py-2 rounded border border-rose-300 text-rose-700 hover:bg-rose-50">
+              Abort — stop after this chunk
+            </button>
+          )}
+          {step === 'done' && (
+            <div className="mt-3 text-sm text-stone-600 space-y-1">
+              <p>{abortRef.current ? 'Aborted.' : 'Finished.'} Rows already written stay written — each one is its own merge with its own provenance doc.</p>
+              {finalizing && <p className="text-stone-500">Revalidating the touched pages…</p>}
+              {finalized && <p className="text-stone-500">Revalidated {finalized.revalidated} paths{finalized.purged ? ' and purged Cloudflare' : ' (Cloudflare purge failed — see server logs)'}.</p>}
+              <p className="text-xs text-stone-500">
+                Supabase <code className="text-[11px]">books_catalog</code> is not written here: every row above bumped{' '}
+                <code className="text-[11px]">updated_at</code>, which the incremental{' '}
+                <code className="text-[11px]">sync-books-catalog.mjs</code> (:45 of every odd hour) keys on — public
+                listings catch up within two hours.
+              </p>
+              {errors.length > 0 && (
+                <details className="mt-2">
+                  <summary className="text-rose-700 cursor-pointer">{errors.length} row{errors.length === 1 ? '' : 's'} did not apply</summary>
+                  <ul className="mt-1 text-xs text-stone-600 max-h-40 overflow-y-auto space-y-0.5">
+                    {errors.map((e, i) => <li key={i} className="font-mono break-all">{e}</li>)}
+                  </ul>
+                </details>
+              )}
+              <button onClick={() => props.onClose(true)} className="mt-2 text-sm px-4 py-2 rounded bg-stone-800 text-white hover:bg-stone-900">
+                Back to the queue
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── work-merge manifest rows ──
+
+interface MergeManifestRow {
+  id: string;
+  author: string;
+  titleA: string;
+  titleB: string;
+  a: string;
+  b: string;
+  nA: number;
+  nB: number;
+  winner: string;
+  loser: string;
+  booksToMove: number;
+  willBeStale: boolean;
+  llmReason: string;
+}
+
+interface MergeManifest extends ManifestResponse<MergeManifestRow> {
+  booksAffected: number;
+  staleCount: number;
+}
+
 function WorkMergesTab({ bph }: { bph: boolean }) {
   const [status, setStatus] = useState<Status>('pending');
   const [verdict, setVerdict] = useState<string>('');
@@ -125,6 +469,7 @@ function WorkMergesTab({ bph }: { bph: boolean }) {
   const [skip, setSkip] = useState(0);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
+  const [batch, setBatch] = useState<'approve' | 'reject' | null>(null);
   const LIMIT = 25;
 
   const load = useCallback(async () => {
@@ -189,6 +534,96 @@ function WorkMergesTab({ bph }: { bph: boolean }) {
         <span className="text-xs text-stone-400 ml-auto">{total} matching{loading ? ' · loading…' : ''}</span>
       </div>
 
+      {/* Batch lane (#4271). Offered only where the LLM screen gives a single
+          answer for the whole slice: `same` → approve, `different` → reject.
+          `unsure` and unscreened rows stay one at a time on purpose. */}
+      {status === 'pending' && !batch && (verdict === 'same' || verdict === 'different') && total > 1 && (
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-stone-200 bg-stone-50/60 px-4 py-3">
+          <span className="text-sm text-stone-700">
+            {total} pending pairs the screen called <strong>{verdict}</strong>.
+          </span>
+          <button onClick={() => setBatch(verdict === 'same' ? 'approve' : 'reject')}
+            className="text-sm px-3 py-1.5 rounded bg-stone-800 text-white hover:bg-stone-900">
+            {verdict === 'same' ? `Batch-approve all ${total} →` : `Batch-reject all ${total} →`}
+          </button>
+          <span className="text-xs text-stone-500">
+            You will see the full list and spot-check {Math.min(20, total)} before anything is written.
+          </span>
+        </div>
+      )}
+
+      {batch && (
+        <BatchLane<MergeManifestRow, MergeItem>
+          title={batch === 'approve' ? `Approve every LLM-‘same’ merge` : `Reject every LLM-‘different’ pair`}
+          whatHappens={batch === 'approve'
+            ? 'Each pair merges immediately: loser books rewritten to the winner, work_id_aliases stamped for the redirect, provenance + revert payload in work_id_merges.'
+            : 'Status only — marks each pair rejected. No book is touched.'}
+          manifestUrl={`/api/admin/work-merges/batch?verdict=${verdict}${bph ? '&bph=1' : ''}`}
+          postUrl="/api/admin/work-merges/batch"
+          bodyBase={{ action: batch, verdict }}
+          idsField="ids"
+          chunkSize={batch === 'approve' ? 25 : 100}
+          keyOf={(m) => m.id}
+          manifestHead={
+            <tr>
+              <th className="px-2 py-1.5 font-medium">Author</th>
+              <th className="px-2 py-1.5 font-medium">Titles</th>
+              <th className="px-2 py-1.5 font-medium">Keeps</th>
+              <th className="px-2 py-1.5 font-medium whitespace-nowrap">Books moved</th>
+            </tr>
+          }
+          renderManifestRow={(m) => (
+            <>
+              <td className="px-2 py-1.5 text-stone-700 whitespace-nowrap">{m.author || '—'}</td>
+              <td className="px-2 py-1.5 text-stone-600">
+                <div className="line-clamp-1">{m.titleA}</div>
+                <div className="line-clamp-1 text-stone-400">{m.titleB}</div>
+              </td>
+              <td className="px-2 py-1.5 font-mono text-[10px] text-stone-500 break-all max-w-[16rem]">
+                {batch === 'approve' ? m.winner : '—'}
+              </td>
+              <td className="px-2 py-1.5 text-stone-600 whitespace-nowrap">
+                {m.willBeStale ? <span className="text-amber-700">already resolved</span> : (batch === 'approve' ? m.booksToMove : '0')}
+              </td>
+            </>
+          )}
+          renderSummary={(d) => {
+            const dd = d as MergeManifest;
+            return batch === 'approve'
+              ? <>{dd.manifest.length} pairs · <strong>{dd.booksAffected} books</strong> change their work_id · {dd.manifest.length} provenance docs written</>
+              : <>{dd.manifest.length} pairs marked rejected · <strong>no book is touched</strong></>;
+          }}
+          renderNotices={(d) => {
+            const dd = d as MergeManifest;
+            return dd.staleCount > 0 ? (
+              <p className="text-xs text-amber-700 mb-2">
+                <strong>{dd.staleCount} of {dd.manifest.length}</strong> have no books left on one side, so they will be
+                marked <code className="text-[11px]">stale</code> rather than merged — approving them writes nothing to
+                any book. Measured 2026-08-28, none of those retired ids appear in{' '}
+                <code className="text-[11px]">work_id_aliases</code>, so they were not merged away: the local
+                <code className="text-[11px]"> local:n:author:title</code> mint moved under them when a title or author
+                was repaired. The queue is holding references to ids nothing carries any more.
+              </p>
+            ) : null;
+          }}
+          spotCheckUrl={(ids) => `/api/admin/work-merges?status=pending&limit=50&ids=${encodeURIComponent(ids.join(','))}`}
+          spotKeyOf={(s) => s.id}
+          renderSpotCheck={(s) => (
+            <>
+              <div className="flex flex-wrap items-baseline gap-x-3 mb-2">
+                <span className="text-sm font-semibold text-stone-800">{s.author || 'unknown author'}</span>
+                {s.llm?.reason && <span className="text-xs text-stone-500 italic">“{s.llm.reason}”</span>}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <WorkSideCard side={s.a} isSuggested={s.suggestedWinner === s.a.workId} />
+                <WorkSideCard side={s.b} isSuggested={s.suggestedWinner === s.b.workId} />
+              </div>
+            </>
+          )}
+          onClose={(didWrite) => { setBatch(null); if (didWrite) { setSkip(0); load(); } }}
+        />
+      )}
+
       {!loading && items.length === 0 && <p className="text-sm text-stone-500">Nothing here.</p>}
 
       <div className="space-y-4">
@@ -245,6 +680,53 @@ function WorkMergesTab({ bph }: { bph: boolean }) {
   );
 }
 
+/** One cluster member, read-only. The action button (if any) is passed as a child. */
+function KeeperMemberCard({ m, suggested, children }: { m: KeeperMember; suggested: boolean; children?: React.ReactNode }) {
+  return (
+    <div className={`rounded-lg border p-3 ${suggested ? 'border-emerald-300 bg-emerald-50/40' : 'border-stone-200'} ${!m.visible ? 'opacity-60' : ''}`}>
+      <div className="flex gap-2 mb-2">
+        <Cover thumb={m.thumb} title={m.title} />
+        <div className="min-w-0">
+          <a href={`/book/${m.id}`} target="_blank" rel="noopener noreferrer" className="text-sm text-stone-800 hover:underline leading-snug line-clamp-2">{m.title || m.id}</a>
+          <div className="text-[11px] text-stone-500 mt-0.5">
+            {m.provider}{m.language ? ` · ${m.language}` : ''}{m.year ? ` · ${m.year}` : ''}
+            {!m.visible && <span className="text-rose-600"> · hidden</span>}
+            {m.ft && <span className="text-purple-600"> · FT</span>}
+            {m.bph && <span className="text-amber-700"> · BPH</span>}
+          </div>
+        </div>
+      </div>
+      <div className="text-[11px] text-stone-500 mb-2">
+        {m.pages} pp · OCR {m.pages ? Math.round((m.ocr / m.pages) * 100) : 0}% · transl. {m.pages ? Math.round((m.translated / m.pages) * 100) : 0}%
+        {m.quality !== null && <> · quality {m.quality}</>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── keeper manifest rows ──
+
+interface KeeperManifestRow {
+  editionKey: string;
+  keeper: string;
+  keeperTitle: string;
+  keeperAuthor: string;
+  keeperFound: boolean;
+  keeperVisible: boolean;
+  nMembers: number;
+  willHide: number;
+  liveFtInCluster: boolean;
+  pageRatio: number | null;
+  others: { id: string; title: string; visible: boolean }[];
+}
+
+interface KeeperManifest extends ManifestResponse<KeeperManifestRow> {
+  booksHidden: number;
+  ftExcluded: number;
+  blocked: KeeperManifestRow[];
+}
+
 function EditionKeepersTab({ bph }: { bph: boolean }) {
   const [status, setStatus] = useState<Status>('pending');
   const [bucket, setBucket] = useState<string>('human');
@@ -255,6 +737,7 @@ function EditionKeepersTab({ bph }: { bph: boolean }) {
   const [skip, setSkip] = useState(0);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
+  const [batchOpen, setBatchOpen] = useState(false);
   const LIMIT = 15;
 
   const load = useCallback(async () => {
@@ -319,6 +802,101 @@ function EditionKeepersTab({ bph }: { bph: boolean }) {
         <span className="text-xs text-stone-400 ml-auto">{total} matching{loading ? ' · loading…' : ''}</span>
       </div>
 
+      {/* Batch lane (#4271) — MECHANICAL_KEEP only, and only clusters with no
+          FT badge at stake. Keeping HIDES books, so this lane is deliberately
+          narrower than the work-merge one. */}
+      {status === 'pending' && !batchOpen && (buckets.MECHANICAL_KEEP || 0) > 1 && (
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-stone-200 bg-stone-50/60 px-4 py-3">
+          <span className="text-sm text-stone-700">
+            {buckets.MECHANICAL_KEEP} pending <strong>MECHANICAL_KEEP</strong> clusters — one member dominates on every axis.
+          </span>
+          <button onClick={() => setBatchOpen(true)} className="text-sm px-3 py-1.5 rounded bg-stone-800 text-white hover:bg-stone-900">
+            Batch-keep the mechanical ones →
+          </button>
+          <span className="text-xs text-stone-500">FT-flagged clusters are excluded and stay per-cluster manual.</span>
+        </div>
+      )}
+
+      {batchOpen && (
+        <BatchLane<KeeperManifestRow, KeeperItem>
+          title="Keep the suggested copy in every mechanical cluster"
+          whatHappens="Each cluster hides its non-keeper members (hidden_reason 'duplicate', duplicate_of → keeper). This removes books from public listings."
+          manifestUrl="/api/admin/edition-keepers/batch"
+          postUrl="/api/admin/edition-keepers/batch"
+          bodyBase={{ action: 'keep' }}
+          idsField="editionKeys"
+          chunkSize={25}
+          keyOf={(m) => m.editionKey}
+          manifestHead={
+            <tr>
+              <th className="px-2 py-1.5 font-medium">Keeper</th>
+              <th className="px-2 py-1.5 font-medium">Hides</th>
+              <th className="px-2 py-1.5 font-medium whitespace-nowrap">Page similarity</th>
+            </tr>
+          }
+          renderManifestRow={(m) => (
+            <>
+              <td className="px-2 py-1.5 text-stone-700">
+                <div className="line-clamp-1">{m.keeperTitle || m.keeper}</div>
+                <div className="text-[10px] text-stone-400">{m.keeperAuthor}</div>
+              </td>
+              <td className="px-2 py-1.5 text-stone-600">
+                {m.willHide} of {m.nMembers - 1}
+                <div className="text-[10px] text-stone-400 line-clamp-1">{m.others.map((o) => o.title || o.id).join(' · ')}</div>
+              </td>
+              <td className="px-2 py-1.5 text-stone-600 whitespace-nowrap">{m.pageRatio !== null ? `${Math.round(m.pageRatio * 100)}%` : '—'}</td>
+            </>
+          )}
+          renderSummary={(d) => {
+            const dd = d as KeeperManifest;
+            return <>{dd.manifest.length} clusters · <strong>{dd.booksHidden} books hidden</strong> from public listings</>;
+          }}
+          renderNotices={(d) => {
+            const dd = d as KeeperManifest;
+            return (
+              <>
+                {dd.manifest.length > 0 && dd.booksHidden === 0 && (
+                  <p className="text-xs text-amber-700 mb-2">
+                    <strong>No book will actually be hidden.</strong> Every non-keeper in these clusters is already
+                    hidden with <code className="text-[11px]">hidden_reason: &lsquo;same_edition_duplicate&rsquo;</code> —
+                    the script lane (<code className="text-[11px]">apply-keeper-choice-triage.mjs</code>) applied them
+                    and never marked the queue rows. Running this reconciles the queue and records who signed off; it
+                    changes nothing a reader sees.
+                  </p>
+                )}
+                {dd.ftExcluded > 0 && (
+                  <p className="text-xs text-purple-800 mb-2">
+                    {dd.ftExcluded} MECHANICAL_KEEP clusters carry a First Translation badge and are excluded — hiding a
+                    badged copy changes what FT counting sees. Review those one at a time.
+                  </p>
+                )}
+                {dd.blocked.length > 0 && (
+                  <p className="text-xs text-amber-700 mb-2">
+                    {dd.blocked.length} further clusters were dropped from the batch: their suggested keeper no longer
+                    exists, or a member has gained an FT badge since the 2026-08-09 triage snapshot.
+                  </p>
+                )}
+              </>
+            );
+          }}
+          spotCheckUrl={(ids) => `/api/admin/edition-keepers?status=pending&bucket=all&limit=50&ids=${encodeURIComponent(ids.join(','))}`}
+          spotKeyOf={(s) => s.editionKey}
+          renderSpotCheck={(s) => (
+            <>
+              <div className="text-xs font-mono text-stone-400 mb-2 line-clamp-1" title={s.editionKey}>{s.editionKey}</div>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {s.members.map((m) => (
+                  <KeeperMemberCard key={m.id} m={m} suggested={m.id === s.suggestedKeeper}>
+                    <div className="text-[11px] text-stone-500">{m.id === s.suggestedKeeper ? 'would be KEPT' : 'would be hidden'}</div>
+                  </KeeperMemberCard>
+                ))}
+              </div>
+            </>
+          )}
+          onClose={(didWrite) => { setBatchOpen(false); if (didWrite) { setSkip(0); load(); } }}
+        />
+      )}
+
       {!loading && items.length === 0 && (
         <p className="text-sm text-stone-500">Nothing here. If the queue is empty entirely, run <code className="text-xs">scripts/maintenance/ingest-keeper-choice-queue.mjs</code> to load a triage snapshot.</p>
       )}
@@ -335,30 +913,14 @@ function EditionKeepersTab({ bph }: { bph: boolean }) {
 
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 mb-3">
               {item.members.map((m) => (
-                <div key={m.id} className={`rounded-lg border p-3 ${m.id === item.suggestedKeeper ? 'border-emerald-300 bg-emerald-50/40' : 'border-stone-200'} ${!m.visible ? 'opacity-60' : ''}`}>
-                  <div className="flex gap-2 mb-2">
-                    <Cover thumb={m.thumb} title={m.title} />
-                    <div className="min-w-0">
-                      <a href={`/book/${m.id}`} target="_blank" rel="noopener noreferrer" className="text-sm text-stone-800 hover:underline leading-snug line-clamp-2">{m.title || m.id}</a>
-                      <div className="text-[11px] text-stone-500 mt-0.5">
-                        {m.provider}{m.language ? ` · ${m.language}` : ''}{m.year ? ` · ${m.year}` : ''}
-                        {!m.visible && <span className="text-rose-600"> · hidden</span>}
-                        {m.ft && <span className="text-purple-600"> · FT</span>}
-                        {m.bph && <span className="text-amber-700"> · BPH</span>}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="text-[11px] text-stone-500 mb-2">
-                    {m.pages} pp · OCR {m.pages ? Math.round((m.ocr / m.pages) * 100) : 0}% · transl. {m.pages ? Math.round((m.translated / m.pages) * 100) : 0}%
-                    {m.quality !== null && <> · quality {m.quality}</>}
-                  </div>
+                <KeeperMemberCard key={m.id} m={m} suggested={m.id === item.suggestedKeeper}>
                   {item.status === 'pending' && (
                     <button disabled={busy === item.editionKey} onClick={() => act(item, 'keep', m.id)}
                       className={`w-full text-xs px-2 py-1.5 rounded text-white transition-colors disabled:opacity-50 ${m.id === item.suggestedKeeper ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-emerald-500/80 hover:bg-emerald-600'}`}>
                       Keep this one · hide {item.members.length - 1} other{item.members.length === 2 ? '' : 's'}
                     </button>
                   )}
-                </div>
+                </KeeperMemberCard>
               ))}
             </div>
 
@@ -402,8 +964,11 @@ export default function IdentityReviewPage() {
         revert path in <code className="text-xs">work_id_merges</code>). <strong>Edition keepers</strong>:
         same printing scanned twice — which copy do readers see? Keeping hides the others as
         duplicates. Screen the merge queue first with{' '}
-        <code className="text-xs">scripts/analysis/stamp-work-merge-queue-llm.mjs</code> and review
-        the <em>unsure</em> lane, not everything.
+        <code className="text-xs">scripts/analysis/stamp-work-merge-queue-llm.mjs</code>, then use
+        the <strong>batch lanes</strong> to clear the screened slices in one sitting and review the{' '}
+        <em>unsure</em> and unscreened lanes by hand. A batch is N single approvals, not a queued
+        job: it shows the whole list, makes you spot-check twenty at random, and then performs the
+        merges inline with the same provenance and revert payload one click writes.
       </p>
 
       <div className="flex items-center gap-2 mb-6 border-b border-stone-200">

--- a/src/lib/identity-review-apply.ts
+++ b/src/lib/identity-review-apply.ts
@@ -1,0 +1,300 @@
+import { revalidatePath } from 'next/cache';
+import type { Db, Document } from 'mongodb';
+import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
+
+/**
+ * The write half of the identity-review surface (#3846, batched in #4271).
+ *
+ * These two functions ARE the write path. Both the one-row endpoints
+ * (`/api/admin/work-merges`, `/api/admin/edition-keepers`) and the batch
+ * endpoints call them, so a batch approval is literally N single approvals —
+ * same aliases, same provenance doc, same revert payload, same `updated_at`
+ * bump the Supabase catalog sync keys on. Nothing about "batch" may fork the
+ * semantics; if a rule changes it changes here, for both lanes at once.
+ *
+ * Actuation stays inline (the #3726 Tier 3 shape): approving performs the
+ * merge in the request, attributed to the signed-in human. No queue row is
+ * left for a later job to consume — see the "writing to a store an automated
+ * job reads is ACTUATION" rule in CLAUDE.md.
+ */
+
+/** Default winner for a work pair: a Wikidata QID beats a local mint; else the id holding more books. */
+export function pickWorkWinner(
+  aWorkId: string,
+  bWorkId: string,
+  nA: number,
+  nB: number,
+): string {
+  const aQ = /^Q\d/.test(aWorkId);
+  const bQ = /^Q\d/.test(bWorkId);
+  if (aQ !== bQ) return aQ ? aWorkId : bWorkId;
+  return nB > nA ? bWorkId : aWorkId;
+}
+
+/**
+ * Marker stamped onto the per-row provenance so a batch run is reconstructable
+ * after the fact ("which merges came from the 2026-08-28 approve-all-same
+ * run, and what did the human spot-check?"). Deliberately a FIELD on the
+ * existing `work_id_merges` / queue docs rather than a new collection — a new
+ * shared collection is shared mutable state that another session can clobber.
+ */
+export interface BatchMarker {
+  /** client-generated run id, stable across the chunks of one run */
+  run_id: string;
+  /** e.g. 'approve-all-same' | 'reject-all-different' | 'keeper-mechanical' */
+  kind: string;
+  /** how many pairs the human eyeballed, and how many they flagged */
+  spot_check?: { reviewed: number; flagged: number; of: number };
+}
+
+export interface WorkMergeResult {
+  id: string;
+  status: 'approved' | 'stale' | 'rejected' | 'error';
+  winner?: string;
+  loser?: string;
+  booksMoved?: number;
+  message?: string;
+  /** ISR paths this row's write invalidated. Callers dedupe across a batch. */
+  paths?: string[];
+}
+
+/**
+ * Apply one `work_merge_queue` approval: rewrite the loser's books onto the
+ * winner, stamp `work_id_aliases` across the whole cluster so `/work/[id]`
+ * 307s the retired id, and write the `work_id_merges` provenance doc that
+ * carries the per-book revert payload.
+ *
+ * The row must already be verified `status: 'pending'` by the caller; the
+ * status flip below is guarded on that so two concurrent reviewers cannot
+ * both apply it.
+ */
+export async function applyWorkMerge(
+  db: Db,
+  row: Document,
+  opts: { winner?: string; note?: string; reviewer: string; now?: Date; batch?: BatchMarker },
+): Promise<WorkMergeResult> {
+  const now = opts.now ?? new Date();
+  const id = row._id as string;
+  const a = row.a as string;
+  const b = row.b as string;
+  const queue = db.collection('work_merge_queue');
+  const booksCol = db.collection('books');
+
+  const cluster = await booksCol
+    .find({ work_id: { $in: [a, b] } }, { projection: { _id: 0, id: 1, work_id: 1 } })
+    .toArray();
+  const nA = cluster.filter((x) => x.work_id === a).length;
+  const nB = cluster.filter((x) => x.work_id === b).length;
+  if (nA === 0 || nB === 0) {
+    // One side has no books left — an earlier merge or repair already moved
+    // them. Nothing to do; mark it so it leaves the pending lane.
+    await queue.updateOne(
+      { _id: id as never, status: 'pending' },
+      { $set: { status: 'stale', reviewed_by: opts.reviewer, reviewed_at: now, updated_at: now } },
+    );
+    return { id, status: 'stale', message: `no books left on ${nA === 0 ? a : b}` };
+  }
+
+  const winner = opts.winner && (opts.winner === a || opts.winner === b)
+    ? opts.winner
+    : pickWorkWinner(a, b, nA, nB);
+  const loser = winner === a ? b : a;
+
+  // Revert path: the prior work_id of every rewritten book, kept in the
+  // provenance doc (the maintenance script keeps the same payload in a backup
+  // file; a request handler keeps it in the doc).
+  const affected = cluster
+    .filter((x) => x.work_id === loser)
+    .map((x) => ({ book_id: x.id as string, old_work_id: loser }));
+
+  const moved = await booksCol.updateMany(
+    { work_id: loser },
+    { $set: { work_id: winner, updated_at: now }, $addToSet: { work_id_aliases: loser } },
+  );
+  // Winner-side books carry the alias too: the redirect describes the WORK,
+  // so every edition under it must resolve the retired id.
+  await booksCol.updateMany(
+    { work_id: winner, work_id_aliases: { $ne: loser } },
+    { $set: { updated_at: now }, $addToSet: { work_id_aliases: loser } },
+  );
+
+  await db.collection('work_id_merges').insertOne({
+    winner,
+    losers: [loser],
+    sources: ['queue:human'],
+    books_rewritten: moved.modifiedCount,
+    affected,
+    resolver: 'human',
+    reviewed_by: opts.reviewer,
+    issue: 3846,
+    applied_at: now,
+    ...(opts.batch ? { batch: opts.batch } : {}),
+  });
+
+  await queue.updateOne(
+    { _id: id as never },
+    {
+      $set: {
+        status: 'approved',
+        winner,
+        note: opts.note || null,
+        ...(opts.batch ? { batch: opts.batch } : {}),
+        reviewed_by: opts.reviewer,
+        reviewed_at: now,
+        updated_at: now,
+      },
+    },
+  );
+
+  return {
+    id,
+    status: 'approved',
+    winner,
+    loser,
+    booksMoved: moved.modifiedCount,
+    paths: [`/work/${winner}`, `/work/${loser}`],
+  };
+}
+
+/** Reject one pair: a status write only, no book is touched. */
+export async function rejectWorkMerge(
+  db: Db,
+  id: string,
+  opts: { note?: string; reviewer: string; now?: Date; batch?: BatchMarker },
+): Promise<WorkMergeResult> {
+  const now = opts.now ?? new Date();
+  const res = await db.collection('work_merge_queue').updateOne(
+    { _id: id as never, status: 'pending' },
+    {
+      $set: {
+        status: 'rejected',
+        note: opts.note || null,
+        ...(opts.batch ? { batch: opts.batch } : {}),
+        reviewed_by: opts.reviewer,
+        reviewed_at: now,
+        updated_at: now,
+      },
+    },
+  );
+  if (res.matchedCount === 0) return { id, status: 'error', message: 'row is not pending' };
+  return { id, status: 'rejected' };
+}
+
+export interface KeeperResult {
+  editionKey: string;
+  status: 'kept' | 'dismissed' | 'error';
+  keeper?: string;
+  hidden?: number;
+  message?: string;
+  paths?: string[];
+}
+
+/**
+ * Apply one `edition_keeper_queue` keep: hide every other member of the
+ * cluster with the same semantics as /api/admin/duplicates (hidden_reason
+ * 'duplicate', duplicate_of → keeper) plus the `updated_at` bump the Supabase
+ * catalog sync keys on — a visibility flip without it is invisible to
+ * Supabase and the hidden book keeps showing up in public listings.
+ */
+export async function applyKeeperChoice(
+  db: Db,
+  row: Document,
+  opts: { keeperId: string; note?: string; reviewer: string; now?: Date; batch?: BatchMarker },
+): Promise<KeeperResult> {
+  const now = opts.now ?? new Date();
+  const editionKey = row._id as string;
+  const memberIds = ((row.members as { id: string }[]) || []).map((m) => m.id);
+  if (!memberIds.includes(opts.keeperId)) {
+    return { editionKey, status: 'error', message: 'keeperId must be a member of the cluster' };
+  }
+  const others = memberIds.filter((m) => m !== opts.keeperId);
+
+  const hidden = await db.collection('books').updateMany(
+    { id: { $in: others }, visible: true },
+    {
+      $set: {
+        hidden: true,
+        visible: false,
+        hidden_reason: 'duplicate',
+        hidden_at: now,
+        duplicate_of: opts.keeperId,
+        updated_at: now,
+      },
+    },
+  );
+
+  await db.collection('edition_keeper_queue').updateOne(
+    { _id: editionKey as never },
+    {
+      $set: {
+        status: 'kept',
+        keeper: opts.keeperId,
+        note: opts.note || null,
+        ...(opts.batch ? { batch: opts.batch } : {}),
+        reviewed_by: opts.reviewer,
+        reviewed_at: now,
+        updated_at: now,
+      },
+    },
+  );
+
+  return {
+    editionKey,
+    status: 'kept',
+    keeper: opts.keeperId,
+    hidden: hidden.modifiedCount,
+    paths: [`/book/${opts.keeperId}`, ...others.map((o) => `/book/${o}`)],
+  };
+}
+
+/** Dismiss one cluster: "not the same edition", no book is touched. */
+export async function dismissKeeperCluster(
+  db: Db,
+  editionKey: string,
+  opts: { note?: string; reviewer: string; now?: Date },
+): Promise<KeeperResult> {
+  const now = opts.now ?? new Date();
+  const res = await db.collection('edition_keeper_queue').updateOne(
+    { _id: editionKey as never, status: 'pending' },
+    {
+      $set: {
+        status: 'dismissed',
+        note: opts.note || null,
+        reviewed_by: opts.reviewer,
+        reviewed_at: now,
+        updated_at: now,
+      },
+    },
+  );
+  if (res.matchedCount === 0) return { editionKey, status: 'error', message: 'cluster is not pending' };
+  return { editionKey, status: 'dismissed' };
+}
+
+/** Hard cap on paths per finalize call — a 980-row run can name ~2,000. */
+const MAX_FINALIZE_PATHS = 2000;
+
+/**
+ * Cache half of a batch run: dedupe the paths every applied row named, mark
+ * them stale for ISR, and purge Cloudflare for the same set.
+ *
+ * NOT a write to any store — the data writes already happened inline, row by
+ * row. The Supabase `books_catalog` mirror is NOT synced here: every write
+ * above bumps `updated_at`, which is exactly what the incremental
+ * `scripts/workers/sync-books-catalog.mjs` (Hetzner, :45 of every odd hour)
+ * keys on, so the mirror catches up within two hours without this route
+ * shelling out. Callers should say so to the human rather than implying the
+ * public listings are already current.
+ */
+export async function finalizeIdentityBatch(paths: string[]): Promise<{ revalidated: number; purged: boolean }> {
+  const uniq = [...new Set(paths.filter((p) => typeof p === 'string' && p.startsWith('/')))].slice(0, MAX_FINALIZE_PATHS);
+  for (const p of uniq) revalidatePath(p);
+  let purged = false;
+  try {
+    await purgeCloudflareUrls(uniq);
+    purged = true;
+  } catch (err) {
+    // A failed purge leaves stale edge HTML, not bad data — report it, don't throw.
+    console.error('[identity-batch] Cloudflare purge failed:', err);
+  }
+  return { revalidated: uniq.length, purged };
+}


### PR DESCRIPTION
Closes #4271.

`work_merge_queue` sat at **1,940 pending with exactly 1 row adjudicated** since 2026-08-08; `edition_keeper_queue` at **311 with none**. The screening was finished weeks ago — the detection and LLM lanes had already sorted 980 pairs into `same` and 745 into `different`. The only bottleneck was that `/curation/identity-review` adjudicates one row per click.

This adds batch lanes that clear a screened slice in one sitting **without changing what a single approval does**.

## Shape — three steps, enforced in order

1. **See the list.** A manifest endpoint (`GET .../batch`) renders *every* row the run would touch — the winner it would pick, and the **live** count of books it would move. Nothing is written to build it. This is the list-first-approve rule; it is also the first time the full set has ever been enumerable.
2. **Spot-check.** 20 rows sampled deterministically (so a reload shows the same 20), rendered through the **same read path a single-row reviewer sees** — the identical card, not a summary. Each is judged *looks right* / *flag*. Flagged rows are **excluded from the run and left pending** — never auto-rejected. Flagging ≥20% of the sample blocks the run outright, on the reasoning that a bad sample means the screen is wrong, not that 20 rows need skipping.
3. **Run.** A client-driven loop of small chunks (25 approve / 100 reject) with a progress bar and a working Abort.

## Actuation stays inline

`src/lib/identity-review-apply.ts` extracts the write path the single-row endpoints already had; both the single and batch endpoints now call it. One row of a 980-row batch is byte-for-byte one click: same `work_id_aliases` stamping, same `work_id_merges` provenance doc carrying the per-book revert payload, same `hidden_reason` / `duplicate_of` / `updated_at` on a keeper hide. **No row is enqueued for a background job to consume** (the ingest-is-actuation rule).

A `batch` marker (run id, kind, spot-check tally) is stamped as a **field on the existing provenance docs**, not in a new collection — a new shared collection is shared mutable state another session can clobber.

## Guards that don't depend on the UI

- A chunk's ids are re-read under the run's **declared verdict**, so an approve-all-`same` run physically cannot touch a `different` row even if the client sends one.
- The keeper lane's filter is fixed at `MECHANICAL_KEEP` + `ft_flag: false`, and **re-checks the live `is_first_translation` badge at write time** — the queue's flag is a 2026-08-09 snapshot, and 9 clusters have since grown a badge it doesn't know about.
- `approve` / `keep` refuse a chunk whose declared spot-check is incomplete or mostly flagged.

## Caches

One deduped `revalidatePath` + Cloudflare purge at the end of a run instead of ~2,000 during it. Supabase `books_catalog` is deliberately **not** written here: every row bumps `updated_at`, which the incremental `sync-books-catalog.mjs` (:45 of every odd hour on Hetzner) keys on. The UI says so rather than implying public listings are already current.

`scripts/audit/identity-stack-gates.mjs` now counts both queues, segmented by LLM verdict and by bucket, so re-accumulation shows up in the table that cannot drift.

## Two findings that contradict the issue's numbers

Measured 2026-08-28, read-only, and surfaced in the manifests rather than buried:

**1. 717 of the 980 `same` pairs are unmergeable.** 763 of the 1,588 work ids those rows reference are carried by **no book any more** — and **none of them appear in `work_id_aliases`**, so they were not merged away. The `local:n:<author>:<normalized-title>` mint moved under them when a title or author was repaired. Approving those writes `stale`, not a merge. The real merge work in that slice is **~263 pairs moving ~277 books**, not 980. The manifest says this in plain language before the human commits.

**2. The keeper batch is 64 clusters, not 89 — and it hides zero books.** 25 of the 89 `MECHANICAL_KEEP` clusters carry `ft_flag: true`, so the batchable set is 64. All 64 have **zero non-keeper still visible**: their 69 non-keepers already carry `hidden_reason: 'same_edition_duplicate'`, which is exactly what `apply-keeper-choice-triage.mjs` writes. The script lane applied these and never marked the queue rows, so "311 pending, zero worked" overstates the outstanding work. Running the lane reconciles the queue and records the sign-off; it changes nothing a reader sees, and the UI says so.

## Verification

- `npx tsc --noEmit` clean; `eslint` clean on every touched file.
- Both manifest queries dry-run against production read-only: work merges 505 ms for 980 rows / 1,588 work ids; keepers 117 ms. Comfortably inside the 60 s route budget.
- `identity-stack-gates.mjs` run against production — new rows read `1940 pending (149 unsure, 980 same, 66 unscreened, 745 different)` and `64 batchable (MECHANICAL_KEEP, no FT badge at stake)`.

## Out of scope — deliberately left undone

- **No batch was run against production.** The queues are exactly as they were; a human clicks the button. This PR is the tooling only.
- **The 66 unstamped merge rows were not stamped.** Running `scripts/analysis/stamp-work-merge-queue-llm.mjs` over them is a paid operation (flash-lite, on the order of a few cents for 66 rows) and the standing rule is to estimate and ask first. They stay in the manual lane until someone runs it.
- **No batch `dismiss` for keepers, and no batch lane for `unsure` / unscreened / `TOSSUP` / `SUSPECT_NOT_SAME` / `SCORED_KEEP`.** Those need a per-row judgement; a bulk button there would quietly empty the queue without a decision being made.
- **The stale-work-id problem itself is not fixed here.** Finding 1 says 717 queue rows point at re-minted ids — that is a defect in how `merge-work-clusters.mjs` freezes work ids into the queue, and it will recur when #4246 Phase 1 enqueues more pairs. Worth its own issue; this PR only makes the condition visible and drains it correctly.
- **No change to the single-row endpoints' behaviour.** The refactor into `identity-review-apply.ts` is intended to be semantics-preserving; the response bodies gained fields (`id`, `paths`) but lost none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcC7qVRrjjrt34nMu2vF92
