### PR TITLE
feat(quote): marginalia flagged as copy-specific evidence in citations (#4362)

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -554,6 +554,15 @@ export async function getQuote(args: {
     );
   }
 
+  // Marginalia (#4362): quote.marginalia_note carries the full guidance; the
+  // tip makes sure it is read rather than passed over.
+  if (quote?.contains_marginalia === true) {
+    tips.push(
+      "This page carries MARGINAL text (<margin>…</margin>). A marginal note exists only in this " +
+        "physical copy — when quoting from one, say 'marginal annotation' and follow quote.marginalia_note.",
+    );
+  }
+
   return {
     ...withCitationLink(result),
     tip: tips.join("\n\n"),

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -4,7 +4,7 @@ import { generateCitations, type Citation } from '@/lib/citation';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getRequestBaseUrl } from '@/lib/shortlinks';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
-import { resolveQuoteText, OCR_ORIGINAL_NOTE, SOURCE_COLUMN_NOTE, type QuoteTextSource } from '@/lib/quote-text';
+import { resolveQuoteText, containsMarginalia, MARGINALIA_NOTE, OCR_ORIGINAL_NOTE, SOURCE_COLUMN_NOTE, type QuoteTextSource } from '@/lib/quote-text';
 import { romanizedForQuote } from '@/lib/romanization';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
@@ -34,6 +34,9 @@ interface QuoteResponse {
     text_source: QuoteTextSource;
     /** Set when text_source is `ocr_original` or `source_column` — see those notes. */
     transcription_note?: string;
+    /** The page carries marginal text (#4362) — copy-specific by nature; see marginalia_note. */
+    contains_marginalia?: boolean;
+    marginalia_note?: string;
     /**
      * Romanization of the original for non-Latin scripts (#3828) — AI-derived
      * apparatus, never a transcription, hence `romanized` and not
@@ -159,6 +162,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
         text_source: quotable.source,
         ...(quotable.source === 'ocr_original' ? { transcription_note: OCR_ORIGINAL_NOTE } : {}),
         ...(quotable.source === 'source_column' ? { transcription_note: SOURCE_COLUMN_NOTE } : {}),
+        // Served text AND the OCR original — the transcription is the
+        // authority on whether the leaf carries a marginal note (#4362).
+        ...(containsMarginalia(quotable.text) || containsMarginalia(page.ocr?.data || '')
+          ? { contains_marginalia: true, marginalia_note: MARGINALIA_NOTE }
+          : {}),
         page: pageNumber,
         book_id: book.id,
         book_title: book.title,

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -5,7 +5,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { readerPageUrl } from '@/lib/slugify';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
-import { resolveQuoteText, OCR_ORIGINAL_NOTE, SOURCE_COLUMN_NOTE, type QuoteTextSource } from '@/lib/quote-text';
+import { resolveQuoteText, containsMarginalia, MARGINALIA_NOTE, OCR_ORIGINAL_NOTE, SOURCE_COLUMN_NOTE, type QuoteTextSource } from '@/lib/quote-text';
 import { romanizedForQuote } from '@/lib/romanization';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { getPageImageUrl } from '@/lib/page-image-url';
@@ -38,6 +38,13 @@ interface QuoteResponse {
     text_source: QuoteTextSource;
     /** Set when text_source is `ocr_original` or `source_column` — see those notes. */
     transcription_note?: string;
+    /**
+     * The page carries marginal text (#4362) — copy-specific by nature: it
+     * exists only in the one physical copy that was scanned. Set together
+     * with `marginalia_note`, which says how to cite it.
+     */
+    contains_marginalia?: boolean;
+    marginalia_note?: string;
     /**
      * ISO code of the language the quoted text is IN — always present, so a
      * caller branches on it rather than assuming English (#4095).
@@ -197,6 +204,12 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
           : {}),
         ...(quotable.source === 'ocr_original' ? { transcription_note: OCR_ORIGINAL_NOTE } : {}),
         ...(quotable.source === 'source_column' ? { transcription_note: SOURCE_COLUMN_NOTE } : {}),
+        // Checked on the served text AND the OCR original: a translation often
+        // renders the note without the mark-up, so the transcription is the
+        // authority on whether the leaf carries one (#4362).
+        ...(containsMarginalia(quotable.text) || containsMarginalia(page.ocr?.data || '')
+          ? { contains_marginalia: true, marginalia_note: MARGINALIA_NOTE }
+          : {}),
         page: pageNumber,
         book_id: book.id,
         book_title: book.title,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -655,6 +655,15 @@ async function getQuote(args: Record<string, unknown>) {
     );
   }
 
+  // Marginalia (#4362) — same logic in mcp-server/src/api.ts (fixes do not
+  // propagate between the two servers).
+  if ((quote as Record<string, unknown> | undefined)?.contains_marginalia === true) {
+    tips.push(
+      'This page carries MARGINAL text (<margin>…</margin>). A marginal note exists only in this ' +
+        "physical copy — when quoting from one, say 'marginal annotation' and follow quote.marginalia_note.",
+    );
+  }
+
   return {
     ...withCitationLink(result),
     continuity,

--- a/src/lib/quote-text.ts
+++ b/src/lib/quote-text.ts
@@ -84,6 +84,33 @@ export const SOURCE_COLUMN_NOTE =
 export const SOURCE_COLUMN_PROVENANCE = 'source-column';
 
 /**
+ * Does this quotable text contain marginalia? (#4362)
+ *
+ * `<margin>` is a real page mark, not an editorial wrapper — its content stays
+ * in quotable text (quote-and-snippet-integrity.md) in two forms: the tag the
+ * OCR prompts emit, and the `[[margin: …]]` bracket form NotesRenderer also
+ * normalizes. A marginal note is COPY-SPECIFIC evidence: it exists in exactly
+ * one physical copy, so a quote drawn from it needs the copy clause
+ * (citation.copy, #4360) and must say it is marginal — a citation that treats
+ * a reader's annotation as the printed body text misattributes the words.
+ */
+export function containsMarginalia(text: string): boolean {
+  return /<margin[\s>]/.test(text) || /\[\[margin:/.test(text);
+}
+
+/**
+ * What a caller has to be told when the quoted page carries marginal text.
+ * Spelled out because agents act on these sentences.
+ */
+export const MARGINALIA_NOTE =
+  'This page carries marginal text (marked <margin>…</margin> or [[margin: …]]). Marginalia are '
+  + 'COPY-SPECIFIC: a marginal note exists only in the one physical copy that was scanned, unlike '
+  + 'the printed body text, which any copy of the edition carries. When quoting from a marginal '
+  + 'note, say so ("marginal annotation"), and cite the holding library named in citation.copy when '
+  + 'present — without the copy, the note cannot be located by a reader. Marginal text may be in a '
+  + 'different hand, language, or century than the printed text.';
+
+/**
  * The quotable text of a page, or null when the page holds nothing citable.
  *
  * Emptiness is measured AFTER wrapper stripping on purpose: a page whose

--- a/tests/unit/quote-marginalia.test.ts
+++ b/tests/unit/quote-marginalia.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Marginalia detection on the quote path (#4362).
+ *
+ * A quote drawn from a `<margin>` block used to cite identically to body
+ * text — but a marginal note exists in exactly ONE physical copy, so the
+ * apparatus must flag it and point at the copy clause (#4360).
+ */
+import { describe, it, expect } from 'vitest';
+import { containsMarginalia, MARGINALIA_NOTE } from '@/lib/quote-text';
+
+describe('containsMarginalia', () => {
+  it('detects the OCR tag form', () => {
+    expect(containsMarginalia('Body text. <margin>Nota bene: mercurius</margin> More body.')).toBe(true);
+    expect(containsMarginalia('<margin lang="la">gloss</margin>')).toBe(true);
+  });
+
+  it('detects the bracket form NotesRenderer also normalizes', () => {
+    expect(containsMarginalia('Body. [[margin: a reader adds a cross here]]')).toBe(true);
+  });
+
+  it('stays quiet on plain body text', () => {
+    expect(containsMarginalia('A page with no marginal apparatus at all.')).toBe(false);
+    // The WORD "margin" is not the mark.
+    expect(containsMarginalia('printed close to the margin of the leaf')).toBe(false);
+    // Other real page marks are not marginalia.
+    expect(containsMarginalia('<sig>B2r</sig> <page-num>28</page-num>')).toBe(false);
+  });
+});
+
+describe('MARGINALIA_NOTE', () => {
+  it('says the two things that matter: copy-specific, and cite the holder', () => {
+    expect(MARGINALIA_NOTE).toContain('COPY-SPECIFIC');
+    expect(MARGINALIA_NOTE).toContain('citation.copy');
+    expect(MARGINALIA_NOTE).toContain('marginal annotation');
+  });
+});


### PR DESCRIPTION
Closes #4362 (core half — see deferral note).

## What

A quote drawn from a `<margin>` block cited identically to body text. But a marginal note exists in exactly ONE physical copy — unlike the printed body, which any copy of the edition carries — so the citation apparatus must say so and point at the copy clause shipped in #4367.

- `containsMarginalia()` + `MARGINALIA_NOTE` in `src/lib/quote-text.ts` (detects both the `<margin>` tag the OCR prompts emit and the `[[margin: …]]` bracket form; the word "margin" in prose does not trigger it).
- Both quote routes serve `quote.contains_marginalia` + `quote.marginalia_note`, checked on the served text AND the OCR original — translations often render the note without mark-up, so the transcription is the authority.
- Both MCP servers' `get_quote` tips surface it, so an AI caller says "marginal annotation" and cites the holding library from `citation.copy`.

## Deliberately deferred
A `pages.has_marginalia` search lane ("show me pages with marginalia") — a new queryable column needs the field-sprawl gate and a search-lanes design pass; the citation path answers from the text itself without one. Noted on #4362.

## Verification
- tsc clean (app + mcp-server); 3,073 unit tests pass incl. new `tests/unit/quote-marginalia.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG2ZHxfHYV6ZHoYuFwSwLw