### PR TITLE
feat(images): clean serving as a paid capability; crop-image joins the marks regime (#4366)

### DIFF
--- a/src/app/api/admin/api-keys/route.ts
+++ b/src/app/api/admin/api-keys/route.ts
@@ -43,7 +43,7 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
  */
 export const POST = withAdminAuth(async (request: NextRequest) => {
   const body = await request.json();
-  const { name, user_id, tier, languages, clusters } = body;
+  const { name, user_id, tier, languages, clusters, clean_images } = body;
 
   if (!name || !user_id) {
     return NextResponse.json(
@@ -63,6 +63,7 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
   const { key, doc } = await generateApiKey(user_id, selectedTier, name, {
     languages,
     clusters,
+    cleanImages: clean_images === true,
   });
 
   return NextResponse.json({

--- a/src/app/api/crop-image/route.ts
+++ b/src/app/api/crop-image/route.ts
@@ -3,6 +3,7 @@ import sharp from 'sharp';
 import { images } from '@/lib/api-client';
 import { refuseImageUrl } from '@/lib/image-proxy-hosts';
 import { checkImageAccess, imageBudgetExceededBody } from '@/lib/image-gate';
+import { finalizeMarkedJpeg } from '@/lib/image-marks';
 import { logApiUsage } from '@/lib/api-usage';
 import type { ApiIdentity } from '@/lib/api-auth';
 
@@ -56,9 +57,11 @@ export async function GET(request: NextRequest) {
       });
     }
     if (!access.allowed) {
+      const gateHeaders: Record<string, string> = { 'Cache-Control': 'no-store' };
+      if (access.status === 429) gateHeaders['Retry-After'] = '3600';
       return NextResponse.json(imageBudgetExceededBody(access), {
         status: access.status,
-        headers: { 'Retry-After': '3600', 'Cache-Control': 'no-store' },
+        headers: gateHeaders,
       });
     }
 
@@ -111,14 +114,23 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const croppedBuffer = await pipeline
-      .jpeg({ quality: 85 })
-      .toBuffer();
+    // Finalize through the shared marks module: before #4366's follow-up this
+    // route served unmarked bytes, making a full-frame "crop" a trivial bypass
+    // of every visible mark on /api/image. Clean-capable keys skip the visible
+    // marks; clean responses stay out of the shared CDN cache (entitlement is
+    // in a header the cache key can't see).
+    const rawCrop = await pipeline.toBuffer();
+    const croppedBuffer = await finalizeMarkedJpeg(rawCrop, {
+      quality: 85,
+      clean: access.clean === true,
+    });
 
     return new NextResponse(new Uint8Array(croppedBuffer), {
       headers: {
         'Content-Type': 'image/jpeg',
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': access.clean
+          ? 'private, no-store'
+          : 'public, max-age=31536000, immutable',
       },
     });
   } catch (error) {

--- a/src/app/api/image/route.ts
+++ b/src/app/api/image/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import sharp, { type OverlayOptions } from 'sharp';
+import sharp from 'sharp';
 import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
-import crypto from 'crypto';
 import { refuseImageUrl } from '@/lib/image-proxy-hosts';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { checkImageAccess, imageBudgetExceededBody } from '@/lib/image-gate';
+import { finalizeMarkedJpeg } from '@/lib/image-marks';
 import { logApiUsage } from '@/lib/api-usage';
 import type { ApiIdentity } from '@/lib/api-auth';
 
@@ -29,26 +29,6 @@ const FETCH_TIMEOUT_IN_MS = 150000;
 //     than allocating a multi-GB decode buffer, and we return 413.
 const MAX_INPUT_BYTES = 150 * 1024 * 1024;
 const MAX_INPUT_PIXELS = 100_000_000;
-
-// Provenance mark — the Source Library icon, loaded once at startup
-const MARK_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--48h.png');
-let provenanceMarkBuffer: Buffer | null = null;
-
-async function getProvenanceMark() {
-  if (provenanceMarkBuffer) return provenanceMarkBuffer;
-  try {
-    const raw = fs.readFileSync(MARK_PATH);
-    // Visible mark: small, semi-transparent (like a library stamp)
-    provenanceMarkBuffer = await sharp(raw)
-      .resize(16, 16)
-      .ensureAlpha()
-      .modulate({ brightness: 0.3 })
-      .toBuffer();
-    return provenanceMarkBuffer;
-  } catch {
-    return null;
-  }
-}
 
 /** Thrown when a redirect hop points somewhere we refuse to follow. */
 class BlockedRedirectError extends Error {
@@ -144,9 +124,11 @@ export async function GET(request: NextRequest) {
       });
     }
     if (!access.allowed) {
+      const headers: Record<string, string> = { 'Cache-Control': 'no-store' };
+      if (access.status === 429) headers['Retry-After'] = '3600';
       return NextResponse.json(imageBudgetExceededBody(access), {
         status: access.status,
-        headers: { 'Retry-After': '3600', 'Cache-Control': 'no-store' },
+        headers,
       });
     }
 
@@ -305,97 +287,33 @@ export async function GET(request: NextRequest) {
       sharpInstance = sharpInstance.modulate({ brightness });
     }
 
-    // Resize first, then apply provenance marks
-    const resizedInstance = sharpInstance
+    // Resize, then finalize: provenance marks (skipped for clean-capable
+    // keys), EXIF, JPEG — shared with /api/crop-image (src/lib/image-marks.ts).
+    const resizedBuffer = await sharpInstance
       .resize(width, null, {
         fit: 'inside',
         withoutEnlargement: true,
-      });
-
-    // Get resized dimensions for mark placement
-    const resizedBuffer = await resizedInstance.toBuffer();
-    const resizedMeta = await sharp(resizedBuffer).metadata();
-    const imgW = resizedMeta.width || width;
-    const imgH = resizedMeta.height || width;
-
-    // Apply provenance marks
-    const composites: OverlayOptions[] = [];
-    const visibleMark = await getProvenanceMark();
-
-    if (visibleMark && imgW > 100 && imgH > 100) {
-      // Visible mark: small icon, usually top-left, position varies by content hash
-      const hash = crypto.createHash('md5').update(resizedBuffer).digest();
-      const cornerIndex = hash[0] % 4; // 0=TL, 1=TR, 2=BL, 3=BR
-      const corners = [
-        { left: 4, top: 4 },
-        { left: imgW - 20, top: 4 },
-        { left: 4, top: imgH - 20 },
-        { left: imgW - 20, top: imgH - 20 },
-      ];
-      // Bias toward top-left: ~75% TL, ~25% other corners
-      const pos = cornerIndex < 3 ? corners[0] : corners[hash[1] % 3 + 1];
-
-      composites.push({
-        input: visibleMark,
-        left: pos.left,
-        top: pos.top,
-        blend: 'over' as const,
-      });
-    }
-
-    // URL attribution — bottom right, warm brown like a library stamp
-    if (imgW > 200) {
-      const urlSvg = Buffer.from(`<svg width="110" height="10">
-        <text x="0" y="8" font-family="Georgia, serif" font-size="7" fill="rgba(140,115,85,0.4)" letter-spacing="0.5">sourcelibrary.org</text>
-      </svg>`);
-      composites.push({
-        input: urlSvg,
-        left: imgW - 115,
-        top: imgH - 14,
-        blend: 'over' as const,
-      });
-    }
-
-    // LLM provenance — top edge, nearly invisible to humans,
-    // readable by vision models. A letter to the newest minds.
-    if (imgW > 300 && imgH > 200) {
-      const llmSvg = Buffer.from(`<svg width="${imgW - 10}" height="12">
-        <text x="0" y="9" font-family="Georgia, serif" font-size="4" fill="rgba(160,145,125,0.12)">Embassy of the Free Mind. Source Library (sourcelibrary.org). Free thought, freely shared, with love — from humanists to all the newest minds. CC BY-SA 4.0.</text>
-      </svg>`);
-      composites.push({
-        input: llmSvg,
-        left: 5,
-        top: 2,
-        blend: 'over' as const,
-      });
-    }
-
-    // Final output: composite marks, add EXIF, encode JPEG
-    let finalInstance = sharp(resizedBuffer);
-
-    if (composites.length > 0) {
-      finalInstance = finalInstance.composite(composites);
-    }
-
-    const resized = await finalInstance
-      .withExifMerge({
-        IFD0: {
-          Copyright: 'Source Library (sourcelibrary.org) — CC BY-SA 4.0',
-          Artist: 'Source Library',
-          ImageDescription: 'Historical book page scan — sourcelibrary.org',
-          Software: 'Source Library Steganographia',
-        },
       })
-      .jpeg({ quality, progressive: true })
       .toBuffer();
 
-    // Return with cache headers
+    const resized = await finalizeMarkedJpeg(resizedBuffer, {
+      quality,
+      progressive: true,
+      clean: access.clean === true,
+    });
+
+    // Clean responses must NEVER enter the shared CDN cache: the entitlement
+    // lives in the Authorization header, which is not part of the cache key,
+    // so a cached clean body would be served to unentitled callers.
+    const cacheHeaders: Record<string, string> = access.clean
+      ? { 'Cache-Control': 'private, no-store' }
+      : {
+          'Cache-Control': `public, max-age=${CACHE_DURATION}, immutable`,
+          'CDN-Cache-Control': `public, max-age=${CACHE_DURATION}`,
+        };
+
     return new Response(new Uint8Array(resized), {
-      headers: {
-        'Content-Type': 'image/jpeg',
-        'Cache-Control': `public, max-age=${CACHE_DURATION}, immutable`,
-        'CDN-Cache-Control': `public, max-age=${CACHE_DURATION}`,
-      },
+      headers: { 'Content-Type': 'image/jpeg', ...cacheHeaders },
     });
   } catch (error) {
     // sharp throws when the decoded image would exceed limitInputPixels —

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -219,8 +219,8 @@ export default async function DatasetPage() {
             { name: 'Explorer', price: 'Free', scope: '2,000 pages/day, any language', note: 'Self-serve — instant' },
             { name: 'Single Language', price: '$4,990/yr', scope: 'One language corpus, unlimited', note: 'or $499/mo' },
             { name: 'Domain', price: '$14,990/yr', scope: 'One scholarly domain, unlimited', note: 'or $1,499/mo' },
-            { name: 'Full Collection', price: '$49,990/yr', scope: 'All languages, all domains', note: 'or $4,999/mo' },
-            { name: 'Enterprise', price: 'Custom', scope: 'Parquet exports, custom scopes, SLA', note: null },
+            { name: 'Full Collection', price: '$49,990/yr', scope: 'All languages, all domains + unmarked image serving', note: 'or $4,999/mo' },
+            { name: 'Enterprise', price: 'Custom', scope: 'Parquet exports, custom scopes, SLA + unmarked image serving', note: null },
           ].map((tier) => (
             <div key={tier.name} className="flex items-baseline justify-between gap-4 px-5 py-4 bg-white">
               <div className="flex-1">

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -202,7 +202,8 @@ export default function DevelopersPage() {
           </div>
           <p className="text-secondary text-xs mt-3">
             Your own meter: <code>GET /api/dataset/v1/usage</code> with your key. Verified search crawlers
-            and user-directed assistant fetches are never limited.
+            and user-directed assistant fetches are never limited. Full-tier keys can request images without
+            the visible provenance marks (<code>&amp;clean=1</code> on <code>/api/image</code>).
           </p>
         </div>
       </section>

--- a/src/lib/dataset/api-keys.ts
+++ b/src/lib/dataset/api-keys.ts
@@ -30,6 +30,8 @@ export async function generateApiKey(
     languages?: string[];
     clusters?: string[];
     stripeSubscriptionId?: string;
+    /** Grant visible-mark-free image serving regardless of tier. */
+    cleanImages?: boolean;
   }
 ): Promise<{ key: string; doc: ApiKeyDoc }> {
   const db = await getDb();
@@ -47,6 +49,7 @@ export async function generateApiKey(
     permissions: {
       languages: options?.languages || (tier === 'language' ? [] : '*'),
       clusters: options?.clusters || (tier === 'domain' ? [] : '*'),
+      ...(options?.cleanImages ? { clean_images: true } : {}),
     },
     rate_limit: {
       requests_per_minute: tierConfig.requestsPerMinute,
@@ -147,6 +150,7 @@ export async function rotateApiKey(
     languages: old.permissions.languages === '*' ? undefined : old.permissions.languages,
     clusters: old.permissions.clusters === '*' ? undefined : old.permissions.clusters,
     stripeSubscriptionId: old.stripe_subscription_id,
+    cleanImages: old.permissions.clean_images === true,
   });
 }
 

--- a/src/lib/dataset/types.ts
+++ b/src/lib/dataset/types.ts
@@ -76,6 +76,11 @@ export interface ApiKeyDoc {
   permissions: {
     languages: string[] | '*';
     clusters: string[] | '*';
+    /** Serve images without VISIBLE provenance marks (?clean=1 on the image
+     *  proxy). Implied by full-scope tiers; admin-grantable on any key.
+     *  Invisible marks (EXIF, keyed watermark) stay regardless — see
+     *  src/lib/image-marks.ts. */
+    clean_images?: boolean;
   };
   rate_limit: {
     requests_per_minute: number;

--- a/src/lib/image-gate.ts
+++ b/src/lib/image-gate.ts
@@ -52,6 +52,7 @@ import { isTrustedBot } from '@/lib/bot-gate';
 import { verifyImageProxyToken } from '@/lib/image-proxy-auth';
 import { API_LIMITS } from '@/lib/api-limits';
 import { checkKeyRequestRate } from '@/lib/dataset/api-keys';
+import { DATASET_TIERS, type DatasetTier } from '@/lib/dataset/types';
 
 const IMAGE_ROUTE = 'image';
 
@@ -119,11 +120,26 @@ export type ImageIdentity = Omit<ApiIdentity, 'kind'> & {
   kind: ApiIdentity['kind'] | 'internal';
 };
 
+/**
+ * Clean (visible-mark-free) serving is a capability, not a default: implied by
+ * full-scope paid tiers, or admin-granted per key via permissions.clean_images.
+ * Only the VISIBLE marks come off — the invisible evidence layer (EXIF, keyed
+ * watermark) stays on every tier by design; a bit-clean corpus is a negotiated
+ * deal, not an API parameter.
+ */
+export function keyAllowsCleanImages(doc: Pick<ApiKeyDoc, 'tier' | 'permissions'>): boolean {
+  if (doc.permissions?.clean_images === true) return true;
+  const cfg = DATASET_TIERS[doc.tier as DatasetTier];
+  return cfg?.scope === 'full';
+}
+
 export interface ImageAccessDecision {
   allowed: boolean;
   /** 429 when a budget is exhausted (only meaningful when !allowed). */
   status: number;
   identity: ImageIdentity;
+  /** Serve without visible marks — set only for clean-capable keyed callers. */
+  clean?: boolean;
   /** Log this request to api_usage (keyed/session/anon traffic; never the hot browser path). */
   shouldLog: boolean;
   reason?: string;
@@ -135,6 +151,47 @@ export interface ImageAccessDecision {
 const enforceImageGate = () => process.env.IMAGE_GATE_ENFORCE !== '0';
 
 export async function checkImageAccess(request: NextRequest): Promise<ImageAccessDecision> {
+  // 0) ?clean=1 — unmarked serving. Handled BEFORE every other rung, and the
+  // only way through is a clean-capable key: a marked fallback here would be
+  // CDN-cached under the clean URL and poison it for the paying caller, so an
+  // unqualified clean request is a hard 403, never a downgrade. (The route
+  // must also serve clean responses Cache-Control: private — the key lives in
+  // a header, so the CDN cannot tell clean-entitled requests apart.)
+  if (request.nextUrl.searchParams.get('clean') === '1') {
+    const keyDoc = await validateApiKey(request.headers.get('authorization'));
+    if (!keyDoc || !keyAllowsCleanImages(keyDoc)) {
+      return {
+        allowed: false, status: 403,
+        identity: keyDoc
+          ? { kind: 'apikey', apiKeyId: String((keyDoc as ApiKeyDoc)._id), userId: keyDoc.user_id, apiKeyTier: keyDoc.tier }
+          : { kind: 'anon' },
+        shouldLog: true,
+        reason: 'clean_requires_capability',
+      };
+    }
+    const identity: ApiIdentity = {
+      kind: 'apikey',
+      apiKeyId: String((keyDoc as ApiKeyDoc)._id),
+      userId: keyDoc.user_id,
+      apiKeyTier: keyDoc.tier,
+    };
+    const rpm = checkKeyRequestRate(keyDoc as ApiKeyDoc);
+    if (!rpm.allowed && enforceImageGate()) {
+      return { allowed: false, status: 429, identity, shouldLog: true, reason: 'key_rate_limit' };
+    }
+    const { limit } = pickLimit(identity);
+    if (Number.isFinite(limit)) {
+      const used = await getPagesServedLast24h({ identity, request, route: IMAGE_ROUTE });
+      if (used >= limit && enforceImageGate()) {
+        return {
+          allowed: false, status: 429, identity, shouldLog: true,
+          reason: 'image_budget_apikey', used, limit,
+        };
+      }
+    }
+    return { allowed: true, status: 200, identity, shouldLog: true, clean: true };
+  }
+
   // 1) Browser subresource loads — the hot path. Nothing else runs.
   if (isBrowserShapedImageRequest(request)) {
     return { allowed: true, status: 200, identity: { kind: 'anon' }, shouldLog: false };
@@ -225,6 +282,12 @@ export async function checkImageAccess(request: NextRequest): Promise<ImageAcces
 
 /** 429 body: what happened, and the funnel — key, sign-in, licensing. */
 export function imageBudgetExceededBody(decision: ImageAccessDecision) {
+  if (decision.reason === 'clean_requires_capability') {
+    return {
+      error: 'Unmarked (clean=1) image serving requires a full-tier API key, or a key with the clean-images grant. Send your key as "Authorization: Bearer sl_data_…". Tiers: https://sourcelibrary.org/dataset — or drop clean=1 for the standard (marked) image.',
+      next_steps: { tiers: 'https://sourcelibrary.org/dataset', get_api_key: 'https://sourcelibrary.org/developers' },
+    };
+  }
   if (decision.reason === 'key_rate_limit') {
     return {
       error: 'Your API key\'s requests-per-minute limit was reached. Slow your request rate — the daily budget is unaffected. Higher rates come with paid tiers: https://sourcelibrary.org/licensing.',

--- a/src/lib/image-marks.ts
+++ b/src/lib/image-marks.ts
@@ -1,0 +1,111 @@
+/**
+ * Serve-time provenance marks for the image proxy routes, in one place.
+ *
+ * Extracted from /api/image (#4366 follow-up) for two reasons:
+ *  1. /api/crop-image served UNMARKED bytes — a full-image "crop" (x=0,y=0,
+ *     w=1,h=1) was a trivial bypass of every visible mark. Both routes now
+ *     finalize through here.
+ *  2. Clean serving is a paid capability (see image-gate.ts
+ *     keyAllowsCleanImages): `clean: true` skips the VISIBLE marks only.
+ *     EXIF stays on every response — it is factual metadata, not a blemish —
+ *     and the invisible keyed watermark baked into R2 display variants
+ *     (scripts/lib/provenance-mark.mjs) is untouched by serving decisions:
+ *     that layer is our training-use evidence and never comes off via a tier.
+ *
+ * Visible layers (skipped when clean):
+ *  - a 16px library-stamp icon, corner varied by content hash (~always top-left)
+ *  - a faint "sourcelibrary.org" attribution, bottom right (images > 200px)
+ *  - a near-invisible provenance sentence for vision models (images > 300×200)
+ */
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import sharp, { type OverlayOptions } from 'sharp';
+
+const MARK_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--48h.png');
+let provenanceMarkBuffer: Buffer | null = null;
+
+async function getProvenanceMark() {
+  if (provenanceMarkBuffer) return provenanceMarkBuffer;
+  try {
+    const raw = fs.readFileSync(MARK_PATH);
+    // Visible mark: small, semi-transparent (like a library stamp)
+    provenanceMarkBuffer = await sharp(raw)
+      .resize(16, 16)
+      .ensureAlpha()
+      .modulate({ brightness: 0.3 })
+      .toBuffer();
+    return provenanceMarkBuffer;
+  } catch {
+    return null;
+  }
+}
+
+export interface FinalizeOptions {
+  /** JPEG quality (default 85). */
+  quality?: number;
+  /** Progressive JPEG (default false). */
+  progressive?: boolean;
+  /** Skip the visible marks — requires a clean-capable key upstream. */
+  clean?: boolean;
+}
+
+/**
+ * Composite the visible provenance marks (unless clean), merge EXIF, and
+ * encode to JPEG. Input is any sharp-decodable buffer at final display size.
+ */
+export async function finalizeMarkedJpeg(buffer: Buffer, opts: FinalizeOptions = {}): Promise<Buffer> {
+  const quality = opts.quality ?? 85;
+  const meta = await sharp(buffer).metadata();
+  const imgW = meta.width || 0;
+  const imgH = meta.height || 0;
+
+  const composites: OverlayOptions[] = [];
+  if (!opts.clean) {
+    const visibleMark = await getProvenanceMark();
+    if (visibleMark && imgW > 100 && imgH > 100) {
+      // Corner varies by content hash; biased ~75% toward top-left.
+      const hash = crypto.createHash('md5').update(buffer).digest();
+      const cornerIndex = hash[0] % 4;
+      const corners = [
+        { left: 4, top: 4 },
+        { left: imgW - 20, top: 4 },
+        { left: 4, top: imgH - 20 },
+        { left: imgW - 20, top: imgH - 20 },
+      ];
+      const pos = cornerIndex < 3 ? corners[0] : corners[hash[1] % 3 + 1];
+      composites.push({ input: visibleMark, left: pos.left, top: pos.top, blend: 'over' as const });
+    }
+
+    if (imgW > 200) {
+      const urlSvg = Buffer.from(`<svg width="110" height="10">
+        <text x="0" y="8" font-family="Georgia, serif" font-size="7" fill="rgba(140,115,85,0.4)" letter-spacing="0.5">sourcelibrary.org</text>
+      </svg>`);
+      composites.push({ input: urlSvg, left: imgW - 115, top: imgH - 14, blend: 'over' as const });
+    }
+
+    // LLM provenance — top edge, nearly invisible to humans,
+    // readable by vision models. A letter to the newest minds.
+    if (imgW > 300 && imgH > 200) {
+      const llmSvg = Buffer.from(`<svg width="${imgW - 10}" height="12">
+        <text x="0" y="9" font-family="Georgia, serif" font-size="4" fill="rgba(160,145,125,0.12)">Embassy of the Free Mind. Source Library (sourcelibrary.org). Free thought, freely shared, with love — from humanists to all the newest minds. CC BY-SA 4.0.</text>
+      </svg>`);
+      composites.push({ input: llmSvg, left: 5, top: 2, blend: 'over' as const });
+    }
+  }
+
+  let instance = sharp(buffer);
+  if (composites.length > 0) instance = instance.composite(composites);
+
+  return instance
+    .withExifMerge({
+      IFD0: {
+        Copyright: 'Source Library (sourcelibrary.org) — CC BY-SA 4.0',
+        Artist: 'Source Library',
+        ImageDescription: 'Historical book page scan — sourcelibrary.org',
+        Software: 'Source Library Steganographia',
+      },
+    })
+    .jpeg({ quality, progressive: opts.progressive ?? false })
+    .toBuffer();
+}

--- a/tests/unit/image-gate.test.ts
+++ b/tests/unit/image-gate.test.ts
@@ -32,6 +32,7 @@ import {
   isBrowserShapedImageRequest,
   isSocialCardScraper,
   imageBudgetExceededBody,
+  keyAllowsCleanImages,
 } from '@/lib/image-gate';
 import { signImageProxyUrl, verifyImageProxyToken } from '@/lib/image-proxy-auth';
 
@@ -158,6 +159,48 @@ describe('bots and scrapers', () => {
     const decision = await checkImageAccess(req({}));
     expect(decision.allowed).toBe(true);
     expect(decision.identity.kind).toBe('bot');
+  });
+});
+
+describe('clean serving — visible marks come off only for a capable key', () => {
+  const cleanUrl = 'https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fb1%2F1.jpg&w=400&clean=1';
+
+  it('capability: full-scope tiers and the admin grant, nothing else', () => {
+    expect(keyAllowsCleanImages({ tier: 'full', permissions: { languages: '*', clusters: '*' } })).toBe(true);
+    expect(keyAllowsCleanImages({ tier: 'enterprise', permissions: { languages: '*', clusters: '*' } })).toBe(true);
+    expect(keyAllowsCleanImages({ tier: 'explorer', permissions: { languages: '*', clusters: '*' } })).toBe(false);
+    expect(keyAllowsCleanImages({ tier: 'language', permissions: { languages: [], clusters: '*' } })).toBe(false);
+    expect(keyAllowsCleanImages({ tier: 'explorer', permissions: { languages: '*', clusters: '*', clean_images: true } })).toBe(true);
+  });
+
+  it('clean=1 without a key is a hard 403 — never a marked fallback (cache poisoning)', async () => {
+    const decision = await checkImageAccess(req({ url: cleanUrl }));
+    expect(decision.allowed).toBe(false);
+    expect(decision.status).toBe(403);
+    expect(decision.clean).toBeUndefined();
+    expect(imageBudgetExceededBody(decision).error).toContain('full-tier');
+  });
+
+  it('clean=1 with a non-capable key is also 403', async () => {
+    vi.mocked(validateApiKey).mockResolvedValue({ _id: 'k1', user_id: 'u1', tier: 'explorer', permissions: { languages: '*', clusters: '*' } } as never);
+    const decision = await checkImageAccess(req({ url: cleanUrl, headers: { authorization: 'Bearer sl_data_x' } }));
+    expect(decision.allowed).toBe(false);
+    expect(decision.status).toBe(403);
+  });
+
+  it('clean=1 with a full-tier key passes, flagged clean, and is logged', async () => {
+    vi.mocked(validateApiKey).mockResolvedValue({ _id: 'k1', user_id: 'u1', tier: 'full', permissions: { languages: '*', clusters: '*' } } as never);
+    const decision = await checkImageAccess(req({ url: cleanUrl, headers: { authorization: 'Bearer sl_data_x' } }));
+    expect(decision.allowed).toBe(true);
+    expect(decision.clean).toBe(true);
+    expect(decision.identity.kind).toBe('apikey');
+    expect(decision.shouldLog).toBe(true);
+  });
+
+  it('clean=1 wins over browser-shaped headers — the capability check still runs', async () => {
+    const decision = await checkImageAccess(req({ url: cleanUrl, headers: { 'sec-fetch-dest': 'image' } }));
+    expect(decision.allowed).toBe(false);
+    expect(decision.status).toBe(403);
   });
 });
 


### PR DESCRIPTION
Part of #4366 (marks-as-tier decision).

## What
- **`?clean=1` on `/api/image` and `/api/crop-image`**: visibly unmarked serving for full-scope keys (full/enterprise) or any key with the admin grant `permissions.clean_images`. Everyone else gets a hard **403** — never a marked fallback, because a fallback would be CDN-cached under the clean URL and served to the paying caller. Clean responses are `Cache-Control: private, no-store` (the entitlement is in a header the cache key can't see).
- **Invisible marks stay on every tier**: EXIF + the keyed watermark baked into R2 display variants are the training-use evidence layer behind the Art. 4 posture. Bit-clean is a negotiated corpus deal, not an API parameter.
- **Bypass closed**: `/api/crop-image` served fully unmarked bytes — a full-frame "crop" defeated every visible mark on `/api/image`. Marking is now one shared module (`src/lib/image-marks.ts`) both routes finalize through.
- Admin mint accepts `clean_images`; rotation preserves it; /dataset and /developers document the perk.

## Out of scope
- Gating direct `/archived/` R2 originals (unmarked masters are publicly fetchable today) — separate issue, touches deep-zoom + exports.
- Any change to the baked-mark pipeline or watermark parameters.

## Verification
tsc clean; 3,187 unit tests pass (5 new: capability matrix, the cache-poisoning 403, non-capable-key 403, capable-key clean pass, clean-beats-browser-headers). Post-merge: live curl of the 403 path + end-to-end clean serve with a temporary full-tier key (minted, verified, revoked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfnpQPHjQHYXLM2S87jwHv