### PR TITLE
Reader on touch: let the scan scroll, keep your pane on a turn, swipe on tablets

### DIFF
--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2572,7 +2572,23 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
       swipeRef.current = null;
       return;
     }
-    swipeRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, axis: null };
+    const x = e.touches[0].clientX;
+    const y = e.touches[0].clientY;
+    // A finger that lands in live selected text is working the selection, not
+    // turning a page — dragging a handle sideways across the 45px floor used
+    // to throw the selection away and jump to the next page. The pad covers
+    // the handles, which sit a little outside the text they belong to.
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed && selection.rangeCount > 0) {
+      const PAD = 24;
+      for (const rect of Array.from(selection.getRangeAt(0).getClientRects())) {
+        if (x >= rect.left - PAD && x <= rect.right + PAD && y >= rect.top - PAD && y <= rect.bottom + PAD) {
+          swipeRef.current = null;
+          return;
+        }
+      }
+    }
+    swipeRef.current = { x, y, axis: null };
   };
   const onTouchMove = (e: React.TouchEvent) => {
     const s = swipeRef.current;

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2413,16 +2413,72 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     }
   }, []);
 
-  // Mobile: one scroller for the stacked panes. Reset it on a page turn so a
-  // new page always starts at the top, and drive paging from a horizontal swipe.
+  // Mobile: one scroller for the stacked panes, and paging driven from a
+  // horizontal swipe.
   const mobileMainRef = useRef<HTMLElement>(null);
+
+  /**
+   * Which stacked pane you were reading when the page turned. Resetting the
+   * column to the top on every turn meant a swipe taken halfway down a
+   * translation landed you back on the next page's scan, so reading a
+   * translation across a page break cost a scroll past the facsimile every
+   * time. Turning a page from inside a pane now keeps you in that pane.
+   */
+  const mobileAnchor = useRef<string | null>(null);
+  // Restoring the anchor scrolls the column, and that scroll must not be read
+  // back as a reading move — on a short page the restore clamps at the foot,
+  // which would re-read the anchor as the scan and lose the pane on the next
+  // turn. Same idea as the zoom guard on the scan sync above.
+  const anchorLock = useRef(0);
+
+  const readMobileAnchor = useCallback(() => {
+    const el = mobileMainRef.current;
+    if (!el) return null;
+    if (el.scrollTop < 24) return null;
+    const probe = el.getBoundingClientRect().top + 8;
+    for (const section of el.querySelectorAll<HTMLElement>('[data-reader-section]')) {
+      const rect = section.getBoundingClientRect();
+      if (rect.top <= probe && rect.bottom > probe) return section.dataset.readerSection ?? null;
+    }
+    return null;
+  }, []);
 
   useEffect(() => {
     ocrRef.current?.scrollTo({ top: 0 });
     enRef.current?.scrollTo({ top: 0 });
-    mobileMainRef.current?.scrollTo({ top: 0 });
     setBarHidden(false);
   }, [r.currentPageId]);
+
+  // Keyed on the page that is actually RENDERED, not the one being navigated
+  // to: an uncached turn changes the id first and the content a fetch later,
+  // and anchoring against the outgoing page's layout puts you nowhere.
+  useLayoutEffect(() => {
+    const el = mobileMainRef.current;
+    if (!el) return;
+    // Read once: the two passes below must place the SAME pane.
+    const anchor = mobileAnchor.current;
+    anchorLock.current = Date.now() + 250;
+    const place = () => {
+      // No anchor, or the new page hasn't got that pane (plenty have no
+      // translation): start at the top, as before.
+      const target = anchor
+        ? el.querySelector<HTMLElement>(`[data-reader-section="${anchor}"]`)
+        : null;
+      if (target) {
+        const delta = target.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        el.scrollTop = Math.max(0, el.scrollTop + delta);
+      } else {
+        el.scrollTop = 0;
+      }
+      lastScrollY.current = el.scrollTop;
+    };
+    place();
+    // The title bar comes back on a turn and the new text settles a beat
+    // later; both change how far the column can scroll, so a position taken
+    // in this pass alone lands short of where it was asked to go.
+    const raf = requestAnimationFrame(place);
+    return () => cancelAnimationFrame(raf);
+  }, [r.currentPage.id]);
 
   /**
    * How much of the viewport the on-screen keyboard is covering. The layout
@@ -2499,7 +2555,8 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     else if (delta > 6) setBarHidden(true);
     else if (delta < -6) setBarHidden(false);
     lastScrollY.current = y;
-  }, []);
+    if (Date.now() > anchorLock.current) mobileAnchor.current = readMobileAnchor();
+  }, [readMobileAnchor]);
 
   // Swipe to page: axis-locked so a vertical read never turns a page, and a
   // horizontal drag has to clear both a distance floor and a vertical bias.

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2560,9 +2560,18 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
 
   // Swipe to page: axis-locked so a vertical read never turns a page, and a
   // horizontal drag has to clear both a distance floor and a vertical bias.
+  // Carried by both layouts — a tablet in landscape gets the desktop grid, and
+  // for a while that meant a touch device with no gesture at all.
   const swipeRef = useRef<{ x: number; y: number; axis: null | 'x' | 'y' } | null>(null);
   const onTouchStart = (e: React.TouchEvent) => {
     if (e.touches.length !== 1) { swipeRef.current = null; return; }
+    // Anything with its own use for a horizontal drag opts out by marking
+    // itself: a zoomed scan is being panned, and a slide-out panel is not the
+    // page you are reading.
+    if ((e.target as HTMLElement | null)?.closest('[data-no-page-swipe]')) {
+      swipeRef.current = null;
+      return;
+    }
     swipeRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, axis: null };
   };
   const onTouchMove = (e: React.TouchEvent) => {
@@ -3029,6 +3038,9 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
           key={browserTranslated ? `translated-${r.currentPageId}` : undefined}
           data-reader-panels-container
           className="relative flex min-h-0"
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
         >
           {r.views.scan && (
             <section
@@ -3053,7 +3065,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
                   and its inline viewer against the nearest positioned parent:
                   the tiled canvas fills this box, over the scan, while the
                   translation stays readable beside it. */}
-              <div className={`relative flex-1 min-h-0 overflow-hidden ${scanZoom > 1 ? '' : 'px-6 py-[22px]'}`}>
+              <div
+                className={`relative flex-1 min-h-0 overflow-hidden ${scanZoom > 1 ? '' : 'px-6 py-[22px]'}`}
+                data-no-page-swipe={scanZoom > 1 || lensOn ? '' : undefined}
+              >
                 <ScanViewer
                   page={r.currentPage}
                   book={r.book}
@@ -3224,6 +3239,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
             <div
               role="dialog"
               aria-labelledby="rv2-panel-title"
+              data-no-page-swipe=""
               className="absolute top-0 left-0 bottom-0 border-r z-40 flex flex-col rv2-slide-in-left"
               style={{
                 width: leftPanelWidth,
@@ -3380,9 +3396,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
               <div
                 className="relative px-4 py-4"
                 style={{ height: 'min(66dvh, 520px)' }}
-                onTouchStart={e => { if (scanZoom > 1 || lensOn) e.stopPropagation(); }}
-                onTouchMove={e => { if (scanZoom > 1 || lensOn) e.stopPropagation(); }}
-                onTouchEnd={e => { if (scanZoom > 1 || lensOn) e.stopPropagation(); }}
+                data-no-page-swipe={scanZoom > 1 || lensOn ? '' : undefined}
               >
                 <ScanViewer
                   page={r.currentPage} book={r.book} zoom={scanZoom} onZoomChange={changeZoom} lensOn={lensOn}

--- a/src/components/reader-v2/ReaderV2Bits.tsx
+++ b/src/components/reader-v2/ReaderV2Bits.tsx
@@ -586,7 +586,12 @@ export function ScanViewer({
         // Capture touch only while the scan is interactive, so a drag over a
         // fitted page still scrolls the mobile column and swipes pages.
         touchAction: zoomed || lensOn ? 'none' : 'auto',
-        overscrollBehavior: 'contain',
+        // Only while it can actually be panned. `overflow: hidden` still makes
+        // this a scroll container, so containing the overscroll on a fitted
+        // page swallowed every vertical drag over the scan instead of passing
+        // it up to the mobile column — and the scan is most of a phone screen,
+        // so the page read as unscrollable until you found the text below it.
+        overscrollBehavior: zoomed ? 'contain' : 'auto',
       }}
       onWheel={onWheel}
       onPointerDown={onPointerDown}


### PR DESCRIPTION
Three things about the v2c reader on touch devices.

## The scan swallowed every scroll

A vertical drag anywhere on the facsimile did nothing. The scan viewer sets `overscroll-behavior: contain`, and an `overflow: hidden` element is still a scroll container, so the gesture was contained in a box that cannot scroll instead of chaining up to the page column. The scan is `min(66dvh, 520px)`, which is the whole first screenful on a phone, so a page opened effectively unscrollable until you found the strip of text below it.

Contained only while zoomed now, which is the case it was there for. Measured on a Pixel 5 emulation: a drag over the scan gave scrollTop 0 to 0; it now gives 0 to 604 to 1127. Panning a zoomed scan still does not drag the column behind it.

## A page turn threw away where you were reading

The column reset to the top on every turn, so a swipe taken halfway down a translation landed you on the next page's scan and you scrolled past the facsimile again to carry on. The pane you were in is now remembered and restored after the turn.

Keyed on the page that actually rendered rather than the one being navigated to: an uncached turn changes the id first and the content a fetch later, so anchoring against the outgoing page's layout puts you nowhere. A short page clamps at the foot of the column, and the restore is guarded so that clamp is not read back as "you were looking at the scan" and lost for the next turn. No anchor, or a page that hasn't got that pane, still starts at the top.

## No swipe at all on a tablet

A tablet in landscape is over 1024px, so it got the side-by-side panes, and the touch handlers only existed on the mobile column. The same axis-locked handlers now sit on the desktop panes container.

Anything with its own use for a horizontal drag opts out by marking itself `data-no-page-swipe`: a zoomed or lensed scan, which is being panned, and the slide-out Contents/Search/Settings panel, which lives inside that container but is not the page you are reading. That marker also replaces the three stopPropagation handlers the mobile scan was carrying for the same purpose.

## Checks

`tsc --noEmit`, `eslint`, and `vitest run` (3188 tests) all pass.

Verified against a local build in emulation.

Phone (Pixel 5):
- a drag over the scan scrolls the column
- a swipe from a translation lands in the translation on the next page, and holds across repeated turns
- a turn taken from the top of the page still starts at the top
- panning a zoomed scan does not turn the page

Tablet (1280x800, touch):
- a horizontal swipe on a pane turns the page, and the reverse swipe goes back
- a vertical drag scrolls the pane and does not turn the page
- a swipe inside the open Contents panel does not turn the page
- panning a zoomed scan does not turn the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eHbLV1PYU8qo9f5T4RZKA