### PR TITLE
feat(search): tell artworks and books apart, in the data and on the card

### DIFF
--- a/scripts/migration/add-books-catalog-content-type.mjs
+++ b/scripts/migration/add-books-catalog-content-type.mjs
@@ -1,0 +1,163 @@
+/**
+ * #4409 — project `books.content_type` into Supabase `books_catalog`.
+ *
+ * Why: artworks and texts share the Mongo `books` collection, and the canonical
+ * rule for telling them apart (isArtworkRecord, src/lib/artwork-record.ts) reads
+ * BOTH `content_type` and `resource_type`. The catalogue mirror carried only
+ * `resource_type`, so search's book lane — which reads books_catalog, not Mongo —
+ * had no way to exclude artworks and rendered all 97 live artwork rows as book
+ * cards pointing at /book/.
+ *
+ * `resource_type` alone is NOT a usable test. One live row is a real Javanese
+ * chronicle ("Babad Tanah Djawi…", id 6a197add50f34ce9f2ea4a0d) carrying
+ * content_type:'text' + resource_type:'text'. A "resource_type IS NOT NULL"
+ * filter would silently delete it from search. That record is the negative
+ * control for this whole change, and this script prints it.
+ *
+ * What it does (idempotent, safe to re-run):
+ *   1. ADD COLUMN IF NOT EXISTS content_type text — nullable, no default.
+ *      NULL means "unknown", which makes the rule fall back to resource_type,
+ *      i.e. exactly the behaviour before this column existed. Rows stay valid
+ *      mid-backfill.
+ *   2. Partial index on content_type = 'artwork' (the only value any caller
+ *      filters on).
+ *   3. Backfill from Mongo — SET for every book with a content_type, and NULL
+ *      any catalog row carrying one Mongo no longer does (a re-run repairs
+ *      drift in both directions).
+ *   4. Verify by reading information_schema and re-counting. A committed
+ *      migration file is not proof of what is in production: the previous
+ *      books_catalog migration (20260828000000, image_display/image_card) is
+ *      committed and its columns do NOT exist on the live table.
+ *
+ * The writer half lives in scripts/workers/sync-books-catalog.mjs: the field
+ * must be in BOTH the Mongo projection and the row builder. A field in the row
+ * builder but NOT the projection reads `undefined` and writes NULL for every
+ * book. Those two edits are a pair.
+ *
+ * Usage:
+ *   secret-lover run -- node scripts/migration/add-books-catalog-content-type.mjs [--dry-run]
+ *   (foreground only — SUPABASE_DB_URL needs Touch ID)
+ */
+import pg from 'pg';
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!SUPABASE_DB_URL || !MONGODB_URI) {
+  console.error('Missing SUPABASE_DB_URL or MONGODB_URI');
+  process.exit(1);
+}
+
+// The one live record that proves the rule needs content_type, not resource_type.
+const NEGATIVE_CONTROL_ID = '6a197add50f34ce9f2ea4a0d';
+
+async function main() {
+  const c = new pg.Client({ connectionString: SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  console.log('1. ALTER TABLE books_catalog ADD COLUMN content_type...');
+  if (!DRY_RUN) {
+    await c.query(`ALTER TABLE books_catalog ADD COLUMN IF NOT EXISTS content_type text`);
+    await c.query(
+      `CREATE INDEX IF NOT EXISTS books_catalog_content_type_artwork_idx
+         ON books_catalog (content_type) WHERE content_type = 'artwork'`
+    );
+  }
+
+  // Verify the column really exists before trusting any write below.
+  const { rows: colRows } = await c.query(
+    `SELECT data_type, is_nullable FROM information_schema.columns
+      WHERE table_name = 'books_catalog' AND column_name = 'content_type'`
+  );
+  if (colRows.length === 0) {
+    if (DRY_RUN) {
+      console.log('   (dry run — column does not exist yet, skipping backfill)');
+      await c.end();
+      await mongo.close();
+      return;
+    }
+    throw new Error('content_type column missing after ALTER — aborting');
+  }
+  console.log(`   column present: ${colRows[0].data_type}, nullable=${colRows[0].is_nullable}`);
+
+  console.log('2. Reading Mongo content_type values...');
+  const docs = await db.collection('books')
+    .find({ content_type: { $exists: true, $ne: null } }, { projection: { _id: 0, id: 1, content_type: 1 } })
+    .toArray();
+  console.log(`   ${docs.length} books carry a content_type in Mongo.`);
+
+  const { rows: before } = await c.query(`SELECT id FROM books_catalog WHERE content_type IS NOT NULL`);
+  console.log(`   ${before.length} catalog rows currently carry one.`);
+
+  const mongoIds = new Set(docs.map(d => d.id));
+  const stale = before.map(r => r.id).filter(id => !mongoIds.has(id));
+
+  if (DRY_RUN) {
+    const inCatalog = await c.query(`SELECT count(*) AS n FROM books_catalog WHERE id = ANY($1)`, [[...mongoIds]]);
+    console.log(`   ${inCatalog.rows[0].n} of them exist in books_catalog (the rest are unsynced).`);
+    console.log(`   ${stale.length} catalog rows would be cleared to NULL.`);
+    console.log('DRY RUN — nothing written.');
+  } else {
+    let updated = 0;
+    for (let i = 0; i < docs.length; i += 1000) {
+      const chunk = docs.slice(i, i + 1000);
+      const res = await c.query(
+        `UPDATE books_catalog b SET content_type = v.ct
+           FROM (SELECT unnest($1::text[]) AS id, unnest($2::text[]) AS ct) v
+          WHERE b.id = v.id AND b.content_type IS DISTINCT FROM v.ct`,
+        [chunk.map(d => d.id), chunk.map(d => String(d.content_type))]
+      );
+      updated += res.rowCount;
+    }
+    console.log(`   Set ${updated} catalog rows.`);
+
+    if (stale.length) {
+      const res = await c.query(`UPDATE books_catalog SET content_type = NULL WHERE id = ANY($1)`, [stale]);
+      console.log(`   Cleared ${res.rowCount} stale rows to NULL.`);
+    }
+  }
+
+  console.log('3. Verifying against the live table...');
+  const { rows: dist } = await c.query(
+    `SELECT coalesce(content_type, '(null)') AS ct, count(*) AS n
+       FROM books_catalog GROUP BY 1 ORDER BY n DESC`
+  );
+  console.log('   content_type distribution:', dist.map(r => `${r.ct}=${r.n}`).join(' '));
+
+  // The exclusion predicate search will actually run, counted on the live table.
+  const { rows: live } = await c.query(
+    `SELECT
+        count(*) FILTER (WHERE visible AND pages_count > 0) AS live_rows,
+        count(*) FILTER (WHERE visible AND pages_count > 0
+                           AND (content_type = 'artwork'
+                                OR (content_type IS NULL AND resource_type IS NOT NULL))) AS live_artworks
+       FROM books_catalog`
+  );
+  console.log(`   live rows: ${live[0].live_rows}, of which artworks excluded from the book lane: ${live[0].live_artworks}`);
+
+  const { rows: control } = await c.query(
+    `SELECT id, title, content_type, resource_type, visible, pages_count,
+            (content_type = 'artwork' OR (content_type IS NULL AND resource_type IS NOT NULL)) AS would_be_excluded
+       FROM books_catalog WHERE id = $1`,
+    [NEGATIVE_CONTROL_ID]
+  );
+  if (control.length === 0) {
+    console.warn(`   WARNING: negative control ${NEGATIVE_CONTROL_ID} not found in books_catalog.`);
+  } else {
+    const r = control[0];
+    console.log(`   negative control "${r.title.slice(0, 40)}…": content_type=${r.content_type} resource_type=${r.resource_type} excluded=${r.would_be_excluded}`);
+    if (r.would_be_excluded) {
+      throw new Error('negative control would be excluded from book search — the rule is wrong, do not ship');
+    }
+  }
+
+  await c.end();
+  await mongo.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -116,9 +116,20 @@ function transformBook(book) {
     doi: book.doi || null,
     work_id: book.work_id || null,
     text_role: book.text_role || null,
-    // content_type:'book' wins — never expose a resource_type for a book, or the catalog
-    // grid (CollectionBookCard) routes it to /artwork/ instead of /book/.
-    resource_type: book.content_type === 'book' ? null : (book.resource_type || null),
+    // Artworks share the `books` collection with texts. Both markers are mirrored,
+    // because telling them apart needs both — see isArtworkRecord() in
+    // src/lib/artwork-record.ts and the NON_ARTWORK_FILTERS the search book lane
+    // applies. Paired with `content_type: 1` in the projection below: a field in
+    // this builder but NOT in the projection reads `undefined` and writes NULL for
+    // every book. Move the two together, always.
+    content_type: book.content_type || null,
+    // An explicit non-artwork content_type wins — never expose a resource_type for
+    // something labelled a text, or the catalog grid (CollectionBookCard) routes it
+    // to /artwork/ instead of /book/. This is not hypothetical: the Javanese
+    // chronicle "Babad Tanah Djawi…" carries content_type:'text' + resource_type:'text'.
+    resource_type: (book.content_type && book.content_type !== 'artwork')
+      ? null
+      : (book.resource_type || null),
     source_url: book.image_source?.source_url || null,
     provider_name: book.image_source?.provider_name || null,
     image_attribution: book.image_source?.attribution || null,
@@ -205,7 +216,7 @@ const projection = {
   // Book detail fields
   summary: 1, 'index.bookSummary.brief': 1, 'reading_summary.overview': 1,
   publisher: 1, place_published: 1, doi: 1, work_id: 1,
-  resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1, text_role: 1,
+  content_type: 1, resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1, text_role: 1,
   source_work_dates: 1,
   'translation_verification.disposition': 1, 'translation_verification.reasoning': 1,
   // Graded FT verdict + screens (#3726 Tier 3) — pure projections; the render

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -8,6 +8,7 @@ import { searchBooksCatalog } from '@/lib/books-catalog';
 import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticArtworkSearch } from '@/lib/semantic-search';
 import { filterVisibleArtworks } from '@/lib/artwork-visibility';
+import { isArtworkRecord } from '@/lib/artwork-record';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { anonSearchGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
@@ -46,6 +47,25 @@ interface GalleryResult {
   type?: string;
   bookTitle: string;
   bookId: string;
+  /** Page the detail was cropped from. Present on ~93% of gallery_images rows
+   *  (192,703 of 206,362) and absent on every CLIP row, so the card treats it
+   *  as optional. It is what lets an illustration card say "from <book>, p. 411"
+   *  rather than wearing a bare title that reads like a standalone artwork. */
+  pageNumber?: number | null;
+}
+
+/**
+ * Fields attached to an artwork hit after the Mongo enrichment below. Both
+ * artwork lanes (semantic RPC rows and the lexical Mongo lane) produce objects
+ * without them, and both get them here so the client's card can render one
+ * shape.
+ */
+interface EnrichedArtwork {
+  slug?: string | null;
+  /** Medium/form. Drives the card's type chip via artworkTypeLabel(). */
+  resource_type?: string | null;
+  /** Holding institution or provider, for the card's subtitle. */
+  holder?: string | null;
 }
 
 interface CollectionResult {
@@ -299,9 +319,21 @@ export async function GET(request: NextRequest) {
     const resultBooks = identityLookupIds.length > 0
       ? await db.collection('books').find(
         { id: { $in: identityLookupIds } },
-        { projection: { _id: 0, id: 1, tenantId: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1 }, maxTimeMS: 5000 }
+        {
+          projection: {
+            _id: 0, id: 1, tenantId: 1, work_id: 1, work_id_aliases: 1, duplicate_of: 1,
+            // For the semantic-lane gate below. Free: this lookup already runs.
+            visible: 1, content_type: 1, resource_type: 1,
+          },
+          maxTimeMS: 5000,
+        }
       ).toArray()
       : [];
+    const semanticGateDocs = new Map<string, { visible?: boolean; content_type?: string | null; resource_type?: string | null }>(
+      resultBooks.map(b => [b.id as string, {
+        visible: b.visible, content_type: b.content_type, resource_type: b.resource_type,
+      }]),
+    );
     const identityByBookId = new Map<string, WorkGroupable>(
       resultBooks.map((b: any) => [b.id as string, {
         book_id: b.id, work_id: b.work_id, work_id_aliases: b.work_id_aliases, duplicate_of: b.duplicate_of,
@@ -421,8 +453,29 @@ export async function GET(request: NextRequest) {
     }
     const filteredVisual = { results: filteredVisualResults, total: filteredVisualResults.length };
 
+    // The semantic lane reads Supabase `book_embeddings` and, unlike every other
+    // lane, had no gate of its own: the keyword lane filters at source
+    // (books_catalog: visible + pages_count + NON_ARTWORK_FILTERS) and the
+    // artwork/gallery/CLIP lanes re-resolve against Mongo via
+    // filterVisibleArtworks. So `match_books_semantic` rows went to the client
+    // as book cards whatever they were. Measured on "tarot" 2026-08-30, 4 of its
+    // 6 results were artwork records with pages_count:0 ("Playing Card",
+    // "HS Tarot", "Jeu de tarot miniature… dessin") — each linking to /book/ for
+    // a thing with no pages — and one of those, "T13 Tarot", is visible:false in
+    // Mongo and was being served anyway.
+    //
+    // Gate both here, off the identity lookup that already ran. A row whose book
+    // is missing from Mongo is dropped too: it cannot be rendered honestly.
+    const semanticGate = (bookId: string): boolean => {
+      const doc = semanticGateDocs.get(bookId);
+      if (!doc) return false;
+      if (doc.visible !== true) return false;
+      return !isArtworkRecord(doc);
+    };
     const filteredSemantic = {
-      results: semanticResult.results.filter(r => r.similarity >= SEMANTIC_SIM_FLOOR),
+      results: semanticResult.results.filter(
+        r => r.similarity >= SEMANTIC_SIM_FLOOR && semanticGate(r.book_id),
+      ),
       total: 0,
     };
     filteredSemantic.total = filteredSemantic.results.length;
@@ -442,20 +495,43 @@ export async function GET(request: NextRequest) {
     // visibility column, so hidden/invisible artworks can surface from the
     // vector lane and 404 on click. Re-check visible:true here and drop any
     // artwork the query doesn't return.
+    //
+    // The same lookup also carries back what the card needs to LOOK like an
+    // artwork rather than a book illustration: the medium (resource_type) and
+    // the museum that holds the object. Doing it here covers both lanes at once
+    // — the semantic lane's RPC rows have neither field, and enriching only the
+    // lexical lane would leave half the strip unlabelled.
     let visibleArtworks = artworksAboveFloor;
     if (artworksAboveFloor.length > 0) {
       try {
         const artworkIds = artworksAboveFloor.map(a => a.book_id);
         const artworkDocs = await db.collection('books').find(
           { id: { $in: artworkIds }, visible: true },
-          { projection: { id: 1, slug: 1 } }
+          {
+            projection: {
+              id: 1, slug: 1, resource_type: 1,
+              contributing_library: 1,
+              'image_source.provider_name': 1,
+              'image_source.contributing_library': 1,
+            },
+          }
         ).maxTimeMS(2000).toArray();
-        const slugMap = new Map(artworkDocs.map(d => [d.id, d.slug]));
+        const docMap = new Map(artworkDocs.map(d => [d.id, d]));
         for (const a of artworksAboveFloor) {
-          (a as any).slug = slugMap.get(a.book_id) || null;
+          const doc = docMap.get(a.book_id);
+          const art = a as EnrichedArtwork;
+          art.slug = doc?.slug || null;
+          art.resource_type = doc?.resource_type || null;
+          // Prefer the institution's own name over the credit line: `provider_name`
+          // reads "The Metropolitan Museum of Art", while image_source.contributing_library
+          // often holds an acquisition note ("Rogers Fund, 1931") that means nothing
+          // as a subtitle.
+          art.holder = doc?.image_source?.provider_name
+            || doc?.contributing_library
+            || null;
         }
-        // Keep only artworks confirmed visible (present in slugMap).
-        visibleArtworks = artworksAboveFloor.filter(a => slugMap.has(a.book_id));
+        // Keep only artworks confirmed visible (present in the map).
+        visibleArtworks = artworksAboveFloor.filter(a => docMap.has(a.book_id));
       } catch { /* non-fatal — fall through with unfiltered list */ }
     }
     let filteredArtworks = {
@@ -863,7 +939,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
         },
         ...(hasYearRange ? [{ $match: { book_year: yearMatch } }] : []),
         { $limit: limit * 2 },
-        { $project: { page_id: 1, detection_index: 1, description: 1, type: 1, thumbnail_url: 1, extracted_url: 1, book_id: 1, book_title: 1, gallery_quality: 1 } },
+        { $project: { page_id: 1, page_number: 1, detection_index: 1, description: 1, type: 1, thumbnail_url: 1, extracted_url: 1, book_id: 1, book_title: 1, gallery_quality: 1 } },
       ], { maxTimeMS: 5000 }).toArray();
     } catch {
       // Fallback to regex if Atlas Search index not ready
@@ -882,7 +958,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
               { 'metadata.figures': queryRegex },
             ],
           },
-          { projection: { page_id: 1, detection_index: 1, description: 1, type: 1, thumbnail_url: 1, extracted_url: 1, book_id: 1, book_title: 1, gallery_quality: 1 } }
+          { projection: { page_id: 1, page_number: 1, detection_index: 1, description: 1, type: 1, thumbnail_url: 1, extracted_url: 1, book_id: 1, book_title: 1, gallery_quality: 1 } }
         )
         .sort({ gallery_quality: -1 })
         .limit(limit)
@@ -906,6 +982,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
         type: img.type,
         bookTitle: img.book_title || '',
         bookId: img.book_id || '',
+        pageNumber: typeof img.page_number === 'number' ? img.page_number : null,
       })),
       total: visibleImages.length,
     };

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -16,6 +16,7 @@ import AuthorSchema from '@/components/seo/AuthorSchema';
 import { authorThesaurusReadpathEnabled, resolveCanonicalAuthor } from '@/lib/author-thesaurus';
 import { classifyNonPersonAuthor, type NonPersonAuthor } from '@/lib/non-person-author';
 import { isPublishedEntity, type EntityPublishFields } from '@/lib/entity-publish';
+import { isArtworkRecord } from '@/lib/artwork-record';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
 export const revalidate = 86400;
@@ -47,23 +48,12 @@ interface Book {
   place?: string;
   image_source?: { contributing_library?: string; provider_name?: string };
   // Used to split the bibliography (texts) from visual works (artworks).
-  // See isArtworkRecord() — older records use resource_type instead.
+  // See isArtworkRecord() in @/lib/artwork-record — older records carry only
+  // resource_type, and an explicit non-artwork content_type always wins.
   content_type?: string;
   resource_type?: string;
   image_display?: string;
   image_thumb?: string;
-}
-
-function isArtworkRecord(b: Pick<Book, 'content_type' | 'resource_type'>): boolean {
-  // 25,368 of 25,383 artworks carry both markers in production; a handful
-  // have only one. Treat either as artwork to avoid leaks during slow
-  // backfills, mirroring the /artist/[slug] page (which keys off
-  // resource_type).
-  // An explicit content_type:'book' always wins: a textual book that happens to
-  // carry a resource_type (e.g. a digitized papyrus text tagged 'papyrus_fragment')
-  // must never be treated as artwork, or it routes to /artwork/ instead of /book/.
-  if (b.content_type === 'book') return false;
-  return b.content_type === 'artwork' || !!b.resource_type;
 }
 
 interface AuthorEntity {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,7 @@ import { useSearchParams, useRouter, useParams, usePathname } from 'next/navigat
 import { useLocale, useLocalePath } from '@/lib/i18n';
 import type { Locale } from '@/lib/locale-path';
 import { SEARCH_STRINGS, EXAMPLE_QUERIES, type SearchStrings } from '@/lib/search-i18n';
+import { artworkTypeLabel } from '@/lib/artwork-record';
 import { localizedCollection } from '@/lib/localized';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { useEmbed } from '@/lib/EmbedContext';
@@ -517,7 +518,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             images.push({
               pageId,
               bookId: g.bookId || '',
-              pageNumber: 0,
+              // Carried through so the card can say which page of which book the
+              // detail was cropped from. CLIP rows have no page number; 0 reads
+              // as "unknown" and the card omits it.
+              pageNumber: typeof g.pageNumber === 'number' ? g.pageNumber : 0,
               detectionIndex,
               imageUrl: g.imageUrl || '',
               thumbnailUrl: g.imageUrl || '',
@@ -552,7 +556,11 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
               type: a.genre || 'artwork',
               isArtwork: true,
               artworkSlug: a.slug || null,
-            } as GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null });
+              // What makes the card readable as an object rather than a page of
+              // one of our books: the medium, and the museum that holds it.
+              artworkType: a.resource_type || a.genre || null,
+              holder: a.holder || null,
+            } as GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null; artworkType?: string | null; holder?: string | null });
           }
           const imTotal = (data.gallery?.total || 0) + (data.visual?.total || 0) + artworkResults.length;
 
@@ -2302,14 +2310,38 @@ function IndexResultCard({ result, query, tenant }: { result: IndexSearchResult;
   );
 }
 
-function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null; aiTerm?: string; visualMatch?: boolean }; query: string; large?: boolean; tenant?: string }) {
+function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null; artworkType?: string | null; holder?: string | null; link?: string | null; aiTerm?: string; visualMatch?: boolean }; query: string; large?: boolean; tenant?: string }) {
   const [imageError, setImageError] = useState(false);
+  const t = SEARCH_STRINGS[useLocale()];
 
   // Provenance chip: images that arrived via LLM term expansion or CLIP
   // similarity are honest neighbors, not matches — say so on the card (#4338).
   const provenance = item.aiTerm
     ? `related · ${item.aiTerm}`
     : item.visualMatch ? 'visual match' : null;
+
+  // The strip mixes two different things and used to render them identically: a
+  // standalone artwork held by a museum (links to /artwork/) and a detail cropped
+  // out of a book we hold (links to /gallery/image/). The second line was
+  // `item.bookTitle` in both cases — a slot meaning "the object's own title" for
+  // one and "the book it came from" for the other. Say which: artworks get a
+  // medium chip and their holder, illustrations get "from <book> · p. N".
+  //
+  // Two producers feed this card and they mark an artwork differently: the
+  // unified-search artworks lane sets `isArtwork` (+ artworkType/holder), while
+  // /api/gallery — which backs the dedicated Images tab — sets `source:'artwork'`
+  // and puts the medium in `type` (see artworkToGalleryItem in gallery-merge.ts).
+  // Reading only one of them left half the artworks wearing a book card.
+  const isArtwork = item.isArtwork === true || item.source === 'artwork';
+  const typeChip = isArtwork ? artworkTypeLabel(item.artworkType || item.type) : null;
+  const subtitle = isArtwork
+    ? (item.holder || item.author || null)
+    : (item.bookTitle ? t.imageFromBook(item.bookTitle) : null);
+  // A NEGATIVE page_number is a soft-hide marker, not a leaf — "p. -154" is both
+  // nonsense to a reader and a leak of an internal flag. Only a positive number
+  // is a page you could turn to. Rendered as its own non-shrinking span so a long
+  // book title truncates without swallowing the page number with it.
+  const pageLabel = !isArtwork && item.pageNumber > 0 ? `p. ${item.pageNumber}` : null;
 
   // Use pre-generated thumbnail/extracted URL first (publicly accessible),
   // fall back to original imageUrl (crop-image API requires auth and breaks for visitors)
@@ -2318,14 +2350,15 @@ function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & {
     ? `/${tenant}/gallery/image/${item.pageId}-${item.detectionIndex}`
     : `/gallery/image/${item.pageId}-${item.detectionIndex}`;
 
-  // Artworks link to /artwork/[slug], gallery images to /gallery/image/[id]
-  const href = item.isArtwork
-    ? `/artwork/${item.artworkSlug || item.pageId}`
-    : `/gallery/image/${item.pageId}-${item.detectionIndex}`;
+  // /api/gallery hands back the canonical URL for a standalone artwork in `link`;
+  // prefer it. Without this the Images tab built `/gallery/image/artwork-<id>`
+  // from the synthetic pageId — a hard 404 on every artwork tile in that tab.
+  const artworkHref = item.link
+    || (item.artworkSlug ? `/artwork/${item.artworkSlug}` : null);
 
   return (
     <Link
-      href={item.isArtwork ? `/artwork/${item.artworkSlug || item.pageId}` : imageHref}
+      href={isArtwork && artworkHref ? artworkHref : imageHref}
       className="group block bg-white rounded-lg border border-border-light overflow-hidden hover:border-accent-gold/30 hover:shadow-md transition-all"
     >
       <div className={`relative bg-warm ${large ? 'aspect-[3/4]' : 'aspect-square'}`}>
@@ -2344,17 +2377,31 @@ function ImageResultCard({ item, query, large, tenant }: { item: GalleryItem & {
             <ImageIcon className="w-8 h-8 text-border-medium" />
           </div>
         )}
-        {provenance && (
-          <span className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/55 text-[10px] leading-tight text-white/90 backdrop-blur-sm">
-            {provenance}
-          </span>
+        {(provenance || typeChip) && (
+          <div className="absolute top-1.5 left-1.5 flex flex-col items-start gap-1">
+            {typeChip && (
+              <span className="px-1.5 py-0.5 rounded bg-black/55 text-[10px] leading-tight text-white/90 backdrop-blur-sm">
+                {typeChip}
+              </span>
+            )}
+            {provenance && (
+              <span className="px-1.5 py-0.5 rounded bg-black/55 text-[10px] leading-tight text-white/90 backdrop-blur-sm">
+                {provenance}
+              </span>
+            )}
+          </div>
         )}
       </div>
       <div className="p-2.5">
         <p className="text-sm text-secondary line-clamp-2 mb-1">
           {query ? <HighlightedText text={item.description} query={query} /> : item.description}
         </p>
-        <p className="text-xs text-muted line-clamp-1">{item.bookTitle}</p>
+        {subtitle && (
+          <p className="text-xs text-muted flex items-baseline gap-1">
+            <span className="truncate">{subtitle}</span>
+            {pageLabel && <span className="shrink-0">· {pageLabel}</span>}
+          </p>
+        )}
       </div>
     </Link>
   );

--- a/src/lib/artwork-record.ts
+++ b/src/lib/artwork-record.ts
@@ -1,0 +1,85 @@
+/**
+ * Is this `books` record an artwork rather than a text?
+ *
+ * Artworks live in the SAME Mongo `books` collection as texts (24,912 of
+ * 110,016 docs on 2026-08-30), so every surface that lists "books" has to make
+ * this call, and until now each one made it differently: /author/[name] carried
+ * a private copy of the rule, /artist/[slug] keyed off `resource_type` alone,
+ * and search never made the distinction at all — so the 97 live artwork records
+ * rendered as book cards linking to /book/.
+ *
+ * The rule, in order:
+ *
+ *   1. `content_type` set to anything other than 'artwork' → NOT an artwork.
+ *      An explicit label always beats an inferred one. This carve-out is what
+ *      keeps a digitized papyrus text tagged `resource_type: 'papyrus_fragment'`
+ *      out of /artwork/, and it is load-bearing for one live record today:
+ *      "Babad Tanah Djawi lan Tanah-Tanah ing Sakiwa-Tengenipoen"
+ *      (id 6a197add50f34ce9f2ea4a0d) is a real Javanese chronicle carrying
+ *      content_type:'text' + resource_type:'text'. Any filter written as
+ *      "resource_type is not null" deletes it from the library.
+ *   2. `content_type === 'artwork'` → artwork.
+ *   3. No `content_type` at all, but a `resource_type` → artwork. 6 records rely
+ *      on this (painting ×2, print ×2, fresco, object); they predate the
+ *      content_type backfill.
+ *
+ * Keep this in step with the SQL predicate in `NON_ARTWORK_FILTERS` below and
+ * with scripts/workers/sync-books-catalog.mjs, which nulls `resource_type` on
+ * anything explicitly labelled a book.
+ */
+export function isArtworkRecord(record: {
+  content_type?: string | null;
+  resource_type?: string | null;
+}): boolean {
+  if (record.content_type && record.content_type !== 'artwork') return false;
+  return record.content_type === 'artwork' || !!record.resource_type;
+}
+
+/**
+ * The same rule as a pair of PostgREST `or` filters for `books_catalog`, for
+ * callers that must exclude artworks in the query rather than after it.
+ *
+ * Apply BOTH — supabase-js sends each `.or()` as its own `or=` param and
+ * PostgREST ANDs them together:
+ *
+ *   for (const f of NON_ARTWORK_FILTERS) query = query.or(f);
+ *
+ * Together they express
+ *   NOT (content_type = 'artwork' OR (content_type IS NULL AND resource_type IS NOT NULL))
+ *
+ * A plain `.not('content_type','eq','artwork')` will NOT do: SQL's three-valued
+ * logic drops every row where content_type IS NULL, which is 19,432 of the
+ * 31,731 live books.
+ *
+ * Measured 2026-08-30: 31,731 live rows → 31,635 with these applied (96
+ * artworks removed, the Babad chronicle kept).
+ */
+export const NON_ARTWORK_FILTERS = [
+  'content_type.is.null,content_type.neq.artwork',
+  'content_type.not.is.null,resource_type.is.null',
+] as const;
+
+/**
+ * `resource_type` values that name a medium or physical form — the only ones
+ * worth showing as a type chip. The field is overloaded: roughly half its
+ * values are subject matter ('religious', 'mythological', 'allegory',
+ * 'genre-scene', 'anatomical') rather than a kind of thing, and a chip reading
+ * "religious" tells a reader nothing about what they are looking at.
+ */
+const MEDIUM_RESOURCE_TYPES = new Set([
+  'print', 'painting', 'drawing', 'object', 'sculpture', 'fresco',
+  'photograph', 'manuscript', 'manuscript-illumination', 'map', 'emblem',
+  'illustration', 'document', 'ritual-object',
+]);
+
+/**
+ * Label for an artwork's type chip. Returns the medium when `resource_type`
+ * names one, and the honest generic 'artwork' when it names a subject instead
+ * (or names nothing at all) — never an empty chip, since the chip's job is to
+ * say "this is not a book we hold".
+ */
+export function artworkTypeLabel(resourceType?: string | null): string {
+  const value = (resourceType || '').trim().toLowerCase();
+  if (!value || !MEDIUM_RESOURCE_TYPES.has(value)) return 'artwork';
+  return value.replace(/-/g, ' ');
+}

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -10,6 +10,7 @@
 
 import { supabase, supabaseAdmin, sanitizeFilterValue } from '@/lib/supabase';
 import { isSingleRealLanguage } from '@/lib/language-canonical';
+import { NON_ARTWORK_FILTERS } from '@/lib/artwork-record';
 
 /**
  * Canonical form of a category value: lowercase, trimmed, spaces → hyphens.
@@ -64,6 +65,9 @@ export interface CatalogBook {
   image_source_provider: string | null;
   categories: string[];
   collections: string[];
+  /** 'artwork' | 'book' | 'text' | null. Paired with resource_type: both are
+   *  needed to tell an artwork from a text — see isArtworkRecord(). */
+  content_type: string | null;
   resource_type: string | null;
   /** original | period-translation | modern-translation — see src/lib/text-role.ts (#2395) */
   text_role: string | null;
@@ -110,7 +114,7 @@ export interface CatalogBookDetail extends CatalogBook {
 // and PostgREST 42703s the whole query on an unknown column — which would take
 // the catalogue down rather than degrade it. They are attached from Mongo by
 // `attachCardVariants()` below instead.
-export const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_translated_es, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
+export const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_translated_es, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, content_type, resource_type, text_role, place_published, ft_verdict, ft_evidence_strength, ft_our_completeness, ft_source_screen, ft_translator_screen';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 
@@ -558,6 +562,16 @@ export async function searchBooksCatalog(
     .gt('pages_count', 0)
     .or(orFilter)
     .limit(limit);
+
+  // Artworks share this table with texts, and a book card linking to /book/ is
+  // the wrong promise for a Met stela — the reader clicks expecting a readable
+  // scan. Search surfaces artworks in their own Images lane instead (see the
+  // artwork lanes in /api/search/unified). Measured 2026-08-30: this drops 96
+  // of 31,731 live rows, e.g. "stela" 27 results → 8, all of them books.
+  // NOT `.not('resource_type','is',null)` — that would also drop the one live
+  // record carrying content_type:'text' + resource_type:'text', a real Javanese
+  // chronicle. See isArtworkRecord().
+  for (const f of NON_ARTWORK_FILTERS) query = query.or(f);
 
   if (opts?.language) query = query.eq('language', opts.language);
   if (opts?.category) query = query.contains('categories', [canonicalizeCategory(opts.category)]);

--- a/src/lib/search-i18n.ts
+++ b/src/lib/search-i18n.ts
@@ -163,6 +163,14 @@ export interface SearchStrings {
   searchingPages: string;
   noMatchingPassages: string;
   untitled: string;
+  /**
+   * Subtitle under an illustration in the Images strip. The strip mixes details
+   * cropped from books we hold with standalone artworks held by museums, and
+   * the two used to wear the same bare title. This says the image is a detail
+   * FROM something. The page number is rendered separately so a long book title
+   * can truncate without taking the page number with it.
+   */
+  imageFromBook: (title: string) => string;
   digitized: string;
   catalogOnly: string;
   collectionBooks: (n: string) => string;
@@ -309,6 +317,7 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     searchingPages: 'Searching pages...',
     noMatchingPassages: 'No matching passages found in this book.',
     untitled: '(untitled)',
+    imageFromBook: (title) => `from ${title}`,
     digitized: 'Digitized',
     catalogOnly: 'Catalog only',
     collectionBooks: (n) => `${n} books`,
@@ -439,6 +448,7 @@ export const SEARCH_STRINGS: Record<Locale, SearchStrings> = {
     searchingPages: 'Buscando en las páginas...',
     noMatchingPassages: 'No se han encontrado pasajes coincidentes en este libro.',
     untitled: '(sin título)',
+    imageFromBook: (title) => `de ${title}`,
     digitized: 'Digitalizado',
     catalogOnly: 'Solo en catálogo',
     collectionBooks: (n) => `${n} libros`,

--- a/supabase/migrations/20260830000000_books_catalog_content_type.sql
+++ b/supabase/migrations/20260830000000_books_catalog_content_type.sql
@@ -1,0 +1,34 @@
+-- books_catalog: mirror `books.content_type` so the catalogue can tell an
+-- artwork from a text.
+--
+-- Artwork records live in the SAME Mongo `books` collection as texts (24,912
+-- of 110,016 docs on 2026-08-30). The canonical rule for telling them apart —
+-- isArtworkRecord(), now src/lib/artwork-record.ts — needs BOTH markers:
+--
+--     content_type = 'artwork'                        → artwork
+--     content_type set to anything else               → NOT artwork
+--     content_type absent, resource_type set          → artwork
+--
+-- The mirror carried only `resource_type`, so no catalogue-fed surface could
+-- apply that rule, and search's book lane rendered the 97 live artwork rows as
+-- book cards linking to /book/. Worse, `resource_type` alone cannot be used as
+-- the test: one live record ("Babad Tanah Djawi lan Tanah-Tanah ing
+-- Sakiwa-Tengenipoen", id 6a197add50f34ce9f2ea4a0d) is a real Javanese
+-- chronicle carrying content_type:'text' + resource_type:'text'. Filtering on
+-- "resource_type IS NOT NULL" would delete a genuine book from search results.
+--
+-- Additive and nullable — a NULL here means "unknown", and the rule falls back
+-- to resource_type exactly as it does in Mongo, so rows stay valid until
+-- scripts/workers/sync-books-catalog.mjs repopulates them.
+--
+-- Apply with scripts/migration/add-books-catalog-content-type.mjs (needs
+-- SUPABASE_DB_URL from the keychain), or paste into the Supabase SQL editor.
+
+ALTER TABLE books_catalog
+  ADD COLUMN IF NOT EXISTS content_type text;
+
+-- The only predicate any caller uses is "is this an artwork?", and artworks are
+-- ~23% of rows. A partial index on the artwork value keeps the exclusion cheap.
+CREATE INDEX IF NOT EXISTS books_catalog_content_type_artwork_idx
+  ON books_catalog (content_type)
+  WHERE content_type = 'artwork';


### PR DESCRIPTION
Artworks live in the **same Mongo `books` collection** as texts (24,912 of 110,016 docs). Search never made the distinction, so a Metropolitan Museum stela and a book we can actually serve looked identical — and clicked through to a `/book/` page for a thing with no pages.

## What was wrong

**1. The books text lane rendered artworks as book cards.** Measured on `stela`: **8 of 8** results were Met objects with `pages_count: 0`. The five *Hieroglyphic Texts from Egyptian Stelae* volumes we actually hold were pushed off the page entirely by them.

**2. The semantic books lane had no gate at all.** Every other lane filters — the keyword lane at source in `books_catalog`, the artwork/gallery/CLIP lanes by re-resolving against Mongo via `filterVisibleArtworks`. `match_books_semantic` rows went to the client as book cards whatever they were. On `tarot`, **4 of its 6 results were artwork records**, and one of those (`T13 Tarot`) is **`visible: false` in Mongo and was being served to the public anyway**.

**3. The Images strip drew both kinds identically.** The second line was `item.bookTitle` for an artwork *and* for a detail cropped from one of our books — a slot meaning "the object's own title" in one case and "the book it came from" in the other.

## The rule

It already existed, as a private copy inside `/author/[name]`: `content_type: 'artwork'` or a bare `resource_type` means artwork, and an explicit `content_type` wins. It is now `src/lib/artwork-record.ts`, shared by the author page, the catalogue query layer, and the search route.

## The negative control

**`resource_type` alone is not a usable test.** One live record — the Javanese chronicle *"Babad Tanah Djawi lan Tanah-Tanah ing Sakiwa-Tengenipoen"* (`6a197add50f34ce9f2ea4a0d`) — carries `content_type: 'text'` + `resource_type: 'text'`. A `resource_type IS NOT NULL` filter would silently delete a real book from the library. That record is the control throughout, and `add-books-catalog-content-type.mjs` **throws** if the rule would exclude it.

Note this also means the rule as written on the author page was subtly wrong (only `content_type === 'book'` won, not `'text'`); the shared version fixes that for both callers.

## Data change

`books_catalog` gains a nullable `content_type text` column plus a partial index on `= 'artwork'`. Additive: `NULL` means "unknown" and the rule falls back to `resource_type`, i.e. exactly the pre-existing behaviour, so rows stay valid mid-backfill.

**Already applied and verified against production** (a committed migration is not proof of what is live — the previous `books_catalog` migration, `20260828000000` for `image_display`/`image_card`, is committed and those columns do **not** exist on the live table; see Out of scope):

```
column present: text, nullable=YES
55,431 books carry a content_type in Mongo → set 55,413 catalog rows
distribution: (null)=54167 book=30500 artwork=24912 text=1
live rows: 31,731, of which artworks excluded from the book lane: 96
negative control "Babad Tanah Djawi…": content_type=text resource_type=text excluded=false
```

96 + the Babad = the 97 live rows carrying a `resource_type`. The sync worker now mirrors `content_type` (projection **and** row builder — they move together) and nulls `resource_type` for anything explicitly labelled a text, not just a book.

## Card change

| | chip | subtitle |
|---|---|---|
| Artwork | medium — `print` / `drawing` / `object` | holding institution, else the artist |
| Illustration | none | `from <book> · p. N` |

A subject-shaped `resource_type` (`religious`, `allegory`, `genre-scene` — roughly half the vocabulary is subject matter, not form) falls back to the honest generic `artwork` rather than putting "religious" in a type chip. The page number sits in its own non-shrinking span so a long book title truncates without swallowing it. A **negative** `page_number` is a soft-hide marker and is never rendered (`p. -154` was appearing). Existing chip/text tokens only — no new design primitives, colours, or spacing values.

## Bonus fix: a hard 404

The dedicated Images tab is fed by `/api/gallery`, which marks artworks with `source: 'artwork'` (not `isArtwork`) and supplies a canonical `link`. The card read neither, so it built `/gallery/image/artwork-<id>` from a synthetic pageId. **Confirmed 404 before, 200 after** — every artwork tile in that tab was a dead link.

## Verified in the running app

Dev server against production data, not just by reading code:

| query | before | after |
|---|---|---|
| `stela` | 8 books, all Met artworks | 6 books, 0 artworks; 21 in the artwork lane |
| `tarot` | semantic 6 (4 artworks, 1 hidden) | semantic 2, both real books |
| `blake` | 4 books | 4 books unchanged; 51 artwork cards, 0 broken hrefs |
| `swedenborg` | 8 books + 4 semantic | unchanged |
| `babad` | chronicle present | **chronicle still present** ← negative control |

Images tab on `blake`: 51 artwork + 33 illustration cards, 0 `/gallery/image/artwork-` hrefs, 0 negative page numbers.

The "no artworks in the books lane" assertion was **re-run as a positive control** — with the filter disabled the Met stelae come straight back — because the first version of that check read a field the route strips, and would have passed vacuously.

`npx tsc --noEmit` clean. ESLint: no new errors (`unified/route.ts` 56 → 55, `search/page.tsx` warnings 6 → 5). `tests/unit/catalog-localized-counter.test.ts` passes.

## Out of scope (deliberately)

- **`/catalog` and `/browse` still list artworks**, routed to `/artwork/` by `CollectionBookCard`. That is intentional there — the catalogue grid is meant to show them. Only search's book lane made the wrong promise.
- **Migration `20260828000000` (`image_display` / `image_card`) has never been applied to production.** Found while inspecting the live schema. Not mine to ship; `BOOK_SELECT` already carries a comment explaining why those columns are deliberately not selected, so nothing is broken — but someone should decide whether that migration is still wanted.
- **The keyword books lane is filtered at source, not re-checked against Mongo.** The semantic lane now gets a read-side gate because it had none; adding a second one to the keyword lane would mean touching the work-collapse plumbing (`groups` / `workKeyByBookId`) and belongs in its own PR.
- **`holder` reads "Wikimedia Commons" for Commons-sourced artworks.** That is the honest provider, not a holding institution. Enriching those with a real repository is a metadata job, not a rendering one.
- **The visibility leak fix (item 2) is arguably a second concern.** It lives in the same three lines of the same lane, and shipping the artwork filter while knowingly leaving a hidden record public seemed worse than the coupling. Happy to split it out if you'd rather review it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdPY9k3RzHJJSArRHcCCpR
