### PR TITLE
feat(entities): published-entity tier — read-side predicate, noindex tail, link gating (#4321)

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -15,6 +15,7 @@ import { getBookThumbnailUrl } from '@/lib/utils';
 import AuthorSchema from '@/components/seo/AuthorSchema';
 import { authorThesaurusReadpathEnabled, resolveCanonicalAuthor } from '@/lib/author-thesaurus';
 import { classifyNonPersonAuthor, type NonPersonAuthor } from '@/lib/non-person-author';
+import { isPublishedEntity, type EntityPublishFields } from '@/lib/entity-publish';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
 export const revalidate = 86400;
@@ -77,6 +78,7 @@ interface AuthorEntity {
   wikidata_birth_date?: string;
   wikidata_death_date?: string;
   portrait_url?: string;
+  book_count?: number;
 }
 
 // dynamicParams + generateStaticParams: generate on first request, not at build time
@@ -199,7 +201,7 @@ async function loadAuthorData(db: any, slug: string): Promise<{
     try {
       entity = await db.collection('entities').findOne(
         { _id: new ObjectId(repBook.author_entity_id) },
-        { projection: { name: 1, canonical_name: 1, description: 1, aliases: 1, viaf_id: 1, wikidata_id: 1, wikipedia_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1 } }
+        { projection: { name: 1, canonical_name: 1, description: 1, aliases: 1, viaf_id: 1, wikidata_id: 1, wikipedia_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1, book_count: 1 } }
       ) as AuthorEntity | null;
     } catch { /* invalid ObjectId */ }
 
@@ -229,7 +231,7 @@ async function loadAuthorData(db: any, slug: string): Promise<{
       try {
         entity = await db.collection('entities').findOne(
           { _id: new ObjectId(entityBookId) },
-          { projection: { name: 1, canonical_name: 1, description: 1, aliases: 1, viaf_id: 1, wikidata_id: 1, wikipedia_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1 } }
+          { projection: { name: 1, canonical_name: 1, description: 1, aliases: 1, viaf_id: 1, wikidata_id: 1, wikipedia_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1, book_count: 1 } }
         ) as AuthorEntity | null;
       } catch { /* invalid ObjectId */ }
     }
@@ -362,14 +364,21 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   const deathYear = entity?.wikidata_death_date?.split('-')[0];
   const lifeDates = !nonPerson && birthYear ? `${birthYear}–${deathYear || '?'}` : null;
 
-  // Encyclopedia entry: use entity directly if we have one, otherwise regex fallback
-  const encyclopediaEntity = entity || await db.collection('entities').findOne(
+  // Encyclopedia entry: use entity directly if we have one, otherwise regex
+  // fallback. The pill only renders for published-tier entities (#4321) — a
+  // below-the-line entry is a noindex page listing a mention or two, and the
+  // one place we deliberately keep linking the tail is nowhere.
+  const encyclopediaCandidate = entity || await db.collection('entities').findOne(
     { type: 'person', $or: [
       { name: { $regex: new RegExp(`^${authorName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') } },
       { aliases: { $regex: new RegExp(`^${authorName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') } },
     ]},
-    { projection: { name: 1 } }
+    { projection: { name: 1, book_count: 1, wikidata_id: 1, description: 1 } }
   );
+  const encyclopediaEntity =
+    encyclopediaCandidate && isPublishedEntity(encyclopediaCandidate as EntityPublishFields)
+      ? encyclopediaCandidate
+      : null;
 
   // Portrait image — static read (enriched offline; CSP-safe CDN URL).
   // Never for a non-person: a portrait is the strongest visual assertion the

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -48,6 +48,7 @@ import ExpandableGuide from '@/components/book/ExpandableGuide';
 import { AISection } from '@/components/embed/AISection';
 import AuthorAuthority from '@/components/book/AuthorAuthority';
 import { linkEntities, buildEntityList } from '@/lib/link-entities';
+import { filterPublishedEntityTerms } from '@/lib/entity-publish';
 import LikeButton from '@/components/ui/LikeButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { BookShare } from '@/components/ui/ShareButton';
@@ -987,7 +988,20 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
   const hasSummary = !!summaryText;
   const showProposedBanner = previewProposed && !!candidate?.brief;
   const isComplete = ocrCount >= totalPages && translatedCount >= totalPages && hasSummary;
-  const summaryEntities = buildEntityList((book as unknown as { index?: { people?: Array<{ term: string }>; places?: Array<{ term: string }>; concepts?: Array<{ term: string }> } }).index);
+  // Prose links go only to published-tier entity pages (#4321) — linking every
+  // index term is how one-book vocabulary like "Axis" earned sitewide links.
+  // On lookup failure, degrade to unlinked prose rather than linking unvetted.
+  const summaryEntities = await (async () => {
+    const all = buildEntityList((book as unknown as { index?: { people?: Array<{ term: string }>; places?: Array<{ term: string }>; concepts?: Array<{ term: string }> } }).index);
+    if (all.length === 0) return all;
+    try {
+      const entityDb = await getReadDb();
+      const published = await filterPublishedEntityTerms(entityDb, all.map(e => e.term));
+      return all.filter(e => published.has(e.term));
+    } catch {
+      return [];
+    }
+  })();
 
   // ============================================================================
   // Book page v2 layout (non-embed only). Tenant/embed reading rooms keep the

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -9,6 +9,7 @@ import {
   normalizeEntityBook,
   type EntityBookRef,
 } from '@/lib/entity-books';
+import { isPublishedEntity } from '@/lib/entity-publish';
 
 // ISR: 24h background revalidation
 export const revalidate = 86400;
@@ -241,6 +242,14 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   return {
     title,
     description,
+    // Published tier only (#4321): below-the-line entities keep rendering as
+    // internal utility pages but are not offered for indexing. Uses the
+    // deduped book_count from getEntity, not the stored field. robots.txt
+    // currently disallows /encyclopedia/ wholesale; this metadata is what
+    // makes narrowing that disallow safe later.
+    ...(entity && !isPublishedEntity(entity)
+      ? { robots: { index: false, follow: true } }
+      : {}),
     alternates: {
       canonical: `/encyclopedia/${encodeURIComponent(decodedName)}`,
     },

--- a/src/lib/entity-publish.ts
+++ b/src/lib/entity-publish.ts
@@ -1,4 +1,4 @@
-import type { Db } from 'mongodb';
+import type { Db, Document, Filter } from 'mongodb';
 
 /**
  * The published tier of the entity layer (#4321).
@@ -51,13 +51,13 @@ export function isPublishedEntity(entity: EntityPublishFields): boolean {
  * from the deduped count (the citable surface gets the accurate value, the
  * link side an indexed approximation).
  */
-export const PUBLISHED_ENTITY_FILTER = {
+export const PUBLISHED_ENTITY_FILTER: Filter<Document> = {
   book_count: { $gte: PUBLISHED_ENTITY_MIN_BOOKS },
   $or: [
     { wikidata_id: { $type: 'string', $ne: '' } },
     { description: { $type: 'string', $ne: '' } },
   ],
-} as const;
+};
 
 /**
  * Which of these index terms name a published entity? One indexed `$in`

--- a/src/lib/entity-publish.ts
+++ b/src/lib/entity-publish.ts
@@ -1,0 +1,82 @@
+import type { Db } from 'mongodb';
+
+/**
+ * The published tier of the entity layer (#4321).
+ *
+ * An entity page is PUBLISHED — indexable, sitemap-eligible, worth linking
+ * from prose — when it has both:
+ *
+ *   - reach:    appears in >= 3 books (a cross-corpus claim needs three
+ *               witnesses; the 2-book case is the "Triple Anatomy" pathology
+ *               where co-occurrence is just the union of two books' indexes)
+ *   - identity: an external anchor — a Wikidata link or a description. This
+ *               is what separates *Ptolemy* from *Axis*: the offline
+ *               enrichment does not deliberately match a common noun used in
+ *               its ordinary sense.
+ *
+ * This is a read-side predicate over existing fields — deliberately not a
+ * stored flag, so no bulk `entities` write can exist, no sweep can be
+ * clobbered by another session, and the tier is reversible by editing this
+ * one function. Below-the-line pages keep rendering (a URL we have shown a
+ * reader must not 404); they are noindexed and internal surfaces stop
+ * linking to them.
+ *
+ * Keep `isPublishedEntity` and `PUBLISHED_ENTITY_FILTER` semantically in
+ * step — one gates on a fetched doc, the other inside a Mongo query, and a
+ * guard that only normalizes one side is inert (see
+ * tests/unit/entity-publish.test.ts, which pins both).
+ */
+export const PUBLISHED_ENTITY_MIN_BOOKS = 3;
+
+export interface EntityPublishFields {
+  book_count?: number | null;
+  wikidata_id?: string | null;
+  description?: string | null;
+}
+
+export function isPublishedEntity(entity: EntityPublishFields): boolean {
+  // Strict `!== ''` (no trim) so this stays exactly expressible as the Mongo
+  // filter below — a guard must normalize BOTH sides, and $ne can't trim.
+  const reach = (entity.book_count ?? 0) >= PUBLISHED_ENTITY_MIN_BOOKS;
+  const identity =
+    (typeof entity.wikidata_id === 'string' && entity.wikidata_id !== '') ||
+    (typeof entity.description === 'string' && entity.description !== '');
+  return reach && identity;
+}
+
+/**
+ * The same tier as a Mongo filter fragment, for gating link lookups.
+ * Note: this reads the stored `book_count`, which on legacy rows can
+ * overcount duplicated `books[]` entries; the page itself decides noindex
+ * from the deduped count (the citable surface gets the accurate value, the
+ * link side an indexed approximation).
+ */
+export const PUBLISHED_ENTITY_FILTER = {
+  book_count: { $gte: PUBLISHED_ENTITY_MIN_BOOKS },
+  $or: [
+    { wikidata_id: { $type: 'string', $ne: '' } },
+    { description: { $type: 'string', $ne: '' } },
+  ],
+} as const;
+
+/**
+ * Which of these index terms name a published entity? One indexed `$in`
+ * read; matches on exact `name` only (the extractors create entities under
+ * the index term verbatim, so the alias fallback the encyclopedia page has
+ * is not needed for gating links built from a book's own index).
+ */
+export async function filterPublishedEntityTerms(
+  db: Db,
+  terms: string[],
+): Promise<Set<string>> {
+  const unique = [...new Set(terms.filter(Boolean))];
+  if (unique.length === 0) return new Set();
+  const docs = await db
+    .collection('entities')
+    .find(
+      { name: { $in: unique }, ...PUBLISHED_ENTITY_FILTER },
+      { projection: { _id: 0, name: 1 }, maxTimeMS: 15000 },
+    )
+    .toArray();
+  return new Set(docs.map((d) => d.name as string));
+}

--- a/tests/unit/entity-publish.test.ts
+++ b/tests/unit/entity-publish.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Published-entity tier (issue #4321).
+ *
+ * The entity layer holds ~1M entities; ~76% appear in one book. A page is
+ * PUBLISHED (indexable, linkable from prose) only with both reach
+ * (book_count >= 3) and identity (wikidata_id or description). The tier is a
+ * read-side predicate — there is deliberately no stored flag to sweep.
+ *
+ * Two things are pinned here:
+ *  1. The predicate's semantics, case by case.
+ *  2. That the Mongo filter fragment agrees with the predicate — a guard
+ *     that only normalizes one side is inert (the link side gates with the
+ *     filter, the page's noindex with the function; if they drift, entities
+ *     get linked-but-noindexed or hidden-but-indexed).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  isPublishedEntity,
+  PUBLISHED_ENTITY_FILTER,
+  PUBLISHED_ENTITY_MIN_BOOKS,
+} from '@/lib/entity-publish';
+
+describe('isPublishedEntity', () => {
+  it('requires BOTH reach and identity', () => {
+    expect(isPublishedEntity({ book_count: 5, wikidata_id: 'Q1234' })).toBe(true);
+    expect(isPublishedEntity({ book_count: 5, description: 'A Greek astronomer.' })).toBe(true);
+    // reach without identity — the "Axis" case: a common noun in many books
+    expect(isPublishedEntity({ book_count: 50 })).toBe(false);
+    // identity without reach — enriched but not yet a cross-corpus claim
+    expect(isPublishedEntity({ book_count: 2, wikidata_id: 'Q1234' })).toBe(false);
+  });
+
+  it('sits exactly at the 3-book boundary', () => {
+    expect(isPublishedEntity({ book_count: 3, wikidata_id: 'Q1' })).toBe(true);
+    expect(isPublishedEntity({ book_count: 2, wikidata_id: 'Q1' })).toBe(false);
+    expect(PUBLISHED_ENTITY_MIN_BOOKS).toBe(3);
+  });
+
+  it('does not accept empty identity fields', () => {
+    expect(isPublishedEntity({ book_count: 10, wikidata_id: '' })).toBe(false);
+    expect(isPublishedEntity({ book_count: 10, wikidata_id: null, description: null })).toBe(false);
+  });
+
+  it('treats a missing book_count as zero', () => {
+    expect(isPublishedEntity({ wikidata_id: 'Q1' })).toBe(false);
+    expect(isPublishedEntity({ book_count: null, wikidata_id: 'Q1' })).toBe(false);
+  });
+});
+
+describe('PUBLISHED_ENTITY_FILTER agrees with the predicate', () => {
+  // Minimal evaluator for the exact operators the filter uses. If the filter
+  // grows an operator this evaluator doesn't know, the test throws — which is
+  // the point: both sides must be updated together.
+  function matchesFilter(doc: Record<string, unknown>): boolean {
+    const evalCond = (value: unknown, cond: Record<string, unknown>): boolean =>
+      Object.entries(cond).every(([op, operand]) => {
+        switch (op) {
+          case '$gte':
+            return typeof value === 'number' && value >= (operand as number);
+          case '$type':
+            return operand === 'string' ? typeof value === 'string' : (() => { throw new Error(`unhandled $type ${operand}`); })();
+          case '$ne':
+            return value !== operand;
+          default:
+            throw new Error(`unhandled operator ${op}`);
+        }
+      });
+    return Object.entries(PUBLISHED_ENTITY_FILTER).every(([key, cond]) => {
+      if (key === '$or') {
+        return (cond as Array<Record<string, Record<string, unknown>>>).some(branch =>
+          Object.entries(branch).every(([f, c]) => evalCond(doc[f], c)),
+        );
+      }
+      return evalCond(doc[key], cond as Record<string, unknown>);
+    });
+  }
+
+  const cases: Array<Record<string, unknown>> = [
+    { book_count: 5, wikidata_id: 'Q1' },
+    { book_count: 5, description: 'x' },
+    { book_count: 3, wikidata_id: 'Q1' },
+    { book_count: 2, wikidata_id: 'Q1' },
+    { book_count: 50 },
+    { book_count: 10, wikidata_id: '' },
+    { book_count: 10, description: '   ' },
+    { wikidata_id: 'Q1' },
+    { book_count: 0, description: 'x' },
+  ];
+
+  it.each(cases.map(c => [JSON.stringify(c), c] as const))('%s', (_label, doc) => {
+    expect(matchesFilter(doc)).toBe(
+      isPublishedEntity(doc as { book_count?: number; wikidata_id?: string; description?: string }),
+    );
+  });
+});


### PR DESCRIPTION
First implementation slice of the #4321 decision (steps a+b of the sequencing posted there): the entity layer is a **cross-corpus finding aid**, and a page is **published** — indexable, worth linking from prose — only with both **reach** (`book_count >= 3`) and **identity** (`wikidata_id` or a description). ~20–25K of the 1.02M entities qualify (measured on prod 2026-08-28).

## In scope

- **`src/lib/entity-publish.ts`** — `isPublishedEntity()` plus the equivalent Mongo filter fragment and a `$in` term-filter helper. Deliberately a **read-side predicate over existing fields**, not a stored flag: no bulk `entities` write exists to sweep, clobber, or pause before builds, and the tier is reversible by editing one function.
- **`/encyclopedia/[name]`** — below-the-line entities serve `robots: noindex, follow` metadata but keep rendering (a URL we have shown a reader must not 404). Decision uses the *deduped* book count from `getEntity`, not the stored field. robots.txt currently disallows `/encyclopedia/` wholesale; this metadata is the prerequisite for narrowing that disallow later (step d).
- **Book-page prose links** (`linkEntities`) — gated through one indexed `$in` lookup. Measured on a 30-book sample: **52% of index terms pass**, so summaries keep their meaningful links and shed the one-book vocabulary (`/encyclopedia/Axis` class). On lookup failure the prose degrades to unlinked rather than linking unvetted.
- **Author page "Mentions in other books" pill** — renders only for published-tier entities.
- **`tests/unit/entity-publish.test.ts`** — pins the tier boundary and asserts the predicate and the Mongo filter agree on the same fixtures (a guard that only normalizes one side is inert; the two sides are used on different surfaces).

## Out of scope, deliberately

- **Timeline gating.** Measured: applying the predicate to the timeline's resolvability filter would drop **2,058 of 6,266 figures (33%)**. `canonical_entities` carries its own Wikidata identity (birth/death dates) even where the legacy `entities` doc lacks `wikidata_id`, so that is a content/enrichment decision, not link hygiene — needs its own issue. The timeline canvas links via JS `window.open`, invisible to crawlers, so nothing is leaking meanwhile.
- **Dead code found, not touched:** `EraHighlights`, `MapSidebar`, `EntityMap`, `EntityMapLoader` have no consumers (grep-verified). Separate cleanup PR if wanted.
- **robots.txt / sitemap changes** (step d — only after this has settled), slugs for the published tier (step c), and the #4111 association-measure Connections rebuild.

No data writes anywhere in this PR. `npx tsc --noEmit` clean; new tests 13/13.

Refs #4321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M1eHHxaWTzyHFcTCo4tR9
