### PR TITLE
fix(book): link the author byline to author_id, not the slugified byline (#4318)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1652,8 +1652,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             <div className="min-w-0" style={{ color: '#f7f2ea' }}>
               {(heroByline.role === 'author' || heroByline.role === 'editor') && (
                 <div className="uppercase text-[10.5px] md:text-[13px] tracking-[0.1em] font-medium mb-1.5 md:mb-2" style={{ color: '#d98a72' }}>
-                  {embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
-                    <Link href={authorUrl(book.author)!} className="hover:opacity-80 transition-opacity">
+                  {embedPolicy.enableBookCollectionNavigation && authorUrl(book.author, book.author_id) ? (
+                    <Link href={authorUrl(book.author, book.author_id)!} className="hover:opacity-80 transition-opacity">
                       {heroByline.role === 'editor' ? <>{t.editedBy} <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />}
                     </Link>
                   ) : (heroByline.role === 'editor' ? <>{t.editedBy} <AuthorName author={heroByline.editor} /></> : <AuthorName author={book.author} />)}
@@ -1931,8 +1931,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 return (
                   <p className="text-base sm:text-lg text-stone-300 mb-1">
                     {heroByline.role === 'author' ? (
-                      embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
-                        <Link href={authorUrl(book.author)!} className="hover:text-white transition-colors">
+                      embedPolicy.enableBookCollectionNavigation && authorUrl(book.author, book.author_id) ? (
+                        <Link href={authorUrl(book.author, book.author_id)!} className="hover:text-white transition-colors">
                           <AuthorName author={book.author} />
                         </Link>
                       ) : <AuthorName author={book.author} />

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -254,7 +254,23 @@ export function authorSlug(author: string): string {
     .replace(/-{2,}/g, '-');
 }
 
-export function authorUrl(author: string): string | null {
+/**
+ * URL for a book's author page.
+ *
+ * Prefer `authorId` (`books.author_id`, the canonical FK) over the byline
+ * string whenever it is present. The byline is what a CATALOGUE said; the
+ * canonical link is who we decided that means, and the two diverge exactly
+ * where it matters. Slugifying the byline sends every book bylined "Thomas" to
+ * `/author/thomas` — Aquinas and Thomas à Kempis alike — so the reader is told
+ * a work is by whoever that bare form happens to resolve to (#4318).
+ *
+ * It also makes the link independent of the thesaurus's MATCH surface. Bare
+ * forenames had to be withdrawn from `variants[]` because they claimed every
+ * namesake; a byline-derived URL would then dead-end, while `author_id` keeps
+ * pointing at the right person.
+ */
+export function authorUrl(author: string, authorId?: string | null): string | null {
+  if (authorId) return `/author/${authorId}`;
   if (!author || author === 'Unknown' || author === 'Anonymous') return null;
   return `/author/${authorSlug(author)}`;
 }

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -45,6 +45,13 @@ export interface Book {
    */
   editor?: string;
   attribution_note?: string;  // "after" for prints after a designer, "circle of", "workshop of", etc.
+  /**
+   * FK to the canonical `authors` thesaurus (`authors._id`). This is THE author
+   * link — `author_entity_id` below points at the retiring `entities` layer and
+   * both are written during the migration. Prefer this one when resolving who a
+   * book is by; `author` is only what the catalogue said (#2179, #4318).
+   */
+  author_id?: string;
   author_entity_id?: string;  // FK to entities collection (entity._id as string) — canonical author identity (VIAF/Wikidata linked)
   /** Display name for the canonical author (denormalised so the book page can render without a join). */
   author_canonical_name?: string;

--- a/tests/unit/slugify.test.ts
+++ b/tests/unit/slugify.test.ts
@@ -143,4 +143,28 @@ describe('authorUrl', () => {
   it('returns null for empty string', () => {
     expect(authorUrl('')).toBeNull();
   });
+
+  // #4318: the byline is what a catalogue said; author_id is who we decided
+  // that means. Slugifying the byline sent every book bylined "Thomas" to
+  // /author/thomas — Aquinas and Thomas à Kempis alike.
+  it('prefers author_id over the byline when both are present', () => {
+    expect(authorUrl('Thomas', 'thomas-a-kempis')).toBe('/author/thomas-a-kempis');
+    expect(authorUrl('Thomas', 'thomas-aquinas')).toBe('/author/thomas-aquinas');
+  });
+
+  it('two books sharing a byline resolve to different authors', () => {
+    expect(authorUrl('Basilius', 'basil-valentine'))
+      .not.toBe(authorUrl('Basilius', 'basil-of-caesarea-2'));
+  });
+
+  it('falls back to the byline when author_id is absent', () => {
+    expect(authorUrl('Michael Maier', undefined)).toBe('/author/michael-maier');
+    expect(authorUrl('Michael Maier', null)).toBe('/author/michael-maier');
+  });
+
+  // A linked book still gets a URL even when the byline alone would yield none,
+  // which is how an "Anonymous"-bylined book reaches its attributed author.
+  it('honours author_id even for placeholder bylines', () => {
+    expect(authorUrl('Anonymous', 'jacobus-de-voragine')).toBe('/author/jacobus-de-voragine');
+  });
 });


### PR DESCRIPTION
Follow-up to #4349, found while verifying that repair in production.

## The bug

The book page built its author link with `authorUrl(book.author)` — the **catalogue's byline string** — and ignored `author_id`, the canonical link that records who we decided that byline means. So the link was never about the book's actual attribution:

- every book bylined `"Thomas"` pointed at `/author/thomas` — Aquinas and Thomas à Kempis alike
- every book bylined `"Basilius"` pointed at one page, whether it was Basil of Caesarea or **Basil Valentine**
- every book bylined `"Dionysius"` pointed at one page, across Pseudo-Dionysius, Denis the Carthusian and Dionysius Periegetes

#4349 corrected all of those attributions in the data. It could not correct the **link**, because the link never consulted the attribution.

## Why it had to be fixed now

#4349 withdrew the bare forenames from `variants[]` — they were claiming every namesake. That is right for the match surface, but it means `/author/thomas` no longer resolves to anybody. Verified by replaying the resolver's own logic against production: every bare slug (`irenaeus`, `basilius`, `jacobus`, `dionysius`, `bernardus`, `hermes`, `thomas`, `bernard`) now returns `notFound`. Production still 301s them to the old docs purely from **stale ISR pages**, not a live wrong answer.

So without this change the sequence would have been: wrong link → dead link. Linking by `author_id` fixes both at once — each book reaches its own author, and the URL stops depending on the thesaurus's match surface at all.

`authorUrl(author, authorId?)` prefers `authorId` when present and falls back to the byline slug otherwise, so every other call site is unchanged.

## Also

Adds `author_id` to the `Book` type. It was **absent** while the retiring `author_entity_id` was present — the canonical FK that `author-identity.md` explicitly says to read (`Read books.author_id → authors._id, not author_entity_id`) was the one field the type could not express, which is why the correct code did not type-check.

## Tests

`npx tsc --noEmit` clean; 28/28 in `tests/unit/slugify.test.ts`. New cases pin the pair that motivated the change — one byline, two `author_id`s, two different URLs — plus the fallback path and the case where a linked book carries a placeholder byline (an `"Anonymous"`-bylined book still reaches its attributed author).

## Follow-up, not in this PR

The stale `/author/<bare>` ISR entries still redirect to the old docs until they revalidate, and `system_config.author_slugs` still holds inert `thomas → "Thomas"`-style entries. Both are cleanup I'll do after this merges, so the link fix is live before the old URLs stop resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YE9mmrQMk6xzi5jwtahtMz
