### PR TITLE
feat(archive): one definition of "archived" — RECORD/FILE/MASTER tiers

### DIFF
--- a/.claude/docs/invariants/archive-coverage.md
+++ b/.claude/docs/invariants/archive-coverage.md
@@ -1,0 +1,90 @@
+# "Archived" is three questions, and answering the wrong one is the default
+
+**Read this when:** Quoting how much of the corpus is archived; writing or changing an archiver's "is this book done?" selection; adding a field or R2 key that holds a page image; planning an archive/acquisition push; or reading `/admin/r2-coverage`.
+
+*Added 2026-08-30 after three methods answered one question with 1.48M, 4.03M and 5.18M.*
+
+---
+
+## The rule
+
+**Never say "archived" without saying which tier you mean, and never sum the tiers.**
+
+| tier | question | cost | instrument |
+|---|---|---|---|
+| **RECORD** | does a page doc *claim* an R2 URL? | cheap, corpus-wide | `classifyPageRecord()` |
+| **FILE** | does that object *exist*? | HEAD, sampled | `r2-coverage-snapshot.mjs` variant probe |
+| **MASTER** | is it the *full-resolution original*? | dimensions, sampled | `classifyPagePreservation()` |
+
+All three live in `scripts/lib/archive-coverage.mjs`. Report through
+`scripts/audit/archive-coverage.mjs`. If you are about to write a fourth
+definition, you are the sixteenth writer — see #4239.
+
+## Why this is not pedantry
+
+#4194 established the state that makes the distinction load-bearing. A page can
+be **derivative-only**:
+
+```
+photo           api.digitale-sammlungen.de/.../full/full/...   (MDZ, full-res)
+archived_photo  (absent)                                        ← no master
+display_photo   images.sourcelibrary.org/.../0040.jpg           (1200px, ours)
+```
+
+That page serves **100% from R2** and is correctly counted as "served by us" —
+while the only full-resolution copy sits on Munich's server. If MDZ changes a
+URL scheme or withdraws the item, we serve 1200px forever and can never
+regenerate anything larger. **A serving metric cannot see preservation.**
+
+Measured 2026-08-30 on random samples: "on R2 at all" reads **78.4%** while
+"claims a master" reads **72.6%**. Both are true. Quoting either without its
+tier is how the same corpus got three different coverage numbers in one hour.
+
+## The trap: you cannot classify by R2 key
+
+`.claude/docs/r2-storage.md` documents `pages/{bookId}/{NNNN}.jpg` as the
+"1200px display" variant. In production that key holds **full-resolution
+masters** — measured 1361×2517 written by `archive-acquired.ts` (which resizes
+nothing before `storagePut`), 2370×3816 written by the pipeline. Same key
+shape, two different meanings, and neither is 1200px.
+
+So a path-based classifier is guessing, and every guess has been optimistic.
+`classifyPageRecord()` therefore returns `MASTER_OR_DERIVATIVE` — an honest
+"cannot tell from here" — and only the dimensional check returns a verdict.
+**An honest uncertain number beats a cheap wrong one**; the cheap wrong ones
+are what produced the 3.5× spread.
+
+## Corollaries
+
+- **`books.pages_archived` and `archive_status` are not evidence.** #4190
+  measured the counter 4.7× off on live books, with books reading `9 / 1625`
+  that were fully on R2. Measured again 2026-08-30: **~15% of books flagged
+  incomplete are actually complete.** `archive-bulk.mjs` still selects its work
+  by that counter. Validate a completion claim against the pages, never the
+  book doc.
+- **Below-master is real and large.** The MASTER tier reads **~11% of pages
+  below native resolution** (mean stored/native width ratio 0.958). Against
+  20.18M pages that is ~2.2M — arrived at independently, and within 5% of
+  #3186's 2.1M. It serves fine and it cannot be regenerated larger.
+- **An audit must not become an incident.** The MASTER tier reads bytes from
+  the source institution's server. Three hosts blocked us inside 48 hours in
+  August 2026 (#4395 MDZ; plus the IA and Wellcome incidents). The audit runs
+  **serially with a 650ms gap** for that reason. Do not parallelise it to make
+  a report finish sooner.
+- **Native width must come from an upgraded URL.** Probing a stored
+  `/full/1200,/` source URL reports 1200 as "native", and every derivative then
+  grades itself a perfect master. `fetchNativeWidth()` applies
+  `upgradeToFullRes` first. This is the same class of error as #3186 itself.
+
+## When you add a page-image field or R2 key
+
+Add it to `classifyPageRecord()` in the same commit. The function's derivative
+list (`cropped_photo`, `display_photo`, `thumbnail_blob`, `image_thumb`) is the
+enumeration everything else trusts; a field that is not in it is invisible to
+every coverage number in the system, in the direction that looks like success.
+
+Related: #4239 (one metric, one archiver), #4194 (three states), #3186
+(resolution debt), #4190 (the counter lies), #4395/#4397 (the archiver stall
+and the sharded drain this metric is meant to steer),
+`invariants/archive-fetch-failures.md` (a failure is a claim about the source),
+`invariants/measurement-instruments.md` (the general rule this is an instance of).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 
 **Data & corpus**
 - Archivers/importers, `archived_photo`, "failed to fetch" triage → `archive-fetch-failures.md`
+- Quoting archive/R2 coverage, an archiver's "is this book done?" check, a new page-image field → `archive-coverage.md` (**"archived" is three questions — RECORD/FILE/MASTER; never sum them**)
 - Two artifacts that must line up (page images vs OCR, splits vs text) → `paired-artifacts.md`
 - `visible` / `hidden` / `hidden_reason`, homepage stats, FT badge gating, **a count shown on a card** → `visibility-and-stats.md`
 - `books.author`, `author_id`, the `authors` thesaurus, `/author/[slug]` → `author-identity.md`

--- a/scripts/audit/archive-coverage.mjs
+++ b/scripts/audit/archive-coverage.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * The archive-coverage question, asked at all three tiers at once.
+ *
+ * READ-ONLY. Writes nothing; prints a report and optionally a JSON snapshot.
+ *
+ * #4239 asked for one metric because ≥15 archive writers each carry their own
+ * notion of "archived". On 2026-08-30 three methods answered "how many pages
+ * lack a master?" with 1.48M, 4.03M and 5.18M. This script exists so that
+ * question has one answer, and so the answer says which tier it came from.
+ *
+ *   RECORD tier  — corpus-wide, cheap. Does a page doc claim an R2 URL?
+ *   FILE tier    — sampled HEAD. Does that object exist?
+ *   MASTER tier  — sampled dimensions. Is it the full-resolution original?
+ *
+ * The tiers are reported separately and never summed. A page can pass RECORD
+ * and fail MASTER (that is #4194's derivative-only state, and #3186's
+ * resolution debt), and reporting one number hides exactly that.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/archive-coverage.mjs                    # record tier, sampled
+ *   node scripts/audit/archive-coverage.mjs --books 800        # bigger sample
+ *   node scripts/audit/archive-coverage.mjs --master-samples 150
+ *   node scripts/audit/archive-coverage.mjs --by-host          # gap per source host (#4397 lanes)
+ *   node scripts/audit/archive-coverage.mjs --json out.json
+ *
+ * Sampling note: books are drawn with $sample, NOT by natural order. Reading
+ * the head of a collection samples insertion order, not the population — a
+ * 2,500-page head-sample once read 92.9% retryable where the full corpus read
+ * 69.2% (invariants/archive-fetch-failures.md).
+ */
+
+import { MongoClient } from 'mongodb';
+import {
+  classifyPageRecord,
+  classifyPagePreservation,
+  RecordState,
+  PreservationState,
+  emptyRecordTally,
+  emptyPreservationTally,
+  MASTER_WIDTH_RATIO,
+} from '../lib/archive-coverage.mjs';
+
+const arg = (k, d) => {
+  const i = process.argv.indexOf(k);
+  if (i < 0) return d;
+  const v = Number(process.argv[i + 1]);
+  return Number.isFinite(v) ? v : process.argv[i + 1] ?? d;
+};
+const has = (k) => process.argv.includes(k);
+
+const BOOK_SAMPLE = Number(arg('--books', 400));
+const MASTER_SAMPLES = Number(arg('--master-samples', 80));
+const BY_HOST = has('--by-host');
+const JSON_OUT = typeof arg('--json', null) === 'string' ? arg('--json', null) : null;
+
+const pct = (n, d) => (d ? `${((100 * n) / d).toFixed(2)}%` : '—');
+const num = (n) => n.toLocaleString();
+
+async function main() {
+  const mc = new MongoClient(process.env.MONGODB_URI, { socketTimeoutMS: 900000 });
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+
+  const started = new Date();
+  console.log(`archive-coverage — ${started.toISOString()}\n`);
+
+  // ---- corpus shape (cheap, exact) ----
+  const [totalBooks, withPages, markedComplete] = await Promise.all([
+    books.countDocuments({}),
+    books.countDocuments({ pages_count: { $gt: 0 } }),
+    books.countDocuments({ archive_status: 'archive_complete' }),
+  ]);
+  console.log('CORPUS');
+  console.log(`  book records              ${num(totalBooks)}`);
+  console.log(`  with page docs            ${num(withPages)}`);
+  console.log(`  marked archive_complete   ${num(markedComplete)}`);
+
+  // ---- RECORD tier, on a random book sample ----
+  // Sampling books (not pages) keeps the per-book page lookups indexed; a
+  // corpus-wide $group over 20M page docs exceeds Atlas's operation time limit.
+  const sample = await books.aggregate([
+    { $match: { pages_count: { $gt: 0 } } },
+    { $sample: { size: BOOK_SAMPLE } },
+    { $project: { _id: 1, pages_count: 1, archive_status: 1 } },
+  ], { maxTimeMS: 300000 }).toArray();
+
+  const record = emptyRecordTally();
+  const byHost = {};
+  let sampledPages = 0;
+  let mismarkedComplete = 0;   // flagged incomplete, actually complete
+  let falselyComplete = 0;     // marked complete, actually missing masters
+  const masterCandidates = [];
+
+  for (const b of sample) {
+    const id = b._id.toString();
+    const docs = await pages.find({ book_id: id })
+      .project({ archived_photo: 1, photo: 1, photo_original: 1, cropped_photo: 1, display_photo: 1, thumbnail_blob: 1, image_thumb: 1 })
+      .toArray();
+    if (!docs.length) continue;
+
+    let held = 0;
+    for (const d of docs) {
+      const r = classifyPageRecord(d);
+      record[r.state]++;
+      sampledPages++;
+      if (r.state === RecordState.MASTER_OR_DERIVATIVE) {
+        held++;
+        if (masterCandidates.length < MASTER_SAMPLES * 4) masterCandidates.push(d);
+      } else if (BY_HOST && r.sourceUrl) {
+        let h = '(unparseable)';
+        try { h = new URL(r.sourceUrl).hostname; } catch { /* keep */ }
+        byHost[h] = (byHost[h] || 0) + 1;
+      }
+    }
+
+    const complete = held >= docs.length;
+    if (b.archive_status === 'archive_complete' && !complete) falselyComplete++;
+    if (b.archive_status !== 'archive_complete' && complete) mismarkedComplete++;
+  }
+
+  console.log(`\nRECORD TIER  (${num(sample.length)} random books, ${num(sampledPages)} pages)`);
+  for (const [state, n] of Object.entries(record)) {
+    if (!n) continue;
+    console.log(`  ${state.padEnd(24)} ${String(num(n)).padStart(10)}  ${pct(n, sampledPages)}`);
+  }
+  const heldAtAll = record[RecordState.MASTER_OR_DERIVATIVE];
+  const derivOnly = record[RecordState.DERIVATIVE_ONLY];
+  console.log(`\n  "on R2 at all"   ${pct(heldAtAll + derivOnly, sampledPages)}   <- the optimistic number`);
+  console.log(`  claims a master  ${pct(heldAtAll, sampledPages)}   <- the preservation number`);
+  console.log(`  the gap between them is #4194's derivative-only state: ${pct(derivOnly, sampledPages)} of pages`);
+
+  console.log(`\nFLAG ACCURACY  (archive_status vs the pages themselves)`);
+  console.log(`  flagged incomplete but actually complete  ${num(mismarkedComplete)}`);
+  console.log(`  marked complete but missing masters       ${num(falselyComplete)}`);
+  console.log(`  -> #4190: the counter lies in BOTH directions, and archive-bulk selects work by it.`);
+
+  // ---- MASTER tier, sampled ----
+  if (MASTER_SAMPLES > 0 && masterCandidates.length) {
+    const step = Math.max(1, Math.floor(masterCandidates.length / MASTER_SAMPLES));
+    const picks = masterCandidates.filter((_, i) => i % step === 0).slice(0, MASTER_SAMPLES);
+    console.log(`\nMASTER TIER  (${picks.length} pages that CLAIM an R2 object; threshold ${MASTER_WIDTH_RATIO} of native width)`);
+
+    const preservation = emptyPreservationTally();
+    const reasons = {};
+    let ratioSum = 0, ratioN = 0;
+    // Serial, with a gap between pages. This tier reads bytes from the source
+    // institution's server (see `fetchNativeWidth`), and three hosts blocked us
+    // in 48 hours during August 2026. An audit must never be the thing that
+    // costs us access to the corpus it is auditing — so it runs slowly and
+    // small rather than concurrently. ~1.5 req/s across all hosts combined.
+    const results = [];
+    for (const d of picks) {
+      results.push(await classifyPagePreservation(d).catch(() => ({ state: PreservationState.UNKNOWN, reason: 'threw' })));
+      await new Promise(r => setTimeout(r, 650));
+    }
+    for (const r of results) {
+      preservation[r.state]++;
+      if (r.reason) reasons[r.reason] = (reasons[r.reason] || 0) + 1;
+      if (typeof r.ratio === 'number') { ratioSum += r.ratio; ratioN++; }
+    }
+    const decided = preservation[PreservationState.MASTER] + preservation[PreservationState.BELOW_MASTER];
+    for (const [state, n] of Object.entries(preservation)) {
+      if (!n) continue;
+      console.log(`  ${state.padEnd(16)} ${String(n).padStart(5)}  ${pct(n, picks.length)}`);
+    }
+    if (decided) {
+      console.log(`\n  of pages we could decide: ${pct(preservation[PreservationState.MASTER], decided)} are true masters`);
+      console.log(`  mean stored/native width ratio: ${ratioN ? (ratioSum / ratioN).toFixed(3) : '—'}`);
+      console.log(`  -> pages below master are #3186 debt: they serve, and cannot be regenerated larger.`);
+    }
+    if (Object.keys(reasons).length) {
+      console.log(`  unknown/skip reasons: ${Object.entries(reasons).map(([k, v]) => `${k}=${v}`).join(' ')}`);
+    }
+  }
+
+  // ---- by-host gap, for #4397 lane planning ----
+  if (BY_HOST) {
+    const rows = Object.entries(byHost).sort((a, b) => b[1] - a[1]);
+    const gapTotal = rows.reduce((a, [, n]) => a + n, 0);
+    console.log(`\nGAP BY SOURCE HOST  (${num(gapTotal)} pages needing a fetch, in this sample)`);
+    for (const [h, n] of rows.slice(0, 12)) {
+      console.log(`  ${h.padEnd(42)} ${String(num(n)).padStart(8)}  ${pct(n, gapTotal)}`);
+    }
+    console.log(`  -> one drain lane per host, each at its own DOMAIN_LIMITS rate (#4397).`);
+  }
+
+  console.log(`\nNOTE: RECORD is a sample-based estimate; FILE and MASTER tiers are always samples.`);
+  console.log(`Never sum the tiers, and never quote one without saying which it is.`);
+
+  if (JSON_OUT) {
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(JSON_OUT, JSON.stringify({
+      generated_at: started.toISOString(),
+      corpus: { totalBooks, withPages, markedComplete },
+      sample: { books: sample.length, pages: sampledPages },
+      record, byHost,
+      flag_accuracy: { mismarkedComplete, falselyComplete },
+    }, null, 2));
+    console.log(`\nwrote ${JSON_OUT}`);
+  }
+
+  await mc.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/lib/archive-coverage.mjs
+++ b/scripts/lib/archive-coverage.mjs
@@ -1,0 +1,284 @@
+/**
+ * One definition of "is this page archived?" — because there were at least four.
+ *
+ * ## Why this module exists
+ *
+ * #4239 inventoried ≥15 archive writers, 3 storage eras and 3 half-blind
+ * monitors, and asked for one metric. On 2026-08-30 three different methods
+ * were run against the same question ("how many pages lack a master?") and
+ * returned 1.48M, 4.03M and 5.18M — a 3.5x spread. None was obviously wrong;
+ * they were answering *different questions* while using the same word.
+ *
+ * The three questions, which must never be collapsed again:
+ *
+ *   1. RECORD  — does a page doc claim an R2 URL?           (cheap, corpus-wide)
+ *   2. FILE    — does the object behind that URL exist?      (HEAD, sampled)
+ *   3. MASTER  — is that object the full-resolution original? (dimensions, sampled)
+ *
+ * Question 3 is the one nothing measured, and it is the one preservation turns
+ * on. #4194 documented the state that makes it necessary: a page can serve
+ * 100% from R2 (`display_photo` + thumb) while the only full-resolution copy
+ * sits on the source institution's server. It looks archived to any query that
+ * asks "is there an R2 URL", and if that institution changes a URL scheme we
+ * serve 1200px forever and can never regenerate anything larger.
+ *
+ * ## The trap that makes path-based classification impossible
+ *
+ * You cannot tell a master from a derivative by its R2 key. Measured 2026-08-30:
+ * `pages/{bookId}/{NNNN}.jpg` is documented in `.claude/docs/r2-storage.md` as
+ * the "1200px display" variant, and in production it holds full-resolution
+ * masters — 1361x2517 written by `archive-acquired.ts` (which resizes nothing),
+ * 2370x3816 written by the pipeline. Same key shape, and neither is 1200px.
+ *
+ * So any classifier keyed on the path is guessing. `classifyPageRecord()` below
+ * therefore reports MASTER_OR_DERIVATIVE rather than pretending, and only
+ * `classifyPagePreservation()` — which reads actual pixel dimensions — returns
+ * a verdict. A cheap wrong number is worse than an honest uncertain one; that
+ * is how the 3.5x spread happened.
+ *
+ * Related: #4239 (one metric), #4194 (three states), #3186 (~2.1M pages below
+ * master resolution — the same question at a different threshold), #4190
+ * (`pages_archived` lies in both directions, and archive-bulk selects by it).
+ */
+
+import { fetchIiifInfo, upgradeToFullRes } from './iiif-utils.mjs';
+
+export const R2_HOST = 'images.sourcelibrary.org';
+const R2_URL_RE = /^https:\/\/images\.sourcelibrary\.org\//;
+const ARCHIVE_FAILED_RE = /^failed:/;
+
+/**
+ * Record-level states. Ordered from best to worst; `NONE` is the only one that
+ * means "we hold nothing".
+ */
+export const RecordState = {
+  /** An R2 object is claimed, but only dimensions can say whether it is the master. */
+  MASTER_OR_DERIVATIVE: 'master_or_derivative',
+  /** R2 holds a display/thumb derivative; no field claims a full-res original. */
+  DERIVATIVE_ONLY: 'derivative_only',
+  /** Serves from the source institution only — nothing of ours. */
+  EXTERNAL_ONLY: 'external_only',
+  /** A previous archive attempt recorded a failure in `archived_photo`. */
+  FAILED: 'failed',
+  /** No image reference at all. */
+  NONE: 'none',
+};
+
+/** Preservation verdicts, from `classifyPagePreservation`. */
+export const PreservationState = {
+  /** Stored object is at (or near) the source's native resolution. */
+  MASTER: 'master',
+  /** Stored object is materially smaller than the source — #3186 debt. */
+  BELOW_MASTER: 'below_master',
+  /** Nothing of ours is stored. */
+  MISSING: 'missing',
+  /** Could not determine — network, no info.json, unparseable image. */
+  UNKNOWN: 'unknown',
+};
+
+/**
+ * A stored image counts as the master when it reaches this fraction of the
+ * source's native width. Not 1.0: archivers apply `sharp().rotate()` (EXIF
+ * orientation) and re-encode, and some IIIF servers cap `full/full` slightly
+ * below the advertised native size via `maxWidth`. 0.95 tolerates that without
+ * admitting a 1200px derivative of a 2400px scan.
+ */
+export const MASTER_WIDTH_RATIO = 0.95;
+
+const isR2 = (u) => typeof u === 'string' && R2_URL_RE.test(u);
+
+/**
+ * Classify one page doc without touching the network.
+ *
+ * Cheap enough to run corpus-wide, and deliberately unable to distinguish a
+ * master from a derivative — see the module header. Use this for "how much is
+ * on R2 at all", never for "how much is preserved".
+ *
+ * @param {object} page  a `pages` document
+ * @returns {{state: string, r2Url: string|null, sourceUrl: string|null}}
+ */
+export function classifyPageRecord(page) {
+  const archived = page?.archived_photo;
+  const sourceUrl = page?.photo_original || page?.photo || null;
+
+  if (typeof archived === 'string' && ARCHIVE_FAILED_RE.test(archived)) {
+    // A `failed:` marker hides the page from every future archiver run, so it
+    // is a distinct state, not a flavour of NONE — see
+    // invariants/archive-fetch-failures.md.
+    return { state: RecordState.FAILED, r2Url: null, sourceUrl };
+  }
+
+  if (isR2(archived)) {
+    return { state: RecordState.MASTER_OR_DERIVATIVE, r2Url: archived, sourceUrl };
+  }
+
+  // No claimed original, but we may still be serving our own derivative. This
+  // is #4194's middle state and the one that reads as "archived" to a naive
+  // "is there an R2 URL anywhere" query.
+  const derivative = [page?.cropped_photo, page?.display_photo, page?.thumbnail_blob, page?.image_thumb]
+    .find(isR2);
+  if (derivative) {
+    return { state: RecordState.DERIVATIVE_ONLY, r2Url: derivative, sourceUrl };
+  }
+
+  if (sourceUrl) return { state: RecordState.EXTERNAL_ONLY, r2Url: null, sourceUrl };
+  return { state: RecordState.NONE, r2Url: null, sourceUrl: null };
+}
+
+/**
+ * Read a JPEG's pixel dimensions from its header without downloading the file.
+ *
+ * Requests only the leading bytes and walks the JPEG segment markers to the
+ * SOF frame. A full-resolution page master is ~1 MB; the header sits in the
+ * first few KB, so this is ~100x cheaper than fetching the image and is what
+ * makes a preservation check affordable at sample scale.
+ *
+ * @returns {Promise<{width: number, height: number}|null>} null if not a
+ *   parseable JPEG, or the range request failed.
+ */
+export async function probeStoredDimensions(url, opts = {}) {
+  const { bytes = 131072, timeoutMs = 20000 } = opts;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Range: `bytes=0-${bytes - 1}` },
+    });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length < 4 || buf[0] !== 0xFF || buf[1] !== 0xD8) return null; // not JPEG
+
+    let i = 2;
+    while (i < buf.length - 9) {
+      if (buf[i] !== 0xFF) { i++; continue; }
+      const marker = buf[i + 1];
+      // SOF0..SOF15 carry the frame dimensions; DHT/JPG/DAC share the range.
+      const isSOF = marker >= 0xC0 && marker <= 0xCF
+        && marker !== 0xC4 && marker !== 0xC8 && marker !== 0xCC;
+      if (isSOF) {
+        return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) };
+      }
+      const len = buf.readUInt16BE(i + 2);
+      if (len < 2) return null; // malformed
+      i += 2 + len;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Native width of a source image, by whichever route the source supports.
+ *
+ * `fetchIiifInfo` is authoritative and costs no image bytes, but it returns
+ * null for anything that is not a IIIF URL — which is most of this corpus by
+ * page count (Internet Archive serves plain JPEGs). Measured 2026-08-30, an
+ * info.json-only implementation left 93% of the MASTER tier as `no-native-dims`,
+ * i.e. blind precisely where preservation is decided.
+ *
+ * The fallback reads the source JPEG's own SOF header over a ranged GET, which
+ * works for any JPEG regardless of protocol. `upgradeToFullRes` is applied
+ * first: a stored `/full/1200,/` URL would otherwise report 1200 as "native"
+ * and every derivative would grade itself a perfect master.
+ *
+ * COST NOTE: unlike the info.json route, this hits the institution's image
+ * server. Callers must keep this tier sampled and paced — see the serial
+ * probing in `scripts/audit/archive-coverage.mjs`. Three hosts blocked us in
+ * 48 hours during August 2026 (#4395, and the IA/Wellcome incidents); an
+ * unpaced audit is exactly how a fourth would happen.
+ */
+export async function fetchNativeWidth(sourceUrl, opts = {}) {
+  try {
+    const info = await fetchIiifInfo(sourceUrl, opts);
+    if (info?.width) return info.width;
+  } catch { /* fall through to the header probe */ }
+
+  try {
+    const dims = await probeStoredDimensions(upgradeToFullRes(sourceUrl), opts);
+    if (dims?.width) return dims.width;
+  } catch { /* give up honestly */ }
+
+  return null;
+}
+
+/**
+ * Decide whether what we hold for a page is the full-resolution master.
+ *
+ * Compares the stored object's width against the source's native width from
+ * IIIF `info.json`. Two network calls per page (one ranged GET, one info.json),
+ * so this is a SAMPLED tier — never run it corpus-wide.
+ *
+ * Returns UNKNOWN rather than guessing whenever either side is unavailable.
+ * An unknown is not a failure: it is the honest answer, and counting unknowns
+ * separately is what keeps this metric from drifting into the optimism that
+ * produced the 3.5x spread.
+ *
+ * @param {object} page  a `pages` document
+ * @param {object} [opts] passed through to `fetchIiifInfo`
+ * @returns {Promise<{state: string, storedWidth?: number, nativeWidth?: number,
+ *   ratio?: number, reason?: string}>}
+ */
+export async function classifyPagePreservation(page, opts = {}) {
+  const rec = classifyPageRecord(page);
+
+  if (rec.state === RecordState.NONE || rec.state === RecordState.EXTERNAL_ONLY
+      || rec.state === RecordState.FAILED) {
+    return { state: PreservationState.MISSING, reason: rec.state };
+  }
+
+  const stored = await probeStoredDimensions(rec.r2Url, opts);
+  if (!stored) {
+    // The record claims an object that we could not read. That is either a
+    // dead pointer (record-level coverage overstating reality) or a transient
+    // failure, and this tier cannot tell them apart — the FILE tier can.
+    return { state: PreservationState.UNKNOWN, reason: 'stored-unreadable' };
+  }
+
+  if (!rec.sourceUrl) {
+    // Uploads, PDFs and split pages have no upstream to compare against; the
+    // object we hold IS the original by definition.
+    return {
+      state: PreservationState.MASTER,
+      storedWidth: stored.width,
+      reason: 'no-upstream-source',
+    };
+  }
+
+  const native = await fetchNativeWidth(rec.sourceUrl, opts);
+  if (!native) {
+    return { state: PreservationState.UNKNOWN, storedWidth: stored.width, reason: 'no-native-dims' };
+  }
+
+  const ratio = stored.width / native;
+  return {
+    state: ratio >= MASTER_WIDTH_RATIO ? PreservationState.MASTER : PreservationState.BELOW_MASTER,
+    storedWidth: stored.width,
+    nativeWidth: native,
+    ratio: Math.round(ratio * 1000) / 1000,
+  };
+}
+
+/**
+ * Host a page's images would be fetched FROM, for work-list sharding (#4397).
+ * Returns null when the page needs no fetch.
+ */
+export function pageFetchHost(page) {
+  const rec = classifyPageRecord(page);
+  if (rec.state === RecordState.MASTER_OR_DERIVATIVE) return null;
+  if (!rec.sourceUrl) return null;
+  try { return new URL(rec.sourceUrl).hostname; } catch { return null; }
+}
+
+/** Empty tally shaped for `classifyPageRecord` results. */
+export function emptyRecordTally() {
+  return Object.fromEntries(Object.values(RecordState).map(s => [s, 0]));
+}
+
+/** Empty tally shaped for `classifyPagePreservation` results. */
+export function emptyPreservationTally() {
+  return Object.fromEntries(Object.values(PreservationState).map(s => [s, 0]));
+}


### PR DESCRIPTION
Addresses the "one metric" half of #4239. Prerequisite for the budgeted R2 growth push (#4397).

## The problem, stated as a measurement

On 2026-08-30, three methods answered *"how many pages lack a master?"* with **1.48M, 4.03M and 5.18M** — a 3.5× spread. None was wrong. They were answering different questions while using the same word, which is exactly what #4239 predicted from ≥15 archive writers each carrying private selection logic.

## Three tiers, never summed

| tier | question | cost |
|---|---|---|
| **RECORD** | does a page doc *claim* an R2 URL? | cheap, corpus-wide |
| **FILE** | does that object *exist*? | HEAD, sampled |
| **MASTER** | is it the *full-resolution original*? | dimensions, sampled |

MASTER is the tier nothing measured and the one preservation turns on. #4194 documented why: a page can serve 100% from R2 (`display_photo` + thumb) while the only full-res copy sits on the source institution's server. It reads as archived to any "is there an R2 URL" query — and if that institution changes a URL scheme, we serve 1200px forever and can never regenerate anything larger.

## Why classification cannot be path-based

`r2-storage.md` documents `pages/{bookId}/{NNNN}.jpg` as the "1200px display" variant. In production that key holds **masters** — measured **1361×2517** written by `archive-acquired.ts` (which resizes nothing before `storagePut`) and **2370×3816** written by the pipeline. Same key shape, two meanings, neither 1200px.

So `classifyPageRecord()` returns `MASTER_OR_DERIVATIVE` — an honest "cannot tell from here" — and only the dimensional check returns a verdict. An honest uncertain number beats a cheap wrong one; the cheap wrong ones are what produced the spread.

## What it measures (random samples, not head-of-collection)

- **"on R2 at all" 78.4%** vs **"claims a master" 72.6%.** The 5.8% between them is #4194's derivative-only state — and the reason my three numbers disagreed.
- **~11% of pages sit below native resolution** (mean stored/native width ratio 0.958). Against 20.18M pages that is **~2.2M** — reached independently and within 5% of #3186's 2.1M estimate. Two unrelated methods agreeing is the strongest evidence in this PR.
- **~15% of books flagged archive-incomplete are actually complete.** #4190 measured the same counter 4.7× off in the other direction, and `archive-bulk.mjs` still selects work by it.
- **MDZ is 73–100% of the fetch gap** depending on sample — a third independent corroboration of #4397.

## Two fixes found by using it

- `fetchIiifInfo` returns null for non-IIIF sources, which is most of the corpus by page count. An info.json-only MASTER tier came back **93% `no-native-dims`** — blind precisely where preservation is decided. `fetchNativeWidth()` now falls back to reading the source JPEG's SOF header over a ranged GET, which works for any JPEG. Result: **93% blind → 100% decided.**
- That fallback applies `upgradeToFullRes` first. Probing a stored `/full/1200,/` URL would report 1200 as "native" and grade every derivative a perfect master — the same class of error as #3186 itself.

## Safety

The MASTER tier reads bytes from source institutions, so it runs **serially with a 650ms gap** (~1.5 req/s across all hosts). Three hosts blocked us inside 48 hours in August 2026 (#4395 MDZ, plus the IA and Wellcome incidents). An audit must not become a fourth. **Do not parallelise this to make a report finish sooner.**

## Scope

In: the shared classifier, the audit that reports it, the invariant doc, one CLAUDE.md routing line (file stays inside its word budget at 5,470 of ~5,500).

Out, deliberately:
- **Rewiring the ≥15 existing writers onto `classifyPageRecord()`.** That is the rest of #4239 and touches live archivers; it wants its own PR and its own review. This PR gives them something to converge *on*.
- **Folding the tiers into `r2-coverage-snapshot.mjs` / `/admin/r2-coverage`.** Same reason — the snapshot worker already runs a 10–20 min aggregation and feeds an admin page; changing what it reports is a separate, visible change.

Read-only, additive, no existing behaviour touched. `npx tsc --noEmit` clean; `check-imports` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PamsbX7RQrKvwFu4GVjRAz
