### PR TITLE
fix(spend): the dial must govern CONSUMPTION, not just dispatch

### DIFF
--- a/scripts/audit/spend-perimeter.mjs
+++ b/scripts/audit/spend-perimeter.mjs
@@ -61,7 +61,8 @@ const UNATTENDED = [
   { match: 'pipeline-orchestrator.mjs', spends: true, gated: true,
     note: 'per-phase budgetAllowsDispatch; verified structurally by check A' },
   { match: 'translate-worker.mjs', spends: true, gated: true,
-    note: 'self-dispatch gated (#3835)' },
+    note: 'whole run gated in main(), not just selfDispatch — see check C',
+    mainGate: 'scripts/workers/translate-worker.mjs' },
   { match: 'enrich-worker.mjs', spends: true, gated: true, note: 'gated (#3855)' },
   { match: 'embed-gemini.mjs', spends: true, gated: true, note: 'pause + dial (#3855)' },
   { match: 'batch-collector.mjs', spends: false, gated: false,
@@ -142,6 +143,29 @@ for (let n = 0; n < phaseOpens.length; n++) {
       kind: 'UNGATED_PHASE',
       what: `orchestrator Phase ${phase} (line ${idx + 1})`,
       why: 'reaches a Gemini call but never calls budgetAllowsDispatch',
+    });
+  }
+}
+
+// ── Check C: a worker's MAIN flow must gate, not merely a helper ───────────
+// This check exists because the first version of this audit passed
+// translate-worker on the strength of the file mentioning budgetAllowsDispatch
+// at all. It did — inside selfDispatch(). Its main() separately picked up
+// already-queued work and asked nothing, and on the 2026-08-30 relight that
+// drained 5,011 orphaned jobs through a $5 ceiling. Presence of a guard is not
+// coverage by it; the absence of a marker is not the absence of a path.
+for (const u of UNATTENDED.filter((x) => x.mainGate)) {
+  const src = read(u.mainGate);
+  const mainIdx = src.search(/async function main\s*\(/);
+  if (mainIdx < 0) {
+    findings.push({ kind: 'NO_MAIN', what: u.mainGate, why: 'expected an async main() to check' });
+    continue;
+  }
+  if (!/budgetAllowsDispatch/.test(src.slice(mainIdx))) {
+    findings.push({
+      kind: 'MAIN_UNGATED',
+      what: u.mainGate,
+      why: 'main() reaches paid work without calling budgetAllowsDispatch — a helper-only gate leaves queued work ungoverned',
     });
   }
 }

--- a/scripts/maintenance/cancel-orphaned-preview-translate.mjs
+++ b/scripts/maintenance/cancel-orphaned-preview-translate.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Cancel orphaned preview-TRANSLATION jobs.
+ *
+ * WHY. #4432 removed import-time preview OCR and the preview translation it
+ * auto-triggered. Removing the trigger does not empty the queue: 5,011
+ * `preview_translate` jobs were already sitting in `jobs`, and the moment the
+ * pipeline was unpaused behind a $5 dial, translate-worker began draining them.
+ *
+ * It drained them THROUGH the ceiling. translate-worker checks the pause and
+ * gates `selfDispatch` on the budget, but consuming already-queued jobs asks
+ * nothing — so the dial cannot stop work that was queued before it was set.
+ * Observed 2026-08-30 22:42Z: $0.72 in 30 minutes with the guard reporting
+ * "CEILING REACHED — no new dispatch". Both statements were true at once.
+ *
+ * The jobs are orphans twice over: the feature that created them is deleted,
+ * and they translate the opening pages of books that are un-enrolled, unarchived
+ * and invisible. Cancelling loses nothing — those books will be translated by
+ * the normal dial-gated path when they reach it.
+ *
+ * Only `pending` jobs are cancelled. Jobs already `processing` are left to
+ * finish rather than half-cancelled, which would leave their pages ambiguous.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/cancel-orphaned-preview-translate.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/cancel-orphaned-preview-translate.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const REASON = 'cancelled: orphaned by #4432 (preview translate removed); drained outside the dial';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const jobs = db.collection('jobs');
+
+const filter = { initiated_by: 'preview_translate', status: 'pending' };
+
+const total = await jobs.countDocuments(filter);
+const [agg] = await jobs.aggregate([
+  { $match: filter },
+  { $group: { _id: null, pages: { $sum: '$progress.total' } } },
+]).toArray();
+const oldest = await jobs.find(filter).sort({ created_at: 1 }).limit(1).project({ created_at: 1 }).toArray();
+const processing = await jobs.countDocuments({ initiated_by: 'preview_translate', status: 'processing' });
+
+console.log(`pending preview_translate jobs : ${total}`);
+console.log(`pages they would translate     : ${agg?.pages ?? 0}`);
+console.log(`oldest queued                  : ${oldest[0]?.created_at?.toISOString() ?? 'n/a'}`);
+console.log(`left running (processing)      : ${processing}`);
+
+if (!APPLY) {
+  console.log('\nDRY RUN — re-run with --apply to cancel.');
+  await client.close();
+  process.exit(0);
+}
+
+const res = await jobs.updateMany(filter, {
+  $set: { status: 'cancelled', cancel_reason: REASON, cancelled_at: new Date(), updated_at: new Date() },
+});
+console.log(`\nmatched ${res.matchedCount}, modified ${res.modifiedCount}`);
+
+const bookIds = await jobs.distinct('book_id', { initiated_by: 'preview_translate', cancel_reason: REASON });
+const cleared = await db.collection('books').updateMany(
+  { id: { $in: bookIds }, 'job.type': 'realtime' },
+  { $unset: { job: '' }, $set: { updated_at: new Date() } },
+);
+console.log(`cleared stale book.job pointers: ${cleared.modifiedCount} of ${bookIds.length} books`);
+
+await client.close();

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -1240,6 +1240,28 @@ async function main() {
     await client.close();
     return;
   }
+
+  // The dial gates the whole RUN, not just selfDispatch (#4436 follow-up).
+  // selfDispatch was gated because it creates new work; but main() also picks
+  // up books already at translate_submitted/translate_partial and resumes
+  // orphaned jobs, and neither asked. On the 2026-08-30 relight that gap was
+  // live: 5,011 preview-translate jobs queued before the dial existed drained
+  // straight through a $5 ceiling while the guard correctly logged "CEILING
+  // REACHED — no new dispatch". Both were true; the ceiling only governed
+  // dispatch, and the expensive path was consumption.
+  //
+  // A queue is stored spend. Anything that turns a queued job into Gemini
+  // calls has to ask, or the dial only limits how fast we ENQUEUE money.
+  if (!await budgetAllowsDispatch(db, 'translate-worker run', { control })) {
+    await db.collection('cron_runs').insertOne({
+      cron: 'hetzner-translate-worker', timestamp: new Date(),
+      duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+      pages_saved: 0, actions: { books_processed: 0, skip_reason: 'daily budget ceiling reached' },
+      errors: [], error_count: 0, summary: 'skipped: daily budget ceiling reached',
+    }).catch(() => {});
+    await client.close();
+    return;
+  }
   // When globally paused with a scope, confine candidate selection to it
   // (module-level SCOPE_FILTER read by selfDispatch).
   if (control?.paused && hasScope(control)) {


### PR DESCRIPTION
Found live, minutes after the $5 dial went on and the line came up. The relight watch caught it.

## What happened

`translate-worker` gated `selfDispatch()` on the budget — that function creates new paid work, and it was the hole #3826 left. But `main()` also picks up books already at `translate_submitted`/`translate_partial`, and resumes orphaned jobs, and **neither asked anything**.

So the worker drained a queue straight through the ceiling while the guard truthfully logged:

```
[spend-guard] spend $57.65 / $5.00 today (UTC, both stores) → CEILING REACHED — no new dispatch
```

Both statements were correct simultaneously. The dial governed **dispatch**; the money was leaving through **consumption**.

**What it was draining:** 5,011 `preview_translate` jobs — **107,938 pages** — queued before the dial existed and orphaned by #4432 when the feature that created them was deleted. *Removing a producer does not empty its queue.* Observed rate ~$1.4/hr, and it would have run for days.

## The fix

`main()` now gates the whole run, not just dispatch. A queue is stored spend: anything that turns a queued job into Gemini calls has to ask, or the ceiling only limits how fast we *enqueue* money.

The orphans were cancelled with the script added here (pending only — the 2 in flight were left to finish rather than half-cancelled, which would leave their pages ambiguous).

## The audit fix matters more

The perimeter audit I added in #4436 **passed `translate-worker`** — because the *file* mentioned `budgetAllowsDispatch`. It did, inside a helper that was not on the path doing the spending.

That is precisely the failure mode the audit exists to catch, committed by the audit. Check C now requires the gate to be reachable from `main()`, and each worker's note records *how it was verified* rather than asserting that it was.

> Presence of a guard is not coverage by it. The absence of a marker is not the absence of a path.

Verified against pre-fix `main`: `MAIN_UNGATED`, exit 1.

## Current exposure — measured, not assumed

| | |
|---|---|
| books at `translate_submitted` / `translate_partial` | **0** |
| remaining source: `ocr_complete` | 52 books, 1,734-page gap |
| how that source is reached | `selfDispatch` — **gated**, currently refusing |

So the leak is closed even before this merges. This is the durable fix, not the emergency stop.

## Still true, and worth repeating

- Today's UTC day already carries ~$58 of pre-fix damage, so the dial refuses everything until 00:00 UTC. Quiet until then is correct behaviour, not a fault.
- `cost_usd` is computed, not billed (#3576). A $5 computed dial is not a $5 invoice.
- The 8 traffic-driven Vercel routes remain outside the dial by construction; the audit prints them every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HCFx8VPFrhmBMGVbcpYQW
