### PR TITLE
Size a book from scandata.xml when its images ship only as a zip (#4311)

### DIFF
--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -118,7 +118,47 @@ export const POST = withCuratorAuth(async (request, session) => {
       }
     }
 
-    // 4. Cross-check: if imagecount or jp2 differs wildly from IIIF, trust IIIF
+    // 4. scandata.xml — the leaf list, for items whose images ship ONLY as a
+    // _jp2.zip. Steps 1-3 all miss that shape: IA's IIIF service does not
+    // answer for these items, `imagecount` is absent from their metadata, and
+    // there are no loose .jp2 files to count because they are inside the zip.
+    //
+    // Measured on the eGangotri Sharada corpus (#4311): 739 of 1,507 candidates
+    // failed here, and a 14-item sample was unanimous — 0/14 resolved via IIIF,
+    // 0/14 had imagecount, 0/14 had loose .jp2, and 14/14 had scandata.xml.
+    // Retrying was useless; the chain simply had no step that fit. This is the
+    // same shape as the DLI/Public Library of India mirror, so it unblocks that
+    // channel too.
+    if (pageCount === 0) {
+      const scandata = files.find((f: { name: string }) => /scandata\.xml$/i.test(f.name));
+      if (scandata) {
+        try {
+          const sdRes = await fetch(
+            `https://archive.org/download/${ia_identifier}/${encodeURIComponent(scandata.name)}`,
+            { signal: AbortSignal.timeout(20000) }
+          );
+          if (sdRes.ok) {
+            const xml = await sdRes.text();
+            // Count <page> elements, ignoring any leaf marked as not part of
+            // the book body — IA marks inserts/colour targets this way and
+            // counting them would inflate the page count.
+            const leaves = xml.match(/<page\b[^>]*>/gi) || [];
+            const excluded = (xml.match(/<addToAccessFormats>\s*false\s*<\/addToAccessFormats>/gi) || []).length;
+            const n = leaves.length - excluded;
+            if (n > 1) {
+              pageCount = n;
+              pageCountSource = 'scandata';
+            }
+          }
+        } catch {
+          // scandata unreachable — fall through to the error below, which is
+          // still the right outcome: better to refuse than to import a book
+          // whose length we are guessing at.
+        }
+      }
+    }
+
+    // 5. Cross-check: if imagecount or jp2 differs wildly from IIIF, trust IIIF
     // (this catches the inflation bug where metadata reports 2-20x too many pages)
 
     if (pageCount === 0) {


### PR DESCRIPTION
## The failure

**739 of 1,507** eGangotri Śāradā candidates failed with `Could not determine page count`. The chain had no step that fits their shape.

A 14-item sample was **unanimous**:

| check | result |
|---|---|
| IIIF manifest resolves | **0 / 14** |
| `imagecount` in metadata | 0 / 14 |
| loose `.jp2` files | 0 / 14 (images are inside `_jp2.zip`) |
| **`scandata.xml` present** | **14 / 14** |

Retrying is useless — every retry hits the same three misses. I confirmed that before writing any code.

## The fix

`scandata.xml` is IA's own leaf list, so it's authoritative rather than inferred. Added as **step 4**, before the refusal.

**Verified against a positive control** — items where IIIF *does* answer, so the new step can be checked against a known-good count instead of trusted blind:

| item | IIIF | scandata |
|---|---|---|
| PurascharanaVidhi… | 18 | **18** ✓ |
| YoniTantraAcharaTantra… | 32 | **32** ✓ |
| cGZu_anantnag-5431… | 17 | **17** ✓ |

On the silent items it returns plausible counts (15, 17) where the import previously refused outright.

Leaves marked `addToAccessFormats: false` are subtracted — IA flags colour targets and inserts that way, and counting them would inflate the book.

## What stays the same

If scandata is unreachable the import **still refuses**. That remains correct: better to refuse than to import a book whose length we're guessing at.

## Blast radius

Unblocks ~739 Sanskrit manuscripts immediately, and the **DLI / Public Library of India** mirror (54K `language:san` items), which has the identical zip-only shape.

`npx tsc --noEmit` clean.

Related: #4311