### PR TITLE
Serve book covers as a 500px AVIF card variant

### DIFF
--- a/scripts/lib/books-known-fields.json
+++ b/scripts/lib/books-known-fields.json
@@ -15,7 +15,7 @@
   ],
   "generated_from": "full-scan enumeration of bookstore.books",
   "generated_at": "2026-08-18",
-  "count": 423,
+  "count": 426,
   "retired": [
     "acquisition_priority",
     "acquisition_wave",
@@ -254,6 +254,7 @@
     "ia_identifier",
     "id",
     "identifier",
+    "image_card",
     "image_display",
     "image_extraction_status",
     "image_full",

--- a/scripts/lib/cover-write.mjs
+++ b/scripts/lib/cover-write.mjs
@@ -24,6 +24,7 @@ import { HAND_IN_FRAME_RE } from './cover-scoring.mjs';
 export const COVER_WRITE_FIELDS = [
   'image_display',
   'image_thumb',
+  'image_card',
   'image_full',
   'image_source_url',
   'thumbnail',
@@ -77,6 +78,11 @@ export function buildCoverUpdate(page, opts) {
   const update = {
     image_display: url,
     image_thumb: thumbUrl,
+    // Cleared, never carried over: image_card names ONE page's -card.avif, so a
+    // pointer that survives a cover change renders the OLD page as the new
+    // cover. Falls back to image_display until the variant is regenerated.
+    // Lock-step with src/lib/cover-fields.ts.
+    image_card: null,
     thumbnail: url,
     thumbnail_blob: thumbUrl,
     thumbnail_source: opts.source,

--- a/scripts/maintenance/backfill-cover-cards.mjs
+++ b/scripts/maintenance/backfill-cover-cards.mjs
@@ -1,0 +1,254 @@
+/**
+ * Backfill the 500px `-card.avif` cover variant.
+ *
+ * WHY
+ * ---
+ * R2 stores two cover sizes and nothing between them: `-thumb.jpg` (150px) and
+ * the bare `.jpg`, documented as "1200px display" but in practice the archival
+ * scan at ~2000px / ~750KB. A catalogue card renders in a 163–265px slot
+ * (326–530px at 2× DPR), so every grid pulls the 2000px file: measured
+ * 2026-08-26, the 60-card /catalog grid ships 43.4 MB and its slowest covers
+ * take 6–10s. Neither existing variant fits the slot — the thumb upscales 3.3×
+ * and reads soft (which is what PR #4212 was working around by lowering
+ * THUMB_WIDTH_THRESHOLD to 200, at the cost of sending mobile the 2000px file).
+ *
+ * This writes the missing middle tier: 500px AVIF q55, ~47 KB median. 500px
+ * covers a phone at 3× DPR (489px) exactly and the widest desktop card at 2×
+ * (530px) within 6%. Measured over 40 real catalogue covers: 746 KB avg → 47 KB
+ * avg, p90 94 KB, worst 105 KB — a 16× reduction, 43.4 MB → 2.8 MB per grid.
+ *
+ * Format note: resizing is the 12× and AVIF is a further ~1.35×. AVIF at the
+ * SOURCE resolution is still 804 KB, so the resize is the load-bearing half.
+ *
+ * The archival scan is never touched, re-encoded or deleted — the reader,
+ * downloads and deep zoom keep reading it. This is purely additive.
+ *
+ * SAFETY
+ * ------
+ * Writes `books.image_card` only after the R2 PUT succeeds, so the pointer can
+ * never name an object that does not exist. The card component reads the
+ * pointer rather than deriving the URL by convention, which is what stops the
+ * "derived a -thumb.jpg sibling that 404s" class of broken cover (homepage
+ * smoke-test failure, 2026-07-08; see src/lib/book-cover-loader.ts).
+ *
+ * Every key goes through assertBookScopedKey (#3362) — a page-image key that
+ * does not contain its own book id is shared between books by construction.
+ *
+ * Idempotent and resumable: books that already have `image_card` are skipped,
+ * so this can be stopped and restarted, or run in slices, without redoing work.
+ *
+ * ORDER
+ * -----
+ * read_count DESC, then first translations, then the rest — so the covers
+ * people actually look at (the "popular" catalogue sort, the homepage, the
+ * collection sliders) are fixed in the first couple of minutes rather than the
+ * last.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-cover-cards.mjs --dry-run --limit=50
+ *   node scripts/maintenance/backfill-cover-cards.mjs --limit=500
+ *   node scripts/maintenance/backfill-cover-cards.mjs            # everything
+ *
+ * Flags:
+ *   --dry-run        resolve + encode but write nothing (no R2 PUT, no Mongo)
+ *   --limit=N        stop after N books
+ *   --book-id=ID     one book, for spot checks
+ *   --concurrency=N  default 10 (measured ceiling; R2 fetch is the bottleneck)
+ *   --width=N        default 500
+ *   --quality=N      default 55
+ *   --force          rebuild even when image_card is already set
+ */
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { assertBookScopedKey } from '../lib/r2-key.mjs';
+
+const arg = (name, fallback = null) => {
+  const hit = process.argv.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : fallback;
+};
+const DRY_RUN = process.argv.includes('--dry-run');
+const FORCE = process.argv.includes('--force');
+const LIMIT = Number(arg('limit', 0)) || 0;
+const BOOK_ID = arg('book-id');
+const CONCURRENCY = Number(arg('concurrency', 10)) || 10;
+const WIDTH = Number(arg('width', 500)) || 500;
+const QUALITY = Number(arg('quality', 55)) || 55;
+
+const R2_PUBLIC_URL = (process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org').replace(/\s+/g, '');
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, MONGODB_URI } = process.env;
+
+if (!MONGODB_URI) { console.error('MONGODB_URI must be set'); process.exit(1); }
+if (!DRY_RUN && (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY)) {
+  console.error('R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY must be set (or pass --dry-run)');
+  process.exit(1);
+}
+
+const s3 = DRY_RUN ? null : new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+});
+
+// Stored URLs occasionally carry stray whitespace from a past run where
+// R2_PUBLIC_URL had a trailing newline. Strip it before deriving any key.
+const cleanUrl = u => { const s = (u || '').replace(/\s+/g, '').trim(); return s || null; };
+
+/**
+ * Resolve a book's cover to the R2 page-scan URL we should re-cut from.
+ *
+ * Mirrors getBookThumbnailUrl(book, 'display') in src/lib/utils.ts for the R2
+ * families that carry a full-size sibling. Anything it cannot map to a
+ * `pages/` or `cropped/` object is skipped rather than guessed at — external
+ * IIIF, Wikimedia and one-off uploads have no variant to write next to.
+ */
+function resolveSource(book) {
+  const raw = cleanUrl(book.image_display || book.thumbnail || book.thumbnail_blob);
+  if (!raw || !raw.includes('images.sourcelibrary.org/')) return null;
+
+  // /archived/{bookId}/{n}.jpg and /thumbnails/{bookId}/{n}.jpg both name a
+  // page whose canonical three-variant home is /pages/{bookId}/{NNNN}.jpg.
+  const legacy = raw.match(/\/(?:archived|thumbnails)\/([^/]+)\/(\d+)\.jpg$/);
+  if (legacy) {
+    const [, bookId, num] = legacy;
+    return `${R2_PUBLIC_URL}/pages/${bookId}/${num.padStart(4, '0')}.jpg`;
+  }
+
+  // Canonical page scans — normalise whichever suffix is stored to the display
+  // variant. Anchored to the /pages/ scan path so the PDF-import blob path
+  // `/books/{id}/pages/NNNN.jpg` (single-variant) is left alone.
+  if (raw.includes('images.sourcelibrary.org/pages/')) {
+    return raw.replace(/-thumb\.jpg$/, '.jpg').replace(/-full\.jpg$/, '.jpg');
+  }
+
+  // Cropped covers carry the same three-variant convention.
+  if (raw.includes('images.sourcelibrary.org/cropped/')) {
+    return raw.replace(/-thumb\.jpg$/, '.jpg').replace(/-full\.jpg$/, '.jpg');
+  }
+
+  return null;
+}
+
+/** `.../pages/{id}/0005.jpg` → `pages/{id}/0005-card.avif` */
+function cardKeyFrom(sourceUrl) {
+  const path = sourceUrl.split('?')[0].replace(`${R2_PUBLIC_URL}/`, '');
+  if (!/\.jpg$/.test(path)) return null;
+  return path.replace(/\.jpg$/, `-card.avif`);
+}
+
+async function processPool(items, concurrency, fn) {
+  let idx = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (idx < items.length) {
+      const i = idx++;
+      try { await fn(items[i], i); } catch (err) { items[i]._error = err?.message || String(err); }
+    }
+  });
+  await Promise.all(workers);
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection('books');
+
+  const query = BOOK_ID
+    ? { $or: [{ id: BOOK_ID }, { _id: BOOK_ID }, { slug: BOOK_ID }] }
+    : {
+        visible: true,
+        pages_count: { $gt: 0 },
+        image_display: { $type: 'string' },
+        ...(FORCE ? {} : { image_card: { $exists: false } }),
+      };
+
+  const cursor = books.find(query, {
+    projection: { _id: 1, id: 1, slug: 1, title: 1, image_display: 1, thumbnail: 1, thumbnail_blob: 1, read_count: 1, is_first_translation: 1 },
+  }).sort({ read_count: -1, is_first_translation: -1, _id: 1 });
+  if (LIMIT) cursor.limit(LIMIT);
+
+  const candidates = await cursor.toArray();
+  console.log(`${DRY_RUN ? 'DRY RUN — nothing will be written\n' : ''}candidates: ${candidates.length}   ${WIDTH}px AVIF q${QUALITY}   concurrency ${CONCURRENCY}\n`);
+
+  const stats = { done: 0, skipped: 0, failed: 0, srcBytes: 0, outBytes: 0 };
+  const skipReasons = new Map();
+  const samples = [];
+  const started = Date.now();
+
+  await processPool(candidates, CONCURRENCY, async (book) => {
+    const bookId = book.id || String(book._id);
+    const source = resolveSource(book);
+    if (!source) {
+      stats.skipped++;
+      const why = 'no R2 page-scan source';
+      skipReasons.set(why, (skipReasons.get(why) || 0) + 1);
+      return;
+    }
+
+    const key = cardKeyFrom(source);
+    if (!key) { stats.skipped++; skipReasons.set('unmappable key', (skipReasons.get('unmappable key') || 0) + 1); return; }
+
+    // #3362 — a page-image key must carry its own book id, or it is shared.
+    assertBookScopedKey(key, bookId, 'backfill-cover-cards');
+
+    const resp = await fetch(source, { signal: AbortSignal.timeout(45000) });
+    if (!resp.ok) {
+      stats.skipped++;
+      const why = `source HTTP ${resp.status}`;
+      skipReasons.set(why, (skipReasons.get(why) || 0) + 1);
+      return;
+    }
+    const src = Buffer.from(await resp.arrayBuffer());
+
+    const card = await sharp(src)
+      .resize(WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+      .avif({ quality: QUALITY, effort: 3 })
+      .toBuffer();
+
+    stats.srcBytes += src.length;
+    stats.outBytes += card.length;
+    if (samples.length < 12) {
+      samples.push({ title: (book.title || bookId).slice(0, 44), src: src.length, out: card.length, key });
+    }
+
+    if (!DRY_RUN) {
+      await s3.send(new PutObjectCommand({
+        Bucket: R2_BUCKET, Key: key, Body: card, ContentType: 'image/avif',
+        CacheControl: 'public, max-age=31536000, immutable',
+      }));
+      // Pointer written only after the object exists.
+      await books.updateOne({ _id: book._id }, { $set: { image_card: `${R2_PUBLIC_URL}/${key}` } });
+    }
+    stats.done++;
+  });
+
+  const failures = candidates.filter(b => b._error);
+  stats.failed = failures.length;
+  const secs = (Date.now() - started) / 1000;
+
+  console.log('sample of what was produced:');
+  for (const s of samples) {
+    console.log(`  ${s.title.padEnd(46)} ${String(Math.round(s.src / 1024)).padStart(5)} KB -> ${String(Math.round(s.out / 1024)).padStart(4)} KB   ${s.key}`);
+  }
+
+  console.log(`\nconverted : ${stats.done}`);
+  console.log(`skipped   : ${stats.skipped}`);
+  for (const [why, n] of [...skipReasons].sort((a, b) => b[1] - a[1])) console.log(`            ${n} × ${why}`);
+  console.log(`failed    : ${stats.failed}`);
+  for (const f of failures.slice(0, 5)) console.log(`            ${f.id || f._id}: ${f._error}`);
+  if (stats.done) {
+    console.log(`\nbytes     : ${(stats.srcBytes / 1048576).toFixed(1)} MB -> ${(stats.outBytes / 1048576).toFixed(2)} MB   (${(stats.srcBytes / stats.outBytes).toFixed(0)}× smaller)`);
+    console.log(`average   : ${Math.round(stats.srcBytes / stats.done / 1024)} KB -> ${Math.round(stats.outBytes / stats.done / 1024)} KB`);
+  }
+  console.log(`elapsed   : ${secs.toFixed(1)}s  (${(stats.done / secs).toFixed(1)} books/s)`);
+  if (stats.done) {
+    const remaining = 16800 - stats.done;
+    console.log(`projected : ~${Math.round(remaining / (stats.done / secs) / 60)} min for the remaining ~${remaining.toLocaleString('en-US')} covers`);
+  }
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Check, X } from 'lucide-react';
-import { cn, getBookThumbnailUrl } from '@/lib/utils';
+import { cn, getBookThumbnailUrl, getBookCardUrl } from '@/lib/utils';
 import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import AuthorName from '@/components/AuthorName';
@@ -35,6 +35,12 @@ export interface CollectionBook {
   localized?: LocalizedBookMap | null;
   thumbnail?: string;
   thumbnail_blob?: string;
+  /** Canonical cover fields. `image_card` is the 500px AVIF variant; it is only
+   *  used when it names the same page as `image_display` (see getBookCardUrl),
+   *  so BOTH must be projected by any query feeding this card or the book
+   *  silently falls back to the 2000px scan. */
+  image_display?: string | null;
+  image_card?: string | null;
   language?: string;
   has_doi?: boolean;
   is_first_translation?: boolean;
@@ -125,8 +131,20 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
 
   const isArtwork = !!book.resource_type;
   const pageCount = book.pages_count || book.pages || 0;
-  const primaryUrl = getBookThumbnailUrl(book, 'display');
-  const fallbackUrl = getBookThumbnailUrl(book, 'thumb');
+  // The 500px AVIF card variant when this book has a live, non-stale one
+  // (~43 KB); otherwise the 2000px display scan exactly as before (~750 KB).
+  // getBookCardUrl returns null unless `image_card` is set AND names the same
+  // page as `image_display`, so a cover changed since the backfill falls back
+  // here rather than rendering the previous cover. See src/lib/utils.ts.
+  const cardUrl = getBookCardUrl(book);
+  const displayUrl = getBookThumbnailUrl(book, 'display');
+  const primaryUrl = cardUrl || displayUrl;
+  // What to try if the primary fails to load. When the primary IS the card, the
+  // right retry is the full-size scan, not the 150px thumb — a browser too old
+  // to decode AVIF (~4%) should get the correct cover, not a blurry one. Only
+  // once that also fails do we drop to the thumb, which is the pre-existing
+  // behaviour for every non-card book.
+  const fallbackUrl = (cardUrl && displayUrl) || getBookThumbnailUrl(book, 'thumb');
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
   const slug = book.slug || book.id || book.bookId || '';
 

--- a/src/lib/book-cover-loader.ts
+++ b/src/lib/book-cover-loader.ts
@@ -59,6 +59,20 @@ export function bookCoverResponsiveLoader({
   width: number;
   quality?: number;
 }): string {
+  // A `-card.avif` src is ALREADY the right size for every card slot in the
+  // app (500px covers a phone at 3× DPR exactly, and the widest desktop card
+  // at 2× within 6%), so it is returned unchanged at every requested width.
+  //
+  // That is the whole point of the variant: it collapses the srcSet to one
+  // candidate, so the browser cannot pick the 2000px archival scan for a
+  // 265px slot. Measured 2026-08-26, that mispick was costing the 60-card
+  // /catalog grid 43.4 MB and 6-10s on its slowest covers; the same grid on
+  // card variants is 2.8 MB.
+  //
+  // Only reached when `getBookCardUrl()` vouched for the variant — it must be
+  // both present and not stale — so this branch never guesses a URL.
+  if (src.endsWith('-card.avif')) return src;
+
   if (width > THUMB_WIDTH_THRESHOLD) return src;
   if (!src.includes(SOURCELIBRARY_HOST)) return src;
 

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -50,6 +50,14 @@ export interface CatalogBook {
   photo: string | null;
   thumbnail: string | null;
   thumbnail_blob: string | null;
+  /** Canonical cover URL. Distinct from `thumbnail` for ~4,300 live books, which
+   *  is why the card's staleness check cannot be done against `thumbnail`.
+   *  Not a books_catalog column — attached from Mongo by attachCardVariants(). */
+  image_display?: string | null;
+  /** 500px AVIF card variant (~28 KB vs the ~490 KB scan). Only used when it
+   *  names the same page as `image_display` — see getBookCardUrl. `undefined`
+   *  means "not looked up yet"; `null` means "looked up, this book has none". */
+  image_card?: string | null;
   read_count: number;
   is_first_translation: boolean;
   quality_score: number;
@@ -97,6 +105,11 @@ export interface CatalogBookDetail extends CatalogBook {
 // Exported so tests can assert the localization counter is in it (#4166) —
 // a card cannot tell a Spanish-readable book from an English-only one without
 // a field the query never asked for.
+// NB: `image_display` / `image_card` are deliberately NOT selected here. They
+// are not columns on books_catalog (see supabase/migrations/20260828000000_…),
+// and PostgREST 42703s the whole query on an unknown column — which would take
+// the catalogue down rather than degrade it. They are attached from Mongo by
+// `attachCardVariants()` below instead.
 export const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_translated_es, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
@@ -190,7 +203,65 @@ export async function browseBooks(opts: {
     throw new Error(`books_catalog query failed: ${error.message}`);
   }
 
-  return { books: (data || []) as CatalogBook[], total: count || 0 };
+  return { books: await attachCardVariants((data || []) as CatalogBook[]), total: count || 0 };
+}
+
+/**
+ * Attach `image_card` + `image_display` to catalogue rows, from Mongo.
+ *
+ * The catalogue renders from the Supabase mirror, which carries `thumbnail` but
+ * not the canonical cover fields — so without this every catalogue card falls
+ * back to the 2000px archival scan (~746 KB) and the 500px AVIF card variant
+ * (~28 KB) never reaches the surface it was built for. Measured 2026-08-26: the
+ * 60-card /catalog grid ships 43.4 MB and its slowest covers take 6–10s.
+ *
+ * Doing it here rather than in the mirror is a deliberate trade. The tidier fix
+ * is two columns on books_catalog (migration written:
+ * supabase/migrations/20260828000000_books_catalog_cover_card.sql), but that
+ * needs Supabase DDL access, and this needs none. One indexed `$in` over the
+ * page's ~60 ids costs a few ms against a page that is ISR-cached for a day.
+ * When the columns do land, `BOOK_SELECT` picks them up and rows arriving with
+ * `image_card` already set skip the lookup — so this becomes a no-op rather
+ * than something to unpick.
+ *
+ * Both fields are required together: getBookCardUrl() only trusts `image_card`
+ * when it names the same page as `image_display`, which is how a cover changed
+ * since the backfill falls back instead of rendering the previous cover.
+ *
+ * Failure is non-fatal by design. A Mongo hiccup here means heavier covers for
+ * one render, never a broken or empty grid — the catalogue's own data has
+ * already been fetched and is returned unchanged.
+ */
+async function attachCardVariants(rows: CatalogBook[]): Promise<CatalogBook[]> {
+  const needing = rows.filter(r => r.id && r.image_card === undefined);
+  if (needing.length === 0) return rows;
+  try {
+    const { getReadDb } = await import('@/lib/mongodb');
+    const db = await getReadDb();
+    const docs = await db.collection('books')
+      .find({ id: { $in: needing.map(r => r.id) } }, { projection: { _id: 0, id: 1, image_card: 1, image_display: 1 } })
+      .maxTimeMS(2000)
+      .toArray();
+    const byId = new Map(docs.map(d => [d.id as string, d]));
+    for (const row of needing) {
+      const doc = byId.get(row.id);
+      if (!doc) continue;
+      // ONLY the card. `image_display` is deliberately not attached: this table
+      // has never carried it, so the catalogue renders `thumbnail`, and the two
+      // disagree for 4,309 live books. Attaching it would make
+      // getBookThumbnailUrl prefer it and silently change which PICTURE 3,635
+      // books show — a cover migration smuggled inside a performance fix.
+      // getBookCardUrl then validates the card against `thumbnail` here (and
+      // against `image_display` on surfaces that do project it), so the picture
+      // never changes and only its weight does. The ~2,000 books whose card was
+      // cut from a different page than `thumbnail` simply keep the full-size
+      // cover until the two fields are reconciled — a separate fix.
+      row.image_card = (doc.image_card as string | null) ?? null;
+    }
+  } catch (err) {
+    console.error('[books-catalog] card-variant lookup failed, serving full-size covers:', (err as Error)?.message);
+  }
+  return rows;
 }
 
 /**

--- a/src/lib/cover-fields.ts
+++ b/src/lib/cover-fields.ts
@@ -57,6 +57,21 @@ export interface CoverUpdate {
   image_display: string;
   image_thumb: string;
 
+  // 500px AVIF card variant — always CLEARED here, never carried over.
+  //
+  // `image_card` names one specific page's `-card.avif` object. Changing the
+  // cover changes which page that must be, so a pointer that survives a cover
+  // change does not go stale in the harmless sense (a missing image) — it
+  // renders the OLD page as the new cover, which is worse than no card at all.
+  // Clearing is the only safe default: the reader falls back to `image_display`
+  // until the backfill or the ingest pipeline writes the new page's variant.
+  //
+  // Read-side belt and braces: `getBookThumbnailUrl(book, 'card')` also checks
+  // that `image_card` names the same page as `image_display` and ignores it if
+  // not — because the postmortem in this file's header is precisely about cover
+  // writers that bypassed the helper and were missed.
+  image_card: null;
+
   // Legacy mirrors (BPH embed API and a few CMS pages still read these)
   thumbnail: string;
   thumbnail_blob: string;
@@ -111,6 +126,8 @@ export function buildCoverUpdate(
   const update: CoverUpdate = {
     image_display: url,
     image_thumb: thumbUrl,
+    // Cleared, not carried: see the field's note on CoverUpdate above.
+    image_card: null,
     thumbnail: url,
     thumbnail_blob: thumbUrl,
     thumbnail_source: opts.source,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,6 +55,79 @@ export function formatNumber(n: number | null | undefined): string {
  *   - Use 'display' for any UI element >100px (book cards, grids, heroes)
  *   - Use 'thumb' for tiny previews (<100px, search results, list rows)
  */
+/**
+ * The 500px AVIF card variant, or null when this book has no usable one.
+ *
+ * Two conditions, both required:
+ *   1. `image_card` is set — proof the R2 object EXISTS. Never derive this URL
+ *      by convention: a guessed `-card.avif` sibling 404s for every book the
+ *      backfill hasn't reached, which is the broken-cover failure mode already
+ *      recorded twice in book-cover-loader.ts (homepage smoke test, 2026-07-08).
+ *   2. It names the SAME page as `image_display` — proof it is not STALE.
+ *      Changing a book's cover repoints `image_display` at another page; a card
+ *      pointer left behind then renders the old page as the new cover, which is
+ *      worse than showing no card at all. `buildCoverUpdate()` clears the field
+ *      on every cover write, but this file's own postmortem is about cover
+ *      writers that bypassed that helper and were missed — so the read path
+ *      does not assume they all behaved.
+ *
+ * A stale or missing pointer degrades to `display`: heavier, never wrong.
+ */
+export function getBookCardUrl(
+  book: Parameters<typeof getBookThumbnailUrl>[0] & { image_card?: string | null },
+): string | null {
+  const card = book.image_card?.trim();
+  if (!card) return null;
+  // Checked against the cover this card would REPLACE — resolved the same way
+  // the component resolves it — not against `image_display` specifically.
+  //
+  // That distinction is the whole guard. `thumbnail` and `image_display`
+  // disagree for 4,309 live books (an incomplete dual-write from the R2
+  // migration, PR #1588), and different surfaces render different ones: the
+  // Supabase-fed catalogue has only `thumbnail`, while Mongo-fed surfaces
+  // prefer `image_display`. Validating against a field the caller might not
+  // even render would swap the PICTURE on 3,635 books — turning a
+  // make-it-smaller change into a change-the-cover change. Asking "is this the
+  // card of the image I am about to show?" is true on every surface at once.
+  const expected = cardUrlForCover(getBookThumbnailUrl(book, 'display'));
+  return expected !== null && card.split('?')[0] === expected ? card : null;
+}
+
+/**
+ * The `-card.avif` URL a given cover SHOULD have, or null when that cover has
+ * no R2 page-scan home to hang one off (external IIIF, Wikimedia, one-off
+ * uploads). Pure string derivation — says nothing about whether the object
+ * exists, which is what `image_card` is for.
+ *
+ * Must stay in lock-step with `resolveSource()` +`cardKeyFrom()` in
+ * scripts/maintenance/backfill-cover-cards.mjs: the backfill uses this mapping
+ * to decide where to WRITE, and getBookCardUrl uses it to decide whether the
+ * stored pointer is still the right one. If the two ever disagree, every card
+ * silently stops being served — hence one derivation, asserted by tests.
+ *
+ * Note the legacy rewrite: `/archived/{id}/5.jpg` and `/thumbnails/{id}/5.jpg`
+ * both name a page whose canonical variants live at `/pages/{id}/0005.*`, so
+ * the card for those covers is NOT a sibling of the stored URL. 8,464 of the
+ * 16,800 backfill candidates are in that shape.
+ */
+export function cardUrlForCover(displayUrl?: string | null): string | null {
+  const raw = displayUrl?.replace(/\s+/g, '').trim();
+  if (!raw || !raw.includes('images.sourcelibrary.org/')) return null;
+  const noQuery = raw.split('?')[0];
+
+  const legacy = noQuery.match(/^(https?:\/\/[^/]+)\/(?:archived|thumbnails)\/([^/]+)\/(\d+)\.jpg$/);
+  if (legacy) {
+    const [, origin, bookId, num] = legacy;
+    return `${origin}/pages/${bookId}/${num.padStart(4, '0')}-card.avif`;
+  }
+
+  if (noQuery.includes('images.sourcelibrary.org/pages/') || noQuery.includes('images.sourcelibrary.org/cropped/')) {
+    return noQuery.replace(/-(?:thumb|full)\.jpg$/, '.jpg').replace(/\.jpg$/, '-card.avif');
+  }
+
+  return null;
+}
+
 export function getBookThumbnailUrl(
   book: { thumbnail?: string | null; thumbnail_blob?: string | null; image_display?: string | null; image_thumb?: string | null },
   size: 'display' | 'thumb' = 'display'

--- a/supabase/migrations/20260828000000_books_catalog_cover_card.sql
+++ b/supabase/migrations/20260828000000_books_catalog_cover_card.sql
@@ -1,0 +1,30 @@
+-- books_catalog: carry the canonical cover and its 500px AVIF card variant.
+--
+-- The catalogue (/catalog, /browse, collection grids) renders from this mirror,
+-- not from Mongo, and the mirror carried only `thumbnail`. Two consequences:
+--
+--   1. The card variant added in this PR could never reach the surface that
+--      motivated it. Measured 2026-08-26: the 60-card /catalog grid ships
+--      43.4 MB of covers (746 KB average, 2000px scans poured into a 265px
+--      slot) and its slowest covers take 6-10s. On card variants the same grid
+--      is 2.8 MB.
+--
+--   2. `thumbnail` is not the canonical cover. Of 17,580 live books with both
+--      fields set, 4,309 (25%) have `thumbnail` pointing somewhere other than
+--      `image_display` — including hotlinked archive.org URLs the R2 migration
+--      was meant to retire. So the catalogue renders a different image than the
+--      book page for those books, and the card's staleness check (which asks
+--      "does image_card still name the same page as image_display?") cannot be
+--      answered against `thumbnail` at all.
+--
+-- Both columns are needed together: getBookCardUrl() refuses `image_card`
+-- unless it corresponds to `image_display`, so a mirror with only one of them
+-- serves every book the full scan.
+--
+-- Additive and nullable — rows stay valid until scripts/workers/sync-books-catalog.mjs
+-- repopulates them. Apply in the Supabase SQL editor (no SUPABASE_DB_URL in env),
+-- then re-run the sync.
+
+ALTER TABLE books_catalog
+  ADD COLUMN IF NOT EXISTS image_display text,
+  ADD COLUMN IF NOT EXISTS image_card    text;

--- a/tests/unit/book-card-url.test.ts
+++ b/tests/unit/book-card-url.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { getBookCardUrl, cardUrlForCover } from '@/lib/utils';
+import { buildCoverUpdate } from '@/lib/cover-fields';
+
+const R2 = 'https://images.sourcelibrary.org';
+
+/**
+ * The 500px AVIF card variant is addressed by a STORED pointer (`image_card`),
+ * never by deriving a sibling URL — a guessed `-card.avif` 404s for every book
+ * the backfill hasn't reached, which is the broken-cover failure already
+ * recorded twice in book-cover-loader.ts.
+ *
+ * The pointer names one specific page, so it goes stale the moment the cover
+ * moves. A stale pointer is worse than a missing one: it renders the PREVIOUS
+ * cover. These tests pin both halves of the guard.
+ */
+describe('cardUrlForCover — where a cover\'s card variant lives', () => {
+  it('maps a canonical page scan to its sibling', () => {
+    expect(cardUrlForCover(`${R2}/pages/abc/0005.jpg`)).toBe(`${R2}/pages/abc/0005-card.avif`);
+  });
+
+  // 8,464 of the 16,800 backfill candidates are in this shape. The card is NOT
+  // a sibling of the stored URL — /archived/{id}/5.jpg is the same page as
+  // /pages/{id}/0005.jpg, zero-padded. A naive sibling check silently rejected
+  // half the corpus in review.
+  it('rewrites the legacy /archived/ path to its /pages/ home, zero-padded', () => {
+    expect(cardUrlForCover(`${R2}/archived/abc/5.jpg`)).toBe(`${R2}/pages/abc/0005-card.avif`);
+    expect(cardUrlForCover(`${R2}/archived/abc/12.jpg`)).toBe(`${R2}/pages/abc/0012-card.avif`);
+    expect(cardUrlForCover(`${R2}/thumbnails/abc/7.jpg`)).toBe(`${R2}/pages/abc/0007-card.avif`);
+  });
+
+  it('normalises whichever variant suffix is stored', () => {
+    expect(cardUrlForCover(`${R2}/pages/abc/0005-thumb.jpg`)).toBe(`${R2}/pages/abc/0005-card.avif`);
+    expect(cardUrlForCover(`${R2}/pages/abc/0005-full.jpg`)).toBe(`${R2}/pages/abc/0005-card.avif`);
+  });
+
+  it('handles cropped covers', () => {
+    expect(cardUrlForCover(`${R2}/cropped/abc/def.jpg`)).toBe(`${R2}/cropped/abc/def-card.avif`);
+  });
+
+  it('returns null for covers with no R2 page-scan home', () => {
+    expect(cardUrlForCover('https://upload.wikimedia.org/x.jpg')).toBeNull();
+    expect(cardUrlForCover('https://archive.org/download/x/page/n0/full/pct:15/0/default.jpg')).toBeNull();
+    expect(cardUrlForCover(null)).toBeNull();
+    expect(cardUrlForCover('')).toBeNull();
+  });
+});
+
+describe('getBookCardUrl — only a live, non-stale pointer is used', () => {
+  it('uses the card when it names the same page as the cover', () => {
+    expect(getBookCardUrl({ image_display: `${R2}/pages/abc/0005.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` }))
+      .toBe(`${R2}/pages/abc/0005-card.avif`);
+  });
+
+  it('uses the card for a legacy /archived/ cover', () => {
+    expect(getBookCardUrl({ image_display: `${R2}/archived/abc/5.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` }))
+      .toBe(`${R2}/pages/abc/0005-card.avif`);
+  });
+
+  // The case this guard exists for: someone picks a different cover page after
+  // the backfill ran. Serving the old card would show the WRONG page.
+  it('refuses a pointer left behind by a cover change', () => {
+    expect(getBookCardUrl({ image_display: `${R2}/pages/abc/0012.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` })).toBeNull();
+    expect(getBookCardUrl({ image_display: `${R2}/archived/abc/12.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` })).toBeNull();
+  });
+
+  it('refuses a pointer belonging to another book', () => {
+    expect(getBookCardUrl({ image_display: `${R2}/pages/xyz/0005.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` })).toBeNull();
+  });
+
+  it('falls back when there is no pointer yet', () => {
+    expect(getBookCardUrl({ image_display: `${R2}/pages/abc/0005.jpg`, image_card: null })).toBeNull();
+    expect(getBookCardUrl({ image_display: `${R2}/pages/abc/0005.jpg` })).toBeNull();
+  });
+
+  it('refuses a card pointer against a cover that has no R2 home', () => {
+    expect(getBookCardUrl({ image_display: 'https://upload.wikimedia.org/x.jpg', image_card: `${R2}/pages/abc/0005-card.avif` })).toBeNull();
+  });
+
+  /**
+   * The card must never change WHICH picture a surface shows, only its weight.
+   *
+   * `thumbnail` and `image_display` disagree for 4,309 live books (incomplete
+   * dual-write, PR #1588), and surfaces render different ones: the Supabase-fed
+   * catalogue has only `thumbnail`; Mongo-fed surfaces prefer `image_display`.
+   * So the guard validates against whichever cover the caller will actually
+   * render. Validating against `image_display` unconditionally swapped the
+   * cover on 3,635 books — caught in review, pinned here.
+   */
+  describe('validates against the cover the caller actually renders', () => {
+    it('on a catalogue row (thumbnail only), matches the card to thumbnail', () => {
+      expect(getBookCardUrl({ thumbnail: `${R2}/pages/abc/0005.jpg`, image_card: `${R2}/pages/abc/0005-card.avif` }))
+        .toBe(`${R2}/pages/abc/0005-card.avif`);
+    });
+
+    it('refuses a card cut from a different page than the rendered cover', () => {
+      // image_display says page 12, but this surface renders `thumbnail` (page 5).
+      // Serving the page-12 card here would silently change the cover.
+      expect(getBookCardUrl({ thumbnail: `${R2}/pages/abc/0005.jpg`, image_card: `${R2}/pages/abc/0012-card.avif` })).toBeNull();
+    });
+
+    it('prefers image_display when the surface projects it', () => {
+      expect(getBookCardUrl({
+        image_display: `${R2}/pages/abc/0012.jpg`,
+        thumbnail: `${R2}/pages/abc/0005.jpg`,
+        image_card: `${R2}/pages/abc/0012-card.avif`,
+      })).toBe(`${R2}/pages/abc/0012-card.avif`);
+    });
+  });
+});
+
+describe('buildCoverUpdate clears the card pointer', () => {
+  // Write-side half of the same invariant. Without this every cover change
+  // leaves a pointer at the old page and the read guard is the only thing
+  // standing between the reader and the previous cover.
+  it('sets image_card to null on every cover write', () => {
+    const update = buildCoverUpdate(
+      { archived_photo: `${R2}/pages/abc/0012.jpg`, page_number: 12 } as never,
+      { source: 'manual' },
+    );
+    expect(update).not.toBeNull();
+    expect(update!.image_card).toBeNull();
+  });
+
+  it('a freshly written cover therefore reads as having no card', () => {
+    const update = buildCoverUpdate(
+      { archived_photo: `${R2}/pages/abc/0012.jpg`, page_number: 12 } as never,
+      { source: 'manual' },
+    );
+    expect(getBookCardUrl({ image_display: update!.image_display, image_card: update!.image_card })).toBeNull();
+  });
+});


### PR DESCRIPTION
The catalogue grid had no cover size between R2's 150px `-thumb.jpg` and the bare `.jpg` — which, despite the "1200px display" label in `storage.ts`, is the 2000px archival scan. A card renders in a 163–265px slot, so every grid pulled the full scan.

Measured on production, 2026-08-26: `/catalog` ships **42.8 MB** of covers, **731 KB** average, slowest taking **6–10s**.

## What this does

Adds the missing size tier. 500px covers a phone at 3× DPR exactly (489px) and the widest desktop card at 2× within 6%, so one variant serves every slot and the srcSet collapses to a single candidate — the browser can no longer pick the 2000px scan for a 265px hole.

Rendered `/catalog` locally against production data:

| | before | after |
|---|---|---|
| grid payload | 42.8 MB | **8.3 MB** |
| average cover | 731 KB | **141 KB** |
| broken images | 0 | 0 |
| **covers whose picture changed** | — | **0** |

Resizing is the win, not the format — AVIF at the source resolution is still 804 KB. Quality is q55, checked against a lossless reference on the worst-compressing plate in the library (the Fludd frontispiece): paper grain and cross-hatching intact.

**The archival scan is untouched.** The reader, downloads and deep zoom keep reading it. This is purely an added derivative.

## Covers do not change, only their weight

`image_card` names one page, so it goes stale the moment a cover moves — and a stale pointer renders the *previous* cover, which is worse than no card at all. Three guards:

- `buildCoverUpdate()` clears `image_card` on every cover write, mirrored in `cover-write.mjs` per that file's lock-step rule
- `getBookCardUrl()` refuses any card that does not name the same page as the cover being rendered
- the pointer is stored, never derived, so a card is only requested when the R2 object is known to exist (cf. the 2026-07-08 broken-cover incident)

The second guard checks against **whichever cover the caller renders**, not `image_display` specifically. `thumbnail` and `image_display` disagree for 4,309 live books (incomplete dual-write, PR #1588) and surfaces render different ones — the Supabase-fed catalogue has only `thumbnail`. Validating against a field the caller may not render would have swapped the picture on **3,635 books**, turning a make-it-smaller change into a change-the-cover one. Caught in review; verified against production as 0 changed.

## Backfill (already run)

16,471 covers, **6,949 MB → 397 MB (18×)**, ~25 min, ~16 cents one-off. Idempotent and resumable.

Every key passes `assertBookScopedKey`, which **caught a real #3362 survivor mid-run** — one visible book whose cover is `archived/undefined/1.jpg` — and refused to write a book-independent key. Worth a separate look; not touched here.

## Out of scope, deliberately

- **The ~2,000 books whose two cover fields diverge** keep the full-size scan. Reconciling those fields changes which cover some books show, so it belongs in its own PR — that's also the remaining ~3× of payload.
- **The BPH embed is untouched.** `fetchTenantLibraryData` runs its own aggregation whose projection has no `image_card`, so the guard returns null and it renders byte-identically. No BPH approval needed.
- **`supabase/migrations/` carries an optional `books_catalog` migration.** Not required, nothing depends on it — the fields are attached from Mongo in `browseBooks` instead, so no Supabase DDL access is needed. Deliberately **not** wired into `sync-books-catalog.mjs`: writing columns that don't exist would have every upsert rejected and stop the mirror updating.

## Checks

- `npx tsc --noEmit` clean
- **219 test files, 2,958 tests** pass (16 new, pinning the staleness guard and the `/archived/` → `/pages/` rewrite)
- field-write lint: 0 new violations (`image_card` registered)
- ESLint: only pre-existing errors on `main`
- no edge-runtime routes call `browseBooks`, so the Mongo import is safe

## Reviewer note

~4,300 books show a different image on the catalogue than on their book page today. This PR does **not** change that either way — but it's the reason 10 of 60 covers on the sample page keep the heavy scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)