### PR TITLE
feat(archive): heartbeat — a silent long run reads as a hang

### DIFF
--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -74,11 +74,38 @@ async function main() {
     }
   };
 
+  // ── Heartbeat ────────────────────────────────────────────────────────────
+  // This run emitted NOTHING between start and finish. At the post-#4395 rate a
+  // batch of 40 books is ~1.4 hours of silence, during which a healthy run and a
+  // hung one are indistinguishable — on 2026-08-30 a stalled run held the
+  // flock for 1h24m and silently no-op'd every subsequent cron, and the only way
+  // to tell progress from a hang was to query Mongo by hand.
+  //
+  // A silent long-running script reads as a hang; the fix is a heartbeat, not an
+  // index (invariants/archive-fetch-failures.md, same lesson from the corpus
+  // sweeps that were killed mid-run for looking dead). Counters are page-grain
+  // because book-grain moves too slowly to distinguish "working" from "stuck".
+  const runStart = Date.now();
+  let pagesDone = 0;
+  let pagesFailed = 0;
+  let booksDone = 0;
+  let workTotal = 0;
+  let currentHost = '-';
+  const hb = setInterval(() => {
+    const mins = (Date.now() - runStart) / 60000;
+    const rate = mins > 0 ? pagesDone / (mins * 60) : 0;
+    const thr = [...hostThrottles.entries()].map(([h, n]) => `${h.split('.')[0]}:${n}`).join(' ');
+    log(`heartbeat ${mins.toFixed(1)}m | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed | ${rate.toFixed(2)} pages/s | host ${currentHost}${thr ? ` | throttled ${thr}` : ''}`);
+  }, 60_000);
+  // Never let the heartbeat hold the process open past the work.
+  if (typeof hb.unref === 'function') hb.unref();
+
   async function archiveIiif(bookId: string) {
     const ps = await pages.find({ book_id: bookId, archived_photo: { $exists: false }, $or: [{ photo: /^https?:/ }, { photo_original: /^https?:/ }] }, { projection: { _id: 1, page_number: 1, photo: 1, photo_original: 1 } }).toArray();
     for (let i = 0; i < ps.length; i += 6) {
       await Promise.all(ps.slice(i, i + 6).map(async (p: any) => {
         const url = upgradeToFullRes(p.photo_original || p.photo);
+        try { currentHost = new URL(url).hostname; } catch { /* keep previous */ }
         try {
           const buf = await rateLimitedFetch(url);
           // Archive at source fidelity: no resolution cap (#3897, matches archive-ia-bulk).
@@ -88,9 +115,11 @@ async function main() {
           const upd: any = { $set: { archived_photo: blob.url } };
           try { const th = await sharp(buf).rotate().resize(150, null, { withoutEnlargement: true }).jpeg({ quality: 60 }).toBuffer(); upd.$set.thumbnail_blob = (await storagePut(`pages/${bookId}/${padded}-thumb.jpg`, th, { contentType: 'image/jpeg', access: 'public' })).url; } catch {}
           await pages.updateOne({ _id: p._id }, upd);
+          pagesDone++;
           hostFailures.clear(); // a success clears the streak
         } catch (e) {
           if (e instanceof HostBlocked) throw e;
+          pagesFailed++;
           noteFailure(url, e); // rethrows HostBlocked once the host looks blocked
         }
       }));
@@ -146,19 +175,27 @@ async function main() {
     }
   }
   let blocked: Error | null = null;
+  workTotal = todo.length;
+  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} — heartbeat every 60s`);
   for (let i = 0; i < todo.length && !blocked; i += CONCURRENCY) {
-    await Promise.all(todo.slice(i, i + CONCURRENCY).map(w => processBook(w).catch((e) => {
-      // Per-book failures stay swallowed (one bad book must not stop a sweep),
-      // but a blocked HOST is a verdict about the source: stop the whole run
-      // and say so, rather than grinding out thousands of doomed requests.
-      if (e instanceof HostBlocked) blocked = e;
-    })));
+    await Promise.all(todo.slice(i, i + CONCURRENCY).map(w => processBook(w)
+      .then(() => { booksDone++; })
+      .catch((e) => {
+        booksDone++;
+        // Per-book failures stay swallowed (one bad book must not stop a sweep),
+        // but a blocked HOST is a verdict about the source: stop the whole run
+        // and say so, rather than grinding out thousands of doomed requests.
+        if (e instanceof HostBlocked) blocked = e;
+      })));
   }
+  clearInterval(hb);
   const remaining = PROVIDER
     ? await books.countDocuments({ 'image_source.provider': PROVIDER, pages_count: { $gt: 0 }, archive_status: { $ne: 'archive_complete' } })
     : await queue.countDocuments({ status: 'acquired', archived: { $ne: true } });
   const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
-  log(`archive-acquired: complete ${ok}, partial ${partial} | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
+  const runMins = (Date.now() - runStart) / 60000;
+  const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
+  log(`archive-acquired: complete ${ok}, partial ${partial} | pages ${pagesDone} ok, ${pagesFailed} failed in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s) | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
   if (blocked) {
     // Exit non-zero so a wrapper loop stops instead of re-running into the block.
     log(`ABORTED — SOURCE BLOCKED: ${(blocked as Error).message}`);


### PR DESCRIPTION
`archive-acquired` emitted **nothing** between start and finish. At the post-#4395 rate a 40-book batch is ~1.4 hours of silence, during which a healthy run and a hung one are indistinguishable.

Not hypothetical. Today a stalled run held `/tmp/sl-arch-acq.lock` for **1h24m** and — because the cron wraps it in `flock -n` — silently no-op'd every subsequent run. The archiver looked dead for three hours, and the only way to tell progress from a hang was to query Mongo by hand.

## What it looks like

```
12:51:37 starting: 3 book(s), concurrency 2 — heartbeat every 60s
12:52:37 heartbeat 1.0m | books 0/3 | pages 6 ok, 4 failed | 0.10 pages/s | host gallica.bnf.fr
12:53:37 heartbeat 2.0m | books 0/3 | pages 11 ok, 4 failed | 0.09 pages/s | host gallica.bnf.fr
```

**Counters are page-grain deliberately.** `books 0/3` across two minutes while pages climb 6 → 11 is precisely the distinction that was missing — a 250-page book is minutes of apparent silence on its own, so book-grain cannot separate "working" from "stuck".

The line also carries the current host and any throttle counts, so #4396's adaptive backoff is visible *while it is happening* rather than only in hindsight. In the capture above the low rate is that backoff engaging on a host I had been hammering during diagnosis — which is the first time that state has been observable at all.

The final summary now reports pages and achieved rate alongside book counts, so a completed run states its own throughput instead of leaving it to be inferred from timestamps.

## Safety

Timer is `unref()`d so it can never hold the process open, and `clearInterval`'d before the summary. No behaviour change to fetching, selection, or the abort path.

Same lesson as the corpus sweeps that were killed mid-run for looking dead — `invariants/archive-fetch-failures.md`: *"the fix is a heartbeat, not an index."* That line was written about a different script and never applied to this one.

`npx tsc --noEmit` clean. Verified live against production (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PamsbX7RQrKvwFu4GVjRAz
