### PR TITLE
Reader: stop showing the unsplit spread beside a split page's text

### DIFF
--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -151,14 +151,20 @@ function proxyUrl(
 }
 
 /**
- * Derive a pre-sized R2 variant from a canonical `pages/{bookId}/{NNNN}` photo
- * URL (handles the `sp` prefix for new-era split halves). Returns null if the
- * photo isn't a canonical pages/ URL.
+ * Derive a pre-sized R2 variant from a canonical `pages/{bookId}/…` photo URL.
+ * Returns null if the photo isn't a canonical pages/ URL.
+ *
+ * Two split-half spellings exist and BOTH must match, or the page falls through
+ * to the /api/image proxy and we pay sharp compute for a file R2 already holds:
+ *   - `sp0014`            — sp + page number
+ *   - `sp69f6a12d…aa2`    — sp + the page's 24-char hex id, which the older
+ *                           `\d{4,}` tail could never match. That silently sent
+ *                           every page of a split book through the proxy.
  */
 function deriveVariant(photo: string | null | undefined, size: 'display' | 'thumb'): string | null {
   if (!photo) return null;
   const m = photo.match(
-    /^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/(?:sp[a-z0-9]*-?)?\d{4,})(-full)?\.jpg$/,
+    /^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/(?:sp[0-9a-f]{16,}|(?:sp[a-z0-9]*-?)?\d{4,}))(-full)?\.jpg$/,
   );
   if (!m) return null;
   return size === 'thumb' ? `${m[1]}-thumb.jpg` : `${m[1]}.jpg`;
@@ -210,6 +216,44 @@ function cropRegion(page: PageImageFields): { xStart?: number; xEnd?: number } |
  * Resolve a display- or thumb-sized URL. Prefers a pre-sized R2 variant, then an
  * IIIF-native resize, then the /api/image proxy. Always browser-safe and bounded.
  */
+/**
+ * Identity of the page-image an R2 URL names, or null when the URL does not
+ * follow that convention (IIIF, external hosts, anything unparseable).
+ *
+ * Normalises the two things that make one page look like two URLs:
+ *   - variant suffix — `x.jpg`, `x-thumb.jpg`, `x-full.jpg` are one image
+ *   - zero padding across path families — `/archived/{b}/5.jpg` is the same
+ *     page as `/pages/{b}/0005.jpg`
+ */
+function r2PageIdentity(url: string): string | null {
+  const q = url.split('?')[0];
+  if (!q.includes('images.sourcelibrary.org/')) return null;
+  const file = (q.split('/').pop() || '').replace(/-(?:thumb|full|card)(?=\.[a-z0-9]+$)/i, '').replace(/\.[a-z0-9]+$/i, '');
+  if (!file) return null;
+  const book = q.match(/\/(?:pages|archived|thumbnails|cropped)\/([^/]+)\//)?.[1];
+  if (!book) return null;
+  // Numeric page filenames compare by value so 5 and 0005 agree; named ones
+  // (`sp<id>`, a cropped image id) compare literally.
+  return `${book}/${/^\d+$/.test(file) ? String(parseInt(file, 10)) : file}`;
+}
+
+/**
+ * Is `variant` a resize of `source`, as far as we can tell?
+ *
+ * PERMISSIVE BY DESIGN. It only answers false when both URLs follow the R2
+ * page convention and name demonstrably different pages. Every other case —
+ * an IIIF URL (whose filename is always `default.jpg`, the size living in the
+ * path), an external host, anything unparseable — returns true and preserves
+ * the pre-existing behaviour. The point is to catch one specific corruption,
+ * not to start second-guessing every stored variant.
+ */
+function variantMatchesSource(variant: string, source: string | null): boolean {
+  if (!source) return true;
+  const a = r2PageIdentity(variant), b = r2PageIdentity(source);
+  if (a === null || b === null) return true;
+  return a === b;
+}
+
 function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string | null {
   const width = size === 'thumb' ? THUMB_WIDTH : DISPLAY_WIDTH;
   const quality = size === 'thumb' ? 60 : 80;
@@ -226,13 +270,27 @@ function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string 
   const candidates = new SizedCandidates();
 
   // (A) Pre-sized R2 variant — only when it matches the *displayed* content.
-  // Skip for old-era split pages: their display_photo / image_thumb are resizes
-  // of the UNcropped image, so using them would show more than the cropped half.
+  //
+  // Two ways a stored variant can be of the WRONG content, both on split pages:
+  //   - old era: the half is `cropped_photo`, and display_photo / image_thumb
+  //     are resizes of the uncropped image.
+  //   - new era: the half is `photo` (`…/sp{id}.jpg`), but display_photo was
+  //     never repointed and still resizes the whole SPREAD. `hasCroppedHalf`
+  //     does not see this one — there is no cropped_photo to look at — so a
+  //     reader got the neighbouring page's image next to this page's OCR
+  //     (reported 2026-08-29 on an encyclopedic outline… p.15, whose scan panel
+  //     showed an introduction spread beside title-page text).
+  //
+  // So the test is not "is this page split" but "is this stored variant a
+  // resize of the source we are actually going to show". `sharesSourceStem`
+  // answers that directly, which also covers any future era.
   if (!hasCroppedHalf) {
-    if (size === 'display' && candidates.accept(page.display_photo)) return page.display_photo;
+    const source = getPageSource(page);
+    const usable = (variant?: string | null) => !!variant && variantMatchesSource(variant, source);
+    if (size === 'display' && usable(page.display_photo) && candidates.accept(page.display_photo)) return page.display_photo;
     if (size === 'thumb') {
-      if (candidates.accept(page.image_thumb)) return page.image_thumb;
-      if (candidates.accept(page.thumbnail_blob)) return page.thumbnail_blob;
+      if (usable(page.image_thumb) && candidates.accept(page.image_thumb)) return page.image_thumb;
+      if (usable(page.thumbnail_blob) && candidates.accept(page.thumbnail_blob)) return page.thumbnail_blob;
     }
     const derived = deriveVariant(page.photo, size);
     if (derived) return derived;

--- a/tests/unit/page-image-url.test.ts
+++ b/tests/unit/page-image-url.test.ts
@@ -30,6 +30,18 @@ const fixtures: Record<string, PageImageFields> = {
     archived_photo: `${R2}/pages/${BOOK}/sp0014-full.jpg`,
     display_photo: `${R2}/pages/${BOOK}/sp0014.jpg`,
   },
+  // New-era split whose display_photo was never repointed at the half — it is
+  // still a resize of the WHOLE SPREAD. Measured in production 2026-08-29 on
+  // "An encyclopedic outline of masonic… philosophy" p.15, whose reader showed
+  // an introduction spread beside OCR of the title page. The fixture above
+  // assumes display_photo is an `sp…` URL; a large part of the corpus is this
+  // shape instead, so the optimistic fixture hid the bug.
+  newSplitStaleDisplay: {
+    split_from_spread: true,
+    photo: `${R2}/pages/${BOOK}/sp0014-full.jpg`,
+    archived_photo: `${R2}/cropped/${BOOK}/sp0014.jpg`,
+    display_photo: `${R2}/pages/${BOOK}/0015.jpg`,
+  },
   // IIIF source, no R2 variant: origin server resizes via /full/{w},/.
   iiif: {
     photo: `https://digi.vatlib.it/iiifimage/MSS_Vat.arm.19/Vat.arm.19_0003.jp2/full/1000,/0/default.jpg`,
@@ -101,6 +113,26 @@ describe('split-from-spread source identity', () => {
   });
   it('new-era: original → the sp… half', () => {
     expect(getPageImageUrl(fixtures.newSplit, 'original')).toBe(`${R2}/pages/${BOOK}/sp0014-full.jpg`);
+  });
+
+  // The reader renders `display`. If that resolves to the spread while the OCR
+  // beside it was read from the half, the two panels describe different pages —
+  // which is what a reader reported on 2026-08-29. `getPageSource` already
+  // returns the half here; the pre-sized-variant tier was overriding it.
+  it('new-era with a STALE display_photo: display must not fall back to the spread', () => {
+    const url = getPageImageUrl(fixtures.newSplitStaleDisplay, 'display')!;
+    expect(url).not.toContain('0015.jpg'); // the spread — the trap
+    expect(url).toContain('sp0014');
+  });
+  it('new-era with a STALE display_photo: thumb stays on the half', () => {
+    const url = getPageImageUrl(fixtures.newSplitStaleDisplay, 'thumb')!;
+    expect(url).not.toContain('0015');
+    expect(url).toContain('sp0014');
+  });
+  it('new-era with a STALE display_photo: source identity is unchanged', () => {
+    // getPageSource was never the problem — it returns the half. The pre-sized
+    // variant tier in resolveSized was overriding it.
+    expect(getPageSource(fixtures.newSplitStaleDisplay)).toBe(`${R2}/pages/${BOOK}/sp0014-full.jpg`);
   });
 });
 


### PR DESCRIPTION
Reported by a reader on p.15 of *An encyclopedic outline of masonic, hermetic, cabbalistic and rosicrucian symbolical philosophy*: the scan panel showed an **introduction spread** while the OCR and translation panels beside it showed the **title page**. The text was right; the picture was wrong.

That page is the right half of a split spread (`split_from_spread`, `split_side: right`, `ocr.data` typed `<page-type>title-page</page-type>`), and the correct half has been on R2 the whole time at `pages/{book}/sp{pageId}.jpg`.

## Cause

`getPageSource()` was never at fault — it returns the half. The pre-sized variant tier in `resolveSized()` was overriding it:

```ts
const hasCroppedHalf = isUsableImageUrl(page.cropped_photo);
// "Skip for old-era split pages…"
if (!hasCroppedHalf) { …return page.display_photo… }
```

The comment says it skips split pages; the condition only catches **old-era** splits, where the half is materialized as `cropped_photo`. On a **new-era** split the half lives in `photo` and there is no `cropped_photo` to see — so the guard passes and a stale `display_photo`, still a resize of the whole spread, wins.

## Fix

The right question isn't "is this page split" but **"is this stored variant a resize of the source we're about to show"**. `variantMatchesSource()` asks that directly, so it also covers any future era.

Permissive by construction: it answers false **only** when both URLs follow the R2 page convention and name demonstrably different pages. IIIF URLs (filename is always `default.jpg`, size in the path), external hosts and anything unparseable are accepted exactly as before. An earlier naive filename comparison rejected both and broke two existing tests — which is how that scope got pinned down.

`r2PageIdentity()` normalises the two ways one page wears two URLs: variant suffix (`-thumb`/`-full`/`-card`) and zero padding across path families, so `/archived/{b}/5.jpg` and `/pages/{b}/0005.jpg` compare equal.

## Also widens `deriveVariant()`

Split halves are spelled two ways and it only matched one:

| spelling | | |
|---|---|---|
| `sp0014` | sp + page number | matched |
| `sp69f6a12d…aa2` | sp + 24-char hex id | **did not** — the `\d{4,}` tail |

So with the guard alone, every page of a hex-id split book fell through to the `/api/image` sharp proxy for a file R2 already holds pre-sized. Verified on the reported page: display and thumb now resolve to direct R2 variants, no proxy. Keeps #1727's free-egress tier first.

## Scope

Measured 2026-08-29, visible books only:

```
1,178 books contain split pages, 378,095 split pages
18,666 pages had display_photo pointing at the spread
1,002 books affected
```

Several are affected on **every** page — 679/679, 510/510, 418/418.

Fixed entirely in the resolver: **no data migration**, and it repairs books whose `display_photo` is still stale rather than requiring them to be swept.

## Verification

- Rendered the reported page against production data: the only `<img>` emitted is the correct half
- 3 new tests pin the production shape. The existing `newSplit` fixture assumed `display_photo` is an `sp…` URL — production often isn't, which is how the bug hid behind a green suite
- `npx tsc --noEmit` clean; **224 files, 3,024 tests** pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)