### PR TITLE
feat(search): collapse copies and group results by work (#4300)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -14,10 +14,36 @@ import { expandLanguages } from '@/lib/language-utils';
 import { logSearchQuery } from '@/lib/search-log';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { logSearchEvent } from '@/lib/search-event-log';
+import { collapseByWork, type WorkGroupable } from '@/lib/search/work-grouping';
+import { fetchWorkFanouts } from '@/lib/search/work-fanout';
 
 export const preferredRegion = 'fra1';
 
 const MAX_PAGE_RESULTS = 25;
+
+/**
+ * Carry a book's identity fields onto a result as transients, so the
+ * work-grain collapse below can read them. Stripped before the response —
+ * `_work_id` was already doing this; aliases and `duplicate_of` join it so
+ * every lane in the app collapses on the same rule (src/lib/search/work-grouping.ts).
+ */
+function attachIdentity(result: SearchResult, book: Record<string, unknown>): void {
+  const r = result as unknown as Record<string, unknown>;
+  if (book.work_id) r._work_id = book.work_id;
+  if (Array.isArray(book.work_id_aliases)) r._work_id_aliases = book.work_id_aliases;
+  if (book.duplicate_of) r._duplicate_of = book.duplicate_of;
+}
+
+/** Read the transients back as the shape `collapseByWork` expects. */
+function identityOf(result: SearchResult): WorkGroupable {
+  const r = result as unknown as Record<string, unknown>;
+  return {
+    book_id: result.book_id,
+    work_id: r._work_id as string | undefined,
+    work_id_aliases: r._work_id_aliases as string[] | undefined,
+    duplicate_of: r._duplicate_of as string | undefined,
+  };
+}
 
 /** Strip XML/HTML tags and clean up OCR artifacts for display */
 function cleanText(text: string): string {
@@ -224,8 +250,8 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         thumbnail_blob: (typedBook as any).thumbnail_blob,
         quality_score: (typedBook as any).quality_score,
       };
-      // Transient field for work-level dedup (stripped before response)
-      if ((typedBook as any).work_id) (result as any)._work_id = (typedBook as any).work_id;
+      // Transient fields for work-level dedup (stripped before response)
+      attachIdentity(result, typedBook as unknown as Record<string, unknown>);
       if ((typedBook as any).text_role) (result as any)._text_role = (typedBook as any).text_role;
       return result;
     }
@@ -260,7 +286,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         try {
           const matchingIds = await searchBookIds(query, { limit: limit * 2 });
           const bookFilters = buildBookFilters();
-          const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1, text_role: 1 };
+          const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1, text_role: 1 };
 
           let books: any[] = [];
           if (matchingIds.length > 0) {
@@ -533,7 +559,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         const pageBooks = await db.collection('books')
           .find(
             { id: { $in: pageBookIds }, ...(tenantId ? { tenantId } : {}) },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, hidden: 1, quality_score: 1, work_id: 1, text_role: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, hidden: 1, quality_score: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1, text_role: 1 } }
           )
           .toArray();
         for (const b of pageBooks) {
@@ -600,7 +626,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           thumbnail: (book as any).thumbnail,
           thumbnail_blob: (book as any).thumbnail_blob,
         };
-        if ((book as any).work_id) (pageResult as any)._work_id = (book as any).work_id;
+        attachIdentity(pageResult, book as unknown as Record<string, unknown>);
         if ((book as any).text_role) (pageResult as any)._text_role = (book as any).text_role;
         results.push(pageResult);
       }
@@ -649,7 +675,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
                 : excludeLanguages.length > 0 ? { language: { $nin: excludeLanguages } }
                 : language ? { language } : {}),
             },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, summary: 1, reading_summary: 1, text_role: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1, summary: 1, reading_summary: 1, text_role: 1 } }
           )
           .maxTimeMS(3000)
           .toArray();
@@ -687,7 +713,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
             thumbnail_blob: book.thumbnail_blob as string | undefined,
             quality_score: (book as any).quality_score,
           };
-          if ((book as any).work_id) (semResult as any)._work_id = (book as any).work_id;
+          attachIdentity(semResult, book as unknown as Record<string, unknown>);
           if ((book as any).text_role) (semResult as any)._text_role = (book as any).text_role;
           results.push(semResult);
         }
@@ -730,7 +756,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
                 : excludeLanguages.length > 0 ? { language: { $nin: excludeLanguages } }
                 : language ? { language } : {}),
             },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, text_role: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1, text_role: 1 } }
           )
           .maxTimeMS(3000)
           .toArray();
@@ -768,7 +794,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           thumbnail: book.thumbnail,
           thumbnail_blob: book.thumbnail_blob,
         };
-        if (book.work_id) (spResult as any)._work_id = book.work_id;
+        attachIdentity(spResult, book as Record<string, unknown>);
         if ((book as any).text_role) (spResult as any)._text_role = (book as any).text_role;
         results.push(spResult);
       }
@@ -906,23 +932,46 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       }
     }
 
-    // Dedup by work_id: keep the first (best-ranked) edition of each work.
-    // Results are already sorted by relevance, so the first hit for a work_id wins.
-    // Books without work_id are always kept (they can't be deduped).
-    const seenWorkIds = new Set<string>();
-    const dedupedResults: SearchResult[] = [];
-    for (const r of results) {
-      const workId = (r as any)._work_id as string | undefined;
-      if (workId) {
-        if (seenWorkIds.has(workId)) continue;
-        seenWorkIds.add(workId);
+    // Collapse to one row per work (#4300). Results are already sorted by
+    // relevance, so the first hit for a work wins and represents it; books with
+    // no blessed work identity are always kept, because "no work_id" means
+    // "not shown to be an edition of anything", not "dedupe me by title".
+    // Shared with the unified and semantic lanes — one definition, so a new
+    // lane can't reintroduce the copies (src/lib/search/work-grouping.ts).
+    const collapsed = collapseByWork(results, { getIdentity: identityOf });
+    const dedupedResults: SearchResult[] = collapsed.results;
+
+    // "N editions of this work →" for rows that replaced siblings. The number
+    // is what /work/[id] renders (fetchWorkFanouts calls that page's own
+    // filter), not how many rows we hid — a count shown to a reader has to
+    // describe the set its link reaches. Suppressed under a tenant: an
+    // edition census across the global library is not a partner reading
+    // room's claim to make (tenant-lockdown.md).
+    // `pages_only` is the MCP passage contract — a caller asking for passages
+    // gets passages, not an edition census, and the extra count queries would
+    // be latency it never asked for.
+    const fanouts = collapsed.groups.length > 0 && !pagesOnly
+      ? await fetchWorkFanouts(
+        db,
+        new Map(collapsed.groups.map(g => [g.key, g.collapsed.length])),
+        { tenantScoped: !!tenantId || !!tenantSlug },
+      )
+      : new Map();
+    const fanoutByResultId = new Map<string, unknown>();
+    if (fanouts.size > 0) {
+      for (const [key, group] of collapsed.byKey) {
+        const fanout = fanouts.get(key);
+        if (fanout) fanoutByResultId.set(group.primary.id, fanout);
       }
-      dedupedResults.push(r);
     }
 
     // Apply offset and strip transient fields
     const paginatedResults = dedupedResults.slice(offset, offset + limit)
-      .map(r => { const { _work_id, _text_role, ...clean } = r as any; return clean as SearchResult; });
+      .map(r => {
+        const { _work_id, _work_id_aliases, _duplicate_of, _text_role, ...clean } = r as any;
+        const fanout = fanoutByResultId.get(r.id);
+        return (fanout ? { ...clean, work_group: fanout } : clean) as SearchResult;
+      });
 
     // For exact year searches, find nearby books (within 5 years)
     let nearby: SearchResult[] = [];

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -249,7 +249,14 @@ export async function GET(request: NextRequest) {
     const collapsed = collapseByWork(results, {
       getIdentity: r => identityByBookId.get((r as { book_id: string }).book_id) ?? {},
     });
-    let grouped = collapsed.results;
+    // Carry the work id out to the client: /search merges this lane with the
+    // separately-fetched keyword lane and can otherwise only compare book ids,
+    // which lets one more edition of an already-represented work back onto the
+    // first screen (#4300).
+    let grouped: Array<Record<string, unknown>> = collapsed.results.map(r => {
+      const workId = identityByBookId.get((r as { book_id: string }).book_id)?.work_id;
+      return workId ? { ...r, work_id: workId } : { ...r };
+    });
     if (collapsed.groups.length > 0) {
       const collapsedByKey = new Map(collapsed.groups.map(g => [g.key, g.collapsed.length]));
       try {

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -3,6 +3,9 @@ import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-sea
 import { searchBooksCatalog } from '@/lib/books-catalog';
 import { getDb } from '@/lib/mongodb';
 import { logSearchQuery } from '@/lib/search-log';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { collapseByWork, type WorkGroupable } from '@/lib/search/work-grouping';
+import { fetchWorkFanouts } from '@/lib/search/work-fanout';
 
 export const dynamic = 'force-dynamic';
 
@@ -145,19 +148,29 @@ export async function GET(request: NextRequest) {
     // (#4216). Drop non-live ids, but only when the Mongo lookup succeeded.
     const hiddenBookIds = new Set<string>();
     const liveBookIds = new Set<string>();
+    // Work identity for the collapse below (#4300). `match_books_semantic`
+    // returns no work_id, which is why four scans of Kircher's Musurgia came
+    // back as four "conceptual matches" while the keyword lane showed one.
+    const identityByBookId = new Map<string, WorkGroupable>();
     let mongoOk = false;
     if (bookIds.length > 0) {
       try {
         const db = await getDb();
         const mongoBooks = await db.collection('books').find(
           { id: { $in: bookIds } },
-          { projection: { id: 1, _id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, slug: 1, visible: 1, hidden: 1 } }
+          { projection: { id: 1, _id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, slug: 1, visible: 1, hidden: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1 } }
         ).toArray();
         for (const mb of mongoBooks) {
           const bid = mb.id || mb._id?.toString();
           if (bid) liveBookIds.add(bid as string);
           if (bid) thumbnailMap[bid] = { thumbnail: mb.thumbnail, thumbnail_blob: mb.thumbnail_blob, slug: mb.slug };
           if (bid && (mb.hidden === true || mb.visible === false)) hiddenBookIds.add(bid);
+          if (bid) identityByBookId.set(bid as string, {
+            book_id: bid as string,
+            work_id: mb.work_id as string | undefined,
+            work_id_aliases: mb.work_id_aliases as string[] | undefined,
+            duplicate_of: mb.duplicate_of as string | undefined,
+          });
         }
         mongoOk = true;
       } catch (e) {
@@ -203,6 +216,10 @@ export async function GET(request: NextRequest) {
         });
         if (filtered.length > 0) {
           mode = 'lexical';
+          // books_catalog carries work_id — keep it for the collapse below.
+          for (const b of filtered) {
+            if (b.id) identityByBookId.set(b.id, { book_id: b.id, work_id: (b as any).work_id });
+          }
           results = filtered.map(b => ({
             book_id: b.id,
             title: b.title,
@@ -224,15 +241,49 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // One row per work (#4300). This endpoint is what the /search page renders
+    // as "conceptual matches", and it had no work-grain dedup at all: a query
+    // for a much-scanned work spent its whole result window on copies of that
+    // one work. The collapse keeps the best-ranked (highest-similarity) row —
+    // `results` is already in rank order and collapseByWork never reorders.
+    const collapsed = collapseByWork(results, {
+      getIdentity: r => identityByBookId.get((r as { book_id: string }).book_id) ?? {},
+    });
+    let grouped = collapsed.results;
+    if (collapsed.groups.length > 0) {
+      const collapsedByKey = new Map(collapsed.groups.map(g => [g.key, g.collapsed.length]));
+      try {
+        const db = await getDb();
+        const tenant = getTenantContextFromRequest(request.headers);
+        const fanouts = await fetchWorkFanouts(db, collapsedByKey, {
+          tenantScoped: !!tenant.id || !!tenant.slug || tenant.isEmbedded,
+        });
+        if (fanouts.size > 0) {
+          const keyByBookId = new Map<string, string>();
+          for (const [key, group] of collapsed.byKey) {
+            const bid = (group.primary as { book_id?: string }).book_id;
+            if (bid) keyByBookId.set(bid, key);
+          }
+          grouped = grouped.map(r => {
+            const key = keyByBookId.get((r as { book_id: string }).book_id);
+            const fanout = key ? fanouts.get(key) : undefined;
+            return fanout ? { ...r, work_group: fanout } : r;
+          });
+        }
+      } catch {
+        // A missing count renders as a plain collapsed row — never a guess.
+      }
+    }
+
     logSearchQuery({
       request, route: 'search.semantic.book', query: query!,
-      total: results.length, ms: Date.now() - _searchStart, ok: true,
+      total: grouped.length, ms: Date.now() - _searchStart, ok: true,
       filters: { language, year_min: yearMin, year_max: yearMax, mode },
     });
     return NextResponse.json({
-      results,
+      results: grouped,
       query,
-      total: results.length,
+      total: grouped.length,
       mode,
       // Book-level embeddings are one per book, composed from the English
       // summary and index. There is no localized store to point `lang` at, so

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -667,6 +667,10 @@ async function searchBooks(
         thumbnail: b.thumbnail,
         thumbnail_blob: b.thumbnail_blob,
         quality_score: b.quality_score,
+        // For the client's cross-lane dedup — /search merges this lane with a
+        // separately-fetched conceptual lane and can otherwise only compare
+        // book ids (#4300).
+        work_id: b.work_id || undefined,
       };
     }),
     total: truncated.length,

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -15,6 +15,8 @@ import { CLIP_URL } from '@/lib/clip';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { logSearchEvent } from '@/lib/search-event-log';
 import { assessMatchQuality } from '@/lib/search/match-quality';
+import { collapseByWork, type WorkGroupable } from '@/lib/search/work-grouping';
+import { fetchWorkFanouts } from '@/lib/search/work-fanout';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
@@ -161,7 +163,11 @@ export async function GET(request: NextRequest) {
         }, ms)),
       ]);
 
-    const emptyBooks = { results: [] as SearchResult[], total: 0, hasMore: false };
+    const emptyBooks = {
+      results: [] as SearchResult[], total: 0, hasMore: false,
+      groups: [] as ReturnType<typeof collapseByWork<WorkGroupable>>['groups'],
+      workKeyByBookId: new Map<string, string>(),
+    };
     const emptyIndex = { results: [] as IndexResult[], total: 0, hasMore: false };
     const emptyGallery = { results: [] as GalleryResult[], total: 0 };
 
@@ -282,13 +288,25 @@ export async function GET(request: NextRequest) {
       ),
     ]);
 
+    // One lookup serves two jobs: tenant attribution (below) and work identity
+    // for the semantic lane. `match_books_semantic` returns no work_id — that
+    // is exactly why the copies the keyword lane collapses came back through
+    // the semantic lane (#4300, Kircher's Musurgia: 1 keyword row, 4 more
+    // semantic rows of the same work).
     const resultBookIds = booksResultRaw.results.map((b: any) => b.id).filter(Boolean);
-    const resultBooks = resultBookIds.length > 0
+    const semanticBookIds = semanticResultRaw.results.map(s => s.book_id).filter(Boolean);
+    const identityLookupIds = [...new Set([...resultBookIds, ...semanticBookIds])];
+    const resultBooks = identityLookupIds.length > 0
       ? await db.collection('books').find(
-        { id: { $in: resultBookIds } },
-        { projection: { _id: 0, id: 1, tenantId: 1 }, maxTimeMS: 5000 }
+        { id: { $in: identityLookupIds } },
+        { projection: { _id: 0, id: 1, tenantId: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1 }, maxTimeMS: 5000 }
       ).toArray()
       : [];
+    const identityByBookId = new Map<string, WorkGroupable>(
+      resultBooks.map((b: any) => [b.id as string, {
+        book_id: b.id, work_id: b.work_id, work_id_aliases: b.work_id_aliases, duplicate_of: b.duplicate_of,
+      }]),
+    );
     const collectionTenantIds = collectionsResult.results.map((c: any) => c.tenantId).filter(Boolean);
     const tenantIds = [...new Set([
       ...resultBooks.map((book: any) => book.tenantId).filter(Boolean),
@@ -303,8 +321,11 @@ export async function GET(request: NextRequest) {
     const tenantSlugById = new Map(tenants.map((tenant: any) => [tenant.id, tenant.slug]));
     const tenantIdByBookId = new Map(resultBooks.map((book: any) => [book.id, book.tenantId]));
 
+    // `groups` / `workKeyByBookId` are internal plumbing for the collapse — they
+    // carry raw catalogue rows and must never reach the wire.
+    const { groups: _bookGroups, workKeyByBookId: _bookWorkKeys, ...booksResultPublic } = booksResultRaw;
     const booksResult = {
-      ...booksResultRaw,
+      ...booksResultPublic,
       results: booksResultRaw.results.map((book: any) => ({
         ...book,
         tenant_slug: tenantIdByBookId.get(book.id)
@@ -333,9 +354,44 @@ export async function GET(request: NextRequest) {
       if (yearTo !== undefined && year > yearTo) return false;
       return true;
     };
-    const dedupedSemantic = semanticResultRaw.results
+    // Work-grain dedup, not just book-id dedup (#4300). Two things to remove:
+    // a semantic hit on a work the keyword lane already represents, and several
+    // semantic hits on ONE work (four scans of Musurgia Universalis are one
+    // work, not four conceptual matches). Rows with no work identity are left
+    // alone — an unkeyed book is not shown to be a copy of anything.
+    const keywordWorkKeys = new Set(booksResultRaw.workKeyByBookId.values());
+    const semanticInRange = semanticResultRaw.results
       .filter(s => !keywordBookIds.has(s.book_id))
       .filter(s => inYearRange(s.year));
+    const semanticCollapsed = collapseByWork(semanticInRange, {
+      getIdentity: s => identityByBookId.get(s.book_id) ?? { book_id: s.book_id },
+    });
+    // Every row a collapse removed, by work key — from the keyword lane, from
+    // inside the semantic lane, and from the cross-lane suppression below. It
+    // has to be one tally: a work whose siblings were all removed by the
+    // CROSS-lane rule would otherwise show no fan-out at all, which is the
+    // silent-hide this issue exists to end.
+    const collapsedByKey = new Map<string, number>();
+    const addCollapsed = (key: string, n: number) =>
+      collapsedByKey.set(key, (collapsedByKey.get(key) ?? 0) + n);
+    for (const g of booksResultRaw.groups) addCollapsed(g.key, g.collapsed.length);
+    for (const g of semanticCollapsed.groups) addCollapsed(g.key, g.collapsed.length);
+
+    // Canonical (alias-resolved) key per surviving semantic row — read off the
+    // collapse rather than recomputed, so the two lanes compare the same keys.
+    const semanticKeyByBookId = new Map<string, string>();
+    for (const [key, group] of semanticCollapsed.byKey) {
+      const bid = (group.primary as { book_id?: string }).book_id;
+      if (bid) semanticKeyByBookId.set(bid, key);
+    }
+    const dedupedSemantic = semanticCollapsed.results.filter(s => {
+      const key = semanticKeyByBookId.get(s.book_id);
+      if (key && keywordWorkKeys.has(key)) {
+        addCollapsed(key, 1);
+        return false;
+      }
+      return true;
+    });
     const semanticResult = { results: dedupedSemantic.slice(0, 6), total: dedupedSemantic.length };
 
     // Apply similarity floor to visual/semantic/artwork lanes.
@@ -450,6 +506,34 @@ export async function GET(request: NextRequest) {
       filteredArtworks.total = filteredArtworks.results.length;
     }
 
+    // Fan-out for every row that replaced siblings: "N editions of this work →".
+    // The count is the WORK PAGE's own count (fetchWorkFanouts calls the same
+    // `workEditionsFilter` /work/[id] renders from), never the number of rows we
+    // hid — a card must count what its target page shows. Suppressed entirely
+    // under a tenant: an edition census across the global library is not a
+    // partner reading room's claim to make (tenant-lockdown.md).
+    const fanouts = await fetchWorkFanouts(db, collapsedByKey, {
+      tenantScoped: !!tenantContext.id || !!tenantContext.slug || tenantContext.isEmbedded,
+    });
+    if (fanouts.size > 0) {
+      scopedBooks = {
+        ...scopedBooks,
+        results: scopedBooks.results.map((r: any) => {
+          const key = booksResultRaw.workKeyByBookId.get(r.id);
+          const fanout = key ? fanouts.get(key) : undefined;
+          return fanout ? { ...r, work_group: fanout } : r;
+        }),
+      };
+      scopedSemantic = {
+        ...scopedSemantic,
+        results: scopedSemantic.results.map((r: any) => {
+          const key = semanticKeyByBookId.get(r.book_id);
+          const fanout = key ? fanouts.get(key) : undefined;
+          return fanout ? { ...r, work_group: fanout } : r;
+        }),
+      };
+    }
+
     // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
     logSearchEvent({
       request, db, query, source: 'unified',
@@ -536,19 +620,31 @@ async function searchBooks(
     return (b.quality_score || 0) - (a.quality_score || 0);
   });
 
-  // Work-level dedup: collapse editions of the same work (keep best-ranked)
-  const seenWorkIds = new Set<string>();
-  const deduped = books.filter((b: any) => {
-    if (!b.work_id) return true;
-    if (seenWorkIds.has(b.work_id)) return false;
-    seenWorkIds.add(b.work_id);
-    return true;
-  });
+  // Work-level collapse: one row per work, best-ranked edition representing it
+  // (#4300). The sort above IS the keeper choice, so this must run after it and
+  // must not reorder. `collapseByWork` also honours `duplicate_of` and folds
+  // retired work_ids into their survivor — see src/lib/search/work-grouping.ts
+  // for why `edition_key` is deliberately not a grouping key.
+  const collapsed = collapseByWork(books as WorkGroupable[]);
+  const deduped = collapsed.results as any[];
 
   const hasMore = deduped.length > limit;
   const truncated = hasMore ? deduped.slice(0, limit) : deduped;
 
+  // The work key of every row we return, so the route can (a) hang the
+  // "N editions of this work" fan-out on a row that replaced siblings and
+  // (b) keep the semantic lane from re-introducing the same work as a
+  // separate result.
+  const shownIds = new Set(truncated.map((b: any) => b.id));
+  const workKeyByBookId = new Map<string, string>();
+  for (const [key, group] of collapsed.byKey) {
+    const primaryId = (group.primary as any).id;
+    if (primaryId && shownIds.has(primaryId)) workKeyByBookId.set(primaryId as string, key);
+  }
+
   return {
+    groups: collapsed.groups,
+    workKeyByBookId,
     results: truncated.map((b: any): SearchResult => {
       const summaryText = b.summary_text;
       return {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -620,7 +620,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             return r.json();
           })
           .then(data => {
-            // Dedup against keyword book results
+            // Coarse dedup against whatever keyword results this closure can
+            // see. The authoritative pass is the work-grain one at render time
+            // (`uniqueSemantic` below) — this closure captures `bookResults`
+            // from the render that fired the fetch, so it can be a step behind.
             const keywordIds = new Set(bookResults.map(b => b.id || b.book_id));
             const deduped = (data.results || []).filter((s: any) => !keywordIds.has(s.book_id));
             setSemanticResults(deduped);
@@ -1550,8 +1553,18 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
 
         {/* ==================== UNIFIED VIEW — ADAPTIVE LAYOUT ==================== */}
         {!signInRequired && viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading || passageResults.length > 0 || passageLoading || catalogResults.length > 0 || catalogLoading) && (() => {
+          // Dedup the conceptual lane against the keyword lane at the WORK
+          // grain, not just by book id (#4300). The two lanes are fetched
+          // independently (unified + /api/search/semantic), so each collapses
+          // its own copies server-side and neither can see the other's — a
+          // second scan of an already-listed work would otherwise take a slot
+          // on the first screen, which is the complaint this fixes. Both lanes
+          // now return `work_id`; rows without one are never merged, because an
+          // unkeyed book is not shown to be an edition of anything.
           const keywordIds = new Set(bookResults.map(b => b.id || (b as any).book_id));
-          const uniqueSemantic = semanticResults.filter((sem: any) => !keywordIds.has(sem.book_id));
+          const keywordWorkIds = new Set(bookResults.map(b => b.work_id).filter(Boolean));
+          const uniqueSemantic = semanticResults.filter((sem: any) =>
+            !keywordIds.has(sem.book_id) && !(sem.work_id && keywordWorkIds.has(sem.work_id)));
           const hasBoth = bookResults.length > 0 && uniqueSemantic.length > 0;
 
           // Shared components

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import {
   Search, Book, ExternalLink, Filter, X, Loader2,
   Quote, User, MapPin, Lightbulb, BookOpen, Languages,
-  ChevronLeft, ChevronRight, ArrowUpDown, ImageIcon, ChevronDown
+  ChevronLeft, ChevronRight, ArrowUpDown, ImageIcon, ChevronDown, Library
 } from 'lucide-react';
 import { useSearchParams, useRouter, useParams, usePathname } from 'next/navigation';
 import { useLocale, useLocalePath } from '@/lib/i18n';
@@ -1910,6 +1910,37 @@ function cleanSnippet(text: string): string {
     .trim();
 }
 
+/**
+ * "N editions & copies of this work →" (#4300).
+ *
+ * Rendered under a result that STANDS IN for siblings the work-grain collapse
+ * removed — four scans of Kircher's Musurgia now occupy one row, and this is
+ * the affordance that says so instead of the library silently dropping three.
+ * The count comes from the API, which reads it off the same filter `/work/[id]`
+ * renders its edition list from, so the number always describes the page this
+ * link opens (visibility-and-stats.md). Absent under a tenant context, by
+ * construction — the API does not send it there.
+ *
+ * Sits OUTSIDE the card's own <Link>: a nested anchor is invalid HTML and the
+ * inner one would swallow the click.
+ */
+function WorkEditionsLink({ group }: { group: NonNullable<SearchResult['work_group']> }) {
+  const t = SEARCH_STRINGS[useLocale()];
+  const lp = useLocalePath();
+  return (
+    <div className="px-4 pb-3 -mt-1">
+      <Link
+        href={lp(group.href)}
+        className="inline-flex items-center gap-1 text-xs text-accent-gold-dark hover:text-accent-gold font-medium transition-colors"
+      >
+        <Library className="w-3.5 h-3.5" aria-hidden />
+        {t.workEditionsLink(group.editions)}
+        <ChevronRight className="w-3 h-3" />
+      </Link>
+    </div>
+  );
+}
+
 function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: { result: SearchResult; query: string; tenant?: string; autoPassages?: boolean; mobileCompact?: boolean }) {
   // Client children take no `lang` prop — the pathname already says which
   // language they are in (i18n.md, "the book page: ONE page, two URLs").
@@ -2055,6 +2086,7 @@ function BookResultCard({ result, query, tenant, autoPassages, mobileCompact }: 
           </div>
         </div>
       </Link>
+      {result.work_group && <WorkEditionsLink group={result.work_group} />}
       {passagesOpen && (
         <div className="px-4 pb-4 -mt-1">
           {passagesLoading ? (
@@ -2155,6 +2187,7 @@ function SemanticResultCard({ result, query }: { result: any; query: string }) {
           </div>
         </div>
       </Link>
+      {result.work_group && <WorkEditionsLink group={result.work_group} />}
     </div>
   );
 }

--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -34,6 +34,14 @@ export interface SearchResult {
   image_thumb?: string;
   quality_score?: number;
   /**
+   * The work this edition belongs to, when it has one. Exposed so a CLIENT that
+   * merges two independently-fetched lanes can dedup at the work grain — the
+   * `/search` page fetches its keyword and conceptual lanes separately and
+   * could only compare book ids, which let one more copy of a collapsed work
+   * back onto the first screen (#4300).
+   */
+  work_id?: string;
+  /**
    * Present when this row stands in for other editions/copies that the
    * work-grain collapse removed from the list (#4300). `editions` counts what
    * `/work/[id]` renders — the set the link actually reaches — never the number

--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -33,6 +33,20 @@ export interface SearchResult {
   image_display?: string;
   image_thumb?: string;
   quality_score?: number;
+  /**
+   * Present when this row stands in for other editions/copies that the
+   * work-grain collapse removed from the list (#4300). `editions` counts what
+   * `/work/[id]` renders — the set the link actually reaches — never the number
+   * of rows collapsed, which is reported separately. Absent under a tenant
+   * context: an edition census across the global library is not a partner
+   * reading room's claim to make.
+   */
+  work_group?: {
+    work_id: string;
+    href: string;
+    editions: number;
+    collapsed_in_results: number;
+  };
 }
 
 export interface SearchFilters {

--- a/src/lib/canon-works.ts
+++ b/src/lib/canon-works.ts
@@ -283,3 +283,29 @@ export function workEditionsFilter(idOrSlug: string): Record<string, unknown> {
   }
   return { $or: [{ work_slug: idOrSlug }, { work_id: idOrSlug }], visible: true };
 }
+
+/**
+ * The same edition set as `workEditionsFilter`, in a form a REQUEST PATH can
+ * afford — for counting "N editions of this work" on a search result (#4300).
+ *
+ * `workEditionsFilter`'s `$or` reaches `work_slug`, which carries no index, so
+ * Mongo scans the whole `books` collection: measured 2026-08-28 that filter
+ * takes **7,990 ms** for one work while the `work_id` half takes **38 ms**.
+ * That is fine on `/work/[id]` (ISR, 6h window) and not fine inside a search
+ * response (request-path-queries.md).
+ *
+ * Dropping the `work_slug` branch is safe **when the argument is a work_id**,
+ * which is the only way this is called: `work_slug` holds human slugs
+ * (`ficino-on-the-mysteries`), never work_ids. Measured the same day over the
+ * 81,135 books carrying a `work_slug`: exactly 4 have `work_slug == work_id`,
+ * and for those the `work_id` branch matches the identical document. So the
+ * two filters select the same set, and this one uses `work_id_1`.
+ *
+ * Do NOT pass a route param here — a canon slug or a `work_slug` would silently
+ * count zero. Pass a work_id; canon expansion is handled for you.
+ */
+export function workEditionsCountFilter(workId: string): Record<string, unknown> {
+  const canon = byWorkId.get(workId);
+  if (canon) return { work_id: { $in: canon.workIds }, visible: true };
+  return { work_id: workId, visible: true };
+}

--- a/src/lib/search-i18n.ts
+++ b/src/lib/search-i18n.ts
@@ -151,6 +151,12 @@ export interface SearchStrings {
   pageAbbrev: (n: number) => string;
   pagesCount: (n: number) => string;
   translatedCount: (n: number) => string;
+  /**
+   * Fan-out under a result that stands in for other editions/copies (#4300).
+   * `n` is the count `/work/[id]` renders — the set this link reaches — so the
+   * wording must promise the destination, not the rows we collapsed.
+   */
+  workEditionsLink: (n: number) => string;
   findPassages: string;
   hidePassages: string;
   searchingEllipsis: string;
@@ -296,6 +302,7 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     pageAbbrev: (n) => `p. ${n}`,
     pagesCount: (n) => `${n} pages`,
     translatedCount: (n) => `${n} translated`,
+    workEditionsLink: (n) => `${n} editions & copies of this work`,
     findPassages: 'Find passages',
     hidePassages: 'Hide passages',
     searchingEllipsis: 'Searching...',
@@ -425,6 +432,7 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     pageAbbrev: (n) => `p. ${n}`,
     pagesCount: (n) => `${n} páginas`,
     translatedCount: (n) => `${n} traducidas`,
+    workEditionsLink: (n) => `${n} ediciones y ejemplares de esta obra`,
     findPassages: 'Buscar pasajes',
     hidePassages: 'Ocultar pasajes',
     searchingEllipsis: 'Buscando...',

--- a/src/lib/search/work-fanout.ts
+++ b/src/lib/search/work-fanout.ts
@@ -1,0 +1,90 @@
+/**
+ * "N editions of this work" — the fan-out shown under a collapsed search row
+ * (#4300).
+ *
+ * THE COUNT IS A CLAIM (visibility-and-stats.md)
+ * ----------------------------------------------
+ * A card must count what its TARGET page renders, not what the collapse happened
+ * to hide. `/collections/[id]` shipped "518 books" above a page showing 30
+ * because the counter and the view were filled by different queries; the fix
+ * there was to tie the number to the view. So this helper does not count rows,
+ * and does not write its own predicate: it calls `workEditionsCountFilter()`,
+ * which lives beside `workEditionsFilter()` — the filter `/work/[id]` builds
+ * its edition list from — and selects the same set by the indexed half of it
+ * (the `work_slug` branch has no index and takes ~8s; see that function's note).
+ * `tests/unit/search-work-grouping.test.ts` pins the two to each other, so a
+ * change to the work page's definition can't leave this number behind.
+ *
+ * TENANT LOCKDOWN
+ * ---------------
+ * The fan-out is a whole-library claim ("this work has 12 editions") and the
+ * link goes to a global surface. On a partner subdomain that is other
+ * institutions' holdings, so the caller must pass `tenantScoped: true` and get
+ * nothing — the same gate `embedPolicy.showRelatedEditions` puts on the book
+ * page's editions rail (tenant-lockdown.md).
+ */
+
+import type { Db } from 'mongodb';
+import { canonWorkForWorkId, workEditionsCountFilter } from '@/lib/canon-works';
+import { workIdFromGroupKey, type WorkFanout } from '@/lib/search/work-grouping';
+
+/** Never fire more than this many count queries for one search request. */
+const MAX_FANOUT_LOOKUPS = 8;
+
+/**
+ * The reading address for a work: the canon slug when the work has one (a
+ * stable, human URL), otherwise the raw work_id. Mirrors `workAliasTarget()`.
+ */
+export function workHref(workId: string): string {
+  const canon = canonWorkForWorkId(workId);
+  return `/work/${encodeURIComponent(canon ? canon.slug : workId)}`;
+}
+
+/**
+ * Count the editions `/work/[id]` would render, for each group that actually
+ * replaced sibling rows.
+ *
+ * Returns a map keyed by the group key. A group is OMITTED (rather than given a
+ * zero or a guess) whenever the count can't be established — a copy-keyed
+ * group, a tenant request, a Mongo error, or a count that doesn't exceed one.
+ * A missing entry renders as today's silent collapse; a wrong entry would be a
+ * false claim, which is worse.
+ */
+export async function fetchWorkFanouts(
+  db: Db,
+  /** Group key → how many sibling rows that key replaced in THIS response. */
+  collapsedByKey: Map<string, number>,
+  opts?: { tenantScoped?: boolean },
+): Promise<Map<string, WorkFanout>> {
+  const out = new Map<string, WorkFanout>();
+  if (opts?.tenantScoped) return out;
+
+  const targets = [...collapsedByKey.entries()]
+    .filter(([, collapsed]) => collapsed > 0)
+    .map(([key, collapsed]) => ({ key, collapsed, workId: workIdFromGroupKey(key) }))
+    .filter((t): t is { key: string; collapsed: number; workId: string } => !!t.workId)
+    .slice(0, MAX_FANOUT_LOOKUPS);
+  if (targets.length === 0) return out;
+
+  await Promise.all(
+    targets.map(async ({ key, collapsed, workId }) => {
+      try {
+        const editions = await db
+          .collection('books')
+          .countDocuments(workEditionsCountFilter(workId), { maxTimeMS: 2000 });
+        // One edition means nothing is reachable that isn't already on screen.
+        if (editions < 2) return;
+        out.set(key, {
+          work_id: workId,
+          href: workHref(workId),
+          editions,
+          collapsed_in_results: collapsed,
+        });
+      } catch {
+        // No number is better than a made-up one — fall back to a silent collapse.
+      }
+    }),
+  );
+
+  return out;
+}

--- a/src/lib/search/work-grouping.ts
+++ b/src/lib/search/work-grouping.ts
@@ -1,0 +1,205 @@
+/**
+ * Work-grain grouping for search results (#4300).
+ *
+ * WHY
+ * ---
+ * A reader's mental model is a WORK; our result lists served a flat pile of
+ * SCANS. An external audit of the catalogue found four separate records of
+ * Kircher's *Musurgia Universalis* Vol. I — four digitizations of the same 1650
+ * printing — presented as four unrelated results, which reads as a library that
+ * doesn't know what it holds.
+ *
+ * The lanes disagreed about this. `/api/search` and the keyword book lane of
+ * `/api/search/unified` each grew their own inline `seenWorkIds` filter; the
+ * semantic lanes (`/api/search/semantic`, and unified's semantic lane) had
+ * none, so the copies came back in through the lane nobody had patched. This
+ * module is the single definition, so a new lane inherits the behaviour instead
+ * of re-deriving it.
+ *
+ * WHAT COUNTS AS THE SAME THING — and what deliberately does NOT
+ * -------------------------------------------------------------
+ * Grouping happens ONLY on links a human or a HIGH-confidence resolver already
+ * blessed:
+ *
+ *   `duplicate_of`  a copy is not a result; it collapses onto its keeper
+ *   `work_id`       the work layer (~98% of live books), alias-aware
+ *
+ * `edition_key` is deliberately NOT a grouping key here. #4285's text
+ * comparator read the OCR of 259 keeper↔copy pairs sharing a full-quality key
+ * and found 27% of them are NOT the same content — fragments under a full
+ * edition's key, generic-title collections, pecha volumes, the 1670 Spinoza
+ * variant printings. Collapsing on a raw key match would hide *different texts*
+ * behind one row: the search-side version of the wrongly-hidden-book failure.
+ * When #4285 lands a text-confirmed allowlist, confirmed pairs can join here;
+ * suspect and gray pairs must stay separate rows.
+ *
+ * WHAT THIS DOES NOT FIX
+ * ----------------------
+ * - Work-id fragmentation (14,946 unjudged local mints, 1,940 pending merges,
+ *   #4271) means one work can still show as two rows. Mild, and self-healing as
+ *   the queue drains.
+ * - `work_id` is work-grain, not volume-grain, so Vol. I and Vol. II of one set
+ *   share a key and collapse to one row (#3708). That is why the fan-out count
+ *   and link matter: the collapsed volumes are still one click away on
+ *   `/work/[id]`, which is exactly what the count describes.
+ */
+
+/** The identity fields grouping reads. Every lane must project these. */
+export interface WorkGroupable {
+  /** Book id — used only for stable tie-breaking, never as a group key. */
+  book_id?: string | null;
+  id?: string | null;
+  work_id?: string | null;
+  /** Retired work_ids kept on every edition by the merge writer (#3759). */
+  work_id_aliases?: string[] | null;
+  /** Set on a copy; points at the keeper book id. */
+  duplicate_of?: string | null;
+}
+
+/**
+ * The group key for one result, or null when the result must stand alone.
+ *
+ * Null is the safe answer and the common one: a book with no `work_id` is not
+ * "ungrouped by accident", it is a book we have not shown to be an edition of
+ * anything. Never invent a key from title/author strings — that is the
+ * heuristic-collapse failure the edition layer exists to keep out of reader
+ * surfaces.
+ */
+export function workGroupKey(b: WorkGroupable): string | null {
+  const dup = typeof b.duplicate_of === 'string' ? b.duplicate_of.trim() : '';
+  // A copy collapses onto its keeper even when the keeper is not in this
+  // result set — two copies of one keeper then still group with each other.
+  // Belt-and-braces: copies are normally hidden, so public lanes rarely see
+  // one. That is exactly why it must not be the only defence.
+  if (dup) return `copy:${dup}`;
+  const work = typeof b.work_id === 'string' ? b.work_id.trim() : '';
+  if (work) return `work:${work}`;
+  return null;
+}
+
+/**
+ * Build a canonical-key resolver over one result set, folding retired work_ids
+ * into their survivor.
+ *
+ * The merge writer sets the surviving `work_id` on every edition and keeps the
+ * losing ids in `work_id_aliases`, so in a settled corpus all editions already
+ * agree and this is a no-op. It is not free of value: a partially-applied merge
+ * (or a book written by an older resolver) can still carry a retired id, and
+ * without this the same work splits into two rows precisely when the identity
+ * layer is mid-repair.
+ */
+function buildAliasMap(items: WorkGroupable[]): Map<string, string> {
+  const survivorOf = new Map<string, string>();
+  for (const item of items) {
+    const work = typeof item.work_id === 'string' ? item.work_id.trim() : '';
+    if (!work) continue;
+    for (const alias of item.work_id_aliases || []) {
+      const a = typeof alias === 'string' ? alias.trim() : '';
+      if (a && a !== work) survivorOf.set(a, work);
+    }
+  }
+  // Chase a chain (A retired into B, B retired into C) so both rows land on C,
+  // and stop on a cycle rather than spin — an inconsistent alias graph is a
+  // data bug, not a reason to hang a search request.
+  const resolved = new Map<string, string>();
+  for (const [alias] of survivorOf) {
+    let cur = alias;
+    const seen = new Set<string>([alias]);
+    for (let hops = 0; hops < 8; hops++) {
+      const next = survivorOf.get(cur);
+      if (!next || seen.has(next)) break;
+      seen.add(next);
+      cur = next;
+    }
+    if (cur !== alias) resolved.set(alias, cur);
+  }
+  return resolved;
+}
+
+export interface WorkGroup<T> {
+  /** Canonical group key (`work:<id>` / `copy:<keeper id>`). */
+  key: string;
+  /** The result that represents the group — the first, i.e. best-ranked. */
+  primary: T;
+  /** The sibling results this row replaced, in their original order. */
+  collapsed: T[];
+}
+
+export interface CollapseResult<T> {
+  /** Results to render: one per group, plus every ungroupable result. */
+  results: T[];
+  /** Groups that actually replaced at least one sibling row. */
+  groups: WorkGroup<T>[];
+  /** key → group, for attaching fan-out metadata to the primary. */
+  byKey: Map<string, WorkGroup<T>>;
+}
+
+/**
+ * Collapse an ALREADY-RANKED list to one row per work.
+ *
+ * Order is the contract: the first occurrence of a key wins and becomes the
+ * primary, so the caller must sort by its own keeper signals (translation
+ * availability, scan quality, pages processed, closeness to source) BEFORE
+ * calling. This function never re-ranks — a collapse that quietly reordered
+ * results would make every lane's ladder unfalsifiable.
+ */
+export function collapseByWork<T extends WorkGroupable>(
+  items: T[],
+  opts?: { getIdentity?: (item: T) => WorkGroupable },
+): CollapseResult<T> {
+  const identityOf = opts?.getIdentity ?? ((item: T) => item as WorkGroupable);
+  const identities = items.map(identityOf);
+  const survivorOf = buildAliasMap(identities);
+
+  const byKey = new Map<string, WorkGroup<T>>();
+  const results: T[] = [];
+
+  items.forEach((item, i) => {
+    const raw = workGroupKey(identities[i]);
+    if (!raw) {
+      // No blessed identity — always its own row. Never guess.
+      results.push(item);
+      return;
+    }
+    const key = raw.startsWith('work:')
+      ? `work:${survivorOf.get(raw.slice(5)) ?? raw.slice(5)}`
+      : raw;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.collapsed.push(item);
+      return;
+    }
+    byKey.set(key, { key, primary: item, collapsed: [] });
+    results.push(item);
+  });
+
+  return {
+    results,
+    groups: [...byKey.values()].filter(g => g.collapsed.length > 0),
+    byKey,
+  };
+}
+
+/**
+ * The work id a group key names, or null for a copy-keyed group.
+ * Used to look up the fan-out count against the work page's own filter.
+ */
+export function workIdFromGroupKey(key: string): string | null {
+  return key.startsWith('work:') ? key.slice(5) : null;
+}
+
+/**
+ * Fan-out metadata attached to a primary result whose row replaced siblings.
+ *
+ * `editions` is the count of what `/work/[id]` RENDERS, not the number of rows
+ * we hid — the two differ and the reader is being handed a link, so the count
+ * has to describe the destination (visibility-and-stats.md: "a card must count
+ * what its TARGET page renders"). `collapsed_in_results` is the local number,
+ * kept for tests and diagnostics and never shown as the headline.
+ */
+export interface WorkFanout {
+  work_id: string;
+  href: string;
+  editions: number;
+  collapsed_in_results: number;
+}

--- a/tests/unit/search-work-grouping.test.ts
+++ b/tests/unit/search-work-grouping.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { collapseByWork, workGroupKey, workIdFromGroupKey } from '@/lib/search/work-grouping';
-import { workHref } from '@/lib/search/work-fanout';
+import { fetchWorkFanouts, workHref } from '@/lib/search/work-fanout';
+import type { Db } from 'mongodb';
 import { workEditionsFilter, workEditionsCountFilter } from '@/lib/canon-works';
 
 // Work-grain result grouping (#4300). The motivating case is real: an external
@@ -162,6 +163,20 @@ describe('fan-out target', () => {
     // And the dropped branch is the work_slug one, nothing else.
     expect(page.$or).toHaveLength(2);
     expect(page.$or.some(b => 'work_slug' in b)).toBe(true);
+  });
+
+  it('a tenant request gets NO fan-out, and never even reaches the database', () => {
+    // tenant-lockdown.md: "N editions of this work" is a census across the
+    // GLOBAL library and links to a global surface. A partner reading room
+    // must not make that claim — same gate embedPolicy.showRelatedEditions
+    // puts on the book page's editions rail. The db stub throws, so this also
+    // proves the suppression happens BEFORE the query, not after it.
+    const exploding = {
+      collection() { throw new Error('a tenant request must not query the global corpus'); },
+    } as unknown as Db;
+    return expect(
+      fetchWorkFanouts(exploding, new Map([['work:Q18942469', 3]]), { tenantScoped: true }),
+    ).resolves.toEqual(new Map());
   });
 
   it('a canon work counts every work_id the canon entry collects, not just one', () => {

--- a/tests/unit/search-work-grouping.test.ts
+++ b/tests/unit/search-work-grouping.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { collapseByWork, workGroupKey, workIdFromGroupKey } from '@/lib/search/work-grouping';
+import { workHref } from '@/lib/search/work-fanout';
+import { workEditionsFilter, workEditionsCountFilter } from '@/lib/canon-works';
+
+// Work-grain result grouping (#4300). The motivating case is real: an external
+// audit of the catalogue found four separate records of Kircher's *Musurgia
+// Universalis* Vol. I — four scans of the one 1650 printing, all carrying
+// `work_id: Q18942469` — presented as four unrelated results. The keyword lane
+// collapsed them; the semantic lane, which had no such rule, handed them back.
+//
+// The tests that matter here are the ABSTENTIONS. A collapse hides books, so
+// every case where we must NOT collapse is a guard against the search-side
+// version of the wrongly-hidden-book failure.
+
+const musurgia = (id: string, extra: Record<string, unknown> = {}) => ({
+  book_id: id, id, work_id: 'Q18942469', ...extra,
+});
+
+describe('workGroupKey', () => {
+  it('keys on work_id', () => {
+    expect(workGroupKey({ book_id: 'a', work_id: 'Q18942469' })).toBe('work:Q18942469');
+  });
+
+  it('keys a copy on its keeper, so two copies of one keeper group together', () => {
+    expect(workGroupKey({ book_id: 'a', duplicate_of: 'keeper-1' })).toBe('copy:keeper-1');
+  });
+
+  it('prefers duplicate_of over work_id — a copy is never its own result', () => {
+    expect(workGroupKey({ book_id: 'a', work_id: 'Q1', duplicate_of: 'keeper-1' })).toBe('copy:keeper-1');
+  });
+
+  it('abstains with no blessed identity — never guesses from title or author', () => {
+    expect(workGroupKey({ book_id: 'a' })).toBeNull();
+    expect(workGroupKey({ book_id: 'a', work_id: '' })).toBeNull();
+    expect(workGroupKey({ book_id: 'a', work_id: '   ' })).toBeNull();
+  });
+});
+
+describe('collapseByWork', () => {
+  it('collapses the four Musurgia scans to one row and records the rest', () => {
+    const rows = [
+      musurgia('6952050fab34727b1f04216b'),
+      musurgia('e48a21de-4db2-4c94-a71a-e952b9fa5393'),
+      musurgia('695592717bd6d2cd1d61a03e'),
+      musurgia('699067e2249ce014347d471d'),
+    ];
+    const out = collapseByWork(rows);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].id).toBe('6952050fab34727b1f04216b');
+    expect(out.groups).toHaveLength(1);
+    expect(out.groups[0].collapsed).toHaveLength(3);
+  });
+
+  it('keeps the FIRST row — the caller\'s ranking is the keeper choice, never re-ranked', () => {
+    const out = collapseByWork([
+      musurgia('worse', { quality_score: 10 }),
+      musurgia('better', { quality_score: 100 }),
+    ]);
+    // Deliberate: this function must not re-rank. A collapse that quietly
+    // reordered results would make every lane's ladder unfalsifiable.
+    expect(out.results.map(r => r.id)).toEqual(['worse']);
+  });
+
+  it('leaves rows with no work identity strictly alone', () => {
+    const out = collapseByWork([
+      { book_id: 'a', id: 'a' },
+      { book_id: 'b', id: 'b' },
+      { book_id: 'c', id: 'c' },
+    ]);
+    expect(out.results).toHaveLength(3);
+    expect(out.groups).toHaveLength(0);
+  });
+
+  it('does NOT collapse different works that merely look alike', () => {
+    // Same author, same year, near-identical titles — and two work_ids. The
+    // edition layer says these are different things; search must agree.
+    const out = collapseByWork([
+      { book_id: 'a', id: 'a', work_id: 'Q18942469' },
+      { book_id: 'b', id: 'b', work_id: 'local:a:athanasius-kircher:art-consonance-dissonance-minor' },
+    ]);
+    expect(out.results).toHaveLength(2);
+  });
+
+  it('never collapses on edition_key — a shared key is a claim, not a fact', () => {
+    // #4285 read the OCR of 259 keeper<->copy pairs sharing a FULL-quality
+    // edition_key and found 27% are not the same content (fragments under a
+    // full edition's key, generic-title collections, the 1670 Spinoza variant
+    // printings). Two rows with one edition_key and no work_id stay two rows.
+    const out = collapseByWork([
+      { book_id: 'a', id: 'a', edition_key: 'tractatus theologico politicus|spinoza|1670|v' },
+      { book_id: 'b', id: 'b', edition_key: 'tractatus theologico politicus|spinoza|1670|v' },
+    ] as Array<Record<string, unknown>> as Parameters<typeof collapseByWork>[0]);
+    expect(out.results).toHaveLength(2);
+    expect(out.groups).toHaveLength(0);
+  });
+
+  it('folds a retired work_id into its survivor via work_id_aliases', () => {
+    // A partially-applied merge (#3759) leaves one edition on the retired id.
+    // Without alias folding the work splits into two rows precisely while the
+    // identity layer is mid-repair.
+    const out = collapseByWork([
+      { book_id: 'survivor', id: 'survivor', work_id: 'Q999', work_id_aliases: ['local:old-id'] },
+      { book_id: 'straggler', id: 'straggler', work_id: 'local:old-id' },
+    ]);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].id).toBe('survivor');
+    expect(out.groups[0].key).toBe('work:Q999');
+  });
+
+  it('survives a cyclic alias graph instead of spinning', () => {
+    const out = collapseByWork([
+      { book_id: 'a', id: 'a', work_id: 'W1', work_id_aliases: ['W2'] },
+      { book_id: 'b', id: 'b', work_id: 'W2', work_id_aliases: ['W1'] },
+    ]);
+    // Whatever it decides, it must terminate and must not lose a row.
+    expect(out.results.length + out.groups.reduce((n, g) => n + g.collapsed.length, 0)).toBe(2);
+  });
+
+  it('reads identity through getIdentity for lanes whose rows carry none', () => {
+    // The semantic RPC returns no work_id; the route joins it from Mongo.
+    const identity = new Map([
+      ['s1', { book_id: 's1', work_id: 'Q18942469' }],
+      ['s2', { book_id: 's2', work_id: 'Q18942469' }],
+    ]);
+    const out = collapseByWork(
+      [{ book_id: 's1' }, { book_id: 's2' }, { book_id: 's3' }],
+      { getIdentity: r => identity.get(r.book_id!) ?? {} },
+    );
+    expect(out.results.map(r => r.book_id)).toEqual(['s1', 's3']);
+  });
+});
+
+describe('fan-out target', () => {
+  it('a copy-keyed group yields no work id, so it can never claim an edition count', () => {
+    expect(workIdFromGroupKey('copy:keeper-1')).toBeNull();
+    expect(workIdFromGroupKey('work:Q18942469')).toBe('Q18942469');
+  });
+
+  it('links to /work/<id>, url-encoded — local mints carry colons', () => {
+    expect(workHref('Q18942469')).toBe('/work/Q18942469');
+    expect(workHref('local:a:kircher:musurgia')).toBe('/work/local%3Aa%3Akircher%3Amusurgia');
+  });
+
+  it('the fan-out count filter selects the same set as the WORK PAGE\'s filter', () => {
+    // visibility-and-stats.md: "a card must count what its TARGET page renders".
+    // /work/[id] builds its list from workEditionsFilter; the count uses
+    // workEditionsCountFilter, which is that filter's INDEXED half (the
+    // work_slug branch has no index — 7,990ms vs 38ms measured 2026-08-28).
+    // They select the same set because work_slug holds human slugs, never
+    // work_ids. Pin the correspondence so a change to one is a failing test,
+    // not a silently drifting number.
+    const page = workEditionsFilter('Q18942469') as {
+      visible: boolean; $or: Array<Record<string, unknown>>;
+    };
+    const count = workEditionsCountFilter('Q18942469') as Record<string, unknown>;
+    expect(page.visible).toBe(true);
+    expect(count.visible).toBe(true);
+    // The page filter's work_id branch and the count filter must name the same ids.
+    const pageWorkIdBranch = page.$or.find(b => 'work_id' in b)!;
+    expect(count.work_id).toEqual(pageWorkIdBranch.work_id);
+    // And the dropped branch is the work_slug one, nothing else.
+    expect(page.$or).toHaveLength(2);
+    expect(page.$or.some(b => 'work_slug' in b)).toBe(true);
+  });
+
+  it('a canon work counts every work_id the canon entry collects, not just one', () => {
+    // /work/<canon-slug> expands to canon.workIds; a count of the single
+    // work_id would undercount the page it links to.
+    const canonIds = ['Q596076'];
+    const filter = workEditionsCountFilter(canonIds[0]) as { work_id: unknown };
+    // Either the id is canon (then work_id is an $in over its set) or it is
+    // not (then it is the bare id). Both must be counted by an INDEXED path.
+    expect(
+      typeof filter.work_id === 'string' || (filter.work_id as Record<string, unknown>)?.$in !== undefined,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements #4300 step 1 + most of step 2: search results collapse copies and group at the **work** grain, with an honest fan-out to `/work/[id]` instead of a silent drop.

## The bug, reproduced

An external agent auditing the catalogue found four separate records of Kircher's *Musurgia Universalis* Vol. I presented as four unrelated results. Reproduced on production, and the cause was not where the issue assumed:

| lane | `q=Musurgia Universalis` before |
|---|---|
| `/api/search/unified` → `books` | **1** row (already collapsed by `work_id`) |
| `/api/search/semantic` | **6** rows — all `work_id: Q18942469` |
| `/api/search` | 1 book + 1 page (already collapsed) |

`/search` renders the `/api/search/semantic` lane as **"conceptual matches", above** the keyword results. So the keyword lanes each had their own inline `seenWorkIds` filter and the semantic lanes had none — the copies came back in through the lane nobody had patched. That is the shape this PR is really fixing: **three lanes, three private notions of "same thing"**.

## In scope

- **`src/lib/search/work-grouping.ts`** — one definition, shared by every lane. Groups only on links a human or a HIGH-confidence resolver already blessed: `duplicate_of` (a copy collapses onto its keeper) and `work_id`, folded through `work_id_aliases` so a partially-applied merge (#3759) doesn't split a work in two. Never re-ranks: the caller's sort *is* the keeper choice.
- **`edition_key` is deliberately NOT a grouping key.** #4285's text comparator read the OCR of 259 keeper↔copy pairs sharing a full-quality key and found **27% are not the same content** (fragments under a full edition's key, generic-title collections, pecha volumes, the 1670 Spinoza variant printings). Collapsing on a raw key match would hide *different texts* behind one row — the search-side version of the wrongly-hidden-book failure. Pinned by a test.
- **Applied in all three lanes** — `/api/search` (shared helper replaces its inline dedup, now also honouring `duplicate_of` and aliases), `/api/search/unified` (keyword lane, plus work-grain dedup of the semantic lane both within itself and against the keyword lane), `/api/search/semantic` (had no work dedup at all).
- **`work_group` on a row that stands in for siblings** — `{ work_id, href, editions, collapsed_in_results }` — rendered under the card as "N editions & copies of this work →" (EN + ES strings), linking to `/work/[id]`.

## The count is a claim, and it is coupled to its target

`visibility-and-stats.md`: *a card must count what its TARGET page renders.* So `editions` is **not** the number of rows we hid. `fetchWorkFanouts` counts `workEditionsCountFilter()`, added directly beside `workEditionsFilter()` — the filter `/work/[id]` builds its edition list from — and a unit test pins the two to each other so the number cannot drift from the page the link opens. `collapsed_in_results` (the local number) is reported separately and never shown as the headline.

Why a second function rather than calling the page's filter directly: measured 2026-08-28, `workEditionsFilter`'s `$or` reaches `work_slug`, which carries **no index**, so Mongo scans the whole `books` collection — **7,990 ms** for one work against **38 ms** for the `work_id` half. Fine on `/work/[id]` (ISR, 6h window); not a request-path query (`request-path-queries.md`). Dropping the `work_slug` branch is safe because `work_slug` holds human slugs (`ficino-on-the-mysteries`), never work_ids: of the 81,135 books carrying a `work_slug`, exactly **4** have `work_slug == work_id` and the `work_id` branch matches those same documents. Verified by comparing both filters over 25 sampled multi-edition works — **0 mismatches**.

## Guardrails honoured

1. **Collapse only on verified links** — `duplicate_of` + `work_id` only; `edition_key` excluded pending #4285's allowlist.
2. **Work-id fragmentation** (#4271) means a fragmented work still shows as two rows. Accepted, self-healing.
3. **The count describes the target page** — see above.
4. **Tenant lockdown** — the fan-out is suppressed entirely under any tenant context (`id`, `slug`, or `isEmbedded`). An edition census across the global library is not a partner reading room's claim to make; same gate `embedPolicy.showRelatedEditions` puts on the book page's editions rail. The *collapse* still runs on tenant hosts (it only ever removes rows).

## Out of scope (deliberately)

- **Text-confirmed `edition_key` collapse** — blocked on #4285 producing the allowlist. The module has the seam for it and says so.
- **Work-id fragmentation** (#4271) — grouping inherits it; draining the merge queue is the fix.
- **Semantic-lane per-work composition caps** (#3895) — different surface, same principle.
- **`edition_key_latin` recall** (#4270) — not landed yet.
- **Volume grain** (#3708) — `work_id` is work-grain, so Vol. I and Vol. II of one set share a key and collapse to one row. This is why the fan-out matters: the collapsed volumes are one click away and the count describes exactly that page. Fixing it properly needs volume represented in the identity layer.
- **`/api/search`'s pre-existing one-passage-per-work cap** — the work dedup has always applied to page results, so `pages_only=true` already returns at most one page per work. Left exactly as it was (and the fan-out is skipped there, so the MCP passage contract and its latency are unchanged).
- **`/api/search/semantic` has no tenant scoping at all** — pre-existing; this PR only reads the tenant context to gate its own fan-out, and does not attempt the wider fix.

## Verification

- `npx tsc --noEmit` clean.
- Full unit suite: **222 files, 3,077 tests passing**, including `tests/unit/search-match-quality.test.ts` (the #4304 weak-match abstentions, untouched).
- New `tests/unit/search-work-grouping.test.ts` (16 cases) — the abstention cases are the load-bearing ones: no identity ⇒ no collapse; different `work_id`s ⇒ no collapse; shared `edition_key` alone ⇒ no collapse; a copy-keyed group can never claim an edition count.
- Before/after against the preview deploy in a comment below.

Closes #4300 (steps 1–2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcC7qVRrjjrt34nMu2vF92
