### PR TITLE
The felt swipe moves the page, not the column

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -479,8 +479,14 @@ body:has([data-reader-v2]) {
   from { opacity: 0; transform: translateX(-14px); }
   to   { opacity: 1; transform: none; }
 }
-.rv2-turn-next { animation: rv2-turn-next 190ms ease-out both; }
-.rv2-turn-prev { animation: rv2-turn-prev 190ms ease-out both; }
+/* `backwards`, not `both`: a filled-forwards animation keeps applying its end
+   value after it finishes, and an animated property beats an inline style, so
+   the pane would sit locked at transform:none and the drag-follow's inline
+   transform would be silently ignored for the rest of the session — the swipe
+   would stop moving anything under the finger after the first page turn. The
+   end state here is the natural state, so there is nothing to hold. */
+.rv2-turn-next { animation: rv2-turn-next 190ms ease-out backwards; }
+.rv2-turn-prev { animation: rv2-turn-prev 190ms ease-out backwards; }
 
 /* Panel contents arrive just after the panel itself, so switching tools reads
    as one movement instead of two things appearing at once. */

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2606,6 +2606,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
       // The pane holds still and its text and facsimile arrive inside it.
       const inner = pane.lastElementChild;
       if (!(inner instanceof HTMLElement)) continue;
+      // The drag-follow writes an inline transform on this same element; leave
+      // it in place and the pane starts its arrival wherever the finger left it.
+      inner.style.transition = '';
+      inner.style.transform = '';
       inner.classList.remove('rv2-turn-next', 'rv2-turn-prev');
       void inner.offsetWidth; // reflow, or the class swap is coalesced and nothing plays
       inner.classList.add(back ? 'rv2-turn-prev' : 'rv2-turn-next');
@@ -2792,13 +2796,26 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
   const dragFollow = (dx: number | null) => {
     const el = mobileMainRef.current;
     if (!el) return;
-    if (dx === null) {
-      el.style.transition = 'transform 180ms ease-out';
-      el.style.transform = '';
-    } else {
-      el.style.transition = 'none';
-      el.style.transform = `translateX(${Math.max(-90, Math.min(90, dx * 0.35))}px)`;
+    // The pane CONTENTS move under the finger, not the column. Moving the
+    // column moved its backgrounds with it, and the gap it opened showed the
+    // bare page behind: a pale band down the side of the screen for the length
+    // of every swipe, against a facsimile that is nowhere near that colour.
+    // The panes hold still and their text and scan slide inside them, which is
+    // the same gesture with nothing behind it to see. (Same reasoning as the
+    // turn animation, which moves these very elements.)
+    for (const pane of Array.from(el.querySelectorAll<HTMLElement>(':scope > section'))) {
+      const inner = pane.lastElementChild;
+      if (!(inner instanceof HTMLElement)) continue;
+      if (dx === null) {
+        inner.style.transition = 'transform 180ms ease-out';
+        inner.style.transform = '';
+      } else {
+        inner.style.transition = 'none';
+        inner.style.transform = `translateX(${Math.max(-90, Math.min(90, dx * 0.35))}px)`;
+      }
     }
+    // A column left translated by an older build would sit off-centre forever.
+    if (el.style.transform) { el.style.transition = ''; el.style.transform = ''; }
   };
   const onTouchMove = (e: React.TouchEvent) => {
     const s = swipeRef.current;


### PR DESCRIPTION
Reported from using it: a white band appears past the side of the page while swiping.

## What it was

The drag-follow from #4386 pulls the whole reading column sideways with the finger, up to 90px. Nothing sits behind the column, so the gap it opens shows the bare page — a pale band down the edge of the screen for the length of every swipe, next to a facsimile that is nowhere near that colour.

Not the turn animation, which was my first guess and wrong.

## The fix

The panes hold still and their text and scan slide inside them. Same gesture, nothing behind it to see. A pane carries its own background, so moving the pane takes the background with it; moving what is inside the pane does not. Same reasoning as #4384's turn animation, which already moves these very elements.

Measured on a Pixel 5: the column stays at 0 where it used to reach -90, the contents take the -90, and both edges of the screen stay inside a pane for the whole drag.

## A second bug this surfaced

The turn animation was declared `animation-fill-mode: both`. A filled-forwards animation keeps applying its end value after it finishes, and an animated property beats an inline style — so once a pane had turned once, the drag-follow's inline transform was silently ignored and the swipe stopped moving anything under the finger for the rest of the session.

`backwards` instead. The end state here is the natural state, so there is nothing to hold. Verified over three consecutive swipes, each still moving the page.

Worth noting this was latent: it only bites now that the drag and the turn animate the same elements. Before this PR the drag moved the column, which carries no animation class.

## Checks

`tsc --noEmit`, `eslint`, `vitest run` (3287 tests), and the device matrix against a local production build.

New matrix checks, passing on every phone profile:
- the felt drag moves the page, not the column — `column 0px, contents [-90,-90], edges pane/pane`
- nothing is left offset after the turn — `column 0px, contents [0,0]`
- the drag still moves the page after a turn (this is the fill-mode regression)

One pre-existing matrix check now reports n/a rather than passing: "scan traps scroll while zoomed" drives the scan's zoom buttons, and #4413 removed the zoom chrome from the touch scan header, so there is nothing to zoom on a phone. Confirmed by enumerating the controls: Pixel 5 has none, desktop still has Zoom in/Zoom out. Stale test, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eHbLV1PYU8qo9f5T4RZKA