### PR TITLE
preservation: back up the text, and state the policy in one place

### DIFF
--- a/.claude/docs/preservation-policy.md
+++ b/.claude/docs/preservation-policy.md
@@ -1,0 +1,164 @@
+# What we preserve, and what we are willing to lose
+
+**Read this when:** deleting anything, designing a backup, adding a store, answering
+"is it safe?", or deciding whether a copy is worth keeping.
+
+*Added 2026-08-30. The principles here were already enforced in code and scattered
+across five places; this file is where they are stated together, because until now
+nobody could read them in one sitting and two of them contradicted each other.*
+
+---
+
+## The one-sentence version
+
+**Keep what cannot be re-made; regenerate what can; and never confuse "we can still
+serve it" with "we still have it."**
+
+## The five principles
+
+### 1. Classify by replaceability, never by convention
+
+Before deleting anything the only question that matters is *could we get this back?*
+
+| class | meaning | policy |
+|---|---|---|
+| **M — master** | irreplaceable, or only by re-acquiring from an institution | never delete |
+| **S — source** | bulk imports/PDFs the corpus was built from | delete only after proving the derived pages exist |
+| **D — derived** | recomputable from an M or S | free to delete and regenerate |
+| **E — editorial** | hand-made site assets | small; losing it means a person redoes design work |
+| **T — transient** | test/prototype scratch | free |
+
+Full prefix inventory: `r2-storage.md`. The near-miss that produced it: `archive/`
+(396 GB) showed every signal of dead weight — referenced by zero page docs, written
+in one day, sitting beside the live `archived/` under a near-identical name. It is
+358,625 JPEG 2000 masters from the BPH partner library with **no `ia_identifier`**,
+so nothing could have re-fetched them. Deleting it would have destroyed partner
+masters to save $71/year.
+
+**Why this keeps happening:** a missing *display* variant is a broken image someone
+reports within the hour. A missing *master* breaks nothing visible. The paths that
+fail silently are exactly the ones that go undocumented, and they are the ones you
+cannot re-create.
+
+### 2. The text is the irreplaceable half, and it is 1.8% of the bytes
+
+This is the principle most likely to be got backwards, because the intuition is that
+the big thing is the important thing.
+
+| | size | can we get it back? |
+|---|---|---|
+| images | ~21.7 TB | mostly yes — from the source institution, expensively |
+| text + metadata | ~42 GB | **no** |
+
+The text was produced here at ~$56.5K of model spend plus years of curatorial
+judgment, and **no institution has a copy**. Re-OCR is not recovery: it re-spends the
+budget and still does not regenerate human editorial corrections, `page_revisions`
+(which record what a specific model produced on a specific day, and so are not
+reproducible even in principle), first-translation evidence, or index attributions.
+
+**Archive the text first. It costs about four cents a month.**
+
+### 3. Tier by re-acquisition path, not by importance
+
+- **tier0** — no public re-acquisition path: `bph`, `cmc_kloss`, `allard_pierson`.
+  If we lose these, they are gone.
+- **tier1** — public institutional repositories. Re-fetchable, expensively, and
+  **only while the institution keeps serving them at the same URLs**.
+- **tier2** — has an `ia_identifier`; Internet Archive holds a copy.
+
+Instrument: `scripts/maintenance/build-preservation-manifest.mjs`.
+
+### 4. "Archived" is three questions, and you never sum them
+
+| tier | question | instrument |
+|---|---|---|
+| **RECORD** | does a page doc *claim* an R2 URL? | `classifyPageRecord()` |
+| **FILE** | does that object *exist*? | HEAD, sampled |
+| **MASTER** | is it the *full-resolution original*? | dimensions, sampled |
+
+Measured 2026-08-30: "on R2 at all" reads **78.4%**, "claims a master" **72.6%**.
+Both true. Quoting either without its tier is how one corpus produced three coverage
+numbers in an hour. Full text: `invariants/archive-coverage.md`.
+
+### 5. An honest uncertain answer beats a cheap wrong one
+
+You cannot classify a page image by its R2 key. `pages/{id}/{NNNN}.jpg` is documented
+as a 1200px display variant and in production also holds 1361×2517 and 2370×3816
+masters. So `classifyPageRecord()` returns `MASTER_OR_DERIVATIVE` — "cannot tell from
+here" — and only a dimensional check returns a verdict. Every cheap guess made before
+this was optimistic, in the direction that looks like success.
+
+## What this means for two specific questions
+
+### Do we keep clean, unmarked material?
+
+**Yes — it is a hard rule, enforced in code, not a convention.** The provenance bake
+writes only to `pages/` keys; it refuses any other prefix, and skips a page whose
+display key *is* its master rather than marking it. Serving tiers can remove *visible*
+marks but never the EXIF or the keyed watermark. Verified 2026-08-30: the IIIF
+manifest's full-resolution `rendering` originals sample 0/25 marked, while its painted
+display bodies sample 25/25 marked.
+
+**But "clean" means unmarked, not immutable.** `archived_photo` is a mutable slot:
+`rearchive-iiif-fullres.mjs` refetches and overwrites it in place. That is how #3186
+corrupted 320 books — `photo_original` turned out to be a differently-indexed sequence
+of the same book (e-rara's PDF carries a generated cover sheet, its IIIF stream does
+not), so every image slid one page under its own text. A perceptual-hash guard now
+runs before any overwrite. **We hold *a* master and sometimes replace it; we do not
+hold a frozen acquisition-time original.**
+
+### Do we keep the highest resolution?
+
+**It is the goal, with a measured deficit and an active repair path — not a guarantee.**
+
+- **~11% of pages are below native resolution** (mean stored/native width ratio
+  0.958) — ~2.2M pages. They serve fine and **cannot be regenerated larger**.
+- **~90,000 pages across 486 live books have no master at all** — derivative-only.
+  They render 100% from our CDN while the only full-resolution copy sits on the
+  partner's server. If that partner changes a URL scheme, we serve 1200px forever.
+- Repair: `rearchive-iiif-fullres.mjs`, `deepzoom-harvest-page-masters.mjs`.
+  Standing detector: `scripts/audit/pages-served-without-a-master.mjs`, weekly.
+
+**Corollary — an audit must not become an incident.** Verifying a master means reading
+bytes from the source institution. Three hosts blocked us inside 48 hours in August
+2026 (MDZ #4395, plus the IA and Wellcome incidents). The audit runs **serially with a
+650ms gap** for that reason. Do not parallelise it to make a report finish sooner.
+
+## What is actually backed up (as of 2026-08-30)
+
+| store | covered by | where | frequency |
+|---|---|---|---|
+| `books`, `books_warehouse`, `deleted_books` | `backup-books.sh` → restic | Hetzner Object Storage nbg1, encrypted | daily 04:00 |
+| `pages`, `page_revisions`, `chapter_texts`, `entities`, `first_translation_attempts`, `gallery_images` | `backup-corpus-text.sh` → restic | same repo, streamed (never lands on disk) | weekly, Sun 06:00 |
+| `bph_works` | 4 layers incl. revisions + JSON export | `bph-catalogue-disaster-recovery.md` | daily |
+| Supabase (`page_translations`, embeddings) | Supabase managed backups | Supabase | daily, 8 retained, **PITR off** |
+| **R2 objects (~21.7 TB)** | **nothing — single copy** | Cloudflare R2 | — |
+
+**The gap that was closed on 2026-08-30.** `backup-books.sh` stops at book metadata,
+on the stated reasoning *"Images live on R2; pages can be re-OCR'd from R2 if needed."*
+That sentence and principle 2 above are the same repo disagreeing with itself, and the
+backup script's version was the one that ran. `backup-corpus-text.sh` implements
+principle 2. Verified by restore rehearsal, not by the job exiting 0: read the snapshot
+back out of restic, `gzip -t` the whole stream, confirm the mongodump magic
+`6de29981`.
+
+**The gap that is still open: R2 has no second copy.** Tier-1 and tier-2 objects are
+re-acquirable in principle; tier-0 (BPH, Kloss, Allard Pierson) is not. A bucket-level
+accident is currently unrecoverable for those. The preservation manifest exists and is
+described as "the deliverable even if no bytes ever move" — no bytes have moved.
+
+**Unverified: MongoDB Atlas cluster snapshots.** The cluster is dedicated (MongoDB
+9.0.0 Enterprise), and Atlas enables Cloud Backup by default on dedicated tiers — but
+it can be switched off, there are no Atlas API credentials in the environment, and
+Atlas is also the one line the cost reference still lists as billing-unknown. **Treat
+Atlas coverage as unknown until someone reads the dashboard.** Per
+`invariants/measurement-instruments.md`, the absence of a marker here is not the
+absence of the mechanism — and its presence is not proof either.
+
+## Related
+
+- `r2-storage.md` — prefix inventory and replaceability table
+- `invariants/archive-coverage.md` — the three tiers, and why key-based classification lies
+- `invariants/archive-fetch-failures.md` — a fetch failure is a claim about the source
+- `bph-catalogue-disaster-recovery.md` — the four-layer model this borrows from
+- `scripts/maintenance/build-preservation-manifest.mjs` — the manifest and its tiering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ relative to `.claude/docs/invariants/`. When in doubt, read the one that looks c
 they open with a "Read this when" line so you can bail in two seconds.
 
 **Data & corpus**
+- **Deleting anything, or "is it safe?" → `../preservation-policy.md`** (**TEXT is the irreplaceable half — 1.8% of bytes**)
 - Archivers/importers, `archived_photo`, "failed to fetch" triage → `archive-fetch-failures.md`
 - Quoting archive/R2 coverage, an archiver's "is this book done?" check, a new page-image field → `archive-coverage.md` (**"archived" is three questions — RECORD/FILE/MASTER; never sum them**)
 - Two artifacts that must line up (page images vs OCR, splits vs text) → `paired-artifacts.md`

--- a/scripts/workers/backup-books.sh
+++ b/scripts/workers/backup-books.sh
@@ -7,7 +7,14 @@
 #   - /root/backups/books-weekly/  — snapshot every Sunday, kept forever (point-in-time)
 #
 # Only backs up book metadata (books, books_warehouse, deleted_books).
-# Images live on R2; pages can be re-OCR'd from R2 if needed.
+#
+# The TEXT (pages, page_revisions, chapter_texts, entities, …) is covered by its
+# sibling, backup-corpus-text.sh — NOT by this script. An earlier version of this
+# comment read "pages can be re-OCR'd from R2 if needed", which left ~20.6M pages
+# of OCR and translation with no offsite copy for months. It is true in the narrow
+# sense and expensive in the real one: re-OCR re-spends the model budget and still
+# cannot regenerate human corrections, page_revisions, or first-translation
+# evidence. See .claude/docs/preservation-policy.md, principle 2.
 #
 # Restore: mongorestore --uri="$MONGODB_URI" --db=bookstore --gzip --dir=/root/backups/books-latest/bookstore
 

--- a/scripts/workers/backup-corpus-text.sh
+++ b/scripts/workers/backup-corpus-text.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# Offsite backup of the IRREPLACEABLE half of the corpus — the text.
+#
+# WHY THIS EXISTS
+# ---------------
+# `backup-books.sh` dumps `books`, `books_warehouse`, `deleted_books` and stops,
+# on the stated reasoning: "Images live on R2; pages can be re-OCR'd from R2 if
+# needed." That leaves ~20.6M `pages` documents — every line of OCR and every
+# translation — with no offsite copy at all.
+#
+# The reasoning is true in the narrow sense and expensive in the real one. Re-OCR
+# means re-spending the model budget (~$56.5K to date), and it does NOT regenerate:
+#   - human editorial corrections made through the reader/editor round-trip,
+#   - `page_revisions` (the double-OCR corpus the whole quality-measurement stack
+#     is built on, and which cannot be recreated because it records what specific
+#     model versions produced on specific days),
+#   - `first_translation_attempts` (verification evidence behind public claims),
+#   - `chapter_texts`, `entities` (book indexes, page attributions).
+#
+# The preservation manifest states the principle this implements:
+#   "TEXT + METADATA … the half that CANNOT be re-acquired: produced here at
+#    ~$56.5K of model spend plus years of curatorial judgment, and no institution
+#    has a copy. Archive it first; it costs about four cents a month."
+# See `.claude/docs/preservation-policy.md` and
+# `scripts/maintenance/build-preservation-manifest.mjs`.
+#
+# WHY IT STREAMS INSTEAD OF LANDING ON DISK
+# -----------------------------------------
+# The box has ~39 GB free and `/root/backups` already holds 14 GB; the collections
+# below are ~33 GB of compressed storage. Landing a dump on disk would risk filling
+# the volume the pipeline workers write to. Each collection is piped straight from
+# `mongodump --archive` into `restic backup --stdin`, so nothing is ever written to
+# local disk. The trade-off is that there is no fast local restore copy — restore
+# comes from the restic repo (see RESTORE below).
+#
+# Cron: Sundays 06:00, after backup-books (04:00) and restic-backup (05:00) so the
+# three never contend for the same upload bandwidth.
+#   0 6 * * 0 /root/sourcelibrary/scripts/workers/backup-corpus-text.sh
+#
+# RESTORE
+#   source /root/.config/restic-hetzner.env
+#   restic snapshots --tag corpus-text
+#   restic dump <snapshot-id> pages.archive.gz > /tmp/pages.archive.gz
+#   mongorestore --uri "$MONGODB_URI" --gzip --archive=/tmp/pages.archive.gz
+#
+set -uo pipefail
+
+REPO_DIR="/root/sourcelibrary"
+LOG="/var/log/sourcelibrary/backup-corpus-text.log"
+mkdir -p "$(dirname "$LOG")"
+
+# Collections that cannot be re-acquired or cheaply regenerated. Anything
+# derivable from images (thumbnails, gallery crops) is deliberately absent —
+# this list is by DESIGN, not by breadth. If you add a store that holds
+# model output or human judgement, add it here in the same commit.
+COLLECTIONS=(
+  pages                        # OCR + translation text — the bulk of the value
+  page_revisions               # double-OCR corpus; records what a model did on a day
+  chapter_texts                # chapter segmentation + text
+  entities                     # book indexes and page attributions
+  first_translation_attempts   # evidence behind public first-translation claims
+  gallery_images               # illustration catalogue (metadata, not the crops)
+)
+
+log() { echo "[$(date -Is)] $1" >> "$LOG"; }
+
+log "=== corpus-text backup start ==="
+
+# shellcheck disable=SC1091
+set -a; source "$REPO_DIR/.env.production.local"; set +a
+# shellcheck disable=SC1091
+source /root/.config/restic-hetzner.env
+
+if [ -z "${MONGODB_URI:-}" ]; then log "FATAL: MONGODB_URI unset"; exit 1; fi
+if [ -z "${RESTIC_REPOSITORY:-}" ]; then log "FATAL: RESTIC_REPOSITORY unset"; exit 1; fi
+
+DB="${MONGODB_DB:-bookstore}"
+STAMP="$(date -u +%F)"
+failed=0
+
+for coll in "${COLLECTIONS[@]}"; do
+  # A dump of a renamed/emptied collection SUCCEEDS and writes an empty archive,
+  # which is the failure mode that leaves you with backups of nothing. Assert the
+  # collection has documents before trusting its dump. (Same lesson as the BPH
+  # catalogue falling out of backup "by breadth, not by design".)
+  # node, not mongosh — mongosh is not installed on this box, and the driver is
+  # already a repo dependency. Prints digits only; exits non-zero if it can't answer.
+  count=$(cd "$REPO_DIR" && node scripts/workers/lib/count-docs.mjs "$DB" "$coll" 2>>"$LOG" | tr -dc '0-9')
+  if [ -z "$count" ] || [ "$count" -eq 0 ] 2>/dev/null; then
+    log "FAIL $coll: expected documents, counted '${count:-<none>}' — NOT dumping (renamed? permissions?)"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  log "$coll: $count docs — dumping to restic"
+  # pipefail alone tells you the pipeline failed, not which half. PIPESTATUS
+  # distinguishes "mongodump died" (retry later) from "restic died" (repo/network),
+  # and without this check a silently-truncated dump uploads as a clean snapshot.
+  mongodump --uri "$MONGODB_URI" --db "$DB" --collection "$coll" --archive --gzip 2>>"$LOG" \
+    | restic backup --stdin --stdin-filename "${coll}.archive.gz" \
+        --tag corpus-text --tag "$coll" --host clawdbot >>"$LOG" 2>&1
+  st=("${PIPESTATUS[@]}")
+  if [ "${st[0]}" -ne 0 ] || [ "${st[1]}" -ne 0 ]; then
+    log "FAIL $coll: mongodump=${st[0]} restic=${st[1]}"
+    failed=$((failed + 1))
+  else
+    log "OK   $coll ($count docs)"
+  fi
+done
+
+# Retention: fewer copies than the nightly metadata dumps — these are large and
+# change slowly (the pipeline is paused; text is append-mostly).
+restic forget --tag corpus-text --keep-weekly 6 --keep-monthly 12 --prune >>"$LOG" 2>&1 \
+  || log "WARN: forget/prune returned non-zero"
+
+log "--- corpus-text snapshots ---"
+restic snapshots --tag corpus-text --compact >>"$LOG" 2>&1 || log "WARN: could not list snapshots"
+
+if [ "$failed" -ne 0 ]; then
+  log "=== corpus-text backup FINISHED WITH $failed FAILURE(S) — $STAMP ==="
+  exit 1
+fi
+log "=== corpus-text backup OK — $STAMP ==="

--- a/scripts/workers/lib/count-docs.mjs
+++ b/scripts/workers/lib/count-docs.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Print a collection's estimated document count, and nothing else.
+ *
+ * Exists because `backup-corpus-text.sh` must refuse to dump a collection that
+ * has gone missing or empty — a mongodump of a renamed collection SUCCEEDS and
+ * writes a valid, empty archive, which is how you end up with a year of backups
+ * of nothing. The Hetzner workers box has `mongodump` and `restic` but NOT
+ * `mongosh`, so the guard is a node one-liner against the driver the repo
+ * already depends on rather than a new package to install.
+ *
+ * Usage: node scripts/workers/lib/count-docs.mjs <db> <collection>
+ * Exits non-zero (and prints nothing to stdout) if it cannot answer.
+ */
+import { MongoClient } from 'mongodb';
+
+const [db, coll] = process.argv.slice(2);
+if (!db || !coll) {
+  console.error('usage: count-docs.mjs <db> <collection>');
+  process.exit(2);
+}
+if (!process.env.MONGODB_URI) {
+  console.error('MONGODB_URI is not set');
+  process.exit(2);
+}
+
+const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 20000 });
+try {
+  await client.connect();
+  const n = await client.db(db).collection(coll).estimatedDocumentCount();
+  process.stdout.write(String(n));
+} catch (e) {
+  console.error(`count failed for ${db}.${coll}: ${e.message}`);
+  process.exit(1);
+} finally {
+  await client.close().catch(() => {});
+}


### PR DESCRIPTION
Two things that turned out to be one concern: **the irreplaceable half of the corpus had no offsite copy**, and **the principles that say it should were scattered across five files and contradicted each other in one of them.**

## The gap

`backup-books.sh` dumps `books`, `books_warehouse`, `deleted_books` and stops. Its comment says why:

> Images live on R2; pages can be re-OCR'd from R2 if needed.

That left **~20.6M `pages` documents — every line of OCR and every translation — with no offsite copy at all.** The reasoning is true in the narrow sense and expensive in the real one. Re-OCR re-spends the model budget (~$56.5K to date) and still does not regenerate:

- human editorial corrections made through the reader/editor round-trip,
- `page_revisions` — which record what a *specific model version produced on a specific day*, and so are not reproducible even in principle,
- `first_translation_attempts` — the evidence behind public first-translation claims,
- `chapter_texts`, `entities` — chapter segmentation and page attributions.

Meanwhile `build-preservation-manifest.mjs` states the opposite principle, in its own header:

> TEXT + METADATA … the half that CANNOT be re-acquired: produced here at ~$56.5K of model spend plus years of curatorial judgment, and no institution has a copy. **Archive it first; it costs about four cents a month.**

Same repo, opposite conclusions about the same data, and the backup script's version was the one actually running. That comment is now corrected rather than left to mislead the next reader.

## What ships

**`backup-corpus-text.sh`** — covers `pages`, `page_revisions`, `chapter_texts`, `entities`, `first_translation_attempts`, `gallery_images`.

It **streams** each `mongodump` straight into `restic --stdin`. The box has ~39 GB free and `/root/backups` already holds 14 GB against ~33 GB of collections, so landing a dump on disk would risk filling the volume the pipeline workers write to. Trade-off stated in the header: no fast local restore copy; restore comes from the restic repo.

Two guards, both from failures this codebase has already had:

- **A `mongodump` of a renamed or emptied collection SUCCEEDS** and writes a valid, empty archive — which is how you end up with a year of backups of nothing. Each collection's document count is asserted before its dump. This is the same failure the BPH catalogue doc warns about: it was in backup "by breadth, not by design."
- **`PIPESTATUS` is checked on both halves.** `pipefail` tells you the pipeline failed without telling you which end, and a silently truncated dump would upload as a clean snapshot.

`count-docs.mjs` exists because the box has `mongodump` and `restic` but **not** `mongosh` — so the guard uses the driver the repo already depends on rather than a new package to install.

## Verified by restore rehearsal, not by exit 0

Ran the real pipe against the smallest collection on the actual box:

```
processed 1 files, 15.330 MiB in 0:04
snapshot 64b6c29a saved
PIPESTATUS=0 0 0
```

Then read it back out:

```
bytes restored:    16,074,713
gzip stream:       VALID (whole file decompresses)
inner magic:       6de29981   (mongodump archive)
uncompressed:      89,232,200 bytes
```

Test snapshot forgotten afterwards.

## `preservation-policy.md`

The single statement of what we keep and why — five principles (classify by replaceability; the text is the irreplaceable half at 1.8% of the bytes; tier by re-acquisition path; "archived" is three questions; an honest uncertain answer beats a cheap wrong one), plus honest answers to the two questions that prompted it:

- **Do we keep clean material?** Yes, and it's enforced in code — but "clean" means *unmarked*, not *immutable*. `archived_photo` is a mutable slot that `rearchive-iiif-fullres.mjs` overwrites in place; that is how #3186 slid every image one page under its own text across 320 books.
- **Do we keep the highest resolution?** It's the goal with a measured deficit: ~11% of pages below native resolution (~2.2M, unrecoverable), and ~90,000 pages across 486 live books with no master at all.

It also records what is **not** covered:

- **R2's 21.7 TB has no second copy.** Tier-1/tier-2 objects are re-acquirable in principle; tier-0 (BPH, Kloss, Allard Pierson) is not.
- **Atlas cluster-snapshot coverage is UNVERIFIED.** The cluster is dedicated (MongoDB 9.0.0 Enterprise) and Atlas enables Cloud Backup by default on dedicated tiers — but it can be switched off, there are no Atlas API credentials in this environment, and Atlas is the one line the cost reference still lists as billing-unknown. Marked unknown rather than assumed either way, per the "absence of a marker is not absence of the mechanism" invariant.

## Deploy step (after merge)

The script needs a cron entry on the Hetzner box — deliberately **not** pre-installed, so nothing references an unmerged file:

```
0 6 * * 0 /root/sourcelibrary/scripts/workers/backup-corpus-text.sh
```

Sunday 06:00, after `backup-books` (04:00) and `restic-backup` (05:00) so the three never contend for upload bandwidth. I can add it once this merges.

## Note on the CLAUDE.md budget

One routing line added, which puts the file 14 words over the ~5,500 guideline (5,514). Flagging rather than gaming it — trimming existing doctrine to make room for a new route is precisely the behaviour that cap was written against, and this seemed the wrong route to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrjrf5NFNsamfMBjpQFNhm
