### PR TITLE
fix(ci): Hetzner deploy watched 2 of the 8 script dirs the box actually runs

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -3,9 +3,24 @@ name: Deploy to Hetzner
 on:
   push:
     branches: [main]
+    # The box runs cron jobs out of EIGHT script directories — measured from its
+    # live crontab 2026-08-30: analysis, analytics, batch, catalog-coverage,
+    # enrichment, eval, maintenance, workers. This filter watched two of them,
+    # and one of those (`scripts/crons/`) does not exist in the repo at all.
+    #
+    # So a fix to a worker's shared library never reached the box on merge. That
+    # is not hypothetical: #4396 fixed the archiver's rate limiter in
+    # `scripts/lib/iiif-utils.mjs` and `scripts/catalog-coverage/`, neither
+    # matched, the workflow stayed silent, and Hetzner kept running the broken
+    # code — with the hourly :17 auto-pull as the only path in. The archiver had
+    # already been livelocked for a day at that point (#4395); a deploy that
+    # silently does not deploy is the worst way to extend an outage.
+    #
+    # `scripts/**` is the honest filter: the box executes from `scripts/`, and
+    # anything under it can change behaviour there. The hourly auto-pull remains
+    # the backstop, not the primary path.
     paths:
-      - 'scripts/workers/**'
-      - 'scripts/crons/**'
+      - 'scripts/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
Merging #4396 did not deploy it.

That PR fixed the archiver's rate limiter — the livelock in #4395 that had held R2 archiving at ~10 books/hour for a day. It touched `scripts/lib/iiif-utils.mjs` and `scripts/catalog-coverage/archive-acquired.ts`. This workflow filters on `scripts/workers/**` and `scripts/crons/**`. Neither matched, no run fired, and Hetzner kept executing the broken code. I only noticed because I checked the box's SHA instead of trusting the merge:

```
$ ssh hetzner 'git -C /root/sourcelibrary log -1 --oneline'
adf4f2a9e docs(invariants): ...   <- the commit BEFORE both merges
```

A deploy that silently does not deploy is the worst way to extend an outage.

## The filter was wrong in both directions

Measured from the box's live crontab, it runs jobs out of **eight** script directories:

```
scripts/analysis/     scripts/enrichment/
scripts/analytics/    scripts/eval/
scripts/batch/        scripts/maintenance/
scripts/catalog-coverage/   scripts/workers/
```

The filter covered **one** of them — plus `scripts/crons/`, which **does not exist in this repo**. So six directories the box actively executes had no fast deploy path, and `scripts/lib/`, imported by every archiver, had none either.

`scripts/**` is the honest filter: the box executes from `scripts/`, so anything under it can change behaviour there. The hourly `:17` auto-pull goes back to being the backstop rather than the only path in.

## Blast radius

More frequent `git fetch + reset --hard origin/main` runs on the box — the same operation the hourly cron already performs, in a 2-minute job. `reset --hard` does not touch untracked files, and the box's working tree is clean apart from untracked scratch (verified before pulling manually today). This does not introduce a new risk class; it makes an existing one fire on merge instead of up to an hour later.

Worth noting for review: `reset --hard` while a long-running job writes a *tracked* file is destructive (`invariants/main-checkout-and-worktrees.md`). That hazard already exists on every hourly pull — this PR increases its frequency, and the real fix is for jobs to write to untracked paths. Flagging rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PamsbX7RQrKvwFu4GVjRAz
