### PR TITLE
Animate the page turn, and hold your pane on short pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -467,6 +467,21 @@ body:has([data-reader-v2]) {
    facsimile is worse than the abrupt swap it replaced. */
 .rv2-page-in { animation: rv2-page-in 200ms ease-out both; }
 
+/* The phone column swapped pages instantly, which on a swipe reads as a jolt
+   rather than as having moved. The new page arrives from the side you sent it,
+   far enough to say a page went by and no further. X only, for the same reason
+   the fade above is opacity only: a vertical rise moves text under the eye. */
+@keyframes rv2-turn-next {
+  from { opacity: 0; transform: translateX(14px); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes rv2-turn-prev {
+  from { opacity: 0; transform: translateX(-14px); }
+  to   { opacity: 1; transform: none; }
+}
+.rv2-turn-next { animation: rv2-turn-next 190ms ease-out both; }
+.rv2-turn-prev { animation: rv2-turn-prev 190ms ease-out both; }
+
 /* Panel contents arrive just after the panel itself, so switching tools reads
    as one movement instead of two things appearing at once. */
 @keyframes rv2-panel-body-in {
@@ -499,6 +514,7 @@ body:has([data-reader-v2]) {
 @media (prefers-reduced-motion: reduce) {
   .rv2-slide-in-left, .rv2-pop, .rv2-slide-up, .rv2-strip-in,
   .rv2-page-in, .rv2-panel-body-in, .rv2-tile-in,
+  .rv2-turn-next, .rv2-turn-prev,
   .rv2-menu-ground, .rv2-menu-item { animation: none; }
 }
 

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2442,13 +2442,19 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
   const readMobileAnchor = useCallback(() => {
     const el = mobileMainRef.current;
     if (!el) return null;
+    // You haven't moved: there is no pane to hold, and a turn starts at the top.
     if (el.scrollTop < 24) return null;
-    const probe = el.getBoundingClientRect().top + 8;
+    const box = el.getBoundingClientRect();
+    // The deepest pane you have brought up the screen — NOT the pane at the top
+    // edge. Plenty of pages are too short for the translation to ever reach the
+    // top, and reading one meant no anchor at all: the pane sat at the foot of
+    // the screen, which is exactly the case a turn used to throw away.
+    const reached = box.bottom - box.height * 0.25;
+    let anchor: string | null = null;
     for (const section of el.querySelectorAll<HTMLElement>('[data-reader-section]')) {
-      const rect = section.getBoundingClientRect();
-      if (rect.top <= probe && rect.bottom > probe) return section.dataset.readerSection ?? null;
+      if (section.getBoundingClientRect().top <= reached) anchor = section.dataset.readerSection ?? null;
     }
-    return null;
+    return anchor;
   }, []);
 
   useEffect(() => {

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -55,6 +55,12 @@ import type { CdliWitness } from '@/lib/types/book';
 // scrolls. Design handoff: design_handoff_reader_page/README.md § 2c.
 
 const INK = 'var(--bg-dark)';
+/** Height of the floating mobile title bar, and of the lead-in the column
+ *  keeps for it. One number: the bar covers the top of the column, so
+ *  anything that scrolls a pane to the top has to clear it. */
+const BAR_H = 52;
+/** How long a scroll up has to have been meant before the bar comes back. */
+const BAR_SHOW_DELAY_MS = 280;
 const STRIP_KEY = 'sl-reader-v2c-strip';
 /** Mobile toolbar height — one row of four tools. */
 const MOBILE_TOOLBAR_H = 52;
@@ -2480,7 +2486,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
         ? el.querySelector<HTMLElement>(`[data-reader-section="${anchor}"]`)
         : null;
       if (target) {
-        const delta = target.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        // Under the bar, not under the top edge of the column: the bar floats
+        // over the column and is always back on screen for a new page, so
+        // aligning to the edge would put the first line behind it.
+        const delta = target.getBoundingClientRect().top - el.getBoundingClientRect().top - BAR_H;
         el.scrollTop = Math.max(0, el.scrollTop + delta);
       } else {
         el.scrollTop = 0;
@@ -2586,6 +2595,28 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
    * changing direction starts the count again.
    */
   const barIntent = useRef(0);
+  /**
+   * The bar waits before coming back. Meeting the threshold mid-scroll and
+   * appearing on the spot put it on screen while the reader was still moving,
+   * which is what made it feel like it jumped out. Leaving is not delayed:
+   * getting out of the way should be immediate.
+   */
+  const barShowTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelBarShow = useCallback(() => {
+    if (barShowTimer.current !== null) {
+      clearTimeout(barShowTimer.current);
+      barShowTimer.current = null;
+    }
+  }, []);
+  const showBarSoon = useCallback(() => {
+    if (barShowTimer.current !== null) return; // already on its way
+    barShowTimer.current = setTimeout(() => {
+      barShowTimer.current = null;
+      setBarHidden(false);
+    }, BAR_SHOW_DELAY_MS);
+  }, []);
+  useEffect(() => cancelBarShow, [cancelBarShow]);
+
   const onMobileScroll = useCallback(() => {
     const el = mobileMainRef.current;
     if (!el) return;
@@ -2600,10 +2631,12 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     // reader wants the whole set of ways out — next, previous, or back to the
     // book — so the bar comes back with it rather than staying hidden.
     const atFoot = el.scrollHeight - (y + el.clientHeight) < 80;
-    if (y < 48 || atFoot) { setBarHidden(false); barIntent.current = 0; }
-    else if (barIntent.current > 16) setBarHidden(true);
-    else if (barIntent.current < -28) setBarHidden(false);
-  }, [readMobileAnchor]);
+    // The top of a page is where the bar lives: no wait there, it is the
+    // resting state rather than something arriving.
+    if (y < 48) { cancelBarShow(); setBarHidden(false); barIntent.current = 0; }
+    else if (barIntent.current > 16) { cancelBarShow(); setBarHidden(true); }
+    else if (barIntent.current < -28 || atFoot) showBarSoon();
+  }, [readMobileAnchor, cancelBarShow, showBarSoon]);
 
   // Swipe to page: axis-locked so a vertical read never turns a page, and a
   // horizontal drag has to clear both a distance floor and a vertical bias.
@@ -3371,25 +3404,29 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
       </div>
 
       {/* ── Mobile / tablet (<lg): stacked panes, filmstrip pinned ───────── */}
-      <div className="lg:hidden flex flex-col flex-1 min-h-0">
-        {/* Clipping is only needed while the bar is collapsing. Left on, it
-            cut off the account menu, which opens downward out of the header. */}
+      <div className="lg:hidden relative flex flex-col flex-1 min-h-0">
+        {/* The bar floats over the column rather than sitting above it in the
+            flow. It used to animate its own height, which resized the scroller
+            under the reader and shoved the text down the screen every time it
+            came back. The column carries a permanent lead-in of the same
+            height instead, so at the top of a page nothing looks different and
+            nothing ever moves. */}
         <header
-          className="shrink-0 relative z-[60]"
+          className="absolute top-0 left-0 right-0 z-[60]"
           style={{
+            height: BAR_H,
             background: INK,
             color: '#fdfcf9',
-            height: barHidden ? 0 : 52,
-            overflow: barHidden ? 'hidden' : 'visible',
-            // Same reason as the filmstrips: a 0-height bar still held a
-            // focusable back-link and menu button, and aria-hidden over them
-            // made that worse rather than better.
+            transform: barHidden ? 'translateY(-100%)' : 'none',
+            // Same reason as the filmstrips: a bar off the top of the screen
+            // still held a focusable back-link and menu button, and aria-hidden
+            // over them made that worse rather than better.
             visibility: barHidden ? 'hidden' : 'visible',
             // visibility is in the transition on purpose. It is a discrete
             // property, so transitioning it holds the old value for the whole
             // duration instead of applying at once — without that the contents
-            // were cut off the screen while the bar was still closing.
-            transition: `height ${BAR_MS}ms ${BAR_EASE}, visibility ${BAR_MS}ms ${BAR_EASE}`,
+            // were cut off the screen while the bar was still leaving.
+            transition: `transform ${BAR_MS}ms ${BAR_EASE}, visibility ${BAR_MS}ms ${BAR_EASE}`,
           }}
         >
           {/* The row fades with the bar rather than being revealed by it.
@@ -3462,6 +3499,9 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
           onTouchMove={onTouchMove}
           onTouchEnd={onTouchEnd}
         >
+          {/* The floating bar's share of the column. Fixed, so the reading
+              area never changes size and the text never shifts. */}
+          <div className="shrink-0" style={{ height: BAR_H }} aria-hidden="true" />
           {r.views.scan && (
             <section style={{ background: SURFACE.scanBed }}>
               <div className="h-[34px] flex items-center justify-between pl-4 pr-1 border-b" style={{ borderColor: 'var(--border-medium)' }}>

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2429,6 +2429,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
   // changing page — the pager, the filmstrip, Contents, a typed page number —
   // is a deliberate move, and lands at the top of the reader.
   const keepPaneOnTurn = useRef(false);
+  // Which way the last turn went, so the new page can arrive from that side.
+  // Taken from the index rather than from the swipe, so the pager, the
+  // filmstrip and a jump all animate the same way a swipe does.
+  const lastIndex = useRef(r.currentIndex);
   // Restoring the anchor scrolls the column, and that scroll must not be read
   // back as a reading move — on a short page the restore clamps at the foot,
   // which would re-read the anchor as the scan and lose the pane on the next
@@ -2478,11 +2482,28 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
       lastScrollY.current = el.scrollTop;
     };
     place();
+
+    // Slide the panes in from the side the turn came from. Restarting the
+    // animation by hand rather than keying the elements: a new key would
+    // remount the column, and the scan would be re-fetched and re-decoded on
+    // every page turn.
+    const back = r.currentIndex < lastIndex.current;
+    lastIndex.current = r.currentIndex;
+    for (const pane of Array.from(el.querySelectorAll<HTMLElement>(':scope > section'))) {
+      pane.classList.remove('rv2-turn-next', 'rv2-turn-prev');
+      void pane.offsetWidth; // reflow, or the class swap is coalesced and nothing plays
+      pane.classList.add(back ? 'rv2-turn-prev' : 'rv2-turn-next');
+    }
+
     // The title bar comes back on a turn and the new text settles a beat
     // later; both change how far the column can scroll, so a position taken
     // in this pass alone lands short of where it was asked to go.
     const raf = requestAnimationFrame(place);
     return () => cancelAnimationFrame(raf);
+    // The RENDERED page only. On an uncached turn the index moves a fetch
+    // ahead of the content, and keying on it too would play the animation
+    // over the outgoing page and then again over the new one.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [r.currentPage.id]);
 
   /**
@@ -3396,6 +3417,11 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
           className="flex-1 min-h-0 overflow-y-auto flex flex-col"
           style={{
             overscrollBehavior: 'contain',
+            // The turn animation slides the panes in from the side, and a pane
+            // sitting 14px to the right is 14px of scrollable width the browser
+            // will scroll sideways to reach — the turn jiggled and could be
+            // left horizontally scrolled if you touched it mid-flight.
+            overflowX: 'hidden',
             background: lastSurface,
             // No scroll-snap here. A proximity snap on the pager made the
             // scroller grab at the finger near the foot of every page, which

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2486,6 +2486,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
         el.scrollTop = 0;
       }
       lastScrollY.current = el.scrollTop;
+      barIntent.current = 0;
     };
     place();
 
@@ -2570,24 +2571,38 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
   }, [leftPanel, keyboardInset, isDesktop]);
 
   // Mobile title bar yields to the reading: it slides away as you read down
-  // and comes back the moment you scroll up. The threshold keeps a jittery
-  // finger from flickering it, and the top of the page always shows it.
+  // and comes back when you scroll up. Height, contents and visibility all
+  // move on this one curve and duration — they used to run at 200ms, 150ms
+  // and instantly, so the bar arrived in pieces and left in one cut.
+  const BAR_MS = 240;
+  const BAR_EASE = 'cubic-bezier(0.22, 0.61, 0.36, 1)';
   const [barHidden, setBarHidden] = useState(false);
   const lastScrollY = useRef(0);
+  /**
+   * Scrolling that has kept going the same way, in pixels: up is negative.
+   * Six pixels of movement used to be enough to throw the whole bar back on
+   * screen, and momentum alone can produce that, so it appeared out of
+   * nothing. Turning it takes a deliberate stretch of scrolling now, and
+   * changing direction starts the count again.
+   */
+  const barIntent = useRef(0);
   const onMobileScroll = useCallback(() => {
     const el = mobileMainRef.current;
     if (!el) return;
     const y = el.scrollTop;
     const delta = y - lastScrollY.current;
+    lastScrollY.current = y;
+    if (Date.now() > anchorLock.current) mobileAnchor.current = readMobileAnchor();
+    if (delta === 0) return;
+    if ((delta > 0) !== (barIntent.current > 0)) barIntent.current = 0;
+    barIntent.current += delta;
     // At the foot of the page the pager appears, and that is exactly when a
     // reader wants the whole set of ways out — next, previous, or back to the
     // book — so the bar comes back with it rather than staying hidden.
     const atFoot = el.scrollHeight - (y + el.clientHeight) < 80;
-    if (y < 48 || atFoot) setBarHidden(false);
-    else if (delta > 6) setBarHidden(true);
-    else if (delta < -6) setBarHidden(false);
-    lastScrollY.current = y;
-    if (Date.now() > anchorLock.current) mobileAnchor.current = readMobileAnchor();
+    if (y < 48 || atFoot) { setBarHidden(false); barIntent.current = 0; }
+    else if (barIntent.current > 16) setBarHidden(true);
+    else if (barIntent.current < -28) setBarHidden(false);
   }, [readMobileAnchor]);
 
   // Swipe to page: axis-locked so a vertical read never turns a page, and a
@@ -3360,7 +3375,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
         {/* Clipping is only needed while the bar is collapsing. Left on, it
             cut off the account menu, which opens downward out of the header. */}
         <header
-          className="shrink-0 transition-[height] duration-200 ease-out relative z-[60]"
+          className="shrink-0 relative z-[60]"
           style={{
             background: INK,
             color: '#fdfcf9',
@@ -3370,6 +3385,11 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
             // focusable back-link and menu button, and aria-hidden over them
             // made that worse rather than better.
             visibility: barHidden ? 'hidden' : 'visible',
+            // visibility is in the transition on purpose. It is a discrete
+            // property, so transitioning it holds the old value for the whole
+            // duration instead of applying at once — without that the contents
+            // were cut off the screen while the bar was still closing.
+            transition: `height ${BAR_MS}ms ${BAR_EASE}, visibility ${BAR_MS}ms ${BAR_EASE}`,
           }}
         >
           {/* The row fades with the bar rather than being revealed by it.
@@ -3377,8 +3397,11 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
               at full strength in a 4px-tall box, so the avatar — the tallest
               thing in the row — appeared first and the rest caught up. */}
           <div
-            className="flex items-center gap-2.5 h-[52px] px-3 transition-opacity duration-150"
-            style={{ opacity: barHidden ? 0 : 1 }}
+            className="flex items-center gap-2.5 h-[52px] px-3"
+            style={{
+              opacity: barHidden ? 0 : 1,
+              transition: `opacity ${BAR_MS}ms ${BAR_EASE}`,
+            }}
           >
             {/* Circles-only mark (the wordmark stays a desktop affordance) */}
             {/* Sized to match the account avatar beside it — the two circles


### PR DESCRIPTION
Two things, both in the phone column.

## The turn arrives from the side

The stacked column swapped its content instantly. After a swipe that reads as a jolt rather than as having moved. The panes now arrive from the side the turn came from: 14px, 190ms, ease-out.

X only, for the same reason the existing `rv2-page-in` fade is opacity only — the note there says a rise "moved the text under the reader's eye, which on a facsimile is worse than the abrupt swap". A horizontal slide follows the swipe instead of fighting it. Direction comes from the page index rather than the gesture, so the pager and the filmstrip animate the same way, and `prefers-reduced-motion` turns it off entirely.

Restarted by hand rather than by keying the elements: a new key would remount the column and re-fetch and re-decode the scan on every turn.

The column now clips its horizontal overflow. A pane sitting 14px to the right is 14px of scrollable width, and the browser scrolls sideways to reach it — measured at `scrollLeft` 11 mid-turn, which jiggled and could leave the column horizontally scrolled if touched mid-flight.

## A pane you were reading is held even when it never reaches the top

A bug in what is already live. The anchor was "the pane at the top of the column", which does not exist on a page whose content fits the screen. Those are exactly the pages where the translation sits at the foot of the screen, so a swipe from one threw it away.

Measured on a Pixel 5: at the bottom of a short page, a swipe landed at `scrollTop` 0 with the translation off the bottom. It now lands at 514, translation at the top. The anchor is the deepest pane you have brought up the screen rather than whichever touches the top edge. Scrolling nowhere still means no anchor, so a turn from the top of a page still starts at the top.

## Checks

`tsc --noEmit`, `eslint`, `vitest run` (3194 tests), and the device matrix against a local production build.

Animation, on a Pixel 5:
- forward swipe starts at +14px / opacity 0, mid-flight +10.2px / 0.27, settles at none / 1
- back swipe starts at -14px, `rv2-turn-prev`
- reduced motion: no animation, no transform, instant
- `scrollLeft` stays 0 for the whole turn, and the page never gains horizontal overflow

Full matrix (Pixel 7, Pixel 5, Galaxy S9+, Galaxy S5 at 320px, Galaxy Tab S4 landscape, Nexus 10, 1280x800 touch, 1024px): 102 checks pass, including a new one for a swipe taken from the foot of a short page. The one red mark is the React #418 hydration warning that also reproduces on live main, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eHbLV1PYU8qo9f5T4RZKA