### PR TITLE
feat(citation): copy-layer citations — holding library + shelfmark, one generateCitations (#4360)

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -540,6 +540,20 @@ export async function getQuote(args: {
   const tips = [ocrOriginal ? OCR_ORIGINAL_TIP : QUOTE_TIP];
   if (romanized) tips.push(ROMANIZED_TIP);
 
+  // Copy clause (#4360): the scan shows one library's physical copy. Appended
+  // only when the API named a genuine holder, so the tip never invites the
+  // model to invent one. The in-app server (src/app/api/mcp/route.ts) carries
+  // the same logic — fixes do not propagate between the two copies.
+  const copy = (result.citation as Record<string, unknown> | undefined)?.copy as
+    | { statement?: string }
+    | undefined;
+  if (copy?.statement) {
+    tips.push(
+      `The scanned images reproduce one physical copy: "${copy.statement}". ` +
+        "When citing copy-specific evidence (marginalia, provenance marks, hand-coloring), include that clause in the citation.",
+    );
+  }
+
   return {
     ...withCitationLink(result),
     tip: tips.join("\n\n"),

--- a/scripts/audit/holding-library-coverage.mjs
+++ b/scripts/audit/holding-library-coverage.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Coverage of the citation copy clause (#4360/#4361): how many live books can
+ * name the library whose physical copy their scan shows, and how many still
+ * carry an AGGREGATOR (Internet Archive, Google Books, …) as their
+ * "contributing library" — a holding that does not exist, which the citation
+ * layer therefore suppresses.
+ *
+ * Read-only. Exit 0 always (reporting, not gating); the aggregator list here
+ * mirrors src/lib/holding-library.ts (AGGREGATORS).
+ *
+ *   node --env-file=.env.production.local scripts/audit/holding-library-coverage.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const AGGREGATOR_VALUES = [
+  'internet archive', 'archive.org', 'google books', 'google',
+  'hathitrust', 'project gutenberg', 'wikimedia commons', 'wikisource',
+  'e-rara (swiss electronic library)', 'e-rara',
+  'iiif source',
+];
+
+const client = await MongoClient.connect(process.env.MONGODB_URI);
+const db = client.db('bookstore');
+const books = db.collection('books');
+const LIVE = { visible: true, pages_count: { $gt: 0 } };
+
+const total = await books.countDocuments(LIVE);
+
+// Same coalescing as resolveHoldingCopy: image_source.* wins, the top-level
+// legacy twin fills in (3,860 live books rely on it until phase 6 runs).
+const LIB_EXPR = { $ifNull: ['$image_source.contributing_library', { $ifNull: ['$contributing_library', ''] }] };
+const MARK_EXPR = { $ifNull: ['$image_source.shelfmark', { $ifNull: ['$shelfmark', ''] }] };
+
+const [row] = await books.aggregate([
+  { $match: LIVE },
+  { $project: { lib: { $toLower: { $toString: LIB_EXPR } }, mark: MARK_EXPR } },
+  { $group: {
+    _id: null,
+    withLibrary: { $sum: { $cond: [{ $gt: [{ $strLenCP: '$lib' }, 0] }, 1, 0] } },
+    withShelfmark: { $sum: { $cond: [{ $gt: [{ $strLenCP: { $toString: '$mark' } }, 0] }, 1, 0] } },
+    aggregator: { $sum: { $cond: [{ $in: ['$lib', AGGREGATOR_VALUES] }, 1, 0] } },
+  } },
+]).toArray();
+const { withLibrary, withShelfmark, aggregator: aggTotal } = row;
+
+const aggRows = await books.aggregate([
+  { $match: LIVE },
+  { $project: { lib: { $toLower: { $toString: LIB_EXPR } } } },
+  { $match: { lib: { $in: AGGREGATOR_VALUES } } },
+  { $group: { _id: '$lib', n: { $sum: 1 } } },
+  { $sort: { n: -1 } },
+]).toArray();
+
+const citable = withLibrary - aggTotal;
+const pct = n => `${((n / total) * 100).toFixed(1)}%`;
+
+console.log(`Live books:                      ${total}`);
+console.log(`contributing_library present:    ${withLibrary} (${pct(withLibrary)}) [either field location]`);
+console.log(`  …but an aggregator, not a holder: ${aggTotal}`);
+console.log(`Copy clause CITABLE (real holder): ${citable} (${pct(citable)})`);
+console.log(`shelfmark present:               ${withShelfmark} (${pct(withShelfmark)})`);
+if (aggRows.length) {
+  console.log('\nAggregator values still standing as holders (run backfill phase 4):');
+  for (const r of aggRows) console.log(`  ${String(r.n).padStart(6)}  ${r._id}`);
+}
+
+// Top holders — variant spellings show up here as near-duplicate rows.
+const top = await books.aggregate([
+  { $match: { ...LIVE, 'image_source.contributing_library': { $nin: [null, ''] } } },
+  { $group: { _id: '$image_source.contributing_library', n: { $sum: 1 } } },
+  { $sort: { n: -1 } },
+  { $limit: 15 },
+]).toArray();
+console.log('\nTop contributing libraries (watch for variant spellings of one institution):');
+for (const r of top) console.log(`  ${String(r.n).padStart(6)}  ${r._id}`);
+
+await client.close();

--- a/scripts/backfill-contributing-library.mjs
+++ b/scripts/backfill-contributing-library.mjs
@@ -3,20 +3,51 @@
  * Backfill image_source.contributing_library for books missing it.
  *
  * Phase 1: Single-institution providers — set name directly (no API calls).
- * Phase 2: IA books — fetch contributor from IA metadata API.
+ * Phase 2: IA books — fetch contributor from IA metadata API (+ call_number → shelfmark).
  * Phase 3: e-rara — extract holding library from OAI-PMH or manifest.
+ * Phase 4 (#4361): books whose contributing_library IS an aggregator name
+ *   ("Internet Archive" — 6,185 live books at time of writing) — replace with
+ *   the IA item's `contributor`, the actual holding institution. An aggregator
+ *   hosted the scan; some library owns the book, and the citation copy clause
+ *   (#4360) refuses to name an aggregator, so these books cite no holder until
+ *   this phase recovers the real one.
+ * Phase 5 (#4361): BPH shelfmark materialization — READ Supabase `bph_works`
+ *   (never write it: .claude/docs/bph-catalogue-disaster-recovery.md), copy
+ *   `shelf_mark` (or the PH-shelfmark in `ubn`) onto the matched Mongo book's
+ *   image_source.shelfmark when empty.
+ *
+ * Value-overwriting phases (4, 5) record a ROW per change in `sweep_log`
+ * (field-sprawl invariant #3969) — including `no-contributor` verdicts, which
+ * double as the checkpoint so re-runs skip items IA has no holder for.
  *
  * Usage:
  *   DRY_RUN=1 node scripts/backfill-contributing-library.mjs          # preview
  *   node scripts/backfill-contributing-library.mjs                     # run all phases
- *   PHASE=1 node scripts/backfill-contributing-library.mjs             # run phase 1 only
- *   PHASE=2 node scripts/backfill-contributing-library.mjs             # run phase 2 only
- *   PHASE=3 node scripts/backfill-contributing-library.mjs             # run phase 3 only
+ *   PHASE=N node scripts/backfill-contributing-library.mjs             # run phase N only
  */
 import { MongoClient } from 'mongodb';
+import { recordSweepAction } from './lib/sweep-log.mjs';
+
+const SWEEP = 'holding-library-4361';
+
+// Sponsors that fund scanning but hold nothing — never a contributing_library.
+const JUNK_SPONSOR = /google|msn|microsoft|sloan foundation|internet archive/i;
+
+// Aggregator values that should never stand as a holding library. Mirror of
+// the read-side list in src/lib/holding-library.ts (AGGREGATORS) — the
+// citation layer filters these on read; this sweep replaces them at the rows.
+const AGGREGATOR_VALUES = [
+  'Internet Archive',
+  'archive.org',
+  'Google Books',
+  'Google',
+  'HathiTrust',
+  'Project Gutenberg',
+];
 
 const DRY_RUN = process.env.DRY_RUN === '1';
 const PHASE = process.env.PHASE ? parseInt(process.env.PHASE) : 0; // 0 = all
+const LIMIT = process.env.LIMIT ? parseInt(process.env.LIMIT) : 0; // 0 = no cap (smoke tests)
 
 // Phase 1: Single-institution provider → contributing_library name
 const PROVIDER_LIBRARY_MAP = {
@@ -105,11 +136,22 @@ async function phase2(db) {
         if (!resp.ok) { failed++; return; }
         const data = await resp.json();
         const meta = data?.metadata;
-        // Try contributor first, then fall back to sponsor or publisher
-        const contributor = meta?.contributor || meta?.sponsor;
+        // Try contributor first, then fall back to sponsor — but a scanning
+        // funder (Google, MSN, Sloan) is not a holder (#4361).
+        const sponsor = typeof meta?.sponsor === 'string' && !JUNK_SPONSOR.test(meta.sponsor) ? meta.sponsor : null;
+        const contributor = meta?.contributor || sponsor;
         if (!contributor || typeof contributor !== 'string') { failed++; return; }
 
+        // IA's call_number is that holder's shelfmark for the copy — the other
+        // half of the citation copy clause (#4360/#4361).
+        const callNumber = typeof meta?.call_number === 'string' ? meta.call_number.trim() : '';
         if (!DRY_RUN) {
+          if (callNumber) {
+            await db.collection('books').updateOne(
+              { _id: book._id, 'image_source.shelfmark': { $exists: false } },
+              { $set: { 'image_source.shelfmark': callNumber } },
+            );
+          }
           await db.collection('books').updateOne(
             { _id: book._id },
             { $set: { 'image_source.contributing_library': contributor } },
@@ -255,6 +297,200 @@ async function phase3(db) {
   return updated;
 }
 
+async function phase4(db) {
+  console.log('\n=== PHASE 4: replace aggregator-as-holder with IA contributor (#4361) ===\n');
+
+  // Books already resolved to "no contributor" in a previous run — the
+  // sweep_log row IS the checkpoint (corpus walks need one; the selection
+  // below is value-based, so without this every re-run would re-fetch the
+  // whole no-contributor tail from IA).
+  const settled = new Set(
+    (await db.collection('sweep_log')
+      .find({ sweep: SWEEP, action: 'no-contributor' }, { projection: { book_id: 1 } })
+      .toArray()).map(r => r.book_id),
+  );
+
+  const books = await db.collection('books').find({
+    'image_source.contributing_library': { $in: AGGREGATOR_VALUES },
+    'image_source.identifier': { $exists: true },
+    'image_source.provider': 'internet_archive',
+    status: { $ne: 'deleted' },
+  }, { projection: { _id: 1, id: 1, 'image_source.identifier': 1, 'image_source.contributing_library': 1 } }).toArray();
+
+  let pending = books.filter(b => !settled.has(b.id));
+  console.log(`${books.length} books carry an aggregator as holder; ${pending.length} unsettled`);
+  if (LIMIT > 0) {
+    pending = pending.slice(0, LIMIT);
+    console.log(`LIMIT=${LIMIT}: processing first ${pending.length} only`);
+  }
+  if (pending.length === 0) return 0;
+
+  let updated = 0;
+  let noContributor = 0;
+  let failed = 0;
+  const BATCH_SIZE = 50;
+
+  for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+    const batch = pending.slice(i, i + BATCH_SIZE);
+
+    await Promise.all(batch.map(async (book) => {
+      const identifier = book.image_source.identifier;
+      try {
+        const resp = await fetch(`https://archive.org/metadata/${identifier}`, {
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!resp.ok) { failed++; return; }
+        const data = await resp.json();
+        const meta = data?.metadata;
+        const contributor = typeof meta?.contributor === 'string' ? meta.contributor.trim() : '';
+        const callNumber = typeof meta?.call_number === 'string' ? meta.call_number.trim() : '';
+
+        // The item itself names no holder: leave the aggregator value (the
+        // read-side citation layer suppresses it) and checkpoint the verdict.
+        if (!contributor || AGGREGATOR_VALUES.some(a => a.toLowerCase() === contributor.toLowerCase())) {
+          noContributor++;
+          if (!DRY_RUN) {
+            await recordSweepAction(db, {
+              sweep: SWEEP, book_id: book.id, action: 'no-contributor',
+              detail: { ia: identifier },
+            });
+          }
+          return;
+        }
+
+        if (!DRY_RUN) {
+          if (callNumber) {
+            await db.collection('books').updateOne(
+              { _id: book._id, 'image_source.shelfmark': { $exists: false } },
+              { $set: { 'image_source.shelfmark': callNumber } },
+            );
+          }
+          await db.collection('books').updateOne(
+            { _id: book._id },
+            { $set: { 'image_source.contributing_library': contributor } },
+          );
+          await recordSweepAction(db, {
+            sweep: SWEEP, book_id: book.id, action: 'holder-recovered',
+            detail: { from: book.image_source.contributing_library, to: contributor, ia: identifier, ...(callNumber ? { shelfmark: callNumber } : {}) },
+          });
+        }
+        updated++;
+      } catch {
+        failed++;
+      }
+    }));
+
+    if ((i + BATCH_SIZE) % 500 === 0 || i + BATCH_SIZE >= pending.length) {
+      console.log(`  ${Math.min(i + BATCH_SIZE, pending.length)}/${pending.length} — ${updated} recovered, ${noContributor} no-contributor, ${failed} failed`);
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  console.log(`\nPhase 4 total: ${updated} recovered, ${noContributor} genuinely holderless, ${failed} failed (transient — re-run retries them)`);
+  return updated;
+}
+
+async function phase5(db) {
+  console.log('\n=== PHASE 5: BPH shelfmark materialization from bph_works (#4361) ===\n');
+  console.log('READS Supabase only — bph_works writes are catalogue-editor-only.\n');
+
+  const { createClient } = await import('@supabase/supabase-js');
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY,
+  );
+
+  // supabase-js caps every response at 1,000 rows — paginate or lose data.
+  const rows = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await supabase
+      .from('bph_works')
+      .select('ubn, shelf_mark, sl_book_id')
+      .not('sl_book_id', 'is', null)
+      .range(from, from + 999);
+    if (error) throw new Error(`bph_works read failed: ${error.message}`);
+    rows.push(...(data || []));
+    if (!data || data.length < 1000) break;
+  }
+  console.log(`${rows.length} bph_works rows matched to a Source Library book`);
+
+  let updated = 0;
+  let skipped = 0;
+  for (const row of rows) {
+    // shelf_mark is the physical mark; a UBN is the BPH catalogue number and
+    // doubles as the shelfmark for manuscripts (PH-numbers).
+    const mark = (row.shelf_mark || '').trim() || (row.ubn ? `UBN ${row.ubn}` : '');
+    if (!mark) { skipped++; continue; }
+
+    if (DRY_RUN) { updated++; continue; }
+    const res = await db.collection('books').updateOne(
+      {
+        id: row.sl_book_id,
+        $or: [
+          { 'image_source.shelfmark': { $exists: false } },
+          { 'image_source.shelfmark': { $in: [null, ''] } },
+        ],
+      },
+      { $set: { 'image_source.shelfmark': mark } },
+    );
+    if (res.modifiedCount > 0) {
+      updated++;
+      await recordSweepAction(db, {
+        sweep: SWEEP, book_id: row.sl_book_id, action: 'bph-shelfmark',
+        detail: { shelfmark: mark, ubn: row.ubn ?? null },
+      });
+    } else {
+      skipped++; // already has a shelfmark, or the book row is gone
+    }
+  }
+
+  console.log(`\nPhase 5 total: ${updated} shelfmarks set, ${skipped} skipped (no mark / already set / unmatched)`);
+  return updated;
+}
+
+async function phase6(db) {
+  console.log('\n=== PHASE 6: consolidate TOP-LEVEL contributing_library/shelfmark into image_source (#4361) ===\n');
+  console.log('3,860 live books carry the holder only at top level (field sprawl); image_source is canonical.\n');
+
+  let total = 0;
+  for (const [from, to] of [
+    ['contributing_library', 'image_source.contributing_library'],
+    ['shelfmark', 'image_source.shelfmark'],
+  ]) {
+    const filter = {
+      [from]: { $nin: [null, ''] },
+      $or: [{ [to]: { $exists: false } }, { [to]: { $in: [null, ''] } }],
+      status: { $ne: 'deleted' },
+    };
+    const count = await db.collection('books').countDocuments(filter);
+    console.log(`${from} → ${to}: ${count} books`);
+    if (count === 0 || DRY_RUN) { total += count; continue; }
+
+    // Set-if-empty copy; the top-level twin stays for now — removing a field
+    // 3,860 rows' READERS may still expect is its own change, not a side
+    // effect of a backfill.
+    const cursor = db.collection('books').find(filter, { projection: { _id: 1, id: 1, [from.split('.')[0]]: 1 } });
+    for await (const book of cursor) {
+      const value = book[from];
+      if (typeof value !== 'string' || !value.trim()) continue;
+      const res = await db.collection('books').updateOne(
+        { _id: book._id, $or: [{ [to]: { $exists: false } }, { [to]: { $in: [null, ''] } }] },
+        { $set: { [to]: value.trim() } },
+      );
+      if (res.modifiedCount > 0) {
+        total++;
+        await recordSweepAction(db, {
+          sweep: SWEEP, book_id: book.id, action: 'consolidated-to-image-source',
+          detail: { field: from, value: value.trim() },
+        });
+      }
+    }
+    console.log(`  → done`);
+  }
+  console.log(`\nPhase 6 total: ${total}`);
+  return total;
+}
+
 async function main() {
   const client = await MongoClient.connect(process.env.MONGODB_URI);
   const db = client.db('bookstore');
@@ -265,6 +501,9 @@ async function main() {
   if (PHASE === 0 || PHASE === 1) total += await phase1(db);
   if (PHASE === 0 || PHASE === 2) total += await phase2(db);
   if (PHASE === 0 || PHASE === 3) total += await phase3(db);
+  if (PHASE === 0 || PHASE === 4) total += await phase4(db);
+  if (PHASE === 0 || PHASE === 5) total += await phase5(db);
+  if (PHASE === 0 || PHASE === 6) total += await phase6(db);
 
   // Final count
   const remaining = await db.collection('books').countDocuments({

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
-import { citationYear, citationYearOrNd } from '@/lib/publication-date';
-import { resolveImprintPlace } from '@/lib/imprint';
+import { generateCitations, type Citation } from '@/lib/citation';
 import { Book, Page, TranslationEdition } from '@/lib/types';
-import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
-import { readerPageUrl } from '@/lib/slugify';
+import { getRequestBaseUrl } from '@/lib/shortlinks';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { resolveQuoteText, OCR_ORIGINAL_NOTE, SOURCE_COLUMN_NOTE, type QuoteTextSource } from '@/lib/quote-text';
 import { romanizedForQuote } from '@/lib/romanization';
@@ -15,18 +13,6 @@ import { isBookReadable } from '@/lib/book-access';
 
 interface RouteContext {
   params: Promise<{ tenant: string; id: string }>;
-}
-
-interface Citation {
-  inline: string;           // (Drebbel 1628, p. 15)
-  footnote: string;         // Full footnote citation
-  bibliography: string;     // Bibliography entry
-  bibtex: string;           // BibTeX format
-  chicago: string;          // Chicago style
-  mla: string;              // MLA style
-  url: string;              // Direct link to page in Source Library
-  short_url: string;        // Shortlink for sharing (e.g., Twitter)
-  doi_url?: string;         // Clickable DOI URL
 }
 
 interface QuoteResponse {
@@ -68,122 +54,6 @@ interface QuoteResponse {
   context?: {
     previous_page?: string;
     next_page?: string;
-  };
-}
-
-function formatAccessedDate(): string {
-  const d = new Date();
-  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
-  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-}
-
-function generateCitations(
-  book: Book,
-  pageNumber: number,
-  bookId: string,
-  pageId: string,
-  baseUrl: string,
-  edition?: TranslationEdition
-): Citation {
-  // `published` is free text: 23% of the corpus is not a year, and ~1,500 books
-  // carry raw Wikidata QuickStatements ("1573date QS:P571,+1573-...Z/9"). That
-  // string was landing in the BibTeX `year` field and the inline citation, i.e.
-  // straight into scholars' bibliographies. Assert a bare year or `n.d.`.
-  const year = citationYearOrNd(book.published);
-  // BibTeX keys must stay alphanumeric — 'n.d.' would emit a key with dots.
-  const bibtexYearKey = citationYear(book.published) ?? 'nd';
-  const author = book.author || 'Unknown';
-  const title = book.display_title || book.title;
-  const doi = edition?.doi || book.doi;
-  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
-  const accessed = formatAccessedDate();
-  const translationYear = edition?.published_at
-    ? new Date(edition.published_at).getFullYear()
-    : new Date().getFullYear();
-
-  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
-  const authorParts = author.split(',').map(s => s.trim());
-  const authorLastFirst = authorParts.length === 2
-    ? `${authorParts[0]}, ${authorParts[1]}`
-    : author;
-  const authorFirstLast = authorParts.length === 2
-    ? `${authorParts[1]} ${authorParts[0]}`
-    : author;
-
-  // Original-edition imprint (place, publisher, format, USTC) of the source
-  // printing being translated — the bibliographic record of the original work,
-  // distinct from the Source Library translation credit. Mirrors the "Cite"
-  // dropdown (CiteButton) and the bibliographic panel (BibliographicInfo).
-  // Family resolver (#4043) — `place_published` alone misses the catalogue
-  // and OCR columns; 3,300 visible books held a place and cited none.
-  const imprintPlace = resolveImprintPlace(book)?.display;
-  const pubImprint = [imprintPlace, book.publisher].filter(Boolean).join(': ');
-  const imprint = [pubImprint, book.format, book.ustc_id ? `USTC ${book.ustc_id}` : ''].filter(Boolean).join('. ');
-  const imprintStr = imprint ? `${imprint}. ` : '';
-
-  // Inline citation
-  const inline = `(${authorParts[0]} ${year}, p. ${pageNumber})`;
-
-  // Footnote (Chicago style note)
-  const footnote = `${authorFirstLast}, ${title}, ${imprintStr}trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
-
-  // Bibliography entry
-  const bibliography = `${authorLastFirst}. ${title}. ${imprintStr}Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`;
-
-  // BibTeX — original imprint (address/publisher) + translation credit (note)
-  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${bibtexYearKey}`;
-  const bibtexLines = [
-    `@book{${bibtexKey},`,
-    `  author = {${authorLastFirst}},`,
-    `  title = {${title}},`,
-    `  year = {${year}},`,
-  ];
-  if (imprintPlace) bibtexLines.push(`  address = {${imprintPlace}},`);
-  bibtexLines.push(`  publisher = {${book.publisher || 'Source Library'}},`);
-  bibtexLines.push(`  translator = {Source Library},`);
-  if (doi) {
-    bibtexLines.push(`  doi = {${doi}},`);
-    bibtexLines.push(`  url = {${doiUrl}},`);
-  }
-  const bibtexNote = [`Translation published ${translationYear}`];
-  if (book.format) bibtexNote.push(book.format);
-  if (book.ustc_id) bibtexNote.push(`USTC ${book.ustc_id}`);
-  bibtexLines.push(`  note = {${bibtexNote.join('; ')}}`);
-  bibtexLines.push(`}`);
-  const bibtex = bibtexLines.join('\n');
-
-  // Chicago (Author-Date)
-  const chicago = `${authorLastFirst}. ${year}. ${title}. ${imprintStr}Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`;
-
-  // MLA
-  const mla = `${authorLastFirst}. ${title}. ${imprintStr}Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
-
-  // Direct URL to page in Source Library (pinned to edition version).
-  // baseUrl is the request host so citations rendered on tenant subdomains
-  // (e.g. bph.sourcelibrary.org) link back to the same subdomain.
-  //
-  // Built from the book's slug, not the requested id: this URL gets printed
-  // into papers and footnotes, so it has to say which book it is. Calling the
-  // API by id would otherwise mint a permanent citation to /book/<objectid>.
-  // Still a relative path joined to the request host, so it stays on the
-  // tenant subdomain (lockdown invariant 4/5).
-  const editionVersion = edition?.version;
-  const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
-
-  // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
-
-  return {
-    inline,
-    footnote,
-    bibliography,
-    bibtex,
-    chicago,
-    mla,
-    url,
-    short_url,
-    doi_url: doiUrl,
   };
 }
 

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -6,6 +6,7 @@ import { isBookReadable } from '@/lib/book-access';
 import { isInnerCircle } from '@/lib/auth-helpers';
 import { isPremiumFormat, isValidDownloadFormat } from '@/lib/download-formats';
 import { checkAndRecordDownload } from '@/lib/download-cap';
+import { resolveHoldingCopy } from '@/lib/holding-library';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -83,6 +84,11 @@ function generateTxtDownload(book: Book, pages: Page[], format: 'translation' | 
   lines.push(`Original Language: ${book.language}`);
   if (book.published) {
     lines.push(`Published: ${book.published}`);
+  }
+  // The physical copy behind the scan (#4360) — cite the holder, not just us.
+  const holdingCopy = resolveHoldingCopy(book);
+  if (holdingCopy) {
+    lines.push(`Source Copy: ${holdingCopy.holding_library}${holdingCopy.shelfmark ? `, shelfmark ${holdingCopy.shelfmark}` : ''}`);
   }
   lines.push('');
 

--- a/src/app/api/books/[id]/editions/front-matter/route.ts
+++ b/src/app/api/books/[id]/editions/front-matter/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { withAuth } from '@/lib/auth-helpers';
+import { resolveHoldingCopy } from '@/lib/holding-library';
 import { resolveImprintPlace } from '@/lib/imprint';
 
 interface RouteContext {
@@ -120,6 +121,10 @@ function buildBookContext(book: Book, pages: Page[]): string {
   if (book.publisher) parts.push(`Printer/Publisher: ${book.publisher}`);
   if (book.ustc_id) parts.push(`USTC catalog number: ${book.ustc_id}`);
   if (bookAny.is_first_translation) parts.push('NOTE: This is believed to be the FIRST English translation of this work.');
+  // The copy behind the scan (#4360): a DOI-minted edition must name whose
+  // physical object it reproduces, not just which host served the images.
+  const holdingCopy = resolveHoldingCopy(bookAny);
+  if (holdingCopy) parts.push(`Source copy: ${holdingCopy.holding_library}${holdingCopy.shelfmark ? `, shelfmark ${holdingCopy.shelfmark}` : ''}`);
   if (bookAny.ia_identifier) parts.push(`Source scan: Internet Archive (${bookAny.ia_identifier})`);
 
   // Categories / tradition
@@ -219,6 +224,7 @@ async function generateMethodology(
   });
 
   const bookAny = book as any;
+  const holdingCopy = resolveHoldingCopy(bookAny);
   const prompt = `Write a concise methodology section (400-600 words) for this AI-translated scholarly edition.
 
 **Facts about how this book was produced:**
@@ -227,7 +233,10 @@ async function generateMethodology(
 - Published: ${book.published}
 - Total pages processed: ${pages.length}
 - AI models used: ${Array.from(models).join(', ') || 'Google Gemini'}
-- Source scan: ${bookAny.ia_identifier ? `Internet Archive (${bookAny.ia_identifier})` : 'digitized page images from a European digital library'}
+- Source scan: ${[
+    holdingCopy ? `the copy held by ${holdingCopy.holding_library}${holdingCopy.shelfmark ? ` (shelfmark ${holdingCopy.shelfmark})` : ''}` : '',
+    bookAny.ia_identifier ? `Internet Archive (${bookAny.ia_identifier})` : '',
+  ].filter(Boolean).join(', via ') || 'digitized page images from a digital library'}
 
 **The actual pipeline (describe exactly this, no more):**
 1. Page images were imported from a digital library and archived

--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { resolveHoldingCopy } from '@/lib/holding-library';
 import { generateGalleryImages } from '@/lib/gallery-image-gen';
 import { getSession } from '@/lib/auth-helpers';
 import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
@@ -187,7 +188,7 @@ export async function GET(
           pageNumber: pageData.page_number,
           readUrl: tenantPath(`/book/${pageData.book?.slug || pageData.book_id}/page/${pageId}`),
           galleryUrl: tenantPath(`/gallery?bookId=${pageData.book_id}`),
-          citation: `${pageData.book?.author || ''}, "${pageData.book?.display_title || pageData.book?.title || 'Unknown'}", p. ${pageData.page_number}, Source Library, ${aiCitationNote(galleryDoc.model)}`,
+          citation: `${pageData.book?.author || ''}, "${pageData.book?.display_title || pageData.book?.title || 'Unknown'}", p. ${pageData.page_number}, ${(() => { const c = resolveHoldingCopy(pageData.book || {}); return c ? `${c.statement}, ` : ''; })()}Source Library, ${aiCitationNote(galleryDoc.model)}`,
           stale: true, // Signal that detection index is stale
         }, {
           headers: tenantResponseHeaders,
@@ -235,7 +236,7 @@ export async function GET(
           pageNumber: pageData.page_number,
           readUrl: tenantPath(`/book/${pageData.book?.slug || pageData.book_id}/page/${pageId}`),
           galleryUrl: tenantPath(`/gallery?bookId=${pageData.book_id}`),
-          citation: `${pageData.book?.author || ''}, "${pageData.book?.display_title || pageData.book?.title || 'Unknown'}", p. ${pageData.page_number}, Source Library, ${aiCitationNote(galleryDoc.model)}`,
+          citation: `${pageData.book?.author || ''}, "${pageData.book?.display_title || pageData.book?.title || 'Unknown'}", p. ${pageData.page_number}, ${(() => { const c = resolveHoldingCopy(pageData.book || {}); return c ? `${c.statement}, ` : ''; })()}Source Library, ${aiCitationNote(galleryDoc.model)}`,
           corrupt: true,
         }, {
           headers: tenantResponseHeaders,
@@ -683,6 +684,12 @@ function buildCitation(page: Record<string, unknown>, detection: Record<string, 
   if (detection.description) {
     parts.push(`[${detection.description}]`);
   }
+
+  // Gallery images are per-copy by declaration (edition-identity.md): this
+  // engraving's hand-coloring or marginal mark exists only in this library's
+  // copy, so name it (#4360).
+  const holdingCopy = book ? resolveHoldingCopy(book as { image_source?: { contributing_library?: string; shelfmark?: string } }) : null;
+  if (holdingCopy) parts.push(holdingCopy.statement);
 
   parts.push('Source Library');
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -643,6 +643,18 @@ async function getQuote(args: Record<string, unknown>) {
   if (translationNote(result)) tips.push(TRANSLATED_ORIGINAL_TIP);
   if (langFallback(result, quoteLang)) tips.push(LANG_FALLBACK_TIP(quoteLang));
 
+  // Copy clause (#4360) — same logic in mcp-server/src/api.ts; the two servers
+  // each read their own copy of this guidance and fixes do not propagate.
+  const holdingCopy = (result.citation as Record<string, unknown> | undefined)?.copy as
+    | { statement?: string }
+    | undefined;
+  if (holdingCopy?.statement) {
+    tips.push(
+      `The scanned images reproduce one physical copy: "${holdingCopy.statement}". ` +
+        'When citing copy-specific evidence (marginalia, provenance marks, hand-coloring), include that clause in the citation.',
+    );
+  }
+
   return {
     ...withCitationLink(result),
     continuity,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1608,7 +1608,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
               )}
               <div className="w-1/3 flex-shrink-0 ml-auto grid grid-cols-3 rounded overflow-hidden divide-x [&_svg]:!w-[15px] [&_svg]:!h-[15px] [&_button]:!p-0 [&_button]:!w-full [&_button]:!h-full [&_button]:!justify-center [&_button]:!rounded-none" style={{ border: '1px solid rgba(245,240,232,0.2)', borderColor: 'rgba(245,240,232,0.2)' }}>
                 {[
-                  <CiteButton key="cite" bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100" iconOnly />,
+                  <CiteButton key="cite" bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} holdingLibrary={book.image_source?.contributing_library} shelfmark={book.image_source?.shelfmark} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100" iconOnly />,
                   <DownloadButton key="dl" bookId={book.id} bookTitle={book.display_title || book.title} hasTranslations={hasTranslations} hasOcr={hasOcr} hasImages={pages.length > 0} imageRestricted={imageRestricted} imageAccess={imageAccess} variant="header" iconOnly />,
                   <LikeButton key="like" targetType="book" targetId={book.id} size="sm" showCount={false} className="!text-stone-100" />,
                 ].map((el, i) => (
@@ -1764,7 +1764,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                       <span className="flex items-center gap-1.5 px-3 py-1.5 cursor-not-allowed text-[13px]" style={{ color: 'rgba(245,240,232,0.4)' }} title="Complete OCR, translation & summary first"><BookMarked className="w-4 h-4" />Publish</span>
                     )}
                   </AuthCheck>
-                  <CiteButton bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
+                  <CiteButton bookId={book.slug || book.id} title={book.title} displayTitle={book.display_title} author={book.author} year={book.published} publisher={book.publisher} placePublished={resolveImprintPlace(book)?.display} format={book.format} ustcId={book.ustc_id} language={book.language} doi={book.doi} holdingLibrary={book.image_source?.contributing_library} shelfmark={book.image_source?.shelfmark} editionVersion={currentEdition?.version} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
                   <DownloadButton bookId={book.id} bookTitle={book.display_title || book.title} hasTranslations={hasTranslations} hasOcr={hasOcr} hasImages={pages.length > 0} imageRestricted={imageRestricted} imageAccess={imageAccess} variant="header" />
                   <BookShare bookId={book.slug || book.id} title={book.display_title || book.title} author={book.author || ''} year={book.published} doi={book.doi} tenantSlug={tenantSlug || undefined} className="!text-stone-100 hover:!text-white hover:!bg-white/15" />
                   <span className="w-px h-5 mx-1" style={{ background: 'rgba(245,240,232,0.18)' }} />
@@ -2196,6 +2196,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                       ustcId={book.ustc_id}
                       language={book.language}
                       doi={book.doi}
+                      holdingLibrary={book.image_source?.contributing_library}
+                      shelfmark={book.image_source?.shelfmark}
                       editionVersion={currentEdition?.version}
                       tenantSlug={tenantSlug || undefined}
                       className="text-stone-300 hover:text-white hover:bg-white/10"

--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -78,7 +78,10 @@ const BOOK_NAV_PROJECTION = {
   // The copy clause of the citation panel (#4360): which library's physical
   // copy the scan shows, and its shelfmark there. Sub-paths only — the full
   // image_source carries license/attribution baggage the reader doesn't use.
+  // The top-level twins are legacy sprawl 3,860 live books still rely on
+  // (consolidation: #4361); resolveHoldingCopy reads both.
   'image_source.contributing_library': 1, 'image_source.shelfmark': 1,
+  contributing_library: 1, shelfmark: 1,
 };
 
 export default async function PageEditorPage({ params, allowHidden = false, lang = 'en' }: PageProps & { allowHidden?: boolean; lang?: Locale }) {

--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -75,6 +75,10 @@ const BOOK_NAV_PROJECTION = {
   pages_translated_es: 1,
   author: 1, published: 1, language: 1, doi: 1, chapters: 1,
   cdli_witnesses: 1, etcsl_id: 1, visible: 1,
+  // The copy clause of the citation panel (#4360): which library's physical
+  // copy the scan shows, and its shelfmark there. Sub-paths only — the full
+  // image_source carries license/attribution baggage the reader doesn't use.
+  'image_source.contributing_library': 1, 'image_source.shelfmark': 1,
 };
 
 export default async function PageEditorPage({ params, allowHidden = false, lang = 'en' }: PageProps & { allowHidden?: boolean; lang?: Locale }) {

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -20,6 +20,7 @@ import { pages as pagesApi, books as booksApi, analytics } from '@/lib/api-clien
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import type { Book, Page } from '@/lib/types';
+import { resolveHoldingCopy } from '@/lib/holding-library';
 import type { ReaderSettings } from './useReaderV2';
 import {
   ChevronLeft, ChevronRight, ChevronRight as ChevronRightSmall,
@@ -1990,7 +1991,7 @@ function PanelContent({
 }: {
   panel: Exclude<LeftPanel, null>;
   r: ReaderState;
-  citationParts: { author: string; title: string; year: string; locator: string; source: string; url: string };
+  citationParts: { author: string; title: string; year: string; locator: string; copy: string; source: string; url: string };
   copied: boolean;
   onCopyCitation: () => void;
   librarianMessages: LibrarianMessage[];
@@ -2163,7 +2164,7 @@ function PanelContent({
             {citationParts.year && <span style={{ color: 'var(--text-muted)' }}> {citationParts.year}</span>}
           </p>
           <p className="font-sans text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-            {[citationParts.locator, citationParts.source].filter(Boolean).join(' · ')}
+            {[citationParts.locator, citationParts.copy.replace(/\.$/, ''), citationParts.source].filter(Boolean).join(' · ')}
           </p>
           <p className="font-sans text-[11.5px] mt-1.5 break-all" style={{ color: 'var(--text-faint)' }}>
             {citationParts.url}
@@ -2544,11 +2545,18 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
   // text on screen while being perfectly correct on the clipboard; setting the
   // title, the locator and the URL apart makes it checkable at a glance
   // without changing a character of what gets pasted.
+  // The copy clause (#4360): the scan shows one library's physical object, and
+  // a citation of the image is a claim about that copy — marginalia and
+  // provenance marks exist nowhere else. Null when no genuine holder is known
+  // (aggregators like Internet Archive are filtered), and then the citation
+  // reads as before.
+  const holdingCopy = resolveHoldingCopy(r.book);
   const citationParts = {
     author: r.book.author ? `${r.book.author}.` : '',
     title: r.book.display_title || r.book.title,
     year: r.book.published ? `(${r.book.published})` : '',
     locator: r.currentPage?.page_number != null ? `p. ${r.currentPage.page_number}` : '',
+    copy: holdingCopy ? `${holdingCopy.statement}.` : '',
     source: 'Source Library',
     url: `https://sourcelibrary.org/book/${r.bookPath}/page/${r.currentPageId}`,
   };
@@ -2556,6 +2564,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     citationParts.author,
     `${citationParts.title}${citationParts.year ? ` ${citationParts.year}` : ''},`,
     `${citationParts.locator}.`,
+    citationParts.copy,
     `${citationParts.source}.`,
     citationParts.url,
   ].filter(Boolean).join(' ');

--- a/src/components/ui/CiteButton.tsx
+++ b/src/components/ui/CiteButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Quote, Copy, Check } from 'lucide-react';
+import { copyClause } from '@/lib/holding-library';
 import { trackEvent } from '@/lib/track-event';
 
 function getRuntimeOrigin(): string {
@@ -77,6 +78,11 @@ interface CiteButtonProps {
   doi?: string;
   pageNumber?: number;
   editionVersion?: string;
+  /** Institution holding the physical copy behind the scan (#4360) — pass the
+   * raw `image_source.contributing_library`; aggregators are filtered here. */
+  holdingLibrary?: string;
+  /** That copy's shelfmark in the holding library (`image_source.shelfmark`). */
+  shelfmark?: string;
   /** Tenant slug (e.g. "bph") — produces /bph/book/… URLs instead of /book/… */
   tenantSlug?: string;
   className?: string;
@@ -100,6 +106,13 @@ function originalImprint(props: CiteButtonProps): string {
   return [pub, props.format, props.ustcId ? `USTC ${props.ustcId}` : ''].filter(Boolean).join('. ');
 }
 
+// A book printed in English was rendered by its own (often named) translator —
+// crediting "Trans. Source Library" there claims work we did not do (#3724).
+// Same rule as generateCitations in @/lib/citation.
+function isEnglishOriginal(props: CiteButtonProps): boolean {
+  return (props.language || '').trim().toLowerCase().startsWith('english');
+}
+
 function generateApa(props: CiteButtonProps, origin: string): string {
   const { author, title, displayTitle, year, doi, pageNumber, editionVersion } = props;
   const url = buildCitableUrl(props, origin);
@@ -111,11 +124,16 @@ function generateApa(props: CiteButtonProps, origin: string): string {
   const accessed = formatAccessedDate();
   const imprint = originalImprint(props);
   const imprintStr = imprint ? `${imprint}. ` : '';
+  // The copy clause (#4360): the imprint names the EDITION, this names the
+  // physical object our images show — "Copy: <holding library>, <shelfmark>".
+  const copy = copyClause(props.holdingLibrary, props.shelfmark);
+  const copyStr = copy ? `${copy.statement}. ` : '';
+  const credit = isEnglishOriginal(props) ? '' : `Trans. Source Library (${yearStr})`;
 
   if (doi) {
-    return `${authorStr}. ${displayName}. ${imprintStr}Trans. Source Library (${yearStr})${version}${page}. https://doi.org/${doi}`;
+    return `${authorStr}. ${displayName}. ${imprintStr}${copyStr}${credit || 'Source Library'}${version}${page}. https://doi.org/${doi}`;
   }
-  return `${authorStr}. (${yearStr}). ${displayName}. ${imprintStr}Source Library${page}. Retrieved ${accessed}, from ${url}`;
+  return `${authorStr}. (${yearStr}). ${displayName}. ${imprintStr}${copyStr}Source Library${page}. Retrieved ${accessed}, from ${url}`;
 }
 
 function generateBibtex(props: CiteButtonProps, origin: string): string {
@@ -131,7 +149,9 @@ function generateBibtex(props: CiteButtonProps, origin: string): string {
     `@book{${citeKey},`,
     `  author = {${authorStr}},`,
     `  title = {${title}},`,
-    `  translator = {{Source Library}},`,
+    // No translator claim on an English original — the transcription is ours,
+    // the English is not (#3724).
+    ...(isEnglishOriginal(props) ? [] : [`  translator = {{Source Library}},`]),
   ];
   if (year) lines.push(`  year = {${year}},`);
   // Original imprint: address = place of publication, publisher = source printer.
@@ -143,9 +163,15 @@ function generateBibtex(props: CiteButtonProps, origin: string): string {
   if (doi) lines.push(`  doi = {${doi}},`);
   if (pageNumber) lines.push(`  pages = {${pageNumber}},`);
   lines.push(`  url = {${buildCitableUrl(props, origin)}},`);
-  const noteParts = ['AI-assisted English translation via Source Library'];
+  const noteParts = [
+    isEnglishOriginal(props)
+      ? 'Text transcribed from the printed page by Source Library'
+      : 'AI-assisted English translation via Source Library',
+  ];
   if (format) noteParts.push(format);
   if (ustcId) noteParts.push(`USTC ${ustcId}`);
+  const copy = copyClause(props.holdingLibrary, props.shelfmark);
+  if (copy) noteParts.push(copy.statement);
   lines.push(`  note = {${noteParts.join('; ')}}`);
   lines.push(`}`);
   return lines.join('\n');
@@ -165,6 +191,8 @@ export default function CiteButton({
   doi,
   pageNumber,
   editionVersion,
+  holdingLibrary,
+  shelfmark,
   tenantSlug,
   className = '',
   iconOnly = false,
@@ -173,7 +201,7 @@ export default function CiteButton({
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const origin = getRuntimeOrigin();
 
-  const props = { bookId, title, displayTitle, author, year, publisher, placePublished, format, ustcId, language, doi, pageNumber, editionVersion, tenantSlug };
+  const props = { bookId, title, displayTitle, author, year, publisher, placePublished, format, ustcId, language, doi, pageNumber, editionVersion, holdingLibrary, shelfmark, tenantSlug };
 
   const copyToClipboard = async (text: string, id: string) => {
     await navigator.clipboard.writeText(text);

--- a/src/lib/citation.ts
+++ b/src/lib/citation.ts
@@ -6,6 +6,7 @@
  * "Translated by Source Library" over an English book the translator's own
  * work — see the credit logic below and #3724.
  */
+import { resolveHoldingCopy, type HoldingCopy } from '@/lib/holding-library';
 import { resolveImprintPlace } from '@/lib/imprint';
 import { citationYear, citationYearOrNd } from '@/lib/publication-date';
 import { getShortUrl } from '@/lib/shortlinks';
@@ -23,6 +24,12 @@ export interface Citation {
   url: string;
   short_url: string;
   doi_url?: string;
+  /**
+   * The physical copy behind the scan (#4360): holding institution and, when
+   * known, its shelfmark there. Absent when we cannot name a genuine holder —
+   * never filled with an aggregator or "unknown".
+   */
+  copy?: HoldingCopy;
 }
 
 function formatAccessedDate(): string {
@@ -116,6 +123,18 @@ export function generateCitations(
     ? null
     : { short: `trans. Source Library ${translationYear}`, long: `Translated by Source Library. ${translationYear}.` };
 
+  /**
+   * The COPY clause (#4360). A scan is a photograph of one physical object; the
+   * imprint above describes the EDITION (any copy of the 1609 printing reads
+   * the same), but marginalia, provenance marks and bindings exist in exactly
+   * one copy — so a citation of our images must say whose object it shows:
+   * `Copy: Bibliotheca Philosophica Hermetica, Amsterdam, PH441`. Null when we
+   * cannot name a genuine holder (no data, or only an aggregator like IA);
+   * then the citation reads exactly as it did before this clause existed.
+   */
+  const copy = resolveHoldingCopy(book);
+  const copyStr = copy ? `${copy.statement}. ` : '';
+
   // Inline citation. Carries the rendering credit when the English is ours —
   // this is the form that gets pasted into prose, and it was the only one that
   // said nothing.
@@ -124,10 +143,10 @@ export function generateCitations(
     : `(${authorParts[0]} ${year}, p. ${pageNumber})`;
 
   // Footnote (Chicago style note)
-  const footnote = `${authorFirstLast}, ${title}, ${imprintStr}${renderingCredit ? `${renderingCredit.short.replace(`Source Library ${translationYear}`, `Source Library (${translationYear})`)}, ` : ''}${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
+  const footnote = `${authorFirstLast}, ${title}, ${imprintStr}${renderingCredit ? `${renderingCredit.short.replace(`Source Library ${translationYear}`, `Source Library (${translationYear})`)}, ` : ''}${pageNumber}${copy ? `. ${copy.statement}` : ''}${doi ? `. DOI: ${doi}` : ''}.`;
 
   // Bibliography entry
-  const bibliography = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${doi ? `DOI: ${doi}.` : `Accessed ${accessed}.`}`;
+  const bibliography = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${copyStr}${doi ? `DOI: ${doi}.` : `Accessed ${accessed}.`}`;
 
   // BibTeX — original imprint (address/publisher) + translation credit (note)
   const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${bibtexYearKey}`;
@@ -149,15 +168,17 @@ export function generateCitations(
     : ['Text transcribed from the printed page by Source Library'];
   if (book.format) bibtexNote.push(book.format);
   if (book.ustc_id) bibtexNote.push(`USTC ${book.ustc_id}`);
+  // BibTeX has no standard copy field, so the clause rides the note.
+  if (copy) bibtexNote.push(copy.statement);
   bibtexLines.push(`  note = {${bibtexNote.join('; ')}}`);
   bibtexLines.push(`}`);
   const bibtex = bibtexLines.join('\n');
 
   // Chicago (Author-Date)
-  const chicago = `${authorLastFirst}. ${year}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${doi ? `${doiUrl}.` : `Accessed ${accessed}.`}`;
+  const chicago = `${authorLastFirst}. ${year}. ${title}. ${imprintStr}${renderingCredit ? `${renderingCredit.long} ` : ''}${copyStr}${doi ? `${doiUrl}.` : `Accessed ${accessed}.`}`;
 
   // MLA
-  const mla = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `Translated by Source Library, ${translationYear}.` : ''}${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
+  const mla = `${authorLastFirst}. ${title}. ${imprintStr}${renderingCredit ? `Translated by Source Library, ${translationYear}.` : ''}${copy ? ` ${copy.statement}.` : ''}${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
 
   // Direct URL to page in Source Library (pinned to edition version).
   // baseUrl is derived from the request host so quotes returned from
@@ -184,5 +205,6 @@ export function generateCitations(
     url,
     short_url,
     doi_url: doiUrl,
+    ...(copy ? { copy } : {}),
   };
 }

--- a/src/lib/holding-library.ts
+++ b/src/lib/holding-library.ts
@@ -1,0 +1,92 @@
+/**
+ * The copy layer of a citation (#4360).
+ *
+ * A digitized book is not an edition — it is a COPY: one physical object with
+ * a shelfmark, owners, and marginalia. A citation of our scan is therefore a
+ * copy-layer claim (see `.claude/docs/invariants/edition-identity.md`), and it
+ * has to name the institution whose object was photographed, or copy-specific
+ * evidence (a marginal note, a censored line) is uncitable: the note exists in
+ * exactly one object, and the reader cannot tell which.
+ *
+ * The data comes from `book.image_source.contributing_library` / `.shelfmark`.
+ * Both are free text with uneven coverage; the backfill and normalization
+ * sweep is #4361. This module holds the read-side judgment those citations
+ * need today:
+ *
+ *  - An AGGREGATOR is not a holder. 6,185 live books carry "Internet Archive"
+ *    as their contributing library — IA hosted the scan, some other library
+ *    owns the book. Emitting "Copy: Internet Archive" would assert a holding
+ *    that does not exist, so aggregator names resolve to null (no clause)
+ *    until #4361 recovers the real holder from IA's `contributor` field.
+ *  - Variant spellings of the same institution get one canonical form, so a
+ *    bibliography does not cite "Bayerische Staatsbibliothek" and
+ *    "Bayerische Staatsbibliothek (Munich)" as two libraries.
+ *
+ * Pure string logic, no imports — safe in client components (CiteButton).
+ */
+
+/** Hosts and platforms that serve scans but do not hold the physical copy. */
+const AGGREGATORS = new Set([
+  'internet archive',
+  'archive.org',
+  'google books',
+  'google',
+  'project gutenberg',
+  'wikimedia commons',
+  'wikisource',
+  'hathitrust', // aggregator of member-library scans; holder is in member metadata
+  // Multi-library national platforms: the platform name tells us the scan's
+  // host, not its holder — the true holder needs #4361's per-item metadata.
+  'e-rara (swiss electronic library)',
+  'e-rara',
+]);
+
+/**
+ * Canonical citation forms for holders that appear under variant names.
+ * Keyed on the lowercased raw value. Kept deliberately small: this is a
+ * read-side patch, not the normalization sweep (#4361 writes canonical
+ * values onto the rows themselves).
+ */
+const CANONICAL: Record<string, string> = {
+  'bayerische staatsbibliothek': 'Bayerische Staatsbibliothek, Munich',
+  'bayerische staatsbibliothek (munich)': 'Bayerische Staatsbibliothek, Munich',
+  'bibliotheca philosophica hermetica': 'Bibliotheca Philosophica Hermetica, Amsterdam',
+  'british library': 'British Library, London',
+  // Gallica is BnF's platform; the holder is the library itself.
+  'gallica (bibliothèque nationale de france)': 'Bibliothèque nationale de France, Paris',
+  'gallica': 'Bibliothèque nationale de France, Paris',
+  'bibliothèque nationale de france': 'Bibliothèque nationale de France, Paris',
+};
+
+export interface HoldingCopy {
+  /** Canonical institution name, with city where the canonical form carries one. */
+  holding_library: string;
+  /** Physical shelfmark/classmark in that library, when known. */
+  shelfmark?: string;
+  /** The rendered clause, without trailing punctuation: `Copy: <library>[, <shelfmark>]`. */
+  statement: string;
+}
+
+/** `Copy: Bibliotheca Philosophica Hermetica, Amsterdam, PH441` — or null when
+ * there is no genuine holder to name. A shelfmark without a library is not
+ * emitted either: "Copy: PH441" locates nothing. */
+export function copyClause(contributingLibrary?: string | null, shelfmark?: string | null): HoldingCopy | null {
+  const raw = (contributingLibrary || '').trim();
+  if (!raw) return null;
+  const key = raw.toLowerCase();
+  if (AGGREGATORS.has(key)) return null;
+  const holding_library = CANONICAL[key] || raw;
+  const mark = (shelfmark || '').trim() || undefined;
+  return {
+    holding_library,
+    ...(mark ? { shelfmark: mark } : {}),
+    statement: `Copy: ${holding_library}${mark ? `, ${mark}` : ''}`,
+  };
+}
+
+/** Resolve the copy clause straight off a book document. */
+export function resolveHoldingCopy(book: {
+  image_source?: { contributing_library?: string; shelfmark?: string };
+}): HoldingCopy | null {
+  return copyClause(book.image_source?.contributing_library, book.image_source?.shelfmark);
+}

--- a/src/lib/holding-library.ts
+++ b/src/lib/holding-library.ts
@@ -39,6 +39,8 @@ const AGGREGATORS = new Set([
   // host, not its holder — the true holder needs #4361's per-item metadata.
   'e-rara (swiss electronic library)',
   'e-rara',
+  // Importer placeholder, not an institution (797 live books, measured 2026-08-29).
+  'iiif source',
 ]);
 
 /**
@@ -50,7 +52,9 @@ const AGGREGATORS = new Set([
 const CANONICAL: Record<string, string> = {
   'bayerische staatsbibliothek': 'Bayerische Staatsbibliothek, Munich',
   'bayerische staatsbibliothek (munich)': 'Bayerische Staatsbibliothek, Munich',
+  'bayerische staatsbibliothek, munich': 'Bayerische Staatsbibliothek, Munich',
   'bibliotheca philosophica hermetica': 'Bibliotheca Philosophica Hermetica, Amsterdam',
+  'embassy of the free mind (bibliotheca philosophica hermetica)': 'Bibliotheca Philosophica Hermetica, Amsterdam',
   'british library': 'British Library, London',
   // Gallica is BnF's platform; the holder is the library itself.
   'gallica (bibliothèque nationale de france)': 'Bibliothèque nationale de France, Paris',
@@ -84,9 +88,22 @@ export function copyClause(contributingLibrary?: string | null, shelfmark?: stri
   };
 }
 
-/** Resolve the copy clause straight off a book document. */
+/**
+ * Resolve the copy clause straight off a book document.
+ *
+ * `image_source.*` is the canonical location, but 3,860 live books (measured
+ * 2026-08-29 — British Library, BPH, Harvard imports among them) carry the
+ * fact only in TOP-LEVEL `contributing_library`/`shelfmark` — field sprawl
+ * the #4361 sweep consolidates. A guard must normalize both sides, so the
+ * read path accepts both until the writers do.
+ */
 export function resolveHoldingCopy(book: {
   image_source?: { contributing_library?: string; shelfmark?: string };
+  contributing_library?: string;
+  shelfmark?: string;
 }): HoldingCopy | null {
-  return copyClause(book.image_source?.contributing_library, book.image_source?.shelfmark);
+  return copyClause(
+    book.image_source?.contributing_library || book.contributing_library,
+    book.image_source?.shelfmark || book.shelfmark,
+  );
 }

--- a/src/lib/kdp-epub.ts
+++ b/src/lib/kdp-epub.ts
@@ -1,6 +1,7 @@
 import archiver from 'archiver';
 import sharp from 'sharp';
 import type { Db } from 'mongodb';
+import { resolveHoldingCopy } from '@/lib/holding-library';
 import { resolveImprintPlace } from '@/lib/imprint';
 import type { Book, Chapter, Page } from '@/lib/types';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
@@ -658,6 +659,11 @@ ${section('People', idx!.people)}${section('Places', idx!.places)}${section('Con
     <dc:creator>${escapeXml(book.author)}</dc:creator>
     <dc:contributor>Source Library (translator)</dc:contributor>
     <dc:publisher>Source Library</dc:publisher>
+    ${(() => {
+      // dc:source names the physical copy the facsimile reproduces (#4360).
+      const copy = resolveHoldingCopy(book);
+      return copy ? `<dc:source>${escapeXml(`Copy held by ${copy.holding_library}${copy.shelfmark ? `, shelfmark ${copy.shelfmark}` : ''}`)}</dc:source>` : '';
+    })()}
     <dc:description>${escapeXml(description)}</dc:description>
     <dc:language>en</dc:language>
     <dc:date>${now}</dc:date>

--- a/src/lib/zenodo.ts
+++ b/src/lib/zenodo.ts
@@ -10,6 +10,7 @@
  */
 
 import { TranslationEdition, Book } from './types';
+import { resolveHoldingCopy } from './holding-library';
 import { resolveImprintPlace } from './imprint';
 
 const ZENODO_API = process.env.ZENODO_SANDBOX === 'true'
@@ -358,6 +359,23 @@ function buildMetadata(book: Book, edition: TranslationEdition) {
     });
   }
 
+  // Copy-level provenance (#4360): the institution's own record of the scanned
+  // copy, and its IIIF manifest — the stable identifier of the digitized
+  // object. Before this, a non-IA book's DOI record carried no provenance link
+  // at all: the edition said only "a European digital library".
+  const imageSource = (book as any).image_source as
+    | { source_url?: string; iiif_manifest?: string }
+    | undefined;
+  for (const url of [imageSource?.source_url, imageSource?.iiif_manifest]) {
+    if (url && /^https?:\/\//.test(url)) {
+      related_identifiers.push({
+        identifier: url,
+        relation_type: { id: 'isderivedfrom' },
+        scheme: 'url',
+      });
+    }
+  }
+
   // Link to Source Library book page
   const bookSlug = (book as any).slug || book.id;
   related_identifiers.push({
@@ -411,6 +429,14 @@ function buildDescription(book: Book, edition: TranslationEdition): string {
     book.ustc_id ? `<li>USTC: ${book.ustc_id}</li>` : '',
     '</ul>',
     '',
+    // The copy behind the scan (#4360) — the edition lines above hold for any
+    // copy of the printing; this names the one physical object we photographed.
+    ...(() => {
+      const copy = resolveHoldingCopy(book as any);
+      return copy
+        ? [`<p><strong>Source copy:</strong> ${copy.holding_library}${copy.shelfmark ? `, shelfmark ${copy.shelfmark}` : ''}.</p>`, '']
+        : [];
+    })(),
     `<p><strong>Translation:</strong> ${edition.page_count} pages translated.</p>`,
     '',
     '<p>The scholarly EPUB includes the complete English translation with facsimile page images, introduction, methodology notes, glossary, and index.</p>',

--- a/tests/unit/citation-copy-clause.test.ts
+++ b/tests/unit/citation-copy-clause.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The copy clause of the citation apparatus (#4360).
+ *
+ * A scan is a photograph of ONE physical object. The imprint describes the
+ * edition — any copy of the 1609 printing reads the same — but marginalia,
+ * provenance marks and bindings exist in exactly one copy, so a citation of
+ * our images must name the institution whose object they show, and must never
+ * name an aggregator as if it held the book.
+ */
+import { describe, it, expect } from 'vitest';
+import { copyClause } from '@/lib/holding-library';
+import { generateCitations } from '@/lib/citation';
+import type { Book } from '@/lib/types';
+
+const base = {
+  id: 'bk1',
+  slug: 'a-book',
+  title: 'Amphitheatrum sapientiae aeternae',
+  author: 'Khunrath, Heinrich',
+  published: '1609',
+  place_published: 'Hanau',
+  publisher: 'Antonius',
+  language: 'Latin',
+} as unknown as Book;
+
+const cite = (book: Book) =>
+  generateCitations(book, 28, 'bk1', 'pg1', 'https://sourcelibrary.org');
+
+describe('copyClause — who actually holds the book', () => {
+  it('names the holder, with shelfmark when known', () => {
+    const c = copyClause('Bibliotheca Philosophica Hermetica', 'PH441');
+    expect(c?.statement).toBe('Copy: Bibliotheca Philosophica Hermetica, Amsterdam, PH441');
+    expect(c?.holding_library).toBe('Bibliotheca Philosophica Hermetica, Amsterdam');
+    expect(c?.shelfmark).toBe('PH441');
+  });
+
+  it('collapses variant spellings to one canonical institution', () => {
+    const a = copyClause('Bayerische Staatsbibliothek');
+    const b = copyClause('Bayerische Staatsbibliothek (Munich)');
+    expect(a?.holding_library).toBe(b?.holding_library);
+  });
+
+  it('refuses to present an aggregator as a holding library', () => {
+    // 6,185 live books carry "Internet Archive" as contributing_library. IA
+    // hosted the scan; some other institution owns the object.
+    for (const agg of ['Internet Archive', 'internet archive', 'Google Books', 'HathiTrust', 'e-rara']) {
+      expect(copyClause(agg, 'shelf-1')).toBeNull();
+    }
+  });
+
+  it('emits nothing for a bare shelfmark — "Copy: PH441" locates nothing', () => {
+    expect(copyClause(undefined, 'PH441')).toBeNull();
+    expect(copyClause('', 'PH441')).toBeNull();
+  });
+
+  it('passes an unmapped institution through as-is', () => {
+    expect(copyClause('John Rylands Library, University of Manchester')?.statement)
+      .toBe('Copy: John Rylands Library, University of Manchester');
+  });
+});
+
+describe('generateCitations — the clause reaches every long form', () => {
+  const held = {
+    ...base,
+    image_source: { contributing_library: 'Bibliotheca Philosophica Hermetica', shelfmark: 'PH441' },
+  } as unknown as Book;
+  const c = cite(held);
+
+  it('carries a structured copy object', () => {
+    expect(c.copy?.holding_library).toBe('Bibliotheca Philosophica Hermetica, Amsterdam');
+    expect(c.copy?.shelfmark).toBe('PH441');
+  });
+
+  it('names the copy in footnote, bibliography, chicago, mla and the bibtex note', () => {
+    for (const form of [c.footnote, c.bibliography, c.chicago, c.mla, c.bibtex]) {
+      expect(form).toContain('Copy: Bibliotheca Philosophica Hermetica, Amsterdam, PH441');
+    }
+  });
+
+  it('keeps the inline form terse — no copy clause there', () => {
+    expect(c.inline).not.toContain('Copy:');
+  });
+});
+
+describe('generateCitations — silence when no genuine holder is known', () => {
+  it('a book with no image_source cites exactly as before', () => {
+    const c = cite(base);
+    expect(c.copy).toBeUndefined();
+    for (const form of [c.inline, c.footnote, c.bibliography, c.chicago, c.mla, c.bibtex]) {
+      expect(form).not.toContain('Copy:');
+    }
+  });
+
+  it('an aggregator-attributed book cites as before too', () => {
+    const c = cite({
+      ...base,
+      image_source: { contributing_library: 'Internet Archive' },
+    } as unknown as Book);
+    expect(c.copy).toBeUndefined();
+    expect(c.footnote).not.toContain('Copy:');
+  });
+});
+
+describe('the copy clause is orthogonal to the rendering credit (#3724)', () => {
+  it('an English original with a known holder gets the copy but no translation claim', () => {
+    const c = cite({
+      ...base,
+      language: 'English',
+      image_source: { contributing_library: 'British Library' },
+    } as unknown as Book);
+    expect(c.footnote).toContain('Copy: British Library, London');
+    expect(c.footnote).not.toContain('trans. Source Library');
+    expect(c.bibtex).not.toContain('translator = {Source Library}');
+  });
+});


### PR DESCRIPTION
Closes #4360.

## What

Every citation surface emitted an edition-layer string (author/title/imprint/USTC/page/Source Library/URL) and never named the institution whose physical copy the scan shows. A citation of a scan is a copy-layer claim (edition-identity.md): marginalia and provenance marks exist in exactly one copy.

- **New `src/lib/holding-library.ts`** — `copyClause()` / `resolveHoldingCopy()`. Aggregators (Internet Archive, Google Books, HathiTrust, e-rara, …) are never presented as holders; variant spellings collapse to one canonical form ("Bayerische Staatsbibliothek (Munich)" → "Bayerische Staatsbibliothek, Munich"). Pure string logic, client-safe.
- **Consolidation:** the tenant quote route's stale inline `generateCitations` (predated #3724 — claimed "trans. Source Library" over English originals, a live bug on tenant subdomains) is deleted; it now imports `@/lib/citation`. CiteButton gets the same credit rule and copy clause.
- **The clause reaches:** quote API (`citation.copy` structured + all long-form strings), CiteButton APA/BibTeX, reader "Cite this page" panel, download header, EPUB OPF `dc:source`, gallery image citations, Zenodo DOI metadata (Source copy line + `source_url`/IIIF manifest as `isderivedfrom`), edition front matter (replaces the anonymous "a European digital library" on DOI-minted editions), both MCP servers' quote tips.
- Books with no genuine holder cite **exactly as before** — no empty clauses, never an aggregator.

## Out of scope
- Backfill/normalization of `contributing_library`/`shelfmark` + BPH UBN materialization → #4361
- Marginalia as a citable class + folio/signature loci → #4362

## Verification
- `npx tsc --noEmit` clean (app + mcp-server)
- 3,059 unit tests pass, incl. new `tests/unit/citation-copy-clause.test.ts` (aggregator refusal, variant collapse, orthogonality to the #3724 credit) and the existing rendering-credit guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG2ZHxfHYV6ZHoYuFwSwLw