### PR TITLE
training-pairs: streaming hashes + finalize-only recovery (#4320)

### DIFF
--- a/.claude/handoffs/2026-08-29-house-model-finetune.md
+++ b/.claude/handoffs/2026-08-29-house-model-finetune.md
@@ -1,0 +1,60 @@
+# House model fine-tune: dataset → tuned Greek translator → two prototypes (2026-08-28/29)
+
+Session arc: Derek asked "can we fine-tune a model on Plato?" → scoped (#4320, closed) →
+shipped end to end in one evening. Full state also in auto-memory
+(`project_house_model_finetune_state.md`).
+
+## Shipped (merged)
+- **#4322** `scripts/export/training-pairs.mjs` — page-aligned original→English pairs.
+  Greek: 255,108 pairs / 1,021 books. Latin: 1,431,745 / 5,822. Private, local
+  (`scripts/output/training-pairs-*`), never public R2. Per-page `<language>` tag gates
+  membership (parsed as a LIST — mixed bilingual pages get their own skip bucket);
+  flag-don't-drop (ratio outliers, MinHash near-dups); whole-book md5 train/val split.
+- **#4328** `to-vertex-sft.mjs` — Vertex SFT format under a token budget, round-robin
+  across books so the cap buys diversity.
+- **#4331** eval + gloss demo server. **#4333** demo reworked into the real experience
+  ("touch the Greek") after Derek's review — v1 was an engineering harness.
+
+## Open PRs (green, awaiting Derek per review-gate rule adopted 2026-08-29)
+- **#4335** Plato dialogue prototype (`scripts/eval/plato-dialogue-server.mjs`).
+- **#4374** training-pairs streaming-hash fix + `--finalize-only` (the Latin build died
+  at a >2 GiB `readFileSync` sha256 — the corpus snapshot's `sha256Stream` lesson,
+  half-reused; recovery already run, Latin manifest verify green).
+
+## Live artifacts
+- **Tuned model** `sl-greek-translator-v1`: Vertex SFT of gemini-2.5-flash-lite,
+  15,332 pairs, 1 epoch, **$42.38** (28,256,133 billable tokens @ $1.50/M — price from
+  the Cloud Billing SKU catalog REST API; CLI lacks the subcommand). Endpoint
+  `projects/877864597985/locations/us-central1/endpoints/6705829608584904704`.
+  Serverless — no idle cost.
+- **Eval**: held-out chrF 0.5624 vs base 0.5023, tuned wins 158/200. **CIRCULAR** —
+  reference is our own pipeline output; measures house-style resemblance, not quality.
+  Do not quote the 79% as quality. Next instrument: score tuned vs base vs pipeline
+  against PD human translations (Jowett etc.) — a few hours, unblocks the production
+  decision.
+- **Demos (local, detached, still running)**: gloss "touch the Greek" at :7788
+  (real pages, selection→popover); Plato dialogue at :7789 (gemini-3-flash-preview +
+  BM25 over 21,630 Platonist leaves, own-vs-successor distinction, leaves-consulted
+  links). Corpus files regenerate via each server's `--prepare`.
+- **3.1 probe**: `gemini-3.1-flash-lite` IS tunable (undocumented; SKU $3/M). Probe job
+  `807722278514065408` SUCCEEDED ($0.55). Its endpoint (multi-region `locations/us`)
+  404'd on serving immediately after — likely propagation; recheck before v2.
+
+## Decisions Derek owns
+1. **v2 tune on gemini-3.1-flash-lite** (the pipeline's own model), same 15K pairs,
+   ≈ $85 — ideally after the independent eval exists.
+2. Whether the tuned model enters the production Greek translation phase (blind
+   spot-read of wins AND the 42 losses first; RECITATION lesson applies to canonical
+   texts).
+3. Reader gloss UI — **#4332** carries the full spec + traps (service-account auth,
+   exact training prompt strings, 15s cold start, strip apparatus from MODEL OUTPUT —
+   the tuned model emits `<note>` because the training pairs carry it).
+
+## Lessons (where they went)
+- Model absorbing transcription apparatus → #4332 + memory. Serving layers clean model
+  output, not just input.
+- Circular eval → memory + this handoff; candidate one-liner for
+  `measurement-instruments.md` if it recurs.
+- 2 GiB hash crash → fixed in code (both export scripts now stream); no new doc.
+- Gemini spend surfaces: Vertex (tuning, GCP project) vs AI Studio key (pipeline
+  workers) — bill separately; `gemini_usage.cost_usd` untrustworthy (existing memory).

--- a/scripts/export/training-pairs.mjs
+++ b/scripts/export/training-pairs.mjs
@@ -162,6 +162,16 @@ function gzWriter(p) {
   };
 }
 
+// Streaming hash — pairs files exceed Node's 2 GiB readFileSync cap (the
+// Latin build crashed at exactly this step; same lesson as the corpus
+// snapshot's sha256Stream).
+function sha256Stream(p) {
+  return new Promise((resolve, reject) => {
+    const h = crypto.createHash('sha256');
+    fs.createReadStream(p).on('data', (d) => h.update(d)).on('end', () => resolve(h.digest('hex'))).on('error', reject);
+  });
+}
+
 async function* gzLines(p) {
   const rl = readline.createInterface({
     input: fs.createReadStream(p).pipe(zlib.createGunzip()),
@@ -307,10 +317,10 @@ async function build() {
       near_duplicate: `MinHash-${SIG_N} 5-gram signature matches an earlier page at >=${NEAR_DUP_MIN}/${SIG_N} (multiple copies of one edition); near_dup_of names the kept page`,
     },
     split_rule: `md5(book_id) % 100 < ${VAL_PCT} → val (whole books, deterministic)`,
-    files: [path.basename(pairsPath), ...(CHAT ? [`chat-${LANG}.jsonl.gz`] : [])].map((f) => {
+    files: await Promise.all([path.basename(pairsPath), ...(CHAT ? [`chat-${LANG}.jsonl.gz`] : [])].map(async (f) => {
       const p = path.join(DIR, f);
-      return { file: f, bytes: fs.statSync(p).size, sha256: crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex') };
-    }),
+      return { file: f, bytes: fs.statSync(p).size, sha256: await sha256Stream(p) };
+    })),
   };
   fs.writeFileSync(path.join(DIR, 'manifest.json'), JSON.stringify(manifest, null, 2));
   console.log(`[build] done: ${nPairs.toLocaleString()} pairs from ${workList.length.toLocaleString()} books ` +
@@ -361,4 +371,44 @@ async function verify(db, manifest, pairsPath) {
   }
 }
 
-build().catch((err) => { console.error(err); process.exit(1); });
+// Rebuild manifest + verify from an existing --dir, streaming the actual
+// shard bytes — recovery path for a build that died in finalization (the
+// 2 GiB readFileSync crash). Per-page skip counts are lost with the build's
+// memory; the manifest says so instead of pretending.
+async function finalizeOnly() {
+  const pairsPath = path.join(DIR, `pairs-${LANG}.jsonl.gz`);
+  if (!fs.existsSync(pairsPath)) { console.error(`[finalize] ${pairsPath} missing`); process.exit(1); }
+  const { client, db } = await getScriptClient({ noTimeout: true });
+  const books = new Set();
+  const perSplit = { train: 0, val: 0 };
+  const flagCounts = {};
+  let nPairs = 0, nSrcChars = 0, nTrChars = 0;
+  for await (const line of gzLines(pairsPath)) {
+    const r = JSON.parse(line);
+    nPairs++; books.add(r.book_id); perSplit[r.split]++;
+    nSrcChars += r.source_text.length; nTrChars += r.translation_en.length;
+    for (const f of r.flags || []) flagCounts[f] = (flagCounts[f] || 0) + 1;
+    if (nPairs % 250000 === 0) console.log(`[finalize] ${nPairs.toLocaleString()} pairs…`);
+  }
+  const chatPath = path.join(DIR, `chat-${LANG}.jsonl.gz`);
+  const manifest = {
+    dataset: `Source Library training pairs (${LANG} → English)`,
+    issue: 'https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/4320',
+    created: new Date().toISOString(),
+    recovered: 'manifest rebuilt from shard bytes after a finalization crash; per-page skip counts were lost with the build process and are NOT included',
+    distribution: 'PRIVATE — local/Hetzner only, never the public R2 bucket',
+    eligibility: { lang: LANG, text_role: 'original', max_year: MAX_YEAR, page_gate: 'per-page <language> tag, never books.language' },
+    counts: { books: books.size, pairs: nPairs, split: perSplit, source_chars: nSrcChars, translation_chars: nTrChars },
+    flagged: flagCounts,
+    split_rule: `md5(book_id) % 100 < ${VAL_PCT} → val (whole books, deterministic)`,
+    files: await Promise.all([pairsPath, ...(fs.existsSync(chatPath) ? [chatPath] : [])].map(async (p) => (
+      { file: path.basename(p), bytes: fs.statSync(p).size, sha256: await sha256Stream(p) }
+    ))),
+  };
+  fs.writeFileSync(path.join(DIR, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  console.log(`[finalize] ${nPairs.toLocaleString()} pairs, ${books.size} books (train ${perSplit.train.toLocaleString()} / val ${perSplit.val.toLocaleString()})`);
+  if (!SKIP_VERIFY) await verify(db, manifest, pairsPath);
+  await client.close();
+}
+
+(has('--finalize-only') ? finalizeOnly() : build()).catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
The Latin export crashed in finalization (readFileSync sha256 > 2 GiB — the corpus snapshot solved this with sha256Stream; this script had reused the pattern only halfway). Fix: streaming hashes, plus a --finalize-only mode that rebuilds manifest + verify from the shard bytes. Already used to recover the Latin dataset: 1,431,745 pairs / 5,822 books, verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4cQrTRsykUTLYYZEcxu48