### PR TITLE
Pager and Contents land at the top of the reader; only a swipe holds your pane

### DIFF
--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2425,6 +2425,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
    * time. Turning a page from inside a pane now keeps you in that pane.
    */
   const mobileAnchor = useRef<string | null>(null);
+  // A swipe is "carry on reading" and keeps your pane. Every other way of
+  // changing page — the pager, the filmstrip, Contents, a typed page number —
+  // is a deliberate move, and lands at the top of the reader.
+  const keepPaneOnTurn = useRef(false);
   // Restoring the anchor scrolls the column, and that scroll must not be read
   // back as a reading move — on a short page the restore clamps at the foot,
   // which would re-read the anchor as the scan and lose the pane on the next
@@ -2456,7 +2460,8 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     const el = mobileMainRef.current;
     if (!el) return;
     // Read once: the two passes below must place the SAME pane.
-    const anchor = mobileAnchor.current;
+    const anchor = keepPaneOnTurn.current ? mobileAnchor.current : null;
+    keepPaneOnTurn.current = false;
     anchorLock.current = Date.now() + 250;
     const place = () => {
       // No anchor, or the new page hasn't got that pane (plenty have no
@@ -2606,7 +2611,15 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     const t = e.changedTouches[0];
     const dx = t.clientX - s.x;
     if (Math.abs(dx) < 45) return;
-    if (dx < 0) r.goNext(); else r.goPrev();
+    if (dx < 0) {
+      if (!nextPage) return;
+      keepPaneOnTurn.current = true;
+      r.goNext();
+    } else {
+      if (!prevPage) return;
+      keepPaneOnTurn.current = true;
+      r.goPrev();
+    }
   };
 
   // Filmstrip: keep the current page centred


### PR DESCRIPTION
Follow-up to #4380. Keeping the pane on every page change was too broad.

Tapping Next or Previous is a deliberate move to another page, and it should start that page from the top — the way opening a page from Contents or the filmstrip does. Restoring your old scroll position there read as the button misbehaving.

A swipe is the one turn that means "carry on reading", so it is now the only turn that restores the pane you were in. The flag is set only when the swipe can actually turn a page, so a swipe at either end of the book does not leave it set for the next button press.

## Checks

`tsc --noEmit`, `eslint`, and the device matrix against a local production build.

Pixel 5, specifically:
- Next from inside a translation: scrollTop 514 to 0
- Previous from inside a translation: 190 to 0
- a swipe from the same place: still lands in the translation
- a swipe past the first page: nothing moves, and the following Next still lands at 0

Full matrix (Pixel 7, Pixel 5, Galaxy S9+, Galaxy S5 at 320px, Galaxy Tab S4 landscape, Nexus 10, 1280x800 touch, 1024px): 92 checks pass. The one red mark is a React #418 hydration warning that also reproduces on live main, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eHbLV1PYU8qo9f5T4RZKA