### PR TITLE
Real-user feedback fixes: fat thumbnails, honest image lanes, collections wayfinding, URL hygiene

### DIFF
--- a/scripts/audit/card-thumbnail-weight.mjs
+++ b/scripts/audit/card-thumbnail-weight.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Detector: card-tier book images must be card-weight — issue #4337.
+ *
+ * The class this guards against: a sweep or import leaves a book's DISPLAY-tier
+ * field (`image_display`/`thumbnail`) pointing at a full-resolution scan. Cards
+ * read that tier (getBookThumbnailUrl 'display'), the #1727 no-op image loader
+ * serves the stored URL at every width, and a book page ships tens of MB — the
+ * March 2026 ETCSL batch put 13–27 MB "thumbnails" on 386 books and a real
+ * user reported "Super slow on this page". A doc did not prevent it; this
+ * check runs against production data.
+ *
+ * Samples N visible books (default 300), resolves the same URL a card would,
+ * HEADs it, and flags anything over the byte budget. Exits 1 when flagged —
+ * cron-friendly (see scripts/audit/ siblings for the issue-filing pattern).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/card-thumbnail-weight.mjs [--sample=300] [--budget-kb=300]
+ */
+import { MongoClient } from 'mongodb';
+
+const SAMPLE = Number((process.argv.find(a => a.startsWith('--sample=')) || '').split('=')[1]) || 300;
+// Default budget is 2000 KB, NOT the ~100 KB a card should cost: measured
+// 2026-08-29, ~57% of visible books serve a 300 KB–4 MB object at the display
+// tier (the pages/{id}/{NNNN}.jpg "display variants" of several eras are
+// full-res). Until that corpus-wide backfill lands (issue #4342), a 300 KB
+// budget would be red every run — an alarm that cannot fall reports nothing.
+// 2 MB catches the catastrophic class (#4337 was 13–27 MB). Lower this to
+// ~300 after the backfill.
+const BUDGET_KB = Number((process.argv.find(a => a.startsWith('--budget-kb=')) || '').split('=')[1]) || 2000;
+const CONCURRENCY = 12;
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+// Deterministic ratchet, independent of sampling: the flat `thumbnails/{id}.jpg`
+// form IS the #4337 bug (a book-level field pointing at the raw full-res
+// object; no small variant derivable from the URL). Repaired to 0 on
+// 2026-08-29 — any nonzero count here means the class recurred.
+const flatFat = await db.collection('books').countDocuments({
+  $or: [
+    { thumbnail: { $regex: '//images\\.sourcelibrary\\.org/thumbnails/[a-f0-9]{24}\\.jpg$' } },
+    { image_display: { $regex: '//images\\.sourcelibrary\\.org/thumbnails/[a-f0-9]{24}\\.jpg$' } },
+  ],
+});
+console.log(`Books with flat thumbnails/{id}.jpg at the display tier: ${flatFat} (must be 0 — #4337)`);
+
+const books = await db.collection('books').aggregate([
+  { $match: { visible: true, pages_count: { $gt: 0 } } },
+  { $sample: { size: SAMPLE } },
+  { $project: { title: 1, thumbnail: 1, image_display: 1, thumbnail_blob: 1 } },
+]).toArray();
+
+// Mirror getBookThumbnailUrl('display'): same field preference AND the same
+// legacy-path rewrites (src/lib/utils.ts) — a stored `archived/{id}/{n}.jpg`
+// is served as `pages/{id}/{0n}.jpg`, so the raw URL is NOT what cards load.
+// First detector draft skipped the rewrites and flagged 70% of the corpus.
+function cardUrl(raw) {
+  let m = raw.match(/\/thumbnails\/([^/]+)\/(\d+)\.jpg$/);
+  if (m) return `https://images.sourcelibrary.org/pages/${m[1]}/${m[2].padStart(4, '0')}.jpg`;
+  m = raw.match(/\/archived\/([^/]+)\/(\d+)\.jpg$/);
+  if (m) return `https://images.sourcelibrary.org/pages/${m[1]}/${m[2].padStart(4, '0')}.jpg`;
+  return raw;
+}
+const targets = books
+  .map(b => ({ id: b._id.toString(), title: b.title, url: cardUrl((b.image_display || b.thumbnail || b.thumbnail_blob || '').trim()) }))
+  .filter(t => t.url.startsWith('https://images.sourcelibrary.org/'));
+
+let idx = 0, checked = 0, unreachable = 0;
+const flagged = [];
+async function worker() {
+  while (idx < targets.length) {
+    const t = targets[idx++];
+    try {
+      const res = await fetch(t.url, { method: 'HEAD', signal: AbortSignal.timeout(15000) });
+      if (!res.ok) { unreachable++; continue; }
+      checked++;
+      const kb = Math.round(parseInt(res.headers.get('content-length') || '0') / 1024);
+      if (kb > BUDGET_KB) flagged.push({ ...t, kb });
+    } catch {
+      unreachable++;
+    }
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+// A probe needs a positive control: if nothing was checkable, the sample is
+// broken, not clean (lesson_probe_needs_a_positive_control).
+if (checked === 0) {
+  console.error(`BROKEN PROBE: 0 of ${targets.length} card URLs were checkable (${unreachable} unreachable) — cannot assert anything.`);
+  await client.close();
+  process.exit(2);
+}
+
+flagged.sort((a, b) => b.kb - a.kb);
+console.log(`Checked ${checked}/${targets.length} sampled visible books (${unreachable} unreachable); budget ${BUDGET_KB} KB.`);
+console.log(`Over budget: ${flagged.length}`);
+for (const f of flagged.slice(0, 20)) {
+  console.log(`  ${(f.kb + ' KB').padStart(9)}  ${f.id}  "${(f.title || '').slice(0, 50)}"  ${f.url}`);
+}
+
+await client.close();
+process.exit(flagged.length > 0 || flatFat > 0 ? 1 : 0);

--- a/scripts/maintenance/fix-gallery-url-newlines-4340.mjs
+++ b/scripts/maintenance/fix-gallery-url-newlines-4340.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Strip embedded whitespace from gallery_images URL fields — issue #4340.
+ *
+ * 7,575 rows carry a literal "\n" after the host in thumbnail_url and
+ * extracted_url ("https://images.sourcelibrary.org\n/gallery/..."), written
+ * ~2026-07-05 by a run whose R2_PUBLIC_URL env value had a trailing newline
+ * (see lesson_env_newline_phantom_sync_success; backfill-card-thumbs.mjs
+ * already defends at read time with cleanUrl()). Browsers strip \n during URL
+ * parsing so <img> mostly survives, but every non-browser consumer (JSON API
+ * clients, MCP agents, OG scrapers) gets a broken URL — and the values flow
+ * out through /api/search/unified today.
+ *
+ * The class-level guard (getR2PublicUrl() trimming its env value) ships in the
+ * same PR, so a rerun of the original writer cannot re-poison these rows.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fix-gallery-url-newlines-4340.mjs --dry-run
+ *   node scripts/maintenance/fix-gallery-url-newlines-4340.mjs --apply
+ */
+import { MongoClient } from 'mongodb';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const FIELDS = ['thumbnail_url', 'extracted_url', 'image_url', 'card_url'];
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+const col = db.collection('gallery_images');
+
+console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}\n`);
+
+const filter = { $or: FIELDS.map(f => ({ [f]: /[\s]/ })) };
+const total = await col.countDocuments(filter);
+console.log(`Rows with whitespace in ${FIELDS.join('/')}: ${total}`);
+
+if (!APPLY) {
+  const sample = await col.find(filter).limit(3).toArray();
+  for (const s of sample) {
+    for (const f of FIELDS) {
+      if (s[f] && /\s/.test(s[f])) console.log(`  ${s._id} ${f}: ${JSON.stringify(s[f]).slice(0, 110)}`);
+    }
+  }
+  console.log('\nDry run only — re-run with --apply to write.');
+} else {
+  // Per-field chained $replaceAll on \n, \r, \t and space. URLs legitimately
+  // never contain raw whitespace, so a blanket strip is safe for these fields.
+  const stripAll = (expr) => [' ', '\t', '\r', '\n'].reduce(
+    (input, ch) => ({ $replaceAll: { input, find: ch, replacement: '' } }),
+    expr,
+  );
+  const stripStages = FIELDS.map(f => ({
+    $set: {
+      [f]: {
+        $cond: [
+          { $eq: [{ $type: `$${f}` }, 'string'] },
+          stripAll(`$${f}`),
+          `$${f}`,
+        ],
+      },
+    },
+  }));
+  const res = await col.updateMany(filter, [
+    ...stripStages,
+    { $set: { updated_at: new Date() } },
+  ]);
+  console.log(`matched=${res.matchedCount} modified=${res.modifiedCount}`);
+
+  await recordSweepAction(db, {
+    sweep: 'gallery-url-newlines-4340',
+    book_id: 'corpus-wide',
+    action: 'stripped-newlines-from-url-fields',
+    detail: { rows_matched: res.matchedCount, rows_modified: res.modifiedCount, fields: FIELDS },
+  });
+
+  const remaining = await col.countDocuments(filter);
+  console.log(`Remaining rows with whitespace after write: ${remaining}`);
+  if (remaining > 0) process.exitCode = 1;
+}
+
+await client.close();

--- a/scripts/maintenance/repair-fat-book-thumbnails-4337.mjs
+++ b/scripts/maintenance/repair-fat-book-thumbnails-4337.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Repair books whose `thumbnail`/`image_display` point at a FULL-RES scan —
+ * issue #4337 (real-user report: "Super slow on this page").
+ *
+ * Symptom: /book/the-lament-for-urim shipped ~91 MB of images — related-book
+ * cards rendered `thumbnails/{bookId}.jpg` objects of 13–27 MB (5306×9957 px
+ * CDLI tablet photos). 386 books (383 visible) have `thumbnail` matching the
+ * flat `thumbnails/{24-hex}.jpg` form; sampled 30 → 20 objects were >500 KB.
+ *
+ * Root cause: repair-cover-thumbs.mjs v2 ("book-level fallback",
+ * thumbnail_source: cover-thumb-repair-booklevel) generated a 150px
+ * `book-thumbnails/{id}-thumb.jpg` and repointed ONLY the thumb-tier fields
+ * (image_thumb/thumbnail_blob), deliberately leaving `thumbnail` and
+ * `image_display` at the full image "for the detail view". But card surfaces
+ * read the DISPLAY tier (getBookThumbnailUrl 'display' → image_display ||
+ * thumbnail), so cards got the full scan. next/image srcSet can't save us:
+ * the #1727 cost policy loader returns the stored URL at every width.
+ *
+ * What this does, per affected book:
+ *   1. Fetch the fat `thumbnails/{id}.jpg` (the only large source these books
+ *      have — no pages/, no archived/ variants).
+ *   2. Generate 1200px display + 600px card variants (same ladder as
+ *      repair-cover-thumbs / #2401 card spec) and upload to
+ *      `book-thumbnails/{id}.jpg` and `book-thumbnails/{id}-card.jpg`.
+ *      The existing 150px `book-thumbnails/{id}-thumb.jpg` is left alone.
+ *   3. Repoint Mongo: image_display → 1200px, thumbnail → 600px card,
+ *      thumbnail_source → 'fat-thumb-repair-4337', bump updated_at (so the
+ *      incremental sync-books-catalog cron propagates to the Supabase grid —
+ *      books_catalog mirrors `thumbnail`).
+ *   4. Record a sweep_log row with the before/after URLs (field-sprawl rule:
+ *      rows, not columns).
+ *
+ * Books where the fat object is already small (<300 KB) are still migrated to
+ * the variant ladder — uniform outcome, and the bare `thumbnails/{id}.jpg`
+ * convention dies here. Fetch/upload failures are recorded as rows and
+ * reported; no silent skips.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/repair-fat-book-thumbnails-4337.mjs --dry-run
+ *   node scripts/maintenance/repair-fat-book-thumbnails-4337.mjs --apply [--limit=N] [--concurrency=6]
+ */
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = Number((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1]) || 0;
+const CONCURRENCY = Number((process.argv.find(a => a.startsWith('--concurrency=')) || '').split('=')[1]) || 6;
+
+const R2_PUBLIC_URL = (process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org').trim();
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
+if (APPLY && (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY)) {
+  console.error('R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY must be set');
+  process.exit(1);
+}
+const s3 = APPLY ? new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+}) : null;
+
+const FLAT_FAT_RE = /^https:\/\/images\.sourcelibrary\.org\/thumbnails\/([a-f0-9]{24})\.jpg$/;
+
+async function putR2(key, body) {
+  await s3.send(new PutObjectCommand({
+    Bucket: R2_BUCKET, Key: key, Body: body, ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=604800',
+  }));
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+
+console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}\n`);
+
+const filter = { thumbnail: FLAT_FAT_RE };
+const targets = await books.find(filter, {
+  projection: { title: 1, thumbnail: 1, image_display: 1, thumbnail_blob: 1, image_thumb: 1, visible: 1 },
+}).limit(LIMIT || 0).toArray();
+console.log(`Books with flat thumbnails/{id}.jpg as thumbnail: ${targets.length}`);
+
+if (!APPLY) {
+  let fat = 0;
+  const sample = targets.slice(0, 15);
+  for (const b of sample) {
+    const res = await fetch(b.thumbnail.trim(), { method: 'HEAD' });
+    const kb = Math.round((parseInt(res.headers.get('content-length') || '0')) / 1024);
+    if (kb > 300) fat++;
+    console.log(`  ${b._id} ${kb} KB visible=${b.visible} "${(b.title || '').slice(0, 45)}"`);
+  }
+  console.log(`\nSample: ${fat}/${sample.length} over 300 KB. Re-run with --apply to repair all ${targets.length}.`);
+  await client.close();
+  process.exit(0);
+}
+
+let ok = 0, failed = 0;
+const failures = [];
+let idx = 0;
+
+async function repairOne(b) {
+  const id = b._id.toString();
+  const fatUrl = b.thumbnail.trim();
+  const resp = await fetch(fatUrl, { signal: AbortSignal.timeout(120000) });
+  if (!resp.ok) throw new Error(`fetch ${resp.status}`);
+  const buf = Buffer.from(await resp.arrayBuffer());
+
+  const displayBuf = await sharp(buf)
+    .resize(1200, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 80, progressive: true })
+    .toBuffer();
+  const cardBuf = await sharp(buf)
+    .resize(600, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 72 })
+    .toBuffer();
+
+  const displayUrl = await putR2(`book-thumbnails/${id}.jpg`, displayBuf);
+  const cardUrl = await putR2(`book-thumbnails/${id}-card.jpg`, cardBuf);
+
+  const res = await books.updateOne(
+    { _id: b._id, thumbnail: b.thumbnail },
+    {
+      $set: {
+        thumbnail: cardUrl,
+        image_display: displayUrl,
+        thumbnail_source: 'fat-thumb-repair-4337',
+        updated_at: new Date(),
+      },
+    },
+  );
+  if (res.modifiedCount !== 1) throw new Error('mongo write raced or matched 0 — not repointed');
+
+  await recordSweepAction(db, {
+    sweep: 'fat-thumb-repair-4337',
+    book_id: id,
+    action: 'repointed-display-tier-to-generated-variants',
+    detail: {
+      old_thumbnail: b.thumbnail,
+      old_image_display: b.image_display || null,
+      new_thumbnail: cardUrl,
+      new_image_display: displayUrl,
+      source_bytes: buf.length,
+      card_bytes: cardBuf.length,
+      display_bytes: displayBuf.length,
+    },
+  });
+}
+
+async function worker() {
+  while (idx < targets.length) {
+    const b = targets[idx++];
+    try {
+      await repairOne(b);
+      ok++;
+    } catch (e) {
+      failed++;
+      failures.push({ id: b._id.toString(), error: e.message });
+      await recordSweepAction(db, {
+        sweep: 'fat-thumb-repair-4337',
+        book_id: b._id.toString(),
+        action: 'repair-failed',
+        detail: { error: e.message, thumbnail: b.thumbnail },
+      }).catch(() => {});
+    }
+    if ((ok + failed) % 25 === 0) console.log(`  [${ok + failed}/${targets.length}] ok=${ok} fail=${failed}`);
+  }
+}
+
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+console.log(`\nDone: ok=${ok} failed=${failed}`);
+for (const f of failures.slice(0, 20)) console.log(`  FAIL ${f.id}: ${f.error}`);
+
+// Verification — the read path, not the write path: count books still matching,
+// and HEAD a few of the new URLs.
+const remaining = await books.countDocuments(filter);
+console.log(`Books still matching flat fat-thumbnail form: ${remaining} (failures above account for these)`);
+const check = await books.find({ thumbnail_source: 'fat-thumb-repair-4337' }).limit(3).toArray();
+for (const b of check) {
+  const r = await fetch(b.thumbnail, { method: 'HEAD' });
+  console.log(`  verify ${b._id}: ${r.status} ${Math.round(parseInt(r.headers.get('content-length') || '0') / 1024)} KB`);
+}
+
+await client.close();
+if (failed > 0) process.exitCode = 1;

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -315,7 +315,15 @@ export async function GET(request: NextRequest) {
 
       // Fallback: $text index (covers description, book_title, book_author)
       if (textItems.length === 0) {
-        filter.$text = { $search: searchQuery };
+        // Multi-word queries: quote the phrase so $text requires the words
+        // together. Bare $text ORs tokens, so "zzzqxv nonexistent" matched 12
+        // rows whose captions contain the word "nonexistent" — garbage served
+        // as if it matched the query (#4338). Single words keep OR semantics
+        // (there is nothing to OR).
+        const phraseQuery = /\s/.test(searchQuery)
+          ? `"${searchQuery.replace(/"/g, '')}"`
+          : searchQuery;
+        filter.$text = { $search: phraseQuery };
         const sortOrder: Record<string, any> = { score: { $meta: 'textScore' }, gallery_quality: -1 };
         const projection = { _id: 0, score: { $meta: 'textScore' as const } };
         textItems = await db.collection('gallery_images')

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -935,7 +935,10 @@ async function searchVisual(db: any, query: string, limit: number, yearRange?: {
     // Search Supabase CLIP embeddings
     const { data, error } = await supabase.rpc('match_clip_text', {
       query_embedding: embedding,
-      match_threshold: 0.22,
+      // 0.22 → 0.26 (#4338): below ~0.26 CLIP hands back plausible-looking
+      // junk (unrelated instruments, screenshots) that the client blends into
+      // the image grid as if it matched the query.
+      match_threshold: 0.26,
       match_count: limit * 2,
     });
     if (error || !data) return { results: [], total: 0 };

--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -21,7 +21,11 @@ export async function GET(request: NextRequest) {
   const query = searchParams.get('q')?.trim();
   const limit = Math.min(parseInt(searchParams.get('limit') || '24'), 100);
   const offset = parseInt(searchParams.get('offset') || '0');
-  const threshold = parseFloat(searchParams.get('threshold') || '0.20');
+  // Default floor raised 0.20 → 0.26 (#4338): at 0.20–0.25 CLIP returns
+  // confidently unrelated images (an oud player and Wikipedia-vandalism
+  // screenshots for "ancient egyptian"), and users read them as broken search.
+  // Callers that want the speculative tail can still pass ?threshold= lower.
+  const threshold = parseFloat(searchParams.get('threshold') || '0.26');
 
   if (!query || query.length < 2) {
     return NextResponse.json({ results: [], query: '', total: 0 });

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -687,20 +687,28 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
 
   const artworks = await artworksPromise;
 
-  // Fetch parent collection if this is a subcollection
+  // Fetch parent collection if this is a subcollection.
+  // `parent` is a string OR an array of slugs (cross-listed pathways like
+  // women-of-the-secret-tradition carry ["hermetica","secret-societies"]).
+  // findOne({slug: <array>}) matches nothing, which silently dropped the
+  // breadcrumb on exactly the cross-listed collections — the ones where a
+  // reader most needs to know where they are (#4339). The child query
+  // ({parent: id}) matches array values natively, so the tree only broke in
+  // the upward direction. First slug wins as the primary trail.
   let parentCollection: { slug: string; name: string } | null = null;
-  if (collection.parent) {
+  const parentSlug = Array.isArray(collection.parent) ? collection.parent[0] : collection.parent;
+  if (parentSlug) {
     const parentDoc = await withTimeout(
       db.collection('collections').findOne(
         tenantId
           ? {
-            slug: collection.parent,
+            slug: parentSlug,
             $or: [
               { tenantId },
               { tenantId: { $exists: false } },
             ],
           }
-          : { slug: collection.parent },
+          : { slug: parentSlug },
         { projection: { slug: 1, name: 1 } },
       ),
       5000, null,

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -291,10 +291,17 @@ export default async function CollectionsPage() {
       </Suspense>
 
       <div className="mt-12">
-        <Suspense fallback={<SectionSkeleton heading="Curated Pathways" sub="Thematic journeys and special collections" />}>
+        <Suspense fallback={<SectionSkeleton heading="Curated Pathways" sub="Thematic journeys drawn from across the core collections" />}>
           <CuratedPathwaysSection />
         </Suspense>
       </div>
+
+      {/* The landing shows ~31 of 300+ collections; without this link the rest
+          are reachable only through search (#4339 — real-user confusion about
+          what the catalog actually contains). */}
+      <Suspense fallback={null}>
+        <AllCollectionsLink />
+      </Suspense>
 
       <Suspense fallback={null}>
         <TimelineSection />
@@ -345,13 +352,29 @@ async function CuratedPathwaysSection() {
     <div>
       <div className="mb-4">
         <h2 className="font-display text-2xl text-primary">Curated Pathways</h2>
-        <p className="text-stone-500 mt-1 text-sm">Thematic journeys and special collections</p>
+        <p className="text-stone-500 mt-1 text-sm">Thematic journeys drawn from across the core collections</p>
       </div>
       <ShowMorePathways initialCount={INITIAL_PATHWAYS} totalCount={items.length}>
         {items.map((col, i) => (
           <CuratedCard key={col.slug} col={col} tenantSlug={tenantSlug} priority={i < 4} />
         ))}
       </ShowMorePathways>
+    </div>
+  );
+}
+
+async function AllCollectionsLink() {
+  const { slug: tenantSlug } = getTenantContextFromRequest(await headers());
+  const href = tenantSlug ? `/${tenantSlug}/collections/all` : '/collections/all';
+  return (
+    <div className="mt-10 text-center">
+      <Link
+        href={href}
+        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-border-light text-sm text-secondary hover:border-accent-gold/40 hover:text-primary transition-colors"
+      >
+        Browse the complete index of collections
+        <span aria-hidden>→</span>
+      </Link>
     </div>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -408,18 +408,23 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
         const existingIds = new Set(imageResults.map(i => `${i.pageId}-${i.detectionIndex}`));
         const newImages: GalleryItem[] = [];
         // Search all image terms in parallel
+        const supplementTerms = imgTerms.slice(0, 3);
         const results = await Promise.allSettled(
-          imgTerms.slice(0, 3).map(term =>
+          supplementTerms.map(term =>
             galleryApi.list({ query: term, limit: 4, maxPerBook: 1 })
           )
         );
-        for (const r of results) {
+        for (const [i, r] of results.entries()) {
           if (r.status !== 'fulfilled') continue;
           for (const item of (r.value.items || [])) {
             const key = `${item.pageId}-${item.detectionIndex}`;
             if (existingIds.has(key)) continue;
             existingIds.add(key);
-            newImages.push(item);
+            // Carry the LLM term that fetched this image so the card can label
+            // it "related · <term>". Unlabeled, these read as direct matches —
+            // a user searching "ancient egyptian" saw tarot layouts because the
+            // expansion suggested "book of thoth" (#4338).
+            newImages.push({ ...item, aiTerm: supplementTerms[i] } as GalleryItem);
           }
         }
         if (newImages.length > 0) {
@@ -494,7 +499,11 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
           // Map unified gallery + visual + artwork results to GalleryItem shape
           // Merge all image sources, deduped by id
           const galleryResults = data.gallery?.results || [];
-          const visualResults = data.visual?.results || [];
+          // CLIP results are approximate by nature — tag them so the card can
+          // say "visual match" instead of presenting an embedding neighbor as
+          // if it matched the query text (#4338: tarot cards under "ancient
+          // egyptian" read as broken search when unlabeled).
+          const visualResults = (data.visual?.results || []).map((v: any) => ({ ...v, visualMatch: true }));
           const artworkResults = (data as any).artworks?.results || [];
           const seenImageIds = new Set<string>();
           const allImageResults = [...galleryResults, ...visualResults];
@@ -516,6 +525,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
               author: '',
               description: g.description || '',
               type: g.type,
+              visualMatch: (g as any).visualMatch || undefined,
             } as GalleryItem);
           }
           // Merge artwork results as image cards. With lexical recall (#2735) a
@@ -2292,8 +2302,14 @@ function IndexResultCard({ result, query, tenant }: { result: IndexSearchResult;
   );
 }
 
-function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null }; query: string; large?: boolean; tenant?: string }) {
+function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null; aiTerm?: string; visualMatch?: boolean }; query: string; large?: boolean; tenant?: string }) {
   const [imageError, setImageError] = useState(false);
+
+  // Provenance chip: images that arrived via LLM term expansion or CLIP
+  // similarity are honest neighbors, not matches — say so on the card (#4338).
+  const provenance = item.aiTerm
+    ? `related · ${item.aiTerm}`
+    : item.visualMatch ? 'visual match' : null;
 
   // Use pre-generated thumbnail/extracted URL first (publicly accessible),
   // fall back to original imageUrl (crop-image API requires auth and breaks for visitors)
@@ -2327,6 +2343,11 @@ function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & {
           <div className="absolute inset-0 flex items-center justify-center">
             <ImageIcon className="w-8 h-8 text-border-medium" />
           </div>
+        )}
+        {provenance && (
+          <span className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/55 text-[10px] leading-tight text-white/90 backdrop-blur-sm">
+            {provenance}
+          </span>
         )}
       </div>
       <div className="p-2.5">

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -41,7 +41,12 @@ function getR2BucketName(): string {
 }
 
 function getR2PublicUrl(): string {
-  return process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+  // .trim() is load-bearing: a trailing "\n" in this env value once poisoned
+  // 7,575 gallery_images rows with "https://images.sourcelibrary.org\n/..."
+  // URLs (#4340, lesson_env_newline_phantom_sync_success). Browsers strip the
+  // newline when parsing, so it shipped unnoticed; every non-browser consumer
+  // got broken URLs.
+  return (process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org').trim();
 }
 
 export function isR2Configured(): boolean {


### PR DESCRIPTION
Fixes from watching a real user (Tommy, Android) struggle on 2026-08-28, plus his feedback-widget row. Closes #4338, closes #4340; substantially addresses #4337 and #4339 (both get follow-up notes on merge).

## In scope

**#4337 — card thumbnails that were full-res scans.**
`scripts/maintenance/repair-fat-book-thumbnails-4337.mjs` (already run against prod, 386/386 ok, 0 failures): generated real 1200px display + 600px card variants from the fat `thumbnails/{id}.jpg` objects and repointed `thumbnail`/`image_display`; `sync-books-catalog` ran after (473 rows). The book page that shipped ~91 MB of images now references 5–52 KB objects. New standing detector `scripts/audit/card-thumbnail-weight.mjs`: deterministic zero-count on the flat fat-thumbnail form + sampled weight check of what cards *actually* load (rewrite-aware).

**#4338 — image lanes presenting neighbors as matches.**
- AI term-expansion images get a `related · <term>` chip; CLIP merges get a `visual match` chip (same honesty pattern as the books lane's existing "Related in the library" section).
- CLIP similarity floors 0.20/0.22 → 0.26 (measured: below ~0.26 returns an oud player and Wikipedia-vandalism screenshots for "ancient egyptian").
- `/api/gallery` `$text` fallback phrase-matches multi-word queries — bare `$text` ORs tokens, so nonsense queries returned real-looking grids.

**#4339 — collections wayfinding.**
- Bug: collections whose `parent` is an *array* (cross-listed pathways) silently lost their breadcrumb — `findOne({slug: <array>})` matches nothing while the child query matches arrays natively, so the tree only broke upward. First slug now wins.
- Landing links the full `/collections/all` index (255+ collections were reachable only via search) and the pathways subtitle says they cut across the wings.

**#4340 — newline-poisoned gallery URLs.**
Sweep (already run: 7,652 rows cleaned, 0 remaining) + `getR2PublicUrl()` now trims its env value, killing the writer class (`lesson_env_newline_phantom_sync_success`).

## Out of scope
- Corpus-wide card-weight backfill (~57% of visible books serve 300 KB–4 MB at the display tier) → #4342; the detector's budget stays at 2 MB until that lands.
- The full collections IA discussion (tree vs tags, labeling on wing pages) → remains open on #4339.
- Recompressing the fat R2 originals themselves.

Data sweeps were executed against production before this PR (they are committed here for provenance + rerun); the code changes deploy with the merge, and the merge's auto purge+warm clears the CDN-cached HTML still referencing fat URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw4wrSSuLsY874BTT3DDLn