### PR TITLE
feat(reader): metered-reader flip-readiness — citation exception, text side doors, copy (#4357)

### DIFF
--- a/src/app/about/faq/page.tsx
+++ b/src/app/about/faq/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getLibraryStats, roundedCountLabel } from '@/lib/library-stats';
+import { meteredReaderEnabled } from '@/lib/free-preview';
 
 export const metadata: Metadata = {
   title: 'FAQ — Source Library',
@@ -245,11 +246,24 @@ function getFaqs(bookCount: string): FAQItem[] {
     question: 'Is this a commercial project?',
     answer: (
       <>
-        <p>
-          Source Library is a non-profit project in partnership with the Embassy of the
-          Free Mind in Amsterdam. All texts, translations, and tools are freely accessible.
-          There are no paywalls.
-        </p>
+        {/* Metered reader (#4357): the access claim must flip in the same
+            deploy as the METERED_READER flag — a site that walls text while
+            promising "no paywalls" breaks faith with exactly the readers who
+            checked. Flag off (the default) keeps the original wording verbatim. */}
+        {meteredReaderEnabled() ? (
+          <p>
+            Source Library is a non-profit project in partnership with the Embassy of the
+            Free Mind in Amsterdam. Every book is freely browsable &mdash; scans, metadata,
+            and a generous free sample of every text &mdash; and a free account unlocks
+            full reading access.
+          </p>
+        ) : (
+          <p>
+            Source Library is a non-profit project in partnership with the Embassy of the
+            Free Mind in Amsterdam. All texts, translations, and tools are freely accessible.
+            There are no paywalls.
+          </p>
+        )}
         <p>
           The project is funded by institutional support and individual contributions.
           Processing thousands of books with AI is expensive &mdash; if you find value

--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -9,6 +9,7 @@ import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 import { markPageForReader, stripProvenanceMarks } from '@/lib/provenance';
 import { gatePagesForRequest } from '@/lib/metered-gate';
+import { verifyCitationToken } from '@/lib/citation-token';
 
 export const preferredRegion = 'fra1';
 
@@ -83,8 +84,12 @@ export async function GET(
 
     // Metered reader (#4357): the 'default' tenant is the main library, so it
     // meters like the global twin; named tenants (bph/kloss/…) are partner
-    // reading rooms and stay exempt. No-op unless METERED_READER=1.
-    [page] = await gatePagesForRequest(db, request, [page], { exempt: tenant !== 'default' });
+    // reading rooms and stay exempt, as is a valid ?cite= citation token for
+    // this page (published citations must always resolve). No-op unless
+    // METERED_READER=1.
+    [page] = await gatePagesForRequest(db, request, [page], {
+      exempt: tenant !== 'default' || verifyCitationToken(id, searchParams.get('cite')),
+    });
 
     // Reader-path provenance: translation carries the invisible imprimatur
     // (deterministic, no ref — cache-safe). Mirrors the global twin.

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -11,6 +11,7 @@ import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { markForExport } from '@/lib/provenance';
 import { attributionBlock, attributionMeta, clientKeyFor, extractionRef } from '@/lib/bot-attribution';
 import { getTranslation } from '@/lib/page-translations';
+import { isMeteredAnonRequest } from '@/lib/metered-gate';
 
 // This route serves quotable page text (get_book_text tells agents to "copy
 // verbatim from the translation field"), so it MUST strip the AI editorial
@@ -119,9 +120,13 @@ export const GET = withApiAuth(async (
 
     const resolvedBookId = book.id || bookId;
 
-    // Bot gating: non-trusted bots get the first 20% of pages from any book
+    // Bot gating: non-trusted bots get the first 20% of pages from any book.
+    // When METERED_READER=1 the same clamp applies to anonymous humans
+    // (#4357) — this route is the highest-volume text egress and would
+    // otherwise hand the reader wall's content out the side door.
     const isBotRequest = isBot(request) && !(await isTrustedBot(request));
-    const botPageLimit = isBotRequest ? botMaxPage(book.pages_count || 0) : undefined;
+    const meteredAnon = !isBotRequest && (await isMeteredAnonRequest(request));
+    const botPageLimit = isBotRequest || meteredAnon ? botMaxPage(book.pages_count || 0) : undefined;
 
     // Provenance. Two layers, deliberately different in reach:
     //   - the INVISIBLE imprimatur goes on every page of every response (this

--- a/src/app/api/dts/document/route.ts
+++ b/src/app/api/dts/document/route.ts
@@ -13,7 +13,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';import { getTenantContextFromRequest } from '@/lib/tenant-context';import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
+import { getReadDb } from '@/lib/mongodb';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
+import { isMeteredAnonRequest } from '@/lib/metered-gate';
+import { resolveTenantId } from '@/lib/tenant-context';
 import { dtsPageText } from '@/lib/dts-text';
 
 const BASE = 'https://sourcelibrary.org';
@@ -79,10 +83,22 @@ export async function GET(request: NextRequest) {
     const bookId = book.id as string;
     const pagesCount = (book.pages_count as number) || 0;
 
-    // Bot gating
+    // Bot gating — and, when METERED_READER=1, the same free-sample clamp
+    // for anonymous humans (#4357): DTS document serves full page text, so
+    // leaving it open would hand the reader wall's content out the side
+    // door. The human clamp applies only to default-tenant books — named
+    // tenants are partner reading rooms and stay exempt, matching the pages
+    // API. (Today every DTS-servable book is tenant-tagged to a partner, so
+    // the human clamp is dormant even with the flag on; it exists for any
+    // future default-tagged book.)
     const bot = isBot(request);
     const trusted = bot && (await isTrustedBot(request));
-    const maxPage = bot && !trusted ? botMaxPage(pagesCount) : pagesCount;
+    const defaultTenantId = await resolveTenantId('default').catch(() => null);
+    const meteredHuman = !bot
+      && tenantId === defaultTenantId
+      && (await isMeteredAnonRequest(request));
+    const clampToFree = (bot && !trusted) || meteredHuman;
+    const maxPage = clampToFree ? botMaxPage(pagesCount) : pagesCount;
 
     // Determine page range to fetch
     let startPage: number;

--- a/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
+++ b/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
@@ -14,6 +14,9 @@ import { getReadDb } from '@/lib/mongodb';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { aiGenerator } from '@/lib/iiif-provenance';
 import { isBookReadable } from '@/lib/book-access';
+import { isMeteredAnonRequest } from '@/lib/metered-gate';
+import { isPageFree, freeMaxPage } from '@/lib/free-preview';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -68,17 +71,17 @@ export async function GET(
     // doc is found we preserve prior behavior (the page lookup below 404s).
     const gateBook = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
-      { projection: { id: 1, visible: 1 } }
+      { projection: { id: 1, visible: 1, pages_count: 1 } }
     );
     if (gateBook && !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
 
-    // Fetch only the field we need
+    // Fetch only the field we need (+ seo_indexable for the metered check)
     const projection =
       type === 'ocr'
-        ? { 'ocr.data': 1, 'ocr.language': 1, 'ocr.model': 1, page_number: 1 }
-        : { 'translation.data': 1, 'translation.language': 1, 'translation.model': 1, page_number: 1 };
+        ? { 'ocr.data': 1, 'ocr.language': 1, 'ocr.model': 1, page_number: 1, seo_indexable: 1 }
+        : { 'translation.data': 1, 'translation.language': 1, 'translation.model': 1, page_number: 1, seo_indexable: 1 };
 
     const page = await db.collection('pages').findOne(
       { book_id: id, page_number: pageNum },
@@ -87,6 +90,29 @@ export async function GET(
 
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
+
+    // Metered reader (#4357): this route serves per-page text with no other
+    // gate — the same asset the reader wall withholds. Beyond the free
+    // sample, anonymous callers get an explicit 403 (NOT an empty
+    // AnnotationPage: an empty list reads as "no transcription exists",
+    // which would be a lie). Requests carrying a tenant context (partner
+    // subdomains/embeds) stay exempt, matching the pages API — it is the
+    // SURFACE that is exempt, not the book. No-op unless METERED_READER=1.
+    if (
+      gateBook
+      && !getTenantContextFromRequest(request).id
+      && !isPageFree(page as { page_number?: number | null; seo_indexable?: boolean }, (gateBook.pages_count as number) || 0)
+      && (await isMeteredAnonRequest(request))
+    ) {
+      return NextResponse.json(
+        {
+          error: 'Sign in to read beyond the free sample',
+          free_pages: freeMaxPage((gateBook.pages_count as number) || 0),
+          sign_in_url: `${BASE}/auth/signin`,
+        },
+        { status: 403, headers: CORS_HEADERS }
+      );
     }
 
     const content = type === 'ocr' ? page.ocr : page.translation;

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -9,6 +9,7 @@ import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 import { markPageForReader, stripProvenanceMarks } from '@/lib/provenance';
 import { gatePagesForRequest } from '@/lib/metered-gate';
+import { verifyCitationToken } from '@/lib/citation-token';
 
 export const preferredRegion = 'fra1';
 
@@ -79,10 +80,13 @@ export async function GET(
     }
 
     // Metered reader (#4357): strip gated text for anonymous callers beyond
-    // the book's free sample. Tenant-scoped requests (proxy-injected
-    // tenantId = partner reading room) are exempt. No-op unless
-    // METERED_READER=1.
-    [page] = await gatePagesForRequest(db, request, [page], { exempt: !!tenantId });
+    // the book's free sample. Exempt: tenant-scoped requests (proxy-injected
+    // tenantId = partner reading room) and a valid citation token for THIS
+    // page (?cite=… from a /q/ shortlink — published citations must always
+    // resolve). No-op unless METERED_READER=1.
+    [page] = await gatePagesForRequest(db, request, [page], {
+      exempt: !!tenantId || verifyCitationToken(id, searchParams.get('cite')),
+    });
 
     // Reader-path provenance: translation carries the invisible imprimatur.
     // Deterministic (no ref), so the cache header below stays valid.

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { getReadDb } from '@/lib/mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { readFreshDashboardSnapshot } from '@/lib/dashboard-snapshot';
+import { meteredReaderEnabled } from '@/lib/free-preview';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
@@ -369,8 +370,12 @@ export default async function ParticipatePage() {
       {/* Principles */}
       <footer className="border-t border-border-light">
         <div className="max-w-5xl mx-auto px-6 py-8">
+          {/* Metered reader (#4357): flips with the METERED_READER flag in
+              the same deploy — see the FAQ page's twin comment. */}
           <p className="text-muted text-sm leading-relaxed">
-            No paywalls, no login walls. AI translations are first drafts &mdash; the originals are always preserved alongside them. Published editions carry DOIs via Zenodo, so your contributions become citable scholarship.
+            {meteredReaderEnabled()
+              ? <>Every book is freely browsable, and a free account unlocks full reading. AI translations are first drafts &mdash; the originals are always preserved alongside them. Published editions carry DOIs via Zenodo, so your contributions become citable scholarship.</>
+              : <>No paywalls, no login walls. AI translations are first drafts &mdash; the originals are always preserved alongside them. Published editions carry DOIs via Zenodo, so your contributions become citable scholarship.</>}
           </p>
         </div>
       </footer>

--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { decodeShortlink } from '@/lib/shortlinks';
+import { mintCitationToken } from '@/lib/citation-token';
+import { meteredReaderEnabled } from '@/lib/free-preview';
 import { Page } from '@/lib/types';
 
 interface RouteContext {
@@ -56,9 +58,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
       );
     }
 
+    // Metered reader (#4357): a citation must resolve even past the free
+    // sample, so the redirect carries a per-page capability token the
+    // page-content API honors for exactly this page (citation-token.ts).
+    // Only minted while metering is on — with the flag off the param would
+    // be inert noise on every shared URL.
+    const cite = meteredReaderEnabled() ? mintCitationToken(page.id) : null;
+    const citeSuffix = cite ? `?cite=${cite}` : '';
+
     // Redirect to the full page URL
     return NextResponse.redirect(
-      new URL(`${prefix}/book/${bookPath}/page/${page.id}`, request.url),
+      new URL(`${prefix}/book/${bookPath}/page/${page.id}${citeSuffix}`, request.url),
       { status: 302 }
     );
   } catch (error) {

--- a/src/components/reader-v2/useReaderV2.ts
+++ b/src/components/reader-v2/useReaderV2.ts
@@ -179,6 +179,27 @@ export function useReaderV2(
     }
   }, [signedIn, currentPage, currentPageId, fetchPage]);
 
+  // Citation exception (#4357): a reader arriving from a /q/ quote link
+  // carries ?cite=<token> — a per-page capability minted by the redirect.
+  // The ISR HTML is still the stripped variant (static render, one HTML for
+  // everyone), so when the page on screen is gated and a token is present,
+  // refetch with it; the API ungates exactly the cited page. The token rides
+  // along on page turns (pageUrl preserves the query) but verifies only for
+  // the page it was minted for, so it cannot be walked along the book.
+  useEffect(() => {
+    if (!(currentPage as Page & { gated?: boolean }).gated) return;
+    if (typeof window === 'undefined') return;
+    const cite = new URLSearchParams(window.location.search).get('cite');
+    if (!cite) return;
+    let cancelled = false;
+    pagesApi.get(currentPageId, { cite }).then((p) => {
+      if (cancelled || !p || (p as Page & { gated?: boolean }).gated) return;
+      cacheRef.current.set(currentPageId, p);
+      setCurrentPage(p);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [currentPage, currentPageId]);
+
   // Reading history beacon (same contract as the production reader)
   useEffect(() => {
     // currentPageId moves synchronously on a page turn; currentPage arrives a

--- a/src/lib/api-client/pages.ts
+++ b/src/lib/api-client/pages.ts
@@ -21,11 +21,16 @@ import type {
  */
 export const pages = {
   /**
-   * Get a single page by ID
+   * Get a single page by ID.
+   *
+   * `cite` (#4357): citation token from a /q/ quote link — the server
+   * serves this one page ungated to a valid token even past the metered
+   * reader's free sample.
    */
-  get: async (id: string): Promise<Page> => {
+  get: async (id: string, opts?: { cite?: string }): Promise<Page> => {
     const tenant = getTenantSlug();
-    return await apiClient.get(`/api/${tenant}/pages/${id}`);
+    const query = opts?.cite ? `?cite=${encodeURIComponent(opts.cite)}` : '';
+    return await apiClient.get(`/api/${tenant}/pages/${id}${query}`);
   },
 
   /**

--- a/src/lib/citation-token.ts
+++ b/src/lib/citation-token.ts
@@ -1,0 +1,44 @@
+/**
+ * Citation tokens — the quote-link exception to the metered reader (#4357).
+ *
+ * A published citation must resolve forever: every /q/ shortlink in a
+ * footnote, and every quote URL we have ever handed out, points a reader at
+ * one specific page. If that page sits beyond the free sample, the wall
+ * would break the citation — so the /q/ redirect appends `?cite=<token>`,
+ * and the page-content API honors a valid token for THAT page only.
+ *
+ * The token is a keyed HMAC of the page id: a per-page capability, no
+ * expiry (citations don't expire), no database. Holding a quote link to
+ * page X lets you read page X — exactly the semantics of a citation — and
+ * nothing else: the token doesn't verify for any other page, so it cannot
+ * be walked along the book.
+ *
+ * Server-only (node crypto + a server secret): never import from a client
+ * component.
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function secret(): string | null {
+  // AUTH_SECRET is the keyed secret guaranteed present wherever the app runs
+  // (src/lib/auth.ts:220 — NextAuth v5 naming; NEXTAUTH_SECRET kept as the
+  // legacy fallback). No fallback VALUE: with no secret we mint nothing and
+  // verify nothing.
+  return process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || null;
+}
+
+export function mintCitationToken(pageId: string): string | null {
+  const key = secret();
+  if (!key || !pageId) return null;
+  return createHmac('sha256', key).update(`cite:${pageId}`).digest('hex').slice(0, 32);
+}
+
+export function verifyCitationToken(pageId: string, token: string | null | undefined): boolean {
+  if (!token || !/^[0-9a-f]{32}$/.test(token)) return false;
+  const expected = mintCitationToken(pageId);
+  if (!expected) return false;
+  try {
+    return timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/metered-gate.ts
+++ b/src/lib/metered-gate.ts
@@ -47,6 +47,22 @@ function logGateHit(request: Request, pagesGated: number): void {
   }
 }
 
+/**
+ * Is this request an anonymous human the metered reader applies to?
+ * False whenever metering is off, or the caller is cron, signed in, or a
+ * trusted bot. Used by full-text surfaces (DTS document, /text) to extend
+ * their existing bot clamp to anonymous humans with the same free-sample
+ * math, without duplicating the exemption ladder.
+ */
+export async function isMeteredAnonRequest(request: Request): Promise<boolean> {
+  if (!meteredReaderEnabled()) return false;
+  if (hasCronAuth(request)) return false;
+  const session = await auth().catch(() => null);
+  if (session?.user) return false;
+  if (await isTrustedBot(request)) return false;
+  return true;
+}
+
 type PageDoc = Record<string, unknown> & {
   book_id?: string;
   page_number?: number | null;

--- a/tests/unit/citation-token.test.ts
+++ b/tests/unit/citation-token.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mintCitationToken, verifyCitationToken } from '@/lib/citation-token';
+
+/**
+ * Pins the citation-token exception to the metered reader (#4357): a /q/
+ * quote link mints a per-page capability so published citations always
+ * resolve. Guards: tokens verify only for the page they were minted for
+ * (cannot be walked along the book), and with no secret nothing mints or
+ * verifies (fail closed).
+ */
+describe('citation tokens', () => {
+  const priorAuth = process.env.AUTH_SECRET;
+  const priorNextAuth = process.env.NEXTAUTH_SECRET;
+  beforeEach(() => {
+    process.env.AUTH_SECRET = 'test-secret-for-citation-tokens';
+    delete process.env.NEXTAUTH_SECRET;
+  });
+  afterEach(() => {
+    if (priorAuth === undefined) delete process.env.AUTH_SECRET;
+    else process.env.AUTH_SECRET = priorAuth;
+    if (priorNextAuth === undefined) delete process.env.NEXTAUTH_SECRET;
+    else process.env.NEXTAUTH_SECRET = priorNextAuth;
+  });
+
+  it('mints a stable 32-hex token and verifies it for the same page', () => {
+    const token = mintCitationToken('page-abc');
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+    expect(mintCitationToken('page-abc')).toBe(token);
+    expect(verifyCitationToken('page-abc', token)).toBe(true);
+  });
+
+  it('a token for one page never verifies for another', () => {
+    const token = mintCitationToken('page-abc')!;
+    expect(verifyCitationToken('page-xyz', token)).toBe(false);
+  });
+
+  it('rejects malformed and missing tokens', () => {
+    expect(verifyCitationToken('page-abc', null)).toBe(false);
+    expect(verifyCitationToken('page-abc', undefined)).toBe(false);
+    expect(verifyCitationToken('page-abc', 'not-a-token')).toBe(false);
+    expect(verifyCitationToken('page-abc', '')).toBe(false);
+  });
+
+  it('fails closed with no secret: mints nothing, verifies nothing', () => {
+    const token = mintCitationToken('page-abc')!;
+    delete process.env.AUTH_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    expect(mintCitationToken('page-abc')).toBeNull();
+    expect(verifyCitationToken('page-abc', token)).toBe(false);
+  });
+});


### PR DESCRIPTION
The last code slice before the metered reader can be turned on. Everything remains **inert** — `METERED_READER` is unset in prod, and with the flag off every change in this PR is a no-op (the copy renders its current wording verbatim).

## Citation exception (decision pt 2 → implemented as recommended)
- `/q/<code>` redirects now append `?cite=<token>` when metering is on — a keyed HMAC of the page id (`src/lib/citation-token.ts`, secret = `AUTH_SECRET`). No expiry: citations don't expire.
- The pages API honors a valid token **for exactly that page**; the reader refetches with it when it finds itself on an ISR-stripped page with a token in the URL. Verified: the token unlocks its page, and the same token on the neighboring gated page stays stripped — a capability that can't be walked along the book.
- Smoke testing caught a real bug: the lib originally read `NEXTAUTH_SECRET`, but auth.ts uses the v5 name `AUTH_SECRET` — tokens would have silently failed to mint in prod (fail-closed, so citations would have hit the wall). Fixed + pinned in `tests/unit/citation-token.test.ts`.

## Text side doors aligned to the wall
- **DTS document**: anonymous humans now get the same free-sample clamp bots always had. Scoped to default-tenant books — every DTS-servable book today is partner-tenant-tagged, and partner surfaces are exempt, so this is dormant armor for future default-tagged books.
- **IIIF canvas ocr/translation**: was fully ungated per-page text. Beyond the sample, anon now gets an explicit 403 with `free_pages` + sign-in URL — deliberately NOT an empty AnnotationPage, which would read as "no transcription exists". Tenant-context requests exempt.
- **`/api/books/[id]/text`**: anon humans clamp like untrusted bots (range cap, chapter gate, `pages_accessible` block all reuse the existing bot machinery). No tenant exemption here — it's a bulk-export API, and bots were never tenant-exempted on it either.
- Left open deliberately: book full-text search and the quote API (short snippets are discovery, not reading — and quoting drives the mission); IIIF **manifests** (image URLs only, and images are not the gated asset).

## Copy
- FAQ "There are no paywalls" and /contribute "No paywalls, no login walls" now render conditionally on the flag, so the site's promise flips in the same deploy as the wall — never before, never after. Flag-off output is byte-identical to today. Wording of the flag-on variants is a proposal — edit freely.
- /beta's "Free access with registration" stays: it remains true under Phase 2 (registration = full access).

## Verified (dev server, METERED_READER=1, prod data)
- `/q/` mints; valid cite → full text; wrong/other-page cite → stripped
- canvas: 403 beyond sample / 200 within; FAQ renders new copy under flag
- `API_AUTH_ENFORCE=1` confirmed present in prod env; `METERED_READER` confirmed absent
- tsc clean, 10/10 policy tests green

## Known judgment call
The proxy's referer-based tenant inference means partner-tenant books can arrive at the global pages API with a tenant context even on the apex, exempting them. That reads as policy, not bug — partner collections stay open everywhere — but it's inference, so noting it explicitly.

Remaining before flip (non-code): announcement/framing, then set `METERED_READER=1` + redeploy; ISR pages rendered pre-flip serve full text for ≤24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUHK3ecPn7x7WUNZxmRsTs