### PR TITLE
provenance: make the mark reach the surfaces machines actually read (#4406)

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -349,3 +349,35 @@ outside this repo entirely.
 known-absent item looked up in the authoritative source beats any amount of reasoning about
 aggregates. Corollary: everything *measured* in that audit held up; everything *inferred* from
 absence did not.
+
+## A detector tuned by one programme is an actuator against another
+
+Two programmes in this repo pointed at the same R2 objects with opposite
+intentions, and neither could see the other (#4406).
+
+- **#2651** regenerates each page's `display_photo` from the master at
+  `min(2000, native)` so the keyed provenance watermark survives recompression.
+- **#3005 Pass 1** flags a `display_photo` that is **≥90% of its master** as
+  "never downsized" and regenerates it to 1200px.
+
+A baked variant measures **100–122%** of its master. So every provenance-marked
+page is, by #3005's definition, textbook bloat — and `regen-display-bloat.mjs`
+would have force-overwritten each one with an unmarked 1200px variant it cannot
+re-sign (it has no key and no edition id at that point). The detector was
+correct on the day it was written; a *different* programme then changed the
+population underneath it, and a threshold that used to mean "nobody downsized
+this" came to mean "somebody marked this."
+
+**The rule: a threshold encodes an assumption about who else writes to the
+population.** Before running any sweep that overwrites or deletes on a measured
+property, ask *what else writes here, and would its output look like my
+detector's positive class?* Then make the guard explicit and **counted** — the
+executor now HEADs the display key, skips objects carrying `provenance`
+metadata, reports them as `marked=N`, and requires `--force-unmark`. A silent
+skip would have been the same failure in the other direction.
+
+Corollary, and the reason this pairs with the section above: the collision is
+invisible from either issue thread. Neither #2651 nor #3005 mentions the other,
+and both are individually well-reasoned. **Shared mutable state is discovered by
+reading the writers, not the plans** — same lesson as the two sessions that both
+wrote `locus_anchors`, one object store instead of one collection.

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -10,12 +10,27 @@
  * itself means the mark travels with the file: it survives direct hotlinks,
  * copy-image-address, and screenshots, with zero recurring serve cost.
  *
- * It marks the EXISTING variant via scripts/lib/provenance-mark.mjs — invisible
- * EXIF (Copyright/Source/edition id) + an invisible keyed watermark on every page
- * + a subtle visible logo on ~1-in-10 pages — and overwrites the SAME R2 key, so
- * no DB pointer changes and no churn. Idempotent: it stamps each object's R2
- * metadata with `provenance: <MARK_VERSION>` and skips anything already marked.
+ * It does NOT mark the existing variant in place. It REGENERATES the display
+ * variant from the clean master at min(DISPLAY_MAX_W, native) and marks that,
+ * via scripts/lib/provenance-mark.mjs — invisible EXIF (Copyright/Source/edition
+ * id) + an invisible keyed watermark on every page + a subtle visible logo on
+ * ~1-in-10 pages — then overwrites the SAME R2 key, so no DB pointer changes and
+ * no churn. Idempotent: it stamps each object's R2 metadata with
+ * `provenance: <MARK_VERSION>` and skips anything already marked.
  * Requires PROVENANCE_SECRET_KEY (the watermark key, shared with the text imprimatur).
+ *
+ * ⚠ THIS COSTS STORAGE, AND THIS PARAGRAPH IS WHY (#4406). The regeneration is at
+ * 2000px while the forward-path generator (scripts/workers/lib/display-image.mjs)
+ * writes display variants at 1200px. Measured like-for-like — same master, same
+ * q85, width the only variable — 2000px is 1.98x the bytes, +336 KB per page:
+ * ~$40/month across the visible corpus, and on a page whose master is <=2000px the
+ * "display copy" ends up LARGER than the master it came from. That is not a bug;
+ * the width was chosen so the keyed watermark survives recompression (detection
+ * z 6.9-8.5 -> 10.7-13) and because the marked variant is the reader's resting
+ * image. It was simply never costed. An earlier header said "marks the EXISTING
+ * variant" — left over from the pre-sl-v3 design — and a cost investigation
+ * believed it, measured the watermark (0.7%, true) instead of the resize (98%),
+ * and cleared this script while it ran for six more weeks. Keep this accurate.
  *
  * The originals used for OCR / download / deep-zoom (`archived_photo`,
  * `photo_original`, `original`/`hires` tiers) are NOT touched — only the
@@ -198,16 +213,25 @@ async function main() {
     } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.displayKey}: ${e.message}`); }
   };
 
-  // Process per-book to keep each Mongo cursor bounded; the pool spans chunks.
-  const BOOK_CHUNK = 500;
+  // Process per-book in chunks, and MATERIALISE each chunk before doing any work.
+  //
+  // The previous shape streamed `for await (const p of cursor)` while each page
+  // did a HEAD + GET + PUT — so the cursor sat idle for far longer than Mongo's
+  // 10-minute timeout, and the run died (June) or wedged forever (Aug 21 → Aug 30,
+  // alive at 0.03s CPU per 20s with the log silent for nine days, which no retry
+  // loop can rescue because the process never exits). Same failure and same fix as
+  // the preservation manifest in b2f253e6: a few tens of thousands of small
+  // projected docs cost nothing to hold; an idle cursor costs the whole run.
+  // Chunk is 100 books, not 500, to keep each materialised batch modest.
+  const BOOK_CHUNK = 100;
   outer:
   for (let i = 0; i < bookIds.length; i += BOOK_CHUNK) {
     const chunk = bookIds.slice(i, i + BOOK_CHUNK);
     const proj = { _id: 0, id: 1, book_id: 1, page_number: 1, display_photo: 1,
       archived_photo: 1, photo_original: 1, cropped_photo: 1, photo: 1, split_from_spread: 1 };
-    const cursor = pages.find({ book_id: { $in: chunk } }, { projection: proj });
+    const batch = await pages.find({ book_id: { $in: chunk } }, { projection: proj }).toArray();
 
-    for await (const p of cursor) {
+    for (const p of batch) {
       scanned++;
       const displayKey = keyFromUrl(p.display_photo);     // pages/ key we may overwrite
       if (!p.display_photo) { skipped++; continue; }

--- a/scripts/maintenance/r2-reclaim/regen-display-bloat.mjs
+++ b/scripts/maintenance/r2-reclaim/regen-display-bloat.mjs
@@ -13,6 +13,10 @@
  *     those and never serves the display variant, so regenerating from the
  *     spread master would bake a wrong (full-spread) image for no benefit (#1814),
  *   - resize with the shared generateDisplayVariants() (1200px + provenance mark),
+ *   - SKIP display variants already carrying a provenance mark (#4406): the
+ *     #2651 bake regenerates those at <=2000px, which reads as 'bloat' to this
+ *     pass's >=90%-of-master detector, and regenerating would strip the keyed
+ *     watermark. Reported as marked=N; --force-unmark overrides deliberately.
  *   - overwrite display + thumb keys, update Mongo display_photo/image_thumb.
  *
  * The master (archived/ or -full) is never touched, so every regenerated display
@@ -26,7 +30,7 @@
  */
 import fs from 'node:fs';
 import readline from 'node:readline';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { generateDisplayVariants } from '../../workers/lib/display-image.mjs';
 import { getPageSource, isUsableImageUrl } from '../../lib/page-image-url.mjs';
 import { mongo, outPath, human } from './lib.mjs';
@@ -37,6 +41,9 @@ const has = (n) => args.includes(`--${n}`);
 
 const DRY_RUN = has('dry-run');
 const VERIFY = has('verify');
+// Escape hatch for a deliberate, whole-corpus width decision (#4406) — NOT for a
+// routine reclaim run. Without it, provenance-marked variants are left alone.
+const FORCE_UNMARK = has('force-unmark');
 const LIMIT = parseInt(getArg('limit') || '0', 10) || Infinity; // candidate rows to consider
 const CONCURRENCY = parseInt(getArg('concurrency') || '8', 10);
 const MIN_RECLAIM = parseInt(getArg('min-reclaim') || '0', 10); // skip rows below this reclaimEst (bytes)
@@ -58,7 +65,7 @@ const PAGE_PROJECTION = {
 
 const st = {
   rows: 0, considered: 0,
-  regen: 0, skipSplit: 0, skipNoSource: 0, skipNotFound: 0, failed: 0,
+  regen: 0, skipSplit: 0, skipNoSource: 0, skipNotFound: 0, skipMarked: 0, failed: 0,
   oldBytes: 0, newBytes: 0, reclaimed: 0, downloadBytes: 0,
   start: Date.now(),
 };
@@ -88,6 +95,28 @@ function resolveSource(page) {
   return { source };
 }
 
+/**
+ * Is this display object a provenance-marked variant written by the #2651 bake?
+ *
+ * THIS GUARD IS THE POINT, NOT AN OPTIMISATION (#4406). Pass 1's detector calls
+ * a display "never downsized" when it is >=90% of its master — and a baked
+ * variant, regenerated at min(2000, native) q85, is routinely 100-122% of the
+ * master it came from. So *every* marked page looks exactly like bloat to this
+ * pass, and regenerating it would silently strip the keyed watermark (this
+ * script's 1200px path cannot re-embed it without the book id and key) and undo
+ * work that costs ~$40/month of storage to produce. Two programmes, one set of
+ * objects, opposite intentions. Skip them and say how many.
+ */
+async function isProvenanceMarked(displayKey) {
+  try {
+    const h = await s3.send(new HeadObjectCommand({ Bucket: BUCKET, Key: displayKey }));
+    return Boolean(h.Metadata?.provenance);
+  } catch {
+    // Missing/unreadable object: let the normal path handle it.
+    return false;
+  }
+}
+
 async function processRow(row, page, db) {
   const { source, skip } = resolveSource(page);
   if (skip === 'split') { st.skipSplit++; return; }
@@ -97,13 +126,17 @@ async function processRow(row, page, db) {
   const displayKey = `pages/${page.book_id}/${num}.jpg`;
   const thumbKey = `pages/${page.book_id}/${num}-thumb.jpg`;
 
+  if (!FORCE_UNMARK && await isProvenanceMarked(displayKey)) { st.skipMarked++; return; }
+
   if (DRY_RUN) { st.regen++; st.oldBytes += row.displaySize; return; }
 
   try {
     const buf = await download(source);
     if (!buf || buf.length === 0) throw new Error(`empty source: ${source.slice(0, 80)}`);
     st.downloadBytes += buf.length;
-    const { display, thumb } = await generateDisplayVariants(buf);
+    const { display, thumb } = await generateDisplayVariants(buf, {
+      bookId: page.book_id, pageNumber: page.page_number,
+    });
     if (VERIFY) {
       const dir = outPath('verify-samples');
       fs.mkdirSync(dir, { recursive: true });
@@ -139,7 +172,7 @@ async function runPool(tasks, db) {
 
 function logProgress() {
   const el = (Date.now() - st.start) / 1000;
-  console.error(`  considered=${st.considered} regen=${st.regen} split=${st.skipSplit} nosrc=${st.skipNoSource} nf=${st.skipNotFound} fail=${st.failed} reclaimed=${human(st.reclaimed)} (${(st.regen / el).toFixed(1)}/s)`);
+  console.error(`  considered=${st.considered} regen=${st.regen} split=${st.skipSplit} nosrc=${st.skipNoSource} nf=${st.skipNotFound} marked=${st.skipMarked} fail=${st.failed} reclaimed=${human(st.reclaimed)} (${(st.regen / el).toFixed(1)}/s)`);
 }
 
 async function main() {
@@ -189,6 +222,7 @@ async function main() {
     config: { MIN_RECLAIM, LIMIT: LIMIT === Infinity ? 'all' : LIMIT, CONCURRENCY },
     manifest_rows: st.rows, considered: st.considered,
     regenerated: st.regen, skip_split: st.skipSplit, skip_no_source: st.skipNoSource,
+    skip_provenance_marked: st.skipMarked,
     skip_not_found: st.skipNotFound, failed: st.failed,
     old_display_bytes: st.oldBytes, old_human: human(st.oldBytes),
     new_display_bytes: st.newBytes, new_human: human(st.newBytes),

--- a/scripts/maintenance/rearchive-iiif-fullres.mjs
+++ b/scripts/maintenance/rearchive-iiif-fullres.mjs
@@ -316,7 +316,9 @@ async function regenerateVariants(page, masterBuffer) {
   const displayKey = toKey(page.display_photo);
   const thumbKey = toKey(page.image_thumb) || toKey(page.thumbnail_blob);
   if (!displayKey && !thumbKey) return;
-  const { display, thumb } = await generateDisplayVariants(masterBuffer);
+  const { display, thumb } = await generateDisplayVariants(masterBuffer, {
+    bookId: page.book_id, pageNumber: page.page_number,
+  });
   if (displayKey) await r2Put(displayKey, display);
   if (thumbKey) await r2Put(thumbKey, thumb);
 }

--- a/scripts/maintenance/repair-cover-thumbs.mjs
+++ b/scripts/maintenance/repair-cover-thumbs.mjs
@@ -163,7 +163,9 @@ async function repairFromBookImage(db, book) {
   const source = bookLevelCoverImage(book);
   if (!source) return false;
   const buf = await download(source);
-  const { thumb } = await generateDisplayVariants(buf);
+  // Only the thumb is used here (book-level cover), but pass the identity anyway
+  // so the discarded display buffer doesn't trip the "unmarked variant" warning.
+  const { thumb } = await generateDisplayVariants(buf, { bookId: book.id, pageNumber: 0 });
   const thumbUrl = await uploadR2(bookThumbKey(book.id), thumb);
   await db.collection('books').updateOne(
     { id: book.id },
@@ -200,7 +202,9 @@ async function repairBook(db, book) {
     const keys = variantKeys(book.id, page.page_number);
     // Regenerate fresh from the CORRECT source (cropped half for split) — bulletproof.
     const buf = await download(source);
-    const { display, thumb } = await generateDisplayVariants(buf);
+    const { display, thumb } = await generateDisplayVariants(buf, {
+      bookId: book.id, pageNumber: page.page_number,
+    });
     const displayUrl = await uploadR2(keys.display, display);
     const thumbUrl = await uploadR2(keys.thumb, thumb);
 

--- a/scripts/migration/backfill-display-images.mjs
+++ b/scripts/migration/backfill-display-images.mjs
@@ -206,7 +206,9 @@ async function processPage(page, db) {
       if (!fullResBuffer || fullResBuffer.length === 0) {
         throw new Error(`empty source download: ${source.slice(0, 100)}`);
       }
-      const { display, thumb } = await generateDisplayVariants(fullResBuffer);
+      const { display, thumb } = await generateDisplayVariants(fullResBuffer, {
+        bookId: page.book_id, pageNumber: page.page_number,
+      });
       displayUrl = await uploadToR2(keys.display, display);
       thumbUrl = await uploadToR2(keys.thumb, thumb);
       stats.bytesUploaded += display.length + thumb.length;

--- a/scripts/workers/lib/display-image.mjs
+++ b/scripts/workers/lib/display-image.mjs
@@ -3,6 +3,16 @@
  * from a full-res image buffer, with provenance marks baked into the display version.
  *
  * Used by all 3 archive workers (archive-ocr, archive-bulk, archive-erara).
+ *
+ * WIDTH DISAGREEMENT — deliberate, and open (#4406). This forward path writes
+ * display variants at DISPLAY_WIDTH (1200). The backfill,
+ * scripts/maintenance/bake-provenance-mark.mjs, REGENERATES them at
+ * min(2000, native) — chosen so the keyed watermark has enough textured blocks
+ * to survive recompression (detection z 6.9-8.5 -> 10.7-13), and because the
+ * marked variant became the reader's resting image. The corpus therefore holds
+ * both widths. Do not "fix" one to match the other unilaterally: 2000px costs
+ * ~$40/month in R2 corpus-wide (measured 1.98x, +336 KB/page), so it is a
+ * spend decision, tracked on #4406. Whoever settles it should change BOTH.
  */
 
 import sharp from 'sharp';
@@ -11,6 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { assertBookScopedKey } from '../../lib/r2-key.mjs';
+import { markImage } from '../../lib/provenance-mark.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -121,13 +132,63 @@ async function applyProvenanceMarks(buffer) {
     .toBuffer();
 }
 
+// Warn once per process, not once per page — an archive run is millions of pages.
+let _warnedNoKeyedMark = null;
+
+/**
+ * Apply the canonical #2651 provenance scheme to a display buffer: EXIF +
+ * LLM-readable message + a keyed invisible watermark on EVERY page, plus a
+ * discreet visible logo on ~1 in 10 (the rate lives inside markImage).
+ *
+ * This is the SAME module the backfill uses (scripts/lib/provenance-mark.mjs),
+ * so a page archived today carries the same detectable mark as a page the
+ * backfill touched. Before #4406 this path applied a local, cosmetic-only
+ * reimplementation to just 10% of pages and embedded no keyed watermark at all,
+ * so 90% of newly archived pages left the system unmarked and none of them were
+ * attributable — while the whole point of #2651 is recognising our scans in the
+ * wild. Every import widened that hole.
+ *
+ * Falls back to the legacy cosmetic marks (never to *nothing*) when the
+ * watermark key or the book id is unavailable, and says so once — a silent
+ * downgrade here is invisible for months.
+ */
+async function applyCanonicalMarks(displayBuffer, bookId, pageNumber) {
+  const key = process.env.PROVENANCE_SECRET_KEY;
+  const reason = !key ? 'PROVENANCE_SECRET_KEY is not set'
+    : !bookId ? 'caller passed no bookId'
+    : null;
+
+  if (!reason) {
+    try {
+      return await markImage(displayBuffer, { editionId: bookId, pageNumber, key });
+    } catch (e) {
+      if (_warnedNoKeyedMark !== 'error') {
+        _warnedNoKeyedMark = 'error';
+        console.warn(`[provenance] keyed mark FAILED, falling back to cosmetic marks: ${e.message}`);
+      }
+    }
+  } else if (_warnedNoKeyedMark !== reason) {
+    _warnedNoKeyedMark = reason;
+    console.warn(
+      `[provenance] display variants are being written WITHOUT the keyed watermark — ${reason}. ` +
+      `They will not be attributable in the wild (#2651).`
+    );
+  }
+
+  // Legacy path: cosmetic marks on ~1 in 10, exactly as before #4406.
+  return Math.random() < 0.1 ? applyProvenanceMarks(displayBuffer) : displayBuffer;
+}
+
 /**
  * Generate display and thumbnail variants from a full-res buffer.
  *
  * @param {Buffer} fullResBuffer - The full-resolution JPEG buffer
- * @returns {{ display: Buffer, thumb: Buffer }} - The generated variants
+ * @param {{ bookId?: string, pageNumber?: number }} [ids] - Identity for the
+ *   provenance mark. Omit ONLY where no page identity exists; omitting it costs
+ *   the keyed watermark and logs a warning.
+ * @returns {{ display: Buffer, thumb: Buffer, displayWidth: number|null, displayHeight: number|null }}
  */
-export async function generateDisplayVariants(fullResBuffer) {
+export async function generateDisplayVariants(fullResBuffer, ids = {}) {
   // Guard BEFORE creating displayPromise: an empty/invalid buffer makes the
   // sharp() constructor throw *synchronously*. If that sync throw happened at
   // the thumbPromise line below, `displayPromise` would already be a pending
@@ -143,9 +204,7 @@ export async function generateDisplayVariants(fullResBuffer) {
       .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
       .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
       .toBuffer();
-    return Math.random() < 0.1
-      ? await applyProvenanceMarks(displayResized)
-      : displayResized;
+    return applyCanonicalMarks(displayResized, ids.bookId, ids.pageNumber);
   })();
 
   const thumbPromise = sharp(fullResBuffer)
@@ -154,7 +213,16 @@ export async function generateDisplayVariants(fullResBuffer) {
     .toBuffer();
 
   const [display, thumb] = await Promise.all([displayPromise, thumbPromise]);
-  return { display, thumb };
+  // The variant's OWN dimensions. The IIIF manifest paints the display variant
+  // (#4406) and needs its real size; without this it can only estimate from the
+  // master. Recorded here so every writer that persists a page doc can store it.
+  let displayWidth = null, displayHeight = null;
+  try {
+    const dm = await sharp(display).metadata();
+    displayWidth = dm.width || null;
+    displayHeight = dm.height || null;
+  } catch { /* dimensions are a nice-to-have; never fail an archive over them */ }
+  return { display, thumb, displayWidth, displayHeight };
 }
 
 /**
@@ -184,7 +252,7 @@ export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uplo
   // while sharp generates the resized variants in parallel.
   const metaPromise = sharp(fullResBuffer).metadata();
   const archivedUploadPromise = uploadFn(archivedKey, fullResBuffer, 'image/jpeg');
-  const variantsPromise = generateDisplayVariants(fullResBuffer);
+  const variantsPromise = generateDisplayVariants(fullResBuffer, { bookId, pageNumber });
 
   // Once variants are ready, start their uploads — they run alongside the full-res upload.
   const variantUploadsPromise = variantsPromise.then(({ display, thumb }) =>
@@ -194,17 +262,24 @@ export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uplo
     ])
   );
 
-  const [archivedUrl, [displayUrl, thumbUrl], meta] = await Promise.all([
+  const [archivedUrl, [displayUrl, thumbUrl], meta, variants] = await Promise.all([
     archivedUploadPromise,
     variantUploadsPromise,
     metaPromise,
+    variantsPromise,
   ]);
 
   return {
     archived: archivedUrl,
     display: displayUrl,
     thumb: thumbUrl,
+    // width/height describe the MASTER (archived_photo), as they always have.
     width: meta.width || null,
     height: meta.height || null,
+    // …and these describe the display variant. Callers that persist a page doc
+    // should store them as display_width / display_height so the IIIF manifest
+    // can state the painted body's true size instead of estimating it (#4406).
+    displayWidth: variants.displayWidth,
+    displayHeight: variants.displayHeight,
   };
 }

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -4,7 +4,12 @@
  * GET /api/iiif/{bookId}/manifest
  *
  * Returns a standards-compliant IIIF manifest for any book in Source Library.
- * Canvases reference the best available image (archived > original > photo).
+ * Canvases PAINT the provenance-marked display variant (`display_photo`) and
+ * offer the unmarked full-resolution original as a labelled `rendering`. That
+ * ordering is the point, not an accident: crawlers read manifests and never run
+ * JS, so the painted body is what gets harvested into datasets, and #2651's goal
+ * is that every image leaving the system carries its attribution mark. Falls
+ * back to archived > original > photo when a page has no marked variant (#4406).
  * OCR and translation annotations are referenced (not inline) and loaded on demand
  * via /api/iiif/{bookId}/canvas/{pageNumber}/{ocr|translation}.
  */
@@ -124,6 +129,11 @@ function extractImageService(url: string): { id: string; type: string; profile: 
 // Default canvas dimensions, used only when a page has no stored pixel size.
 const DEFAULT_WIDTH = 1500;
 const DEFAULT_HEIGHT = 2160;
+
+// Width cap the provenance bake regenerates display variants at
+// (scripts/maintenance/bake-provenance-mark.mjs DISPLAY_MAX_W). Used only to
+// estimate a marked body's size when the writer recorded no dimensions.
+const MARKED_DISPLAY_MAX_W = 2000;
 
 // `image_source.provider` has accumulated alternate keys over time; map the
 // aliases back to the canonical key that LIBRARY_PARTNERS is registered under
@@ -252,6 +262,8 @@ export async function GET(
             photo: 1,
             photo_original: 1,
             archived_photo: 1,
+            display_photo: 1,
+            display_width: 1, display_height: 1,
             image_width: 1, image_height: 1,
             thumbnail_blob: 1, image_thumb: 1,
             thumbnail: 1, image_display: 1,
@@ -424,22 +436,52 @@ export async function GET(
     const canvases = pagesLight.map((page) => {
       const pageNum = page.page_number;
       const canvasId = `${BASE}/api/iiif/${id}/canvas/p${pageNum}`;
-      const imageUrl = page.archived_photo || page.photo_original || page.photo;
-      const service = imageUrl ? extractImageService(imageUrl) : null;
+      // The ORIGINAL, unmarked master (or the partner's IIIF URL on
+      // derivative-only pages). Still offered — as an explicit `rendering`
+      // below — but no longer the default body. See #4406.
+      const originalUrl = page.archived_photo || page.photo_original || page.photo;
+      // The provenance-marked display variant is what we PAINT (#2651): crawlers
+      // read manifests and never run JS, so the body is what gets harvested, and
+      // #2651's goal is that every image leaving the system carries the mark.
+      const paintedUrl = page.display_photo || originalUrl;
+      const isMarked = Boolean(page.display_photo);
+      // A `service` must describe the body it is attached to. The marked variant
+      // is a plain R2 object with no Image API service, so only attach the
+      // upstream service when the body IS that upstream image.
+      const service = !isMarked && paintedUrl ? extractImageService(paintedUrl) : null;
 
       // Use the real digitized pixel size when archiving recorded it, so that
       // xywh region citation / annotation targeting lands on the correct part
       // of the image. Fall back to a nominal page size only when unknown.
+      // NOTE: canvas dimensions stay in the MASTER's pixel space even when the
+      // painted body is the smaller marked variant — existing annotation targets
+      // are expressed against it, and IIIF viewers scale the body to the canvas.
       const width = page.image_width || DEFAULT_WIDTH;
       const height = page.image_height || DEFAULT_HEIGHT;
 
       const imageBody: Record<string, unknown> = {
-        id: imageUrl,
+        id: paintedUrl,
         type: 'Image',
         format: 'image/jpeg',
-        width,
-        height,
       };
+      // Body dimensions, most trustworthy first:
+      //  1. what the variant writer actually recorded (display_width/height);
+      //  2. else derive from the master, capped at the bake's DISPLAY_MAX_W —
+      //     exact for baked pages, and for the not-yet-baked 1200px ones still
+      //     the right ASPECT (which is what a viewer lays out on), only a
+      //     pixel-density hint that is generous;
+      //  3. else fall through to the canvas dimensions.
+      if (isMarked && page.display_width && page.display_height) {
+        imageBody.width = page.display_width;
+        imageBody.height = page.display_height;
+      } else if (isMarked && page.image_width && page.image_height) {
+        const bodyW = Math.min(MARKED_DISPLAY_MAX_W, page.image_width);
+        imageBody.width = bodyW;
+        imageBody.height = Math.round((page.image_height * bodyW) / page.image_width);
+      } else {
+        imageBody.width = width;
+        imageBody.height = height;
+      }
       if (service) {
         imageBody.service = [service];
       }
@@ -466,6 +508,20 @@ export async function GET(
           },
         ],
       };
+
+      // Keep the full-resolution original reachable for legitimate scholarly use —
+      // as a labelled `rendering`, not as the thing a bulk harvester takes by
+      // default. Only when it is a DIFFERENT image from the one we painted.
+      if (originalUrl && originalUrl !== paintedUrl) {
+        canvas.rendering = [
+          {
+            id: originalUrl,
+            type: 'Image',
+            format: 'image/jpeg',
+            label: { en: ['Full-resolution original scan'] },
+          },
+        ];
+      }
 
       // Thumbnail
       const thumbUrl = page.thumbnail_blob || page.thumbnail;

--- a/src/lib/og-page-card.tsx
+++ b/src/lib/og-page-card.tsx
@@ -59,6 +59,7 @@ const OG_BOOK_PROJECTION = {
 };
 const OG_PAGE_PROJECTION = {
   _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1,
+  display_photo: 1,
   cropped_photo: 1, crop: 1, 'translation.data': 1, 'ocr.data': 1,
   // The language-keyed map (and its legacy Spanish field) so the Spanish card
   // can excerpt the Spanish text rather than the English pivot.
@@ -99,7 +100,13 @@ export async function renderPageOgImage(id: string, pageId: string, lang: Locale
   const title = (book ? localizedTitle(book as Book & { localized?: LocalizedBookMap }, lang) : '') || t.unknownTitle;
   const author = book?.author || t.unknownAuthor;
   const pageNum = page?.page_number || '?';
-  const imageUrl = (page as any)?.enhanced_photo || page?.compressed_photo || page?.archived_photo || page?.photo;
+  // Prefer the provenance-marked display variant (#2651/#4406): an OG card is
+  // scraped and re-hosted by every platform that renders a link preview, so it
+  // is one of the most-copied images we emit and should carry its mark.
+  // enhanced_photo stays ahead of it — it is a deliberate cover-selection
+  // preference and is currently ~0% populated.
+  const imageUrl = (page as any)?.enhanced_photo || page?.compressed_photo
+    || (page as any)?.display_photo || page?.archived_photo || page?.photo;
 
   // Truncate title if too long
   const displayTitle = title.length > 50 ? title.substring(0, 47) + '...' : title;


### PR DESCRIPTION
Closes the actionable half of #4406. **The width decision itself is deliberately NOT in this PR** — it costs ~$40/month and is yours.

## Why

#2651's goal, in its own words:

> every page image that leaves the system carries a provenance mark, so we can recognize our content in the wild

The corpus is CC BY-SA 4.0, so this is attribution, not DRM. But the mark was landing on the surface *humans* look at, and not on the ones *machines* read — which is backwards, because machines are who the mark is for.

## What changed

**1. IIIF manifest and OG card now carry the mark.**

`/api/iiif/{id}/manifest` painted `archived_photo` — the unmarked original. Crawlers read manifests and never execute JS, so the painted body is what lands in datasets; #2653's reader change only fixed the human-facing view. Canvases now paint `display_photo`, with the full-res original offered as a labelled `rendering` so scholarly use keeps it explicitly rather than by default.

Two things held constant on purpose:
- **Canvas dimensions stay in the master's pixel space.** Existing `xywh` annotation targets are expressed against it (see `image-quality-and-bboxes.md`); IIIF viewers scale the body to the canvas.
- **`service` is attached only when the body IS the upstream IIIF image.** A service must describe its own body, and the marked R2 variant has none.

Same reasoning for `og-page-card` — an OG card is scraped and re-hosted by every platform that renders a link preview.

**2. The forward path now marks every page, with the real watermark.**

`generateDisplayVariants` ended with:

```js
return Math.random() < 0.1 ? await applyProvenanceMarks(displayResized) : displayResized;
```

`applyProvenanceMarks` was a *local reimplementation* — visible icon, URL text, EXIF — that never imported `provenance-mark.mjs` and embedded **no keyed watermark and no edition id**. So newly archived pages were 90% unmarked, 10% cosmetically marked, 0% attributable, and every import widened the hole (1.24M pages on Aug 28 alone). It now calls the same `markImage()` the backfill uses, on every page.

Verified end to end on a real page, not just typechecked:

| check | result |
|---|---|
| detect with our key | `present: true, z=59.3` |
| detect with a wrong key | `present: false, z=-1.9` |
| call without ids (negative control) | `present: false` + a one-time warning |

When the key or book id is missing it falls back to the old cosmetic marks rather than nothing, and logs once — a silent downgrade here stays invisible for months.

**3. A collision that would have erased the whole programme.**

#3005's Pass 1 flags a display as "never downsized" when it is ≥90% of its master. A baked variant, regenerated at ≤2000px q85, is routinely **100–122%** of its master — so *every* provenance-marked page reads as bloat, and `regen-display-bloat.mjs` would have force-overwritten it with an unmarked 1200px variant. Two programmes, one set of objects, opposite intentions, and nothing between them.

It now HEADs the display key, skips anything carrying `provenance` metadata, reports it as `marked=N`, and requires `--force-unmark` to do otherwise.

**4. The bake's nine-day hang.**

It streamed a Mongo cursor while each page did HEAD+GET+PUT, so the cursor idled far past the 10-minute timeout. It has been alive but wedged since Aug 21 03:54 — 0.03s of CPU per 20s — and the wrapper's 40-attempt retry loop cannot help, because the process never exits. Each chunk is now materialised before any work, exactly as `b2f253e6` did for the preservation manifest.

**5. The header that caused all of this.**

It said the script "marks the EXISTING variant". One commit in #2653 switched it to regenerate-from-source at 2000px and never updated the docstring. A later cost investigation read the header, measured the *watermark* (0.7% — true), cleared the script, and the real cause ran six more weeks at ~$22/month of permanent storage. Both files now state the width disagreement and its measured price.

## Out of scope, deliberately

- **The 1200-vs-2000 width decision** (~$40/month at completion). Both writers now document that they disagree and why; neither was changed unilaterally.
- **Persisting `display_width`/`display_height` from the eight archive workers.** `uploadPageVariants` now returns them. Until they are stored, the manifest derives a body size that is exact for baked pages and aspect-correct for the rest.
- **Gating `/archived/` itself** — that is #4373, still open, and a separate decision.
- **Gallery crops in `sitemap.ts`** (`<image:loc>`) point at `gallery_images.image_url` directly. Served via `/api/gallery/image/[id]` they pick up serve-time marks; advertised to crawlers as a raw R2 URL they may not. Not touched here; worth its own look.

## Verification

- `npx tsc --noEmit` clean
- 233 test files / 3,201 tests pass; 5 integration files / 41 tests pass
- `node --check` on all six changed scripts
- watermark positive + negative controls above, against production R2 and a real master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrjrf5NFNsamfMBjpQFNhm
