### PR TITLE
fix(ocr): pin the model on preview jobs — the worker default is the dear one

### DIFF
--- a/src/lib/preview-ocr.ts
+++ b/src/lib/preview-ocr.ts
@@ -12,6 +12,7 @@
 import { nanoid } from 'nanoid';
 import { getDb } from './mongodb';
 import { enqueuePagesForJob } from './queue-utils';
+import { getModelForBook } from './types/ai-models';
 import type { JobStatus } from './types/job';
 
 const PREVIEW_PAGE_COUNT = 25;
@@ -43,6 +44,21 @@ export async function queuePreviewOcr(
 
     if (pages.length === 0) return;
 
+    // Pin the model on the job. The OCR worker falls back to DEFAULT_MODEL
+    // (full flash) when `config.model` is absent, so leaving it unset routed
+    // EVERY preview job to the expensive model regardless of language — during
+    // the 2026-08-27 acquisition push that was 4,450 Latin-script books at
+    // ~6x the flash-lite rate. `getModelForBook` still returns full flash for
+    // BPH, non-Latin scripts, and unknown language, so the safe default is
+    // preserved; only the languages the routing rule already trusts get lite.
+    const book = await db
+      .collection('books')
+      .findOne(
+        { id: bookId },
+        { projection: { language: 1, 'image_source.provider': 1 } },
+      );
+    const model = getModelForBook(book as Parameters<typeof getModelForBook>[0]);
+
     const pageIds = pages.map((p) => p.id);
     const jobId = nanoid(12);
 
@@ -61,6 +77,7 @@ export async function queuePreviewOcr(
       config: {
         page_ids: pageIds,
         preview: true,
+        model,
       },
       initiated_by: 'import_preview',
       created_at: new Date(),
@@ -77,7 +94,7 @@ export async function queuePreviewOcr(
     await enqueuePagesForJob(bookId, pageIds, 'ocr', jobId);
 
     console.log(
-      `[preview-ocr] Queued ${pageIds.length} pages for preview OCR on book ${bookId}`,
+      `[preview-ocr] Queued ${pageIds.length} pages for preview OCR on book ${bookId} (model: ${model})`,
     );
   } catch (err) {
     // Non-blocking — log and continue

--- a/tests/unit/preview-ocr-model-routing.test.ts
+++ b/tests/unit/preview-ocr-model-routing.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Preview OCR must PIN a model on the job it creates.
+ *
+ * INCIDENT (2026-08-27..30). `queuePreviewOcr` writes a `jobs` row with
+ * `config: { page_ids, preview: true }` and no `model`. The OCR worker
+ * (src/workers/ocr-processor-logic.ts) resolves the model as
+ * `job.config.model || DEFAULT_MODEL`, and DEFAULT_MODEL is the FULL flash
+ * model. So every newly imported book's 25-page preview ran on the expensive
+ * model, never consulting `getModelForBook`.
+ *
+ * It cost nothing visible until the acquisition push imported 3,998 books in
+ * one day: 110,646 preview pages for 4,450 Latin-script books — a language the
+ * routing rule explicitly trusts to flash-lite — billed at the full-flash rate.
+ *
+ * The shape to guard is not "preview OCR is cheap" but "the job carries an
+ * EXPLICIT model". A worker-side default that is also the most expensive option
+ * turns every omission into a silent overspend, so the omission is the bug.
+ *
+ * These are source-level assertions on purpose: `queuePreviewOcr` reaches for a
+ * live Mongo connection, and the failure being pinned is a missing field in the
+ * inserted document, which is visible in the source without one.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { getModelForBook, DEFAULT_MODEL, DEFAULT_LITE_MODEL } from '../../src/lib/types/ai-models';
+
+const root = path.join(__dirname, '..', '..');
+const previewOcrSrc = readFileSync(path.join(root, 'src/lib/preview-ocr.ts'), 'utf8');
+const workerSrc = readFileSync(path.join(root, 'src/workers/ocr-processor-logic.ts'), 'utf8');
+
+describe('preview OCR pins an explicit model', () => {
+  it('resolves the model through getModelForBook, not the worker default', () => {
+    expect(previewOcrSrc).toContain('getModelForBook');
+  });
+
+  it('writes the resolved model into the job config', () => {
+    // The inserted job document must carry `model`, or the worker falls back
+    // to DEFAULT_MODEL for every preview job regardless of language.
+    const config = previewOcrSrc.match(/config:\s*\{[^}]*\}/s);
+    expect(config, 'preview-ocr.ts no longer has a recognisable job config block').not.toBeNull();
+    expect(config![0]).toMatch(/\bmodel\b/);
+  });
+
+  it('the worker default it guards against is still the expensive model', () => {
+    // If this ever stops being true the guard above is arguably optional —
+    // but so is this test, and it should be revisited deliberately rather than
+    // quietly diverging from the reason it exists.
+    expect(workerSrc).toContain('job.config.model || DEFAULT_MODEL');
+    expect(DEFAULT_MODEL).toBe('gemini-3-flash-preview');
+  });
+});
+
+describe('the routing rule the preview path must honour', () => {
+  it('sends Latin-script books to the cheap model', () => {
+    // 4,450 of the books in the incident carried exactly this language.
+    expect(getModelForBook({ language: 'latin' })).toBe(DEFAULT_LITE_MODEL);
+    expect(getModelForBook({ language: 'German' })).toBe(DEFAULT_LITE_MODEL);
+  });
+
+  it('keeps the safe default for BPH, non-Latin scripts, and unknown language', () => {
+    expect(getModelForBook({ image_source: { provider: 'bph' }, language: 'latin' })).toBe(DEFAULT_MODEL);
+    expect(getModelForBook({ language: 'sanskrit' })).toBe(DEFAULT_MODEL);
+    expect(getModelForBook({ language: null })).toBe(DEFAULT_MODEL);
+    expect(getModelForBook(null)).toBe(DEFAULT_MODEL);
+  });
+});


### PR DESCRIPTION
## Why

OCR spend jumped from roughly nothing to **\$392 over Aug 27–30**. It is all one path.

`queuePreviewOcr` (`src/lib/preview-ocr.ts`) fires a 25-page sample OCR at every newly imported book, so metadata enrichment has text to work with within minutes instead of hours. It writes its `jobs` row with `config: { page_ids, preview: true }` — **no `model`**.

The OCR worker resolves the model as `job.config.model || DEFAULT_MODEL` (`src/workers/ocr-processor-logic.ts:120`), and `DEFAULT_MODEL` is `gemini-3-flash-preview`, the full-price model. So the preview path never consulted `getModelForBook` and always ran at the expensive rate.

That cost nothing visible while imports trickled. Then the acquisition push landed:

| day | books imported | preview pages | realtime OCR |
|---|---|---|---|
| 2026-08-26 | 91 | 2,225 | \$5.57 |
| 2026-08-27 | 3,998 | 94,355 | \$64.38 |
| 2026-08-28 | 561 | 13,464 | \$168.55 |
| 2026-08-29 | — | — | \$133.74 |
| 2026-08-30 | 865 | 20,884 | \$25.40 (partial) |

Resolving the 4,825 distinct books against their `language`:

- **110,646 calls / \$380.20 — Latin-script books on full flash.** 4,450 of them are `latin`, a language `LATIN_SCRIPT_LANGUAGES` explicitly trusts to flash-lite.
- 3,438 calls / \$11.96 — non-Latin or unknown language, correctly routed to flash by the rule.
- 4 calls — BPH, correctly flash.

So ~97% of the spend went to books the routing rule would have sent to the cheap model, at roughly 6x the rate.

## What changed

`queuePreviewOcr` reads the book it was handed and resolves the model through `getModelForBook`. That function is unchanged and still returns full flash for BPH, non-Latin scripts, and unknown/absent language — **the safe default is preserved**; only the languages the rule already trusts move to lite. The Tibetan-hallucination reasoning behind the allowlist is untouched.

## The guard

`tests/unit/preview-ocr-model-routing.test.ts` pins the *shape*, not the price: a preview job must carry an **explicit** model. A worker-side default that is also the most expensive option turns every omission into a silent overspend, so the omission is the defect. The test fails on the pre-fix file (verified by stashing the change).

It also asserts the worker fallback is still `DEFAULT_MODEL` — if that ever stops being the expensive model, the guard should be revisited deliberately rather than quietly diverging from its reason for existing.

## Audited, not changed

Other live OCR job creators were checked for the same gap. `/api/jobs/queue-books` already calls `getModelForBook`; `/api/admin/bulk-ocr-new` uses `DEFAULT_BATCH_MODEL` (batch API, already half price); `/api/scan/start-ocr` pins `DEFAULT_MODEL` explicitly on a manual, low-volume flow. `preview-ocr` was the only high-volume path missing it.

## Out of scope

- **776 preview jobs are still queued on the old default** (18,395 pages, ~\$7/hr still burning at time of writing). Patching their `config.model` in Mongo would stop that immediately, but it mutates a queue live workers are consuming, so it is a separate deliberate call — not bundled here.
- **How much of the \$392 counts as waste depends on #3576.** `gemini_usage.cost_usd` is computed, never billed, and flash-lite is priced 0.075/0.30 in one lane and 0.25/1.50 in another. Under the first the avoidable share is ~\$335; under the second, ~\$190. Either way the routing bug is the cause; only the size of the number is unsettled.
- Whether enrichment needs all 25 preview pages, or would do with the first few, is a product question worth asking separately — it is the larger lever on volume, independent of model choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HCFx8VPFrhmBMGVbcpYQW