### PR TITLE
docs(claude): demote a closed backlog item stated as current

### DIFF
--- a/.claude/handoffs/2026-08-30-r2-cost-to-resolution-debt.md
+++ b/.claude/handoffs/2026-08-30-r2-cost-to-resolution-debt.md
@@ -1,0 +1,132 @@
+# From "what is R2 costing us?" to "we are not getting full resolution" — 2026-08-30
+
+One session, one thread pulled all the way. It started as a storage-cost question and
+ended at the acquisition path. Every finding below is measured, not inferred; where a
+number did not reproduce that is said plainly.
+
+## What was asked, and where it went
+
+"Can we move hidden books to cheaper storage? What is R2 costing?" → R2 is 21.7 TB /
+~$326 a month, ~95% of the Cloudflare bill, and hidden books are 56% of it. Cold-tier
+options were costed. But the live question turned out to be the **+165 GB/day with a
+flat object count** that the cost doc had listed as unexplained for two weeks.
+
+That unexplained line led to a bake nobody was watching, a backup that excluded the
+corpus's irreplaceable half, and finally to the acquisition path silently storing
+capped derivatives as masters.
+
+## Merged and deployed
+
+| PR | | commit |
+|---|---|---|
+| #4409 | provenance reaches the surfaces machines read | `46cf73e0` — **live, verified on prod** |
+| #4414 | text backup + `preservation-policy.md` | `5666b095` |
+| #4428 | resolution debt measurable; instrument fix | `f2049bbc` |
+
+Open: **#4434** (archiver dimension guard), **#4435** (CLAUDE.md budget demotion).
+
+## The findings, in the order they fell
+
+**1. The 165 GB/day was `bake-provenance-mark.mjs`.** It does not mark in place — it
+*regenerates* `display_photo` from the master at `min(2000, native)` while the forward
+generator writes 1200px. Same key overwritten → flat object count; 2.8× the pixels →
+the bytes. Controlled test (same master, same q85, width the only variable): **1.98×,
++336 KB/page**. Independently, Cloudflare's own analytics: 165 GB/day ÷ ~500K
+PutObject/day = **330 KB/put**. ~1.5 TB / ~$22 a month spent, ~$40 at completion.
+
+**Why an earlier investigation cleared it:** the script's header said it "marks the
+EXISTING variant" — true at birth, changed mid-PR by a commit that never updated the
+docstring. That investigation measured the *watermark* (0.7%, correct) instead of the
+*resize* (98%). **A controlled test only clears a suspect of the hypothesis it varied.**
+
+**2. The bake had been hung for nine days** — alive, 0.03s CPU per 20s, log silent since
+Aug 21. The 40-attempt wrapper cannot rescue a process that never exits. Stopped
+(wrapper first, or it relaunches the unfixed code), cause fixed, log annotated.
+
+**3. Two programmes aimed opposite intentions at the same objects.** #3005 Pass 1 calls
+a display "never downsized" at ≥90% of its master; a baked variant is 100–122% of its
+master. So every marked page reads as bloat and `regen-display-bloat.mjs` would have
+stripped the watermark from all of it. Guarded, counted, `--force-unmark` to override.
+
+**4. The mark was on what people see, not what machines take.** `/api/iiif/{id}/manifest`
+painted the unmarked original; crawlers read manifests and never run JS. Now paints
+`display_photo` with the full-res original as a labelled `rendering`. Verified on
+production: **606/606 canvases**, painted bodies 25/25 marked, renderings 0/25.
+The forward path also marked only 10% of new pages, with a *local reimplementation*
+carrying no keyed watermark at all — now `markImage()` on every page (z=59.3 our key,
+z=−1.9 wrong key).
+
+**5. `pages` had no offsite copy.** `backup-books.sh` stopped at book metadata on the
+reasoning "pages can be re-OCR'd from R2" — while the preservation manifest says the
+text is the half that *cannot* be re-acquired. Same repo, opposite conclusions, and the
+script's version was the one running. `backup-corpus-text.sh` now streams six
+collections into restic (no disk landing — 39 GB free vs 33 GB of collections). **First
+run completed: 20,663,445 pages in 54 min, six snapshots, restore-rehearsed.**
+
+**6. We are not getting full resolution, and could not measure it.** `/full/full/` is a
+*request*; seven hosts silently cap (Kyoto 8.69×, TU Delft 5.92×, Manchester 3.25×).
+`fetchIiifNativeRes` defeats it and was wired into **two** callers.
+
+- EAP (goes through the stitching worker): **11/14 full res**, median ratio 1.000
+- e-rara (PDF at `pdftoppm -r 200`): **0/14**, median **0.667**, 1.92M pages
+- Positive control, Manchester: `/full/full/` = 1366×2000 = **29% of native**;
+  tile-stitched = 4782×7000 = **100%**. A 12× pixel recovery, available today.
+
+**The selection effect that hid it:** answering the question needs stored *and* native
+width. Corpus records stored on 66.7%, native on **7.7%** — and that 7.7% is almost
+exactly what `archive-eap.mjs` wrote, the one worker that stitches *and* records. Over
+that subset the corpus reads **95.2% full-resolution**. **The population we could
+measure was the population we had archived correctly.**
+
+**And the instrument leaned toward good news:** `fetchNativeWidth`'s fallback fetched
+`/full/full/` and called the answer native — on a capping host that *is* the cap, so
+ratio 1.0, perfect master. Now returns `null` for those hosts.
+
+**Withdrawn:** the invariant doc's "~11% below master (ratio 0.958)". Two same-day runs
+gave **63.8%** and **42.8%**. Do not quote a single figure until the recording lands.
+
+## Not-obvious things worth keeping
+
+- **Read from R2 directly, not through `images.sourcelibrary.org`,** for any corpus-wide
+  object sweep. Via the CDN: 2.5/s and millions of cold edge fills. Direct origin with a
+  12 KB first range: **13.4/s**.
+- **A `mongodump` of a renamed collection succeeds** and writes a valid *empty* archive.
+  Assert the document count first.
+- **`pipefail` says the pipeline failed, not which half.** `PIPESTATUS` distinguishes a
+  dead dump from a dead uploader; without it a truncated dump uploads as a clean snapshot.
+- **Kill the wrapper before the worker,** or the retry loop relaunches the unfixed code.
+- **The negative control caught my own guard being a decoration** — `RECORDS_NATIVE`
+  matched `fetchIiifInfo` in an *import*, so deleting the recording left the test green.
+  Delete the guarded line and watch it go red, every time.
+
+## Open, and all of them decisions rather than bugs
+
+1. **Atlas cluster-snapshot coverage is UNVERIFIED** — no API credentials here. Dashboard
+   check. Decides whether the new backup is a second copy or the only one.
+2. **`PDF_DPI = 200`** on 1.92M e-rara pages, commented "Good balance of quality vs size";
+   and **#3186's e-rara lane parked** as "marginal res gain not worth a bespoke pass".
+   0/14 at full res and a 0.667 median contest that judgement. Un-parking needs the
+   `rearchive_blocked` dHash guard on — e-rara is the provider whose cover-sheet offset
+   corrupted 323 books.
+3. **The #4406 width question.** 2000px does not make the mark stronger (median z 8.5 vs
+   8.8) but does buy coverage: **28/33 vs 31/33** surviving a q60 recompress, at 2.19× the
+   bytes. Three costed options on the issue, including mark-at-1200-and-retry-at-2000
+   (~$8/mo instead of ~$40 for the same detection rate).
+4. **Seven archivers still don't record native width** — `NATIVE_WIDTH_DEBT` in
+   `tests/unit/archivers-record-dimensions.test.ts` is the list, and it shrinks by deletion.
+5. **The bake is stopped and must be restarted deliberately** once #4409's cursor fix is
+   on the box. Do not relaunch `/root/run-provbake.sh` blind.
+6. **R2's 21.7 TB still has no second copy.** Tier-0 (BPH, Kloss, Allard Pierson) is not
+   re-acquirable.
+
+## The thread running under all of it
+
+Nothing here failed loudly. A bake ran six weeks past its acquittal; a backup script's
+comment quietly excluded 20.6M pages; an audit's fallback graded capped scans as perfect
+masters; two programmes aimed opposite intentions at one set of objects. Each was
+individually well-reasoned. They failed where they met each other, or where a number was
+written down once and never re-checked.
+
+**The durable fix in every case was making the system record what it actually did**, so
+the next person does not have to re-derive it from the outside — and, where the property
+is mechanical, asserting it in a test rather than a sentence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,6 @@ If `code-review-graph` is installed (per-machine, see `.claude/docs/code-review-
 ## System Map
 - **Interactive diagram:** https://sourcelibrary.org/platform/admin/system-map — click any node for details, key files, collections, gotchas (requires platform login)
 - **Markdown reference:** `.claude/docs/system-map.md` — full text version with file layout, collection inventory, dead code list
-- **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera components may remain. Note: rithmomachia is a live feature (`/rithmomachia`, at `src/app/rithmomachia`), not dead code.
 
 ## Knowledge Maintenance
 - **After fixing a non-trivial bug**, proactively update the relevant memory file following the `/lesson` workflow. Don't wait to be asked.


### PR DESCRIPTION
The `gnite` down-pass.

CLAUDE.md sat **37 words over** the ~5,500 budget after today's preservation-policy routing line. This was the clearest thing not earning its place:

> **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera components may remain. Note: rithmomachia is a live feature…

A **closed** issue described in the present tense, in the file that loads on every turn in every terminal.

Both halves are already in `system-map.md` — which the line directly above it points at — at line 242 (`rithmomachia/ # Game components (14, live feature)`) and line 341 (`Issue #258 closed. These remain with no imports anywhere:`). Nothing is lost.

**5,537 → 5,508 words.** That offsets the routing line added earlier today, which is the trade the budget asks for: adding to CLAUDE.md means fitting it or demoting something.

Also checked in the same pass: the corpus stats on line 118 were re-measured today by another session and agree with mine to within normal drift, so no stale figures to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrjrf5NFNsamfMBjpQFNhm