### PR TITLE
docs(invariants): artworks share the books collection — every search lane must exclude them

### DIFF
--- a/.claude/docs/invariants/search-filters-and-lanes.md
+++ b/.claude/docs/invariants/search-filters-and-lanes.md
@@ -87,3 +87,37 @@ STABLE and is rejected (`42P17`), which is why these use `COALESCE(x,'') || ' '`
 `add-bph-diacritic-normalization.sql` shows `concat_ws` and **does not match
 deployed reality** — read `pg_get_expr` off the live column, not the migration
 file.
+
+---
+
+## Artworks share the `books` collection, so every lane must exclude them (#4415, 2026-08-30)
+
+24,912 of ~110,058 `books_catalog` rows are artworks — museum prints, paintings,
+drawings — living in the same collection as texts. **A lane that filters only on
+`visible` + `pages_count > 0` serves them as books.** The books lane did exactly
+that for 97 rows: searching *stela* returned 8 Met objects with `pages_count: 0`
+and pushed the five *Hieroglyphic Texts from Egyptian Stelae* volumes we actually
+hold off the page. The **semantic** lane had no gate at all and was serving
+`T13 Tarot` — `visible: false` in Mongo — to the public.
+
+Three traps, all of which bit during the fix:
+
+- **Do not filter on "`resource_type` is set."** One live book (*Babad Tanah
+  Djawi lan Tanah-Tanah ing Sakiwa-Tengenipoen*) is `content_type: 'text'` with
+  `resource_type: 'text'`, and that filter hides it. Use the shared
+  `isArtworkRecord()` in `src/lib/artwork-record.ts`: an explicit **non-artwork**
+  `content_type` always wins. Keep that record as the negative control — a fix
+  that stops returning it is a regression, not a fix.
+- **PostgREST `.not(col,'eq',v)` drops NULL rows** to three-valued logic. 19,432
+  live books have a NULL `content_type`; a plain negation deletes them from
+  results. Use the chained `or` form (`NON_ARTWORK_FILTERS` in
+  `src/lib/books-catalog.ts`).
+- **A lane check that reads a field the route strips is vacuous.** The first
+  "no artworks in the books lane" assertion passed against a response that never
+  carries the field. Run the positive control — disable the filter, watch the Met
+  stelae come back — or the green check means nothing. See
+  `tests-that-are-not-guards.md`.
+
+Corollary for counting, not just serving: any aggregate over `books` inflates
+unless it excludes artworks. A naive author query for "William Blake" returns
+777 records, of which **776 are prints and drawings**.


### PR DESCRIPTION
Records the #4415 lesson where it will be read: `.claude/docs/invariants/search-filters-and-lanes.md`.

**In scope** — one doc section covering why the artwork leak happened and the three traps that bit while fixing it:
- filtering on `resource_type` presence hides a real book (the Javanese chronicle, `content_type: 'text'`) — use the shared `isArtworkRecord()`, where an explicit non-artwork `content_type` wins
- PostgREST `.not(col,'eq',v)` drops the 19,432 live books with a NULL `content_type` to three-valued logic
- a lane assertion that reads a field the route strips is vacuous — the positive control is what made the check real

**Out of scope** — no `CLAUDE.md` body change. That file is at 5,519 words against its ~5,500 budget, and the routing line for this doc already exists, so this costs nothing there.

The dedupe half of the same session (#4419) already documented its own lesson in `edition-identity.md`, so nothing is added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdPY9k3RzHJJSArRHcCCpR