### PR TITLE
feat(reader): metered reader behind METERED_READER flag, default OFF (#4357)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -8,6 +8,7 @@ import { createRevision } from '@/lib/page-revisions';
 import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 import { markPageForReader, stripProvenanceMarks } from '@/lib/provenance';
+import { gatePagesForRequest } from '@/lib/metered-gate';
 
 export const preferredRegion = 'fra1';
 
@@ -79,6 +80,11 @@ export async function GET(
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
+
+    // Metered reader (#4357): the 'default' tenant is the main library, so it
+    // meters like the global twin; named tenants (bph/kloss/…) are partner
+    // reading rooms and stay exempt. No-op unless METERED_READER=1.
+    [page] = await gatePagesForRequest(db, request, [page], { exempt: tenant !== 'default' });
 
     // Reader-path provenance: translation carries the invisible imprimatur
     // (deterministic, no ref — cache-safe). Mirrors the global twin.

--- a/src/app/api/[tenant]/pages/batch/route.ts
+++ b/src/app/api/[tenant]/pages/batch/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { markPageForReader } from '@/lib/provenance';
+import { gatePagesForRequest } from '@/lib/metered-gate';
+import { meteredReaderEnabled } from '@/lib/free-preview';
 
 export const preferredRegion = 'fra1';
 
@@ -44,17 +46,28 @@ export async function POST(
     const tenantFilter = tenant === 'default' ? { $in: [tenantId, null] } : tenantId;
 
     const db = await getDb();
-    const pages = await db.collection('pages').find(
+    let pages = await db.collection('pages').find(
       { id: { $in: limitedIds }, tenantId: tenantFilter },
       { projection: { detected_images: 0 } }
     ).toArray();
+
+    // Metered reader (#4357): 'default' tenant = the main library, metered
+    // like the global twin; named tenants are exempt partner reading rooms.
+    // No-op unless METERED_READER=1.
+    pages = await gatePagesForRequest(db, request, pages, { exempt: tenant !== 'default' });
 
     // Strip MongoDB _id; weave the reader-path provenance mark into each
     // translation (deterministic, cache-safe — mirrors the global twin).
     const cleaned = pages.map(({ _id, ...rest }) => markPageForReader(rest));
 
+    // With metering on, the body depends on who asked — keep it out of any
+    // shared cache (POSTs aren't CDN-cached today; belt and braces).
+    const cacheControl = meteredReaderEnabled()
+      ? 'private, no-store'
+      : 'public, max-age=0, s-maxage=60, stale-while-revalidate=300';
+
     return NextResponse.json({ pages: cleaned }, {
-      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' },
+      headers: { 'Cache-Control': cacheControl },
     });
   } catch (error) {
     console.error('Batch pages error:', error);

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -8,6 +8,7 @@ import { createRevision } from '@/lib/page-revisions';
 import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 import { markPageForReader, stripProvenanceMarks } from '@/lib/provenance';
+import { gatePagesForRequest } from '@/lib/metered-gate';
 
 export const preferredRegion = 'fra1';
 
@@ -76,6 +77,12 @@ export async function GET(
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
+
+    // Metered reader (#4357): strip gated text for anonymous callers beyond
+    // the book's free sample. Tenant-scoped requests (proxy-injected
+    // tenantId = partner reading room) are exempt. No-op unless
+    // METERED_READER=1.
+    [page] = await gatePagesForRequest(db, request, [page], { exempt: !!tenantId });
 
     // Reader-path provenance: translation carries the invisible imprimatur.
     // Deterministic (no ref), so the cache header below stays valid.

--- a/src/app/api/pages/batch/route.ts
+++ b/src/app/api/pages/batch/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { markPageForReader } from '@/lib/provenance';
+import { gatePagesForRequest } from '@/lib/metered-gate';
+import { meteredReaderEnabled } from '@/lib/free-preview';
 
 export const preferredRegion = 'fra1';
 
@@ -36,18 +38,31 @@ export async function POST(request: NextRequest) {
     if (tenantId) filter.tenantId = tenantId;
 
     const db = await getDb();
-    const pages = await db.collection('pages').find(
+    let pages = await db.collection('pages').find(
       filter,
       { projection: { detected_images: 0 } }
     ).toArray();
+
+    // Metered reader (#4357): strip gated text for anonymous callers beyond
+    // each book's free sample. Tenant-scoped requests are exempt. No-op
+    // unless METERED_READER=1.
+    pages = await gatePagesForRequest(db, request, pages, { exempt: !!tenantId });
 
     // Strip MongoDB _id; weave the reader-path provenance mark into each
     // translation. Deterministic (content-keyed, no ref), so the shared
     // s-maxage cache below serves identical bytes to every caller.
     const cleaned = pages.map(({ _id, ...rest }) => markPageForReader(rest));
 
+    // With metering on, the body depends on who asked (session vs anon) —
+    // never let a shared cache serve one caller's variant to another. POSTs
+    // aren't CDN-cached today, so this is belt and braces, not a behavior
+    // change for the flag-off default.
+    const cacheControl = meteredReaderEnabled()
+      ? 'private, no-store'
+      : 'public, max-age=0, s-maxage=60, stale-while-revalidate=300';
+
     return NextResponse.json({ pages: cleaned }, {
-      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' },
+      headers: { 'Cache-Control': cacheControl },
     });
   } catch (error) {
     console.error('Batch pages error:', error);

--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -12,6 +12,7 @@ import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getTranscriptionsForPage } from '@/lib/music-transcriptions';
 import { jsonLdHtml } from '@/lib/json-ld';
 import { markPageForReader } from '@/lib/provenance';
+import { meteredReaderEnabled, isPageFree, stripGatedPage } from '@/lib/free-preview';
 import { localePath, type Locale } from '@/lib/locale-path';
 import { READER_STRINGS } from '@/lib/book-i18n';
 import { localizedTitle } from '@/lib/localized';
@@ -75,6 +76,8 @@ const BOOK_NAV_PROJECTION = {
   pages_translated_es: 1,
   author: 1, published: 1, language: 1, doi: 1, chapters: 1,
   cdli_witnesses: 1, etcsl_id: 1, visible: 1,
+  // Metered reader (#4357): isPageFree() needs the book's page total.
+  pages_count: 1,
 };
 
 export default async function PageEditorPage({ params, allowHidden = false, lang = 'en' }: PageProps & { allowHidden?: boolean; lang?: Locale }) {
@@ -145,11 +148,28 @@ export default async function PageEditorPage({ params, allowHidden = false, lang
   // zero-width characters so search snippet matching is untouched.
   const jsonLd = buildPageJsonLd(book, serializedPage, `https://sourcelibrary.org${localePath(`/book/${bookPath}/page/${pageId}`, lang)}`);
 
+  // Metered reader (#4357): beyond the free sample, the ISR HTML carries the
+  // page WITHOUT its text — for everyone, which is what keeps it statically
+  // cacheable (an ISR render can't see who's asking). Signed-in readers get
+  // the full text refetched client-side (useReaderV2's gated-page effect);
+  // anonymous readers see the scan with a sign-in pane. seo_indexable pages
+  // are always free, so every Google-indexed reader URL keeps its full text
+  // and its `isAccessibleForFree: true` JSON-LD stays honest. Editor preview
+  // (allowHidden) and tenant/embed reading rooms are exempt. No-op unless
+  // METERED_READER=1.
+  const metered = meteredReaderEnabled()
+    && !allowHidden
+    && !(ctx?.id || ctx?.isEmbedded)
+    && !isPageFree(serializedPage as unknown as { page_number?: number | null; seo_indexable?: boolean }, (book as unknown as { pages_count?: number }).pages_count);
+  const servedPage = metered
+    ? (stripGatedPage(serializedPage as unknown as Record<string, unknown>, (book as unknown as { pages_count?: number }).pages_count || 0) as unknown as Page)
+    : serializedPage;
+
   // The flight payload the reader (and anything scraping this URL) receives
   // carries the invisible provenance imprimatur in the translation. It is
   // deterministic — content-keyed, no per-request input — so this page stays
   // safely ISR/CDN-cacheable. The editor save path strips it before storing.
-  const markedPage = markPageForReader(serializedPage, scopedBookId);
+  const markedPage = markPageForReader(servedPage, scopedBookId);
 
   return (
     <>

--- a/src/components/reader-v2/PaneEmptyState.tsx
+++ b/src/components/reader-v2/PaneEmptyState.tsx
@@ -49,6 +49,29 @@ function EmptyPane({
 }
 
 /**
+ * Metered reader (#4357): pane content for a page whose text the server
+ * withheld (page.gated — beyond the book's free sample, signed-out caller).
+ * The scan pane stays live; this renders where the transcription/translation
+ * would be. Deliberately NOT the "not transcribed yet" wording — that state
+ * means the text does not exist; this one means it exists and is a sign-in
+ * away. Signed-in readers never see it: useReaderV2 refetches gated pages
+ * once a session is present.
+ */
+export function GatedPane({ page }: { page: Page }) {
+  const pathname = usePathname();
+  const t = getReaderStrings(useLocale()).paneGated;
+  const freePages = page.gate?.free_pages || 0;
+  const signInHref = `/auth/signin?callbackUrl=${encodeURIComponent(pathname || '/')}`;
+  return (
+    <EmptyPane label={t.label} body={t.body(freePages)}>
+      <a href={signInHref} className={actionButtonClass} style={actionButtonStyle}>
+        {t.signIn}
+      </a>
+    </EmptyPane>
+  );
+}
+
+/**
  * Empty-state content for one reader pane (OCR or translation) when that
  * pane has no text. Renders in place of ReaderProse's plain italic line.
  *

--- a/src/components/reader-v2/ReaderV2Bits.tsx
+++ b/src/components/reader-v2/ReaderV2Bits.tsx
@@ -11,7 +11,7 @@ import type { Book, Page } from '@/lib/types';
 import type { CdliWitness } from '@/lib/types/book';
 import type { CorpusInfo } from '@/lib/text-provenance';
 import type { ReaderSettings } from './useReaderV2';
-import { PaneEmptyState } from './PaneEmptyState';
+import { PaneEmptyState, GatedPane } from './PaneEmptyState';
 
 // Shared presentational pieces for the v2 reader design previews. All values
 // map to existing Source Library tokens (globals.css) — no new primitives.
@@ -204,6 +204,13 @@ export function ReaderProse({
   const raw = kind === 'ocr' ? (page.ocr?.data || '') : (page.translation?.data || '');
   const text = suppressBlockquote ? raw.replace(/^[ \t]*>[ \t]?/gm, '') : raw;
   const lang = kind === 'ocr' ? book.language : 'English';
+
+  // Metered reader (#4357): the server withheld this page's text (beyond the
+  // free sample, signed-out caller). Must come before the empty check — a
+  // gated page IS empty, but "not transcribed yet" would be a lie.
+  if (page.gated) {
+    return <GatedPane page={page} />;
+  }
 
   // An empty pane is several different situations wearing one sentence: a page
   // nobody has transcribed, a page transcribed but not translated, a blank

--- a/src/components/reader-v2/useReaderV2.ts
+++ b/src/components/reader-v2/useReaderV2.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Book, Page } from '@/lib/types';
 import { pages as pagesApi, readingHistory } from '@/lib/api-client';
+import { useStableSession } from '@/hooks/useStableSession';
 import { useEmbedHref } from '@/lib/EmbedContext';
 import { getPageDisplayUrl } from '@/lib/utils';
 
@@ -155,6 +156,28 @@ export function useReaderV2(
     if (idx >= 0) prefetchAround(idx);
     return () => { cancelled = true; };
   }, [currentPageId, currentPage.id, fetchPage, pageList, prefetchAround]);
+
+  // Metered reader (#4357): the ISR HTML and any pre-sign-in fetches carry
+  // the STRIPPED variant of gated pages (the static render can't see who is
+  // asking). Once a session is present, purge those from the cache and
+  // refetch the one on screen — the API serves signed-in callers the full
+  // text. Without this, a reader who signs in at the wall keeps staring at
+  // the wall until a hard reload.
+  const { data: gateSessionData } = useStableSession();
+  const signedIn = !!gateSessionData?.user;
+  useEffect(() => {
+    if (!signedIn) return;
+    for (const [id, p] of cacheRef.current) {
+      if ((p as Page & { gated?: boolean }).gated) cacheRef.current.delete(id);
+    }
+    if ((currentPage as Page & { gated?: boolean }).gated) {
+      fetchPage(currentPageId).then((p) => {
+        // Only swap in a real page: on a fetch failure (or a still-gated
+        // response) keep what's on screen — the wall, not a blank.
+        if (p && !(p as Page & { gated?: boolean }).gated) setCurrentPage(p);
+      });
+    }
+  }, [signedIn, currentPage, currentPageId, fetchPage]);
 
   // Reading history beacon (same contract as the production reader)
   useEffect(() => {

--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -12,8 +12,11 @@
 
 import { validateApiKey } from '@/lib/dataset/api-keys';
 import { CONTENT_LICENSE } from '@/lib/license-info';
+import { FREE_PAGE_PERCENT, freeMaxPage } from '@/lib/free-preview';
 
-const BOT_PAGE_PERCENT = 20; // % of pages bots can read from each book
+// % of pages bots can read from each book — shared with the metered reader
+// (free-preview.ts) so the bot sample and the human sample can never drift.
+const BOT_PAGE_PERCENT = FREE_PAGE_PERCENT;
 
 const KNOWN_BOTS = [
   'gptbot', 'chatgpt', 'oai-searchbot',
@@ -90,8 +93,7 @@ export async function isTrustedBot(request: Request): Promise<boolean> {
  * Returns 0 if pages_count is unknown (deny by default).
  */
 export function botMaxPage(pagesCount: number): number {
-  if (!pagesCount || pagesCount <= 0) return 0;
-  return Math.max(1, Math.floor(pagesCount * BOT_PAGE_PERCENT / 100));
+  return freeMaxPage(pagesCount);
 }
 
 export function botGateResponse(book: {

--- a/src/lib/free-preview.ts
+++ b/src/lib/free-preview.ts
@@ -1,0 +1,98 @@
+/**
+ * Metered reader — the free-preview policy (#4357, Phase 2).
+ *
+ * Anonymous readers get a free sample of every book; the rest of the TEXT
+ * (transcription, translation, and derived text) asks for a sign-in. Page
+ * IMAGES are never gated here: the reader's nav list already ships every
+ * page's image URLs in ISR HTML and the files live on public R2/IIIF origins,
+ * so an image gate would be theatre — and illustrations staying browsable is
+ * deliberate (they are the free front door, indexed via /gallery and /artwork).
+ *
+ * The free set for a book is:
+ *   - the first FREE_PAGE_PERCENT% of pages (same rule bots have always had —
+ *     bot-gate.ts delegates its math here so the two can never drift), PLUS
+ *   - every seo_indexable page. Reader pages are noindex by default (#2688);
+ *     only seo_indexable pages are in Google, and keeping exactly those free
+ *     means every indexed page stays fully accessible: no cloaking exposure,
+ *     no paywall structured data needed, and buildPageJsonLd's
+ *     `isAccessibleForFree: true` stays honest (it only emits on
+ *     seo_indexable pages).
+ *
+ * MASTER SWITCH: the METERED_READER env var. Unset (the default) the gate is
+ * inert everywhere. Flipping it on requires a deploy, and ISR reader pages
+ * rendered before the flip keep serving full text until they revalidate
+ * (up to 24h) — flip it before announcing, not after.
+ *
+ * Enforcement points (all of them check meteredReaderEnabled() first):
+ *   - /api/pages/[id] + /api/pages/batch, and their /api/[tenant]/ twins —
+ *     the routes the reader's client-side page turns actually fetch from
+ *   - the ISR reader page itself (direct deep links to gated pages)
+ * Tenant-context traffic is exempt: partner reading rooms (BPH etc.) were
+ * promised as open reading surfaces and have their own agreements.
+ */
+
+export const FREE_PAGE_PERCENT = 20;
+
+export function meteredReaderEnabled(): boolean {
+  return process.env.METERED_READER === '1';
+}
+
+/**
+ * Highest page_number in a book's free sample. 0 when pages_count is unknown
+ * (deny by default — same contract botMaxPage always had).
+ */
+export function freeMaxPage(pagesCount: number): number {
+  if (!pagesCount || pagesCount <= 0) return 0;
+  return Math.max(1, Math.floor(pagesCount * FREE_PAGE_PERCENT / 100));
+}
+
+/**
+ * Is this page in the book's free sample?
+ *
+ * Pages without a real page_number (null/negative — inserts, archived
+ * spreads, unnumbered front matter) count as free: they are not the asset
+ * being metered and a wall on an unnumbered flyleaf is just confusing.
+ */
+export function isPageFree(
+  page: { page_number?: number | null; seo_indexable?: boolean },
+  pagesCount: number | undefined,
+): boolean {
+  if (page.seo_indexable === true) return true;
+  const n = page.page_number;
+  if (n == null || n < 0) return true;
+  return n <= freeMaxPage(pagesCount || 0);
+}
+
+/** Fields that carry the metered asset: page text and everything derived from it. */
+const GATED_TEXT_FIELDS = [
+  'ocr', 'translation', 'translation_es', 'translations', 'summary',
+  'modernized', 'transliteration', 'translation_summary',
+  'translation_keywords', 'word_alignment',
+] as const;
+
+export interface GateInfo {
+  free_pages: number;
+  pages_count: number;
+  sign_in_url: string;
+}
+
+/**
+ * Strip the gated text from a page document and mark it, leaving images and
+ * layout metadata intact so the scan stays browsable. Returns a NEW object.
+ */
+export function stripGatedPage<T extends Record<string, unknown>>(
+  page: T,
+  pagesCount: number,
+): T & { gated: true; gate: GateInfo } {
+  const stripped: Record<string, unknown> = { ...page };
+  for (const field of GATED_TEXT_FIELDS) delete stripped[field];
+  return {
+    ...(stripped as T),
+    gated: true as const,
+    gate: {
+      free_pages: freeMaxPage(pagesCount),
+      pages_count: pagesCount,
+      sign_in_url: '/auth/signin',
+    },
+  };
+}

--- a/src/lib/metered-gate.ts
+++ b/src/lib/metered-gate.ts
@@ -1,0 +1,101 @@
+/**
+ * Metered-reader enforcement for the page-content API routes (#4357 Phase 2).
+ *
+ * The reader's client-side page turns fetch content from /api/pages/[id],
+ * /api/pages/batch and their /api/[tenant]/ twins — so this, not the ISR
+ * HTML, is where the wall actually holds. The ISR reader page applies the
+ * same policy to the first page it embeds (see free-preview.ts for the
+ * policy and the master METERED_READER switch).
+ *
+ * Like anon-gate.ts (and unlike withApiAuth), same-origin browser traffic is
+ * NOT exempt — metering logged-out humans in the reader is the whole point.
+ * Exempt: signed-in sessions, cron/pipeline (Bearer CRON_SECRET), trusted
+ * bots (search crawlers, user-initiated assistant fetches, API-key holders,
+ * our MCP server — bot-gate's isTrustedBot), and any tenant-scoped request
+ * (partner reading rooms; the routes pass `exempt` for those).
+ */
+import type { Db } from 'mongodb';
+import { auth } from '@/lib/auth';
+import { getDb } from '@/lib/mongodb';
+import { getClientIp } from '@/lib/rate-limit';
+import { anonymizeIp } from '@/lib/anonymize-ip';
+import { hasCronAuth } from '@/lib/book-access';
+import { isTrustedBot } from '@/lib/bot-gate';
+import { meteredReaderEnabled, isPageFree, stripGatedPage } from '@/lib/free-preview';
+
+/**
+ * One row per walled request in analytics_events (same shape as
+ * anon-gate.ts's logGateHit) — the conversion signal Phase 3 pricing needs.
+ * Fire-and-forget; never throws, never delays the response.
+ */
+function logGateHit(request: Request, pagesGated: number): void {
+  try {
+    const country = request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown';
+    const ip = anonymizeIp(getClientIp(request) || 'unknown');
+    Promise.race([
+      (async () => {
+        const db = await getDb();
+        await db.collection('analytics_events').insertOne({
+          event: 'gate_hit', feature: 'metered-reader', pages_gated: pagesGated,
+          country, ip, timestamp: new Date(), created_at: new Date(),
+        });
+      })(),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]).catch(() => {});
+  } catch {
+    /* never throw */
+  }
+}
+
+type PageDoc = Record<string, unknown> & {
+  book_id?: string;
+  page_number?: number | null;
+  seo_indexable?: boolean;
+};
+
+/**
+ * Apply the metered-reader policy to page docs about to be returned to the
+ * client: strip the text from pages outside their book's free sample unless
+ * the caller is entitled to them. Returns the input array (same order),
+ * with gated pages replaced by stripped copies.
+ *
+ * `exempt` short-circuits everything (tenant-scoped routes pass true).
+ * With METERED_READER unset this is a no-op costing one env read.
+ */
+export async function gatePagesForRequest<T extends PageDoc>(
+  db: Db,
+  request: Request,
+  pages: T[],
+  { exempt = false }: { exempt?: boolean } = {},
+): Promise<T[]> {
+  if (!meteredReaderEnabled() || exempt || pages.length === 0) return pages;
+  if (hasCronAuth(request)) return pages;
+
+  const session = await auth().catch(() => null);
+  if (session?.user) return pages;
+  if (await isTrustedBot(request)) return pages;
+
+  // pages_count per distinct book (usually exactly one — the reader batches
+  // within a single book).
+  const bookIds = [...new Set(pages.map((p) => p.book_id).filter(Boolean))] as string[];
+  if (bookIds.length === 0) return pages;
+  const books = await db.collection('books').find(
+    { id: { $in: bookIds } },
+    { projection: { _id: 0, id: 1, pages_count: 1 }, maxTimeMS: 5000 }
+  ).toArray();
+  const pagesCountByBook = new Map(books.map((b) => [b.id as string, (b.pages_count as number) || 0]));
+
+  let gatedCount = 0;
+  const result = pages.map((p) => {
+    const pagesCount = pagesCountByBook.get(p.book_id as string);
+    // A page whose book we can't resolve stays ungated: fail open — a
+    // transient lookup miss must not wall content the policy says is free.
+    if (pagesCount === undefined) return p;
+    if (isPageFree(p, pagesCount)) return p;
+    gatedCount++;
+    return stripGatedPage(p, pagesCount) as unknown as T;
+  });
+
+  if (gatedCount > 0) logGateHit(request, gatedCount);
+  return result;
+}

--- a/src/lib/reader-strings.ts
+++ b/src/lib/reader-strings.ts
@@ -360,6 +360,14 @@ export interface ReaderStrings {
     thanksWillPrioritise: string;
   };
 
+  /** Metered reader (#4357): pane shown past the free sample for signed-out readers. */
+  paneGated: {
+    label: string;
+    /** `…past the first {n} pages…` */
+    body: (freePages: number) => string;
+    signIn: string;
+  };
+
   /** Save panel (likes, not folders — see SavePanel.tsx's own comment). */
   save: {
     anonymousNotice: string;
@@ -750,6 +758,11 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       thanksWillEmail: 'Thanks — we’ll email you when this page is translated.',
       thanksWillPrioritise: 'Thanks — we’ll prioritize this book.',
     },
+    paneGated: {
+      label: 'Sign in to keep reading',
+      body: (freePages) => `The scan is free to browse. Reading the transcription and translation past the first ${freePages} pages asks for a free account.`,
+      signIn: 'Sign in — it’s free',
+    },
     save: {
       anonymousNotice: 'Saves work without an account, on this device only.',
       signInToKeep: 'Sign in to keep them everywhere',
@@ -1118,6 +1131,11 @@ export const READER_UI_STRINGS: Record<Locale, ReaderStrings> = {
       requested: 'Solicitada',
       thanksWillEmail: 'Gracias. Te escribiremos cuando esta página esté traducida.',
       thanksWillPrioritise: 'Gracias. Daremos prioridad a este libro.',
+    },
+    paneGated: {
+      label: 'Inicia sesión para seguir leyendo',
+      body: (freePages) => `El escaneo se puede hojear libremente. Para leer la transcripción y la traducción más allá de las primeras ${freePages} páginas hace falta una cuenta gratuita.`,
+      signIn: 'Inicia sesión — es gratis',
     },
     save: {
       anonymousNotice: 'Puedes guardar sin una cuenta; se guarda solo en este dispositivo.',

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -47,6 +47,17 @@ export interface Page {
   // Canonical type: WordAlignmentData in src/lib/word-alignment.ts.
   word_alignment?: import('@/lib/word-alignment').WordAlignmentData;
 
+  // Metered reader (#4357): set by the server (free-preview.ts stripGatedPage)
+  // on pages served to anonymous readers beyond the book's free sample — the
+  // text fields are absent and the reader shows a sign-in pane instead of the
+  // "not yet transcribed" empty state. Never stored on the pages collection.
+  gated?: boolean;
+  gate?: { free_pages: number; pages_count: number; sign_in_url: string };
+
+  // SEO: demand-proven pages opened to indexing (#2688); always in the free
+  // sample when the metered reader is on.
+  seo_indexable?: boolean;
+
   // Page classification from OCR (title-page, frontispiece, toc, etc.)
   page_type?: string;
 

--- a/tests/unit/free-preview.test.ts
+++ b/tests/unit/free-preview.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FREE_PAGE_PERCENT,
+  freeMaxPage,
+  isPageFree,
+  stripGatedPage,
+  meteredReaderEnabled,
+} from '@/lib/free-preview';
+import { botMaxPage } from '@/lib/bot-gate';
+
+/**
+ * Pins the metered-reader free-preview policy (#4357 Phase 2). Guards:
+ *  - the master switch defaults OFF (unset env ⇒ inert everywhere)
+ *  - the human sample and the bot sample share one formula (no drift)
+ *  - seo_indexable pages are ALWAYS free — this is the invariant that keeps
+ *    every Google-indexed reader page fully accessible, which is what lets
+ *    reader JSON-LD keep `isAccessibleForFree: true` without cloaking
+ *  - stripGatedPage removes every text-bearing field and no image field
+ */
+describe('free-preview policy', () => {
+  it('is OFF by default: METERED_READER unset means no metering anywhere', () => {
+    expect(process.env.METERED_READER).toBeUndefined();
+    expect(meteredReaderEnabled()).toBe(false);
+  });
+
+  it('free sample math matches the bot gate exactly', () => {
+    for (const n of [0, 1, 4, 5, 100, 250, 999]) {
+      expect(freeMaxPage(n)).toBe(botMaxPage(n));
+    }
+    expect(freeMaxPage(100)).toBe(20);
+    expect(freeMaxPage(4)).toBe(1); // never less than one free page
+    expect(freeMaxPage(0)).toBe(0); // unknown length: deny by default
+    expect(FREE_PAGE_PERCENT).toBe(20);
+  });
+
+  it('pages inside the sample are free, pages beyond it are not', () => {
+    expect(isPageFree({ page_number: 20 }, 100)).toBe(true);
+    expect(isPageFree({ page_number: 21 }, 100)).toBe(false);
+  });
+
+  it('seo_indexable pages are free regardless of position', () => {
+    expect(isPageFree({ page_number: 99, seo_indexable: true }, 100)).toBe(true);
+  });
+
+  it('unnumbered and negative pages are free (inserts, flyleaves)', () => {
+    expect(isPageFree({ page_number: null }, 100)).toBe(true);
+    expect(isPageFree({}, 100)).toBe(true);
+    expect(isPageFree({ page_number: -1 }, 100)).toBe(true);
+  });
+
+  it('stripGatedPage removes text fields, keeps images, marks the page', () => {
+    const page = {
+      id: 'p1', book_id: 'b1', page_number: 50,
+      photo: 'https://images.example/1.jpg',
+      archived_photo: 'https://images.example/a.jpg',
+      thumbnail: 'https://images.example/t.jpg',
+      page_type: 'text', columns: 2,
+      ocr: { data: 'secret transcription', language: 'Latin' },
+      translation: { data: 'secret translation', language: 'English' },
+      translations: { es: { data: 'secreto', language: 'Spanish' } },
+      summary: { data: 'secret summary' },
+      transliteration: { data: 'secret' },
+      translation_summary: 'secret',
+      translation_keywords: ['secret'],
+      word_alignment: { spans: [] },
+    };
+    const gated = stripGatedPage(page, 100);
+    // every text field gone
+    for (const field of ['ocr', 'translation', 'translations', 'summary',
+      'transliteration', 'translation_summary', 'translation_keywords', 'word_alignment']) {
+      expect(gated).not.toHaveProperty(field);
+    }
+    // scan stays browsable
+    expect(gated.photo).toBe(page.photo);
+    expect(gated.archived_photo).toBe(page.archived_photo);
+    expect(gated.thumbnail).toBe(page.thumbnail);
+    expect(gated.page_type).toBe('text');
+    // marked, with the numbers the wall copy needs
+    expect(gated.gated).toBe(true);
+    expect(gated.gate.free_pages).toBe(20);
+    expect(gated.gate.pages_count).toBe(100);
+    // input object untouched (routes reuse it)
+    expect(page.ocr.data).toBe('secret transcription');
+  });
+});


### PR DESCRIPTION
Phase 2 slice 1 of #4357 — the 20%-free metered reader, shipped **inert**: the `METERED_READER` env var is the master switch and it is unset in prod. Merging this changes nothing user-visible; it stages the machinery so the wall can be turned on deliberately, with comms, later.

## The model
- **Free set per book** = first 20% of pages (exact same `botMaxPage` math the bot gate has used all along — `bot-gate.ts` now delegates to the shared `free-preview.ts` so the two can never drift) **∪ every `seo_indexable` page**.
- Beyond it, anonymous readers get the page **with its text stripped** (ocr/translation/summary and derived fields): the scan stays browsable, and the transcription/translation panes render a localized (en/es) sign-in wall. Images are deliberately not gated — the nav list already ships every page's image URLs in ISR HTML and the files are on public R2/IIIF, so an image gate would be theatre; illustrations staying open is the point (they're the indexed free front door, #4364).
- **No cloaking exposure by construction**: reader pages are noindex except `seo_indexable` ones (#2688), and those are always free — so every Google-indexed reader URL keeps full text, everyone sees identical HTML per URL, and the existing `isAccessibleForFree: true` JSON-LD stays honest. No paywall structured data needed.

## Enforcement points
- `/api/pages/[id]` + `/api/pages/batch` and the `/api/[tenant]/` twins — where the reader's client-side page turns actually fetch content (`useReaderV2` → `pagesApi`).
- The ISR reader page's embedded first page (direct deep links). ISR stays fully cacheable: the stripped variant is served to everyone; signed-in sessions purge gated cache entries and refetch (new effect in `useReaderV2`).
- Exempt: sessions, Bearer $CRON_SECRET, trusted bots (search crawlers/user-fetch agents/API keys/MCP via `isTrustedBot`), named tenants + embeds (partner reading rooms), editor preview routes.
- Batch responses switch to `private, no-store` when metering is on (body becomes caller-dependent).
- Every walled request logs a `gate_hit` row (`feature: 'metered-reader'`) — the conversion signal Phase 3 pricing needs.

## Verified (dev server with METERED_READER=1, prod data)
- anon free page → full text; anon gated page → `gated:true`, no ocr/translation, photo intact
- CRON bearer and Googlebot UA on a gated page → full text
- batch with one free + one gated id → correct per-page split
- gated reader HTML: mid-text prose from both OCR and translation **absent** (positive control: same probe finds the free page's prose **present**); wall strings render
- `tsc --noEmit` clean, eslint clean, new `tests/unit/free-preview.test.ts` (6 tests) pins the policy and the OFF default

## Before the flag ever flips (tracked in #4357, NOT in this PR)
- Quote-shortlink/DOI exception (citations must resolve)
- Escape-hatch alignment: IIIF manifests, DTS document, book full-text search
- Copy updates ("no paywalls, no login walls" on /contribute, FAQ, beta) + announcement
- ISR staleness note: pages rendered before the flip serve full text until revalidation (≤24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUHK3ecPn7x7WUNZxmRsTs