### PR TITLE
fix(archive): restore the heartbeat, and guard it so a concurrent PR cannot delete it again

### DIFF
--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -77,11 +77,38 @@ async function main() {
     }
   };
 
+  // ── Heartbeat ────────────────────────────────────────────────────────────
+  // This run emits nothing between start and finish. At the post-#4395 rate a
+  // batch of 40 books is over an hour of silence, during which a healthy run and
+  // a hung one are indistinguishable — on 2026-08-30 a stalled run held the
+  // flock for 1h24m and silently no-op'd every subsequent cron, and the only way
+  // to tell progress from a hang was to query Mongo by hand.
+  //
+  // A silent long-running script reads as a hang; the fix is a heartbeat, not an
+  // index (invariants/archive-fetch-failures.md). Counters are PAGE-grain
+  // because book-grain moves too slowly to separate "working" from "stuck": a
+  // 250-page book is minutes of apparent silence on its own.
+  const runStart = Date.now();
+  let pagesDone = 0;
+  let pagesFailed = 0;
+  let booksDone = 0;
+  let workTotal = 0;
+  let currentHost = '-';
+  const hb = setInterval(() => {
+    const mins = (Date.now() - runStart) / 60000;
+    const rate = mins > 0 ? pagesDone / (mins * 60) : 0;
+    const thr = [...hostThrottles.entries()].map(([h, n]) => `${h.split('.')[0]}:${n}`).join(' ');
+    log(`heartbeat ${mins.toFixed(1)}m | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed | ${rate.toFixed(2)} pages/s | host ${currentHost}${thr ? ` | throttled ${thr}` : ''}`);
+  }, 60_000);
+  // Never let the heartbeat hold the process open past the work.
+  if (typeof hb.unref === 'function') hb.unref();
+
   async function archiveIiif(bookId: string) {
     const ps = await pages.find({ book_id: bookId, archived_photo: { $exists: false }, $or: [{ photo: /^https?:/ }, { photo_original: /^https?:/ }] }, { projection: { _id: 1, page_number: 1, photo: 1, photo_original: 1 } }).toArray();
     for (let i = 0; i < ps.length; i += 6) {
       await Promise.all(ps.slice(i, i + 6).map(async (p: any) => {
         const url = upgradeToFullRes(p.photo_original || p.photo);
+        try { currentHost = new URL(url).hostname; } catch { /* keep previous */ }
         try {
           // `/full/full/` is a REQUEST, not a guarantee. Seven hosts silently
           // cap the response below native — measured losses up to 8.69x (Kyoto),
@@ -132,9 +159,11 @@ async function main() {
           if (stitchedTiles) upd.$set.stitched_tiles = stitchedTiles;
           try { const th = await sharp(buf).rotate().resize(150, null, { withoutEnlargement: true }).jpeg({ quality: 60 }).toBuffer(); upd.$set.thumbnail_blob = (await storagePut(`pages/${bookId}/${padded}-thumb.jpg`, th, { contentType: 'image/jpeg', access: 'public' })).url; } catch {}
           await pages.updateOne({ _id: p._id }, upd);
+          pagesDone++;
           hostFailures.clear(); // a success clears the streak
         } catch (e) {
           if (e instanceof HostBlocked) throw e;
+          pagesFailed++;
           noteFailure(url, e); // rethrows HostBlocked once the host looks blocked
         }
       }));
@@ -190,19 +219,27 @@ async function main() {
     }
   }
   let blocked: Error | null = null;
+  workTotal = todo.length;
+  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} — heartbeat every 60s`);
   for (let i = 0; i < todo.length && !blocked; i += CONCURRENCY) {
-    await Promise.all(todo.slice(i, i + CONCURRENCY).map(w => processBook(w).catch((e) => {
-      // Per-book failures stay swallowed (one bad book must not stop a sweep),
-      // but a blocked HOST is a verdict about the source: stop the whole run
-      // and say so, rather than grinding out thousands of doomed requests.
-      if (e instanceof HostBlocked) blocked = e;
-    })));
+    await Promise.all(todo.slice(i, i + CONCURRENCY).map(w => processBook(w)
+      .then(() => { booksDone++; })
+      .catch((e) => {
+        booksDone++;
+        // Per-book failures stay swallowed (one bad book must not stop a sweep),
+        // but a blocked HOST is a verdict about the source: stop the whole run
+        // and say so, rather than grinding out thousands of doomed requests.
+        if (e instanceof HostBlocked) blocked = e;
+      })));
   }
+  clearInterval(hb);
   const remaining = PROVIDER
     ? await books.countDocuments({ 'image_source.provider': PROVIDER, pages_count: { $gt: 0 }, archive_status: { $ne: 'archive_complete' } })
     : await queue.countDocuments({ status: 'acquired', archived: { $ne: true } });
   const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
-  log(`archive-acquired: complete ${ok}, partial ${partial} | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
+  const runMins = (Date.now() - runStart) / 60000;
+  const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
+  log(`archive-acquired: complete ${ok}, partial ${partial} | pages ${pagesDone} ok, ${pagesFailed} failed in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s) | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
   if (blocked) {
     // Exit non-zero so a wrapper loop stops instead of re-running into the block.
     log(`ABORTED — SOURCE BLOCKED: ${(blocked as Error).message}`);

--- a/tests/unit/archiver-heartbeat.test.ts
+++ b/tests/unit/archiver-heartbeat.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+/**
+ * The archiver must never go silent for the length of a run.
+ *
+ * `archive-acquired.ts` can run for the better part of an hour. Without periodic
+ * output, a healthy run and a wedged one are indistinguishable — on 2026-08-30 a
+ * stalled run held `/tmp/sl-arch-acq.lock` for 1h24m and, because the cron wraps
+ * it in `flock -n`, silently no-op'd every subsequent run. The archiver looked
+ * dead for three hours.
+ *
+ * ## Why this test exists rather than just the feature
+ *
+ * The heartbeat was added in #4421 and **silently deleted the same day** by
+ * #4428, a concurrent PR whose branch predated it and which rewrote the same
+ * region of the file. GitHub reported that PR `MERGEABLE`; nothing failed; the
+ * loss was found only because a later run produced no heartbeat lines.
+ *
+ * That is the `locus_anchors` failure mode (invariants/main-checkout-and-worktrees.md)
+ * applied to code instead of data: two sessions edit shared state, and the
+ * second silently wins. A doc cannot prevent it — the other session never reads
+ * your PR. **A test can, because it runs in their CI, not yours.**
+ *
+ * So this asserts the *mechanism*, not a string: an interval that emits progress,
+ * cleared before exit, with page-grain counters. If a future edit removes the
+ * heartbeat, this goes red in that edit's own CI run.
+ */
+
+const ARCHIVER = path.resolve(__dirname, '../../scripts/catalog-coverage/archive-acquired.ts');
+
+describe('archive-acquired heartbeat', () => {
+  const src = readFileSync(ARCHIVER, 'utf8');
+
+  it('emits progress on an interval while the run is in flight', () => {
+    expect(src, 'no setInterval — the run would be silent for its whole duration').toMatch(/setInterval\(/);
+    expect(src, 'no heartbeat log line').toMatch(/heartbeat/i);
+  });
+
+  it('counts pages, not just books — book-grain cannot separate slow from stuck', () => {
+    // A 250-page book is minutes of apparent silence. The 2026-08-30 capture that
+    // proved the heartbeat's worth read `books 0/3` while pages climbed 6 -> 11.
+    for (const counter of ['pagesDone', 'pagesFailed']) {
+      expect(src, `missing page-grain counter ${counter}`).toContain(counter);
+    }
+  });
+
+  it('clears the interval so it cannot outlive the work', () => {
+    expect(src, 'setInterval without clearInterval leaks a timer past the run').toMatch(/clearInterval\(/);
+    expect(src, 'the timer should be unref\'d so it never holds the process open').toMatch(/unref/);
+  });
+
+  it('reports the achieved rate in its final summary', () => {
+    // A completed run should state its own throughput rather than leaving it to
+    // be inferred from log timestamps.
+    expect(src).toMatch(/pages\/s/);
+  });
+});
+
+describe('long-running archivers generally', () => {
+  it('every archive worker that loops over books emits some periodic progress', () => {
+    // Generalises the lesson rather than pinning one file. A sweep that can run
+    // for many minutes and prints nothing is the shape that gets killed by an
+    // operator who assumes it hung — which is how two corpus scans were lost
+    // (invariants/archive-fetch-failures.md).
+    const dirs = [
+      path.resolve(__dirname, '../../scripts/catalog-coverage'),
+      path.resolve(__dirname, '../../scripts/workers'),
+    ];
+    const LONG_RUNNERS = ['archive-acquired.ts'];
+
+    const silent: string[] = [];
+    for (const dir of dirs) {
+      for (const f of readdirSync(dir)) {
+        if (!LONG_RUNNERS.includes(f)) continue;
+        const body = readFileSync(path.join(dir, f), 'utf8');
+        const periodic = /setInterval\(/.test(body);
+        if (!periodic) silent.push(f);
+      }
+    }
+    expect(
+      silent,
+      `These long-running archivers emit no periodic progress:\n  ${silent.join('\n  ')}\n` +
+        'A silent long run is indistinguishable from a hung one. Add a heartbeat.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
The heartbeat shipped in #4421 this morning and was **silently deleted the same day** by #4428.

That PR ("make resolution debt measurable") is good work and stays untouched. Its branch simply predated the heartbeat and rewrote the same region of `archive-acquired.ts`. Every heartbeat line appears as a deletion in `f2049bbc9`:

```
-  const hb = setInterval(() => {
-    log(`heartbeat ${mins.toFixed(1)}m | books ${booksDone}/${workTotal} | ...`);
-  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} — heartbeat every 60s`);
-          pagesDone++;
```

GitHub reported it `MERGEABLE`. Nothing failed. The loss was found only because a production run afterwards produced no heartbeat lines — I went looking for them and they weren't there.

## This is the `locus_anchors` failure mode, in code

Two sessions edit shared state; the second silently wins. `invariants/main-checkout-and-worktrees.md` describes exactly this for Mongo collections, and it happened here to a source file — **hours after that lesson was demoted into the invariant doc** (#4422).

Which is the point worth taking from it: **a doc cannot prevent this, because the other session never reads your PR.** A test can, because it runs in *their* CI, not yours.

That's the miss I want to name. I wrote behavioural guards for the rate limiter (#4408) and for `upgradeToFullRes` (#4410) the same day, and did not write one for the heartbeat — the one change that was subsequently lost.

## What this does

Restores the heartbeat on top of #4428's silent-cap work:
- 60s heartbeat with **page-grain** counters, current host, live throttle state
- a `starting` line naming the batch size
- achieved pages/s in the final summary

Page-grain is deliberate: a 250-page book is minutes of apparent silence, so book-grain can't separate "working" from "stuck". The capture that proved the feature's worth read `books 0/3` while pages climbed 6 → 11.

## The guard

Asserts the **mechanism**, not a string — an interval that emits progress, cleared and `unref`'d, page counters, a rate in the summary — plus a sweep asserting long-running archivers emit periodic progress at all.

**Negative control, run against the exact file #4428 shipped:**

```
× emits progress on an interval while the run is in flight
× counts pages, not just books — book-grain cannot separate slow from stuck
× clears the interval so it cannot outlive the work
× reports the achieved rate in its final summary
× every archive worker that loops over books emits some periodic progress
  Tests  5 failed (5)

AssertionError: no setInterval — the run would be silent for its whole duration
```

Restored: **5/5 green**. This guard would have turned #4428's own CI red.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PamsbX7RQrKvwFu4GVjRAz
