### PR TITLE
A missing imagecount is not an empty book — eGangotri enumerated as zero (#4311)

### DIFF
--- a/scripts/import/egangotri-tantra-wave.mjs
+++ b/scripts/import/egangotri-tantra-wave.mjs
@@ -67,7 +67,15 @@ const SUBJECTS = ['Tantra', 'Jyotish', 'Ayurveda', 'Vaidyaka', 'Dharmashastra', 
  * harder here would only produce confident wrong titles.
  */
 export function parseFilename(raw) {
-  const t = String(raw || '').replace(/\bE\s*Gangotri\s*(Digital\s*Preservation\s*Trust)?\b/gi, ' ').replace(/\s{2,}/g, ' ').trim();
+  const t = String(raw || '')
+    // the trust signs its own uploads; that is provenance, not a title
+    .replace(/\bE\s*Gangotri\b/gi, ' ')
+    .replace(/\bDigital\s*Preservation\s*(Trust|Foundation)\b/gi, ' ')
+    // leading SCAN date, not a date of the work: "04 04 2023 …", "1 July …",
+    // "18 May …". Anchored to the start so a date inside a title survives.
+    .replace(/^\s*\d{1,2}[\s.\-/]+\d{1,2}[\s.\-/]+\d{2,4}\s+/, '')
+    .replace(/^\s*\d{1,2}\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+/i, '')
+    .replace(/\s{2,}/g, ' ').trim();
   const script = (t.match(new RegExp(`\\b(${SCRIPTS.join('|')})\\b`, 'i')) || [])[1] || null;
   const subject = (t.match(new RegExp(`\\b(${SUBJECTS.join('|')})\\w*\\b`, 'i')) || [])[1] || null;
 

--- a/scripts/import/egangotri-tantra-wave.mjs
+++ b/scripts/import/egangotri-tantra-wave.mjs
@@ -161,10 +161,16 @@ async function main() {
         language: 'Sanskrit',
         original_language: 'Sanskrit',
         'field_provenance.language': { source: 'manual_curator_override', value: 'Sanskrit', reason: 'eGangotri Indic MS; IA language signals unreliable (#4311)' },
-        ...(meta.script ? { script: meta.script } : {}),
         updated_at: new Date(),
       },
-      ...(meta.subject ? { $addToSet: { categories: meta.subject } } : {}),
+      // Script and subject go into `categories`, which is a WHITELISTED field.
+      // An earlier cut wrote `books.script`, which is not in
+      // scripts/lib/books-known-fields.json — i.e. it silently minted a new
+      // column on `books`, which is the #3969 defect. A sweep records a value
+      // in an existing field or a ROW, never a new column.
+      ...(meta.script || meta.subject
+        ? { $addToSet: { categories: { $each: [meta.subject, meta.script].filter(Boolean) } } }
+        : {}),
     });
     const after = await books.findOne({ id: bookId }, { projection: { language: 1, pages_count: 1, visible: 1, hidden: 1, title: 1 } });
     console.log(`  OK ${p.ia_identifier} → ${bookId} | ${after?.title?.slice(0, 46)} | lang=${after?.language} pages=${after?.pages_count} visible=${after?.visible} hidden=${after?.hidden} (lang-fix modified=${upd.modifiedCount})`);

--- a/scripts/import/egangotri-tantra-wave.mjs
+++ b/scripts/import/egangotri-tantra-wave.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Sanskrit wave 2 — eGangotri tantra/āgama manuscripts from the Internet Archive.
+ * Issue #4311 workstream 3 (follow-on to the Wellcome wave).
+ *
+ * eGangotri Digital Preservation Trust digitises Indian manuscript collections
+ * at source (Kashmir, Jammu, Varanasi maths): Sharada and Devanāgarī tantra,
+ * āgama, stotra and jyotiṣa MSS that exist nowhere else digitally. Per
+ * .claude/docs/sanskrit-sources.md this is one of the two channels that combine
+ * yield with scriptability.
+ *
+ * Candidate list is produced by:
+ *   node --env-file=.env.production.local --import tsx \
+ *     scripts/import/enumerate-dedupe-source.ts \
+ *     --ia-query 'mediatype:(texts) AND creator:("eGangotri") AND (tantra OR agama OR tantric)' \
+ *     --rows 2000 --out <file>
+ *
+ * TWO SOURCE HAZARDS THIS SCRIPT HANDLES, both measured on the real list:
+ *
+ * 1. THE FILENAME IS THE CATALOGUE RECORD. eGangotri items carry no structured
+ *    metadata; the title is a filename shaped
+ *      {Title} {MS number} {Alm N Shlf N} {Script} {Subject}
+ *    e.g. "Yantra Chintamani Alm 26 Shlf 6 5995 1568 Ka Devanagari Tantra".
+ *    Imported raw, the shelf locator becomes part of the book's title forever.
+ *    parseFilename() lifts script + subject into real metadata and strips the
+ *    locator noise out of the title.
+ *
+ * 2. IA MIS-TAGS THE LANGUAGE OF INDIC SCANS, SYSTEMATICALLY. /api/import/ia's
+ *    resolveLanguage deliberately trusts IA's empirical signals over the
+ *    caller's hint, and those signals are wrong for Devanāgarī/Sharada: the
+ *    same class of scans has imported as Marathi, Hindi, Nepali, Latin and
+ *    English before. So this script RE-ASSERTS language + original_language in
+ *    Mongo after each import, with field_provenance marking it a curator
+ *    override. Do not remove that step because a spot check looked fine.
+ *
+ * Books land HIDDEN per the import-workflow invariant; QA before any go-live.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/import/egangotri-tantra-wave.mjs --limit 5
+ *   node --env-file=.env.production.local scripts/import/egangotri-tantra-wave.mjs --limit 5 --commit
+ */
+
+import { MongoClient } from 'mongodb';
+import { readFileSync } from 'node:fs';
+
+const COMMIT = process.argv.includes('--commit');
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const LIMIT = parseInt(arg('--limit', '5'), 10);
+const LIST = arg('--list', './_tmp-egangotri-tantra.json');
+const BASE = arg('--base', 'https://sourcelibrary.org/api/import/ia');
+const CRON_SECRET = process.env.CRON_SECRET;
+if (COMMIT && !CRON_SECRET) { console.error('CRON_SECRET not set'); process.exit(1); }
+
+const SCRIPTS = ['Devanagari', 'Sharada', 'Grantha', 'Bengali', 'Telugu', 'Malayalam', 'Nandinagari', 'Newari', 'Tamil', 'Oriya', 'Kannada', 'Gujarati'];
+const SUBJECTS = ['Tantra', 'Jyotish', 'Ayurveda', 'Vaidyaka', 'Dharmashastra', 'Alankar', 'Vyakaran', 'Vedanta', 'Nyaya', 'Purana', 'Kavya', 'Sahitya', 'Stotra', 'Yoga', 'Agama', 'Shaiva', 'Mimansa', 'Sankhya', 'Veda', 'Smriti'];
+
+/**
+ * The convention puts script and subject at the END of the filename, so only a
+ * TRAILING token may be stripped. Stripping them globally mangles real titles:
+ * Mālinīvijayottara **Tantra** IS the work's name, and "Antyeshti Vidhi (from
+ * Tantra Shastra)" loses its sense. A subject word in the middle of a title is
+ * part of the title.
+ *
+ * What remains may still be untidy (collection numbers, dates). That is
+ * deliberate — these import HIDDEN, and sanskrit-sources.md prescribes
+ * title-page OCR at QA as the step that produces the real title. Guessing
+ * harder here would only produce confident wrong titles.
+ */
+export function parseFilename(raw) {
+  const t = String(raw || '').replace(/\bE\s*Gangotri\s*(Digital\s*Preservation\s*Trust)?\b/gi, ' ').replace(/\s{2,}/g, ' ').trim();
+  const script = (t.match(new RegExp(`\\b(${SCRIPTS.join('|')})\\b`, 'i')) || [])[1] || null;
+  const subject = (t.match(new RegExp(`\\b(${SUBJECTS.join('|')})\\w*\\b`, 'i')) || [])[1] || null;
+
+  const TRAILING = new RegExp(
+    `[\\s\\-–—.]*\\b(?:(?:${SCRIPTS.join('|')})|(?:${SUBJECTS.join('|')})\\w*|` +
+    `(?:Alm|Almira|Shlf|Shelf)\\s*\\.?\\s*\\d+[A-Za-z]?|Manuscript|MSS?|` +
+    `Ka|Kha|Ga|Gha|Nga|\\d{3,6})\\b[\\s\\-–—.]*$`, 'i');
+
+  let title = t;
+  for (let i = 0; i < 8; i++) {
+    const next = title.replace(TRAILING, '').trim();
+    if (next === title || next.length < 4) break;
+    title = next;
+  }
+  return { title: title || t, script, subject };
+}
+
+async function main() {
+  const data = JSON.parse(readFileSync(LIST, 'utf8'));
+  const all = data.candidates.filter(c => c.status !== 'REUPLOAD');
+  const batch = all.slice(0, LIMIT);
+  console.log(`list: ${all.length} candidates; importing ${batch.length}${COMMIT ? '' : ' (DRY RUN)'}`);
+
+  const parsed = batch.map(c => ({ ...c, ...parseFilename(c.title) }));
+  for (const p of parsed) {
+    console.log(`  ${p.ia_identifier}`);
+    console.log(`     raw:   ${p.title !== p.clean ? String(p.title).slice(0, 78) : ''}`);
+    console.log(`     title: ${parseFilename(p.title).title}   [${p.script || '?'} / ${p.subject || '?'}]`);
+  }
+  if (!COMMIT) { console.log('\nDRY RUN — nothing imported. Add --commit.'); return; }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+
+  let ok = 0, failed = 0;
+  for (const p of parsed) {
+    const meta = parseFilename(p.title);
+    let res, body;
+    try {
+      res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${CRON_SECRET}` },
+        body: JSON.stringify({
+          ia_identifier: p.ia_identifier,
+          title: meta.title || p.title,
+          // These are anonymous manuscripts and the route requires an author.
+          // 'Unknown' is the corpus's honest-absence value (the Wellcome wave
+          // settled 17 books this way). Do NOT substitute the holding
+          // collection: an institution in `author` is emitted as a schema.org
+          // Person by four separate emitters (see corporate-bylines.ts).
+          author: 'Unknown',
+          language: 'Sanskrit',
+          original_language: 'Sanskrit',
+          categories: meta.subject ? [meta.subject] : undefined,
+          visible: false,
+          hidden: true,
+        }),
+        signal: AbortSignal.timeout(120000),
+      });
+      body = await res.json().catch(() => ({}));
+    } catch (e) {
+      console.error(`  FAIL ${p.ia_identifier}: ${e.message}`);
+      failed++;
+      continue;
+    }
+    if (!res.ok) {
+      // 409 = already held; that is a correct refusal, not an error.
+      console.error(`  ${res.status === 409 ? 'HELD' : 'FAIL'} ${p.ia_identifier}: ${body.error || res.status}`);
+      failed++;
+      continue;
+    }
+    // The route returns `bookId` (not book_id/id). Getting this wrong made the
+    // language re-assertion below a silent no-op on the first pilot run.
+    const bookId = body.bookId || body.book_id || body.id;
+    if (!bookId) { console.error(`  WARN ${p.ia_identifier}: import succeeded but no bookId in response: ${JSON.stringify(body).slice(0,200)}`); }
+    ok++;
+
+    // Re-assert language. The import route resolves language from IA's own
+    // signals, which are wrong for Indic scans as a rule, not occasionally.
+    const upd = await books.updateOne({ id: bookId }, {
+      $set: {
+        language: 'Sanskrit',
+        original_language: 'Sanskrit',
+        'field_provenance.language': { source: 'manual_curator_override', value: 'Sanskrit', reason: 'eGangotri Indic MS; IA language signals unreliable (#4311)' },
+        ...(meta.script ? { script: meta.script } : {}),
+        updated_at: new Date(),
+      },
+      ...(meta.subject ? { $addToSet: { categories: meta.subject } } : {}),
+    });
+    const after = await books.findOne({ id: bookId }, { projection: { language: 1, pages_count: 1, visible: 1, hidden: 1, title: 1 } });
+    console.log(`  OK ${p.ia_identifier} → ${bookId} | ${after?.title?.slice(0, 46)} | lang=${after?.language} pages=${after?.pages_count} visible=${after?.visible} hidden=${after?.hidden} (lang-fix modified=${upd.modifiedCount})`);
+  }
+  console.log(`\nimported ${ok}, failed/held ${failed}`);
+  await client.close();
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(e => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/import/enumerate-dedupe-source.ts
+++ b/scripts/import/enumerate-dedupe-source.ts
@@ -29,6 +29,12 @@
  *   --ia-query RAW         raw IA advancedsearch query (overrides the two above)
  *   --rows N               max candidates to pull (default 200)
  *   --min-images N         skip items with fewer than N page images (default 10)
+ *   --resolve-images       for items the search index gives no imagecount for,
+ *                          read the real page count from IA's IIIF manifest.
+ *                          Needed for whole channels (eGangotri: 0% coverage).
+ *   --resolve-concurrency N  parallel manifest fetches while resolving (default 4).
+ *                          Do NOT raise this casually: at 12 archive.org
+ *                          throttled us to an 87% failure rate within minutes.
  *   --out PATH             write candidate JSON here (default: stdout table only)
  */
 
@@ -44,6 +50,29 @@ const IA_QUERY_RAW = arg('--ia-query');
 const ROWS = parseInt(arg('--rows', '200'), 10);
 const MIN_IMAGES = parseInt(arg('--min-images', '10'), 10);
 const OUT = arg('--out');
+const RESOLVE_IMAGES = process.argv.includes('--resolve-images');
+const RESOLVE_CONCURRENCY = parseInt(arg('--resolve-concurrency', '4'), 10);
+
+// Page count for an item whose `imagecount` the search index does not carry.
+// Same first step the /api/import/ia route uses (IIIF canvases), so a count
+// here matches the count the import will actually produce.
+// A short deadline is deliberate. Measured over eGangotri: a manifest either
+// answers in ~0.6-3s or does not answer at all, and ~25% fall in the second
+// group. Waiting 25s and then RETRYING them turned a 4-minute job into a
+// 4-hour one for no extra data. Unknown is a fine answer here — the import
+// route resolves the count itself and fails closed if it cannot.
+async function resolveImageCount(identifier: string): Promise<number | null> {
+  try {
+    const r = await fetch(`https://iiif.archive.org/iiif/${identifier}/manifest.json`, { signal: AbortSignal.timeout(10000) });
+    if (!r.ok) return null;
+    const m = await r.json();
+    if (Array.isArray(m.items)) return m.items.length;
+    if (Array.isArray(m.sequences?.[0]?.canvases)) return m.sequences[0].canvases.length;
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function buildIaQuery() {
   if (IA_QUERY_RAW) return IA_QUERY_RAW;
@@ -69,7 +98,12 @@ async function enumerateIA() {
     title: Array.isArray(d.title) ? d.title[0] : (d.title || ''),
     author: Array.isArray(d.creator) ? d.creator[0] : (d.creator || ''),
     year: d.year || null,
-    images: d.imagecount || 0,
+    // `imagecount` is ABSENT from the advancedsearch index for whole channels
+    // (every eGangotri item, for one). Coercing that to 0 made --min-images
+    // reject 100% of them as THIN — a missing field read as an empty book.
+    // null means "unknown", which is not the same as "none": resolve it with
+    // --resolve-images, never silently treat it as a reason to skip.
+    images: d.imagecount != null && d.imagecount !== '' ? Number(d.imagecount) : null,
     language: Array.isArray(d.language) ? d.language.join(',') : (d.language || ''),
   }));
 }
@@ -121,28 +155,84 @@ async function main() {
   await client.close();
   console.error(`DEDUPE: against ${held.total} held books`);
 
+  if (RESOLVE_IMAGES) {
+    const unknown = candidates.filter(c => c.images == null);
+    console.error(`RESOLVE: ${unknown.length} items have no imagecount — reading page counts from IA's IIIF manifests`);
+    let done = 0, failed = 0, next = 0;
+    // Worker pool, NOT fixed batches: with batches, one slow manifest blocks the
+    // other five in its group, and the whole pass runs at the speed of its worst
+    // item. Each worker just takes the next index when it is free.
+    // Bail if the source has clearly stopped answering us, instead of grinding
+    // through thousands of items at a 0% success rate and calling it progress
+    // (the #4341 lesson: a swallowed failure reads as slow, not as blocked).
+    let aborted = false;
+    const worker = async () => {
+      for (;;) {
+        if (aborted) return;
+        const i = next++;
+        if (i >= unknown.length) return;
+        unknown[i].images = await resolveImageCount(unknown[i].ia_identifier);
+        if (unknown[i].images == null) failed++;
+        if (++done % 200 === 0) console.error(`  …${done}/${unknown.length} (${failed} unresolved)`);
+        if (done >= 120 && failed / done > 0.6) {
+          aborted = true;
+          console.error(`  ABORT: ${failed}/${done} manifest fetches failed (>60%). archive.org is almost certainly throttling —`);
+          console.error(`  lower --resolve-concurrency (4 is the tested default) or drop --resolve-images. Sizes stay UNKNOWN_SIZE, which is honest.`);
+          return;
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: Math.max(1, RESOLVE_CONCURRENCY) }, worker));
+    // Say what stayed unknown. A silent skip here would put items back in the
+    // same hole the missing-imagecount bug dug.
+    console.error(`  resolved ${done - failed}/${unknown.length}; ${failed} still unknown (manifest fetch failed)`);
+  }
+
+  // Dedupe WITHIN the candidate list, not only against holdings. A source can
+  // carry the same item twice: eGangotri re-uploads manuscripts with a
+  // `_2017xx` identifier suffix, and 431 of 1,689 tantra candidates were such
+  // pairs. Nothing downstream would have caught it — each id is genuinely new
+  // to us, so both would import as separate books.
+  const seenBase = new Map<string, string>();
+  for (const c of candidates) {
+    const base = String(c.ia_identifier).replace(/_\d{6}$/, '').toLowerCase();
+    if (!seenBase.has(base)) seenBase.set(base, c.ia_identifier);
+  }
+
   const rows = candidates.map(c => {
     const cls = classify(c, held);
-    const tooThin = (c.images || 0) < MIN_IMAGES;
-    return { ...c, status: tooThin && cls.status === 'NEW' ? 'THIN' : cls.status, reason: tooThin ? `${c.images} images < ${MIN_IMAGES}` : cls.reason };
+    if (cls.status !== 'NEW') return { ...c, status: cls.status, reason: cls.reason };
+    const base = String(c.ia_identifier).replace(/_\d{6}$/, '').toLowerCase();
+    const keeper = seenBase.get(base);
+    if (keeper && keeper !== c.ia_identifier) {
+      return { ...c, status: 'REUPLOAD', reason: `same item as ${keeper} (source re-upload)` };
+    }
+    // Unknown size is a gap in our knowledge, not a property of the book.
+    if (c.images == null) return { ...c, status: 'UNKNOWN_SIZE', reason: 'no imagecount; re-run with --resolve-images' };
+    const tooThin = c.images < MIN_IMAGES;
+    return { ...c, status: tooThin ? 'THIN' : 'NEW', reason: tooThin ? `${c.images} images < ${MIN_IMAGES}` : cls.reason };
   });
 
   const counts = rows.reduce((m, r) => (m[r.status] = (m[r.status] || 0) + 1, m), {});
   console.error(`\nRESULT: ${JSON.stringify(counts)}`);
   console.error(`  NEW = not held, worth subject-filtering for import.`);
-  console.error(`  LIKELY_DUP / HELD = skip. TITLE_CLASH = same title diff author (check). THIN = too few images.\n`);
+  console.error(`  LIKELY_DUP / HELD = skip. TITLE_CLASH = same title diff author (check). THIN = too few images.`);
+  console.error(`  REUPLOAD = the SAME item twice in this list (source re-upload) — import the keeper only.`);
+  console.error(`  UNKNOWN_SIZE = source gave no imagecount — NOT a judgement about the book; re-run with --resolve-images.\n`);
 
   // Readable table — NEW first
-  const order = { NEW: 0, TITLE_CLASH: 1, THIN: 2, LIKELY_DUP: 3, HELD: 4 };
+  const order = { NEW: 0, TITLE_CLASH: 1, UNKNOWN_SIZE: 2, THIN: 3, REUPLOAD: 4, LIKELY_DUP: 5, HELD: 6 };
   rows.sort((a, b) => (order[a.status] - order[b.status]) || String(a.title).localeCompare(String(b.title)));
   for (const r of rows) {
     console.log(`  [${r.status.padEnd(11)}] ${String(r.ia_identifier).padEnd(16)} img=${String(r.images).padStart(4)} | ${String(r.title).slice(0, 50)}`);
   }
 
   if (OUT) {
-    const newOnes = rows.filter(r => r.status === 'NEW' || r.status === 'TITLE_CLASH');
+    // UNKNOWN_SIZE rides along: dropping it here would hide the very items the
+    // missing-imagecount bug used to swallow.
+    const newOnes = rows.filter(r => r.status === 'NEW' || r.status === 'TITLE_CLASH' || r.status === 'UNKNOWN_SIZE');
     writeFileSync(OUT, JSON.stringify({ query: buildIaQuery(), generatedFrom: candidates.length, heldCount: held.total, counts, candidates: newOnes }, null, 2));
-    console.error(`\nWrote ${newOnes.length} review candidates (NEW + TITLE_CLASH) → ${OUT}`);
+    console.error(`\nWrote ${newOnes.length} review candidates (NEW + TITLE_CLASH + UNKNOWN_SIZE) → ${OUT}`);
     console.error(`Next: subject-filter this list by hand, then import the approved ids.`);
   }
 }


### PR DESCRIPTION
## What

`enumerate-dedupe-source.ts` coerced IA's absent `imagecount` to `0`, so `--min-images` classified every candidate as `THIN`. On the eGangotri channel that is **100% of items** — a 1,689-item Sanskrit tantra corpus we hold **none** of enumerated as "0 candidates", which reads as "the source has nothing."

The field is simply not in IA's advancedsearch index for that uploader. Every item probed carries a `Single Page Processed JP2 ZIP` and resolves 17–550 canvases via IIIF.

## Changes

- `images` is `null` (unknown) when the source omits the field, never `0`.
- New **`UNKNOWN_SIZE`** status, distinct from `THIN`, and it rides along in `--out` rather than being dropped — dropping it would re-hide exactly what the bug hid.
- **`--resolve-images`** reads real page counts from IA's IIIF manifest — the same first step `/api/import/ia` uses, so a count here matches what an import will produce.
- New **`REUPLOAD`** status. eGangotri uploads the same manuscript twice with a `_2017xx` suffix; **453 of 1,689** candidates were such pairs. Dedupe ran only against *holdings*, so both ids looked new and both would have imported.
- `scripts/import/egangotri-tantra-wave.mjs` — the wave importer.

## Resolve-pass sizing, learned the hard way

Fixed batches let one 25s timeout stall five siblings, and concurrency 12 got us throttled to an **87% failure rate**. Now: worker pool, default concurrency **4**, 10s deadline, no retry, and an **abort when >60% fail** rather than grinding on at zero throughput — #4341's lesson applied here.

## The importer's two source hazards, both measured

1. **The filename IS the catalogue record.** Script/subject are lifted into metadata, and only **trailing** tokens are stripped — Mālinīvijayottara ***Tantra*** is the work's name, not a subject tag. An earlier global strip mangled it.
2. **IA mis-tags Indic scans' language systematically.** The 4-book pilot came back **Malayalam, Bengali, "Ne", Marathi — 4 of 4 wrong.** Language is re-asserted after import with curator provenance.

## Verification

4-book pilot imported hidden, correct `Sanskrit`, real page counts (39/116/300/550). One candidate correctly refused — no IIIF manifest, no jp2 files, so the route failed closed rather than importing a zero-page book.

`npx tsc --noEmit` clean.

## Out of scope

The full wave (**1,236 unique candidates** after re-upload dedupe) is **not** imported here — that is a size/storage decision for Derek. Only the 4 pilot books exist.

Related: #4311, #4341