### PR TITLE
fix(citation): refuse null-holder tokens — 'Copy: unknown library' asserts nothing

### DIFF
--- a/scripts/audit/holding-library-coverage.mjs
+++ b/scripts/audit/holding-library-coverage.mjs
@@ -18,6 +18,8 @@ const AGGREGATOR_VALUES = [
   'hathitrust', 'project gutenberg', 'wikimedia commons', 'wikisource',
   'e-rara (swiss electronic library)', 'e-rara',
   'iiif source',
+  // Null-holder tokens IA metadata itself serves — suppressed read-side.
+  'unknown library', 'unknown',
 ];
 
 const client = await MongoClient.connect(process.env.MONGODB_URI);

--- a/scripts/backfill-contributing-library.mjs
+++ b/scripts/backfill-contributing-library.mjs
@@ -33,6 +33,12 @@ const SWEEP = 'holding-library-4361';
 // Sponsors that fund scanning but hold nothing — never a contributing_library.
 const JUNK_SPONSOR = /google|msn|microsoft|sloan foundation|internet archive/i;
 
+// Null-holder tokens IA itself serves ("unknown library" on many Google
+// scans). Writing one asserts a holder that isn't known; 18 slipped through
+// phase 4's first run before this guard (read side suppresses them too —
+// src/lib/holding-library.ts).
+const NULL_HOLDER = /^(unknown( library)?|n\/?a|none|-)$/i;
+
 // Aggregator values that should never stand as a holding library. Mirror of
 // the read-side list in src/lib/holding-library.ts (AGGREGATORS) — the
 // citation layer filters these on read; this sweep replaces them at the rows.
@@ -143,7 +149,7 @@ async function phase2(db) {
         // funder (Google, MSN, Sloan) is not a holder (#4361).
         const sponsor = typeof meta?.sponsor === 'string' && !JUNK_SPONSOR.test(meta.sponsor) ? meta.sponsor : null;
         const contributor = meta?.contributor || sponsor;
-        if (!contributor || typeof contributor !== 'string') { failed++; return; }
+        if (!contributor || typeof contributor !== 'string' || NULL_HOLDER.test(contributor.trim())) { failed++; return; }
 
         // IA's call_number is that holder's shelfmark for the copy — the other
         // half of the citation copy clause (#4360/#4361).
@@ -353,7 +359,7 @@ async function phase4(db) {
 
         // The item itself names no holder: leave the aggregator value (the
         // read-side citation layer suppresses it) and checkpoint the verdict.
-        if (!contributor || AGGREGATOR_VALUES.some(a => a.toLowerCase() === contributor.toLowerCase())) {
+        if (!contributor || NULL_HOLDER.test(contributor) || AGGREGATOR_VALUES.some(a => a.toLowerCase() === contributor.toLowerCase())) {
           noContributor++;
           if (!DRY_RUN) {
             await recordSweepAction(db, {

--- a/src/lib/holding-library.ts
+++ b/src/lib/holding-library.ts
@@ -41,6 +41,12 @@ const AGGREGATORS = new Set([
   'e-rara',
   // Importer placeholder, not an institution (797 live books, measured 2026-08-29).
   'iiif source',
+  // Null-holder tokens: IA's own metadata says "unknown library" for many
+  // Google-scanned items, and old backfills wrote it verbatim (641 books,
+  // 156 live, measured 2026-08-29). "Copy: unknown library" asserts nothing —
+  // the honest citation omits the clause.
+  'unknown library',
+  'unknown',
 ]);
 
 /**

--- a/tests/unit/citation-copy-clause.test.ts
+++ b/tests/unit/citation-copy-clause.test.ts
@@ -53,6 +53,14 @@ describe('copyClause — who actually holds the book', () => {
     expect(copyClause('', 'PH441')).toBeNull();
   });
 
+  it('refuses null-holder tokens — "Copy: unknown library" asserts nothing', () => {
+    // IA metadata itself says "unknown library" on many Google scans, and old
+    // backfills wrote it verbatim (641 books measured 2026-08-29).
+    for (const tok of ['unknown library', 'Unknown', 'IIIF Source']) {
+      expect(copyClause(tok, 'shelf-1')).toBeNull();
+    }
+  });
+
   it('passes an unmapped institution through as-is', () => {
     expect(copyClause('John Rylands Library, University of Manchester')?.statement)
       .toBe('Copy: John Rylands Library, University of Manchester');


### PR DESCRIPTION
Found while auditing the #4361 provenance ledger: IA's own metadata says **"unknown library"** for many Google-scanned items. Old backfills wrote it verbatim (641 books, 156 live), phase 4's first run added 18 more — and the new copy clause was emitting **"Copy: unknown library"** on those books, exactly what #4360 promised never to do.

- **Read side**: 'unknown library'/'unknown' join the denylist in `src/lib/holding-library.ts` — clause omitted, like aggregators.
- **Sweep**: `NULL_HOLDER` guard in phases 2 & 4 so it is never written again.
- **Audit**: `holding-library-coverage.mjs` counts them as non-holders.
- **Stored values untouched** — they're what IA said, and the sweep_log rows record who wrote them when. Suppress on read; don't rewrite history.

Tests: new denylist case in `citation-copy-clause.test.ts` (12 pass), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG2ZHxfHYV6ZHoYuFwSwLw