### PR TITLE
fix(archive): make the per-host rate limiter actually limit, and treat 429 as slow-down not stop

### DIFF
--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -41,16 +41,32 @@ async function main() {
   // catch below meant the loop kept firing thousands of doomed requests and
   // reported "partial" progress instead of a failure. Per
   // invariants/archive-fetch-failures.md a 403 is never auto-retried.
+  //
+  // 429 is deliberately NOT in that set. Lumping it in with 401/403 conflated
+  // two different verdicts: "you may not have this" (stop, ask a human) versus
+  // "you are going too fast" (slow down, keep going). MDZ 429'd every run from
+  // 2026-08-29 and the conflation turned each hourly cron into abort-at-25 →
+  // sleep an hour → retry at the identical rate → abort again, netting ~10
+  // books/hour against a 3.2k backlog (#4395). A 429 now feeds the rate limiter
+  // in iiif-utils, which halves the host's rate and honours Retry-After, so the
+  // run converges on a rate the host will serve instead of stopping.
   const hostFailures = new Map<string, number>();
+  const hostThrottles = new Map<string, number>();
   const FAIL_ABORT = 25;
   class HostBlocked extends Error {}
   const noteFailure = (url: string, err: unknown) => {
     let host = 'unknown';
     try { host = new URL(url).hostname; } catch { /* keep 'unknown' */ }
     const msg = String((err as Error)?.message ?? err);
+    if (/\b429\b/.test(msg)) {
+      // Throttling is not a block. Count it for visibility only — the backoff
+      // itself already happened inside rateLimitedFetch.
+      hostThrottles.set(host, (hostThrottles.get(host) ?? 0) + 1);
+      return;
+    }
     // Only auth/blocking statuses count toward the abort — a slow or oversized
     // page is a per-page problem, not a host verdict.
-    if (!/\b(401|403|429)\b/.test(msg)) return;
+    if (!/\b(401|403)\b/.test(msg)) return;
     const n = (hostFailures.get(host) ?? 0) + 1;
     hostFailures.set(host, n);
     if (n >= FAIL_ABORT) {
@@ -141,7 +157,8 @@ async function main() {
   const remaining = PROVIDER
     ? await books.countDocuments({ 'image_source.provider': PROVIDER, pages_count: { $gt: 0 }, archive_status: { $ne: 'archive_complete' } })
     : await queue.countDocuments({ status: 'acquired', archived: { $ne: true } });
-  log(`archive-acquired: complete ${ok}, partial ${partial} | un-archived acquired remaining ${remaining}`);
+  const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
+  log(`archive-acquired: complete ${ok}, partial ${partial} | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
   if (blocked) {
     // Exit non-zero so a wrapper loop stops instead of re-running into the block.
     log(`ABORTED — SOURCE BLOCKED: ${(blocked as Error).message}`);

--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -21,7 +21,12 @@
 export const DOMAIN_LIMITS = {
   'archive.org': 10,
   'gallica.bnf.fr': 3,
-  'api.digitale-sammlungen.de': 5,
+  // MDZ began 429-ing every archive run on 2026-08-29/30 (see #4395). The
+  // nominal 5/s was never what we actually sent — the old bucket released
+  // every waiter at once, so 60 in-flight callers produced 55 requests in a
+  // single second. Lowered to 2/s while we re-earn their tolerance; raise
+  // again only with evidence from a clean run, not by assumption.
+  'api.digitale-sammlungen.de': 2,
   'iiif.wellcomecollection.org': 5,
   'www.e-rara.ch': 2,
   'digi.vatlib.it': 3,
@@ -40,7 +45,13 @@ export const DOMAIN_LIMITS = {
 
 const DEFAULT_LIMIT = 5;
 
+// Per-host scheduling state: { nextSlot, penalty }.
+//   nextSlot — epoch ms of the next unclaimed send slot for this host.
+//   penalty  — divisor applied to the configured limit after a 429, so a host
+//              that tells us to slow down actually gets a slower caller.
 const _domainBuckets = new Map();
+
+const MAX_PENALTY = 16; // floor: a 2/s host lands at one request every 8s
 
 export function getDomainLimit(url) {
   try {
@@ -49,6 +60,64 @@ export function getDomainLimit(url) {
   } catch {
     return DEFAULT_LIMIT;
   }
+}
+
+function bucketFor(host) {
+  let b = _domainBuckets.get(host);
+  if (!b) { b = { nextSlot: 0, penalty: 1 }; _domainBuckets.set(host, b); }
+  return b;
+}
+
+/**
+ * Claim one send slot for `host` and wait until it comes due.
+ *
+ * The previous implementation counted requests inside a one-second window and,
+ * when the window was full, made every waiter sleep and then RESET the window.
+ * Under concurrency that inverts the intent: N waiters all observe a full
+ * window, all sleep the same interval, and all wake and fire together. Measured
+ * with 60 in-flight callers against a nominal 5/s limit: 5 requests in the
+ * first second, then 55 in the next — an 11x burst, which is what MDZ was
+ * actually throttling (#4395).
+ *
+ * This version hands each caller its own slot spaced 1/limit apart. The claim
+ * is synchronous — there is no `await` between reading and writing `nextSlot` —
+ * so concurrent callers queue instead of colliding. Slots are real backpressure:
+ * the 60th caller genuinely waits its turn rather than jumping the line.
+ */
+async function claimSlot(host, limit) {
+  const b = bucketFor(host);
+  const interval = 1000 / Math.max(limit / b.penalty, 0.05);
+  const now = Date.now();
+  const slot = Math.max(now, b.nextSlot);
+  b.nextSlot = slot + interval;         // claimed synchronously — no await above
+  const wait = slot - now;
+  if (wait > 0) await new Promise(r => setTimeout(r, wait));
+}
+
+/**
+ * Record that `host` asked us to slow down (HTTP 429) and back off for real.
+ *
+ * A 429 is an instruction about RATE, not a refusal of access — unlike a 401 or
+ * 403, the correct response is to go slower, not to stop. Halving the effective
+ * limit and pushing the next slot out by `Retry-After` (when the host supplies
+ * one) means a throttled host converges on a rate it will serve instead of the
+ * caller retrying into the same wall.
+ */
+export function noteRateLimited(url, retryAfterSeconds) {
+  let host; try { host = new URL(url).hostname; } catch { return; }
+  const b = bucketFor(host);
+  b.penalty = Math.min(b.penalty * 2, MAX_PENALTY);
+  const cooldown = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+    ? retryAfterSeconds * 1000
+    : 5000;
+  b.nextSlot = Math.max(b.nextSlot, Date.now() + cooldown);
+  return b.penalty;
+}
+
+/** Effective (post-penalty) rate for a host, for logging. */
+export function effectiveLimit(url) {
+  let host; try { host = new URL(url).hostname; } catch { return null; }
+  return getDomainLimit(url) / bucketFor(host).penalty;
 }
 
 /**
@@ -73,21 +142,11 @@ export async function rateLimitedFetch(url, opts = {}) {
   try { host = new URL(url).hostname; } catch { host = 'unknown'; }
   const limit = getDomainLimit(url);
 
-  if (!_domainBuckets.has(host)) _domainBuckets.set(host, { last: 0, count: 0 });
-  const bucket = _domainBuckets.get(host);
-
   let lastErr;
   for (let attempt = 0; attempt <= retries; attempt++) {
-    // Rate-limit gate, evaluated per attempt so retries also yield to the bucket.
-    const now = Date.now();
-    if (now - bucket.last > 1000) { bucket.count = 0; bucket.last = now; }
-    if (bucket.count >= limit) {
-      const wait = 1000 - (now - bucket.last);
-      if (wait > 0) await new Promise(r => setTimeout(r, wait));
-      bucket.count = 0;
-      bucket.last = Date.now();
-    }
-    bucket.count++;
+    // Rate gate, evaluated per attempt so retries queue behind fresh requests
+    // rather than jumping ahead of them.
+    await claimSlot(host, limit);
 
     const controller = new AbortController();
     const t = setTimeout(() => controller.abort(), timeout);
@@ -102,6 +161,13 @@ export async function rateLimitedFetch(url, opts = {}) {
         // worth retrying with backoff.
         if (res.status >= 400 && res.status < 500 && res.status !== 429) {
           throw new Error(`HTTP ${res.status}`);
+        }
+        // A 429 is the host telling us our RATE is wrong. Retrying at the same
+        // rate is the one response guaranteed not to work — slow this host down
+        // for every subsequent caller, not just this retry.
+        if (res.status === 429) {
+          const ra = Number(res.headers.get('retry-after'));
+          noteRateLimited(url, ra);
         }
         lastErr = new Error(`HTTP ${res.status}`);
       } else {


### PR DESCRIPTION
Fixes #4395.

The R2 archiver has been netting **~10 books/hour** since 2026-08-29, aborting every hourly run on `api.digitale-sammlungen.de: 34 consecutive auth/block responses (HTTP 429)`. Only 18.03% of the August acquisition wave is on R2. Two independent defects, both measured rather than inferred.

### 1. The limiter released every waiter at once

`iiif-utils.mjs` counted requests in a 1s window and, when full, made each waiter sleep and then **reset the window** — so N concurrent callers all saw a full window, all slept the same interval, and all woke together.

Reproduced with the old code's exact algebra, 60 concurrent callers against the nominal 5/s limit:

```
requests per second-bucket: {"0": 5, "1": 55}
worst second: 55 requests (11.0x the configured limit)
```

Replaced with per-host slot claiming — each caller takes a slot spaced `1/limit` apart, claimed synchronously so no `await` sits between reading and writing `nextSlot`. After:

```
20 concurrent callers, 2/s limit: {"0":2,"1":2,"2":2,"3":2,"4":2,"5":2,"6":2,"7":2,"8":2,"9":2}
worst second: 2 (limit 2)
```

### 2. A 429 aborted the run instead of slowing it

`noteFailure()` counted `401|403|429` alike toward abort-at-25, so every run aborted → slept an hour → retried at the identical rate → aborted. A livelock: nothing in the loop changed the variable causing the failure.

429 is a rate instruction, not a refusal. It now feeds the limiter — effective rate halves per 429 (floor 1/16th), `Retry-After` honoured, run continues:

```
effective limit before 429: 2
after one 429 (Retry-After: 3): 1
after a second 429: 0.5
floor after many 429s: 0.125
```

**401/403 behaviour is unchanged** — still abort, still never auto-retried, per `invariants/archive-fetch-failures.md`. This PR does not weaken that rule; it stops a throttle from being mistaken for it.

### Also

- MDZ 5 → 2 req/s while we re-earn their tolerance.
- Throttle counts in the run summary, so a throttled host is visible without reading traces.

### Scope

In: the limiter, the 401/403-vs-429 distinction, the MDZ number.

Out, deliberately: **cross-host sharding of the work list.** With a correct limiter, a batch of same-host books now serializes behind that host's rate, so throughput is bounded by the slowest source in the batch. Sharding the work list by host so many hosts drain concurrently is the change that decides whether the backlog takes days or weeks — it deserves its own PR and its own review. Raising `--concurrency` in the crontab should wait for that too.

### Blast radius

All six `rateLimitedFetch` callers inherit the fix (archive-acquired, archive-unarchived-books, rearchive-iiif-fullres, rearchive-iiif-manifest, deepzoom-harvest-page-masters). The exported signature is unchanged and nothing outside the module touched `_domainBuckets`. `npx tsc --noEmit` clean.

### Verifying after merge

Watch `/var/log/sourcelibrary/archive-acquired.log` for a run ending **without** `ABORTED`, showing `throttled api.digitale-sammlungen.de:N` if MDZ still pushes back, and `un-archived acquired remaining` falling faster than ~10/hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PamsbX7RQrKvwFu4GVjRAz
