### PR TITLE
One place writes books.collections, and it bumps updated_at (#4399)

### DIFF
--- a/.claude/docs/supabase.md
+++ b/.claude/docs/supabase.md
@@ -107,7 +107,7 @@ Audited 2026-05-14. Every Mongo→Supabase write path in the codebase:
 
 | # | Path | Trigger | Schedule | Fields | Status |
 |---|---|---|---|---|---|
-| 1 | MongoDB books → `books_catalog` | Hetzner `scripts/workers/sync-books-catalog.mjs` | every 5 min, last-10-min window | ~40 fields incl. `thumbnail`, `thumbnail_blob`, title, author, language, pages_count, pages_ocr/translated/blank, categories, collections, cover_image, summary_text, doi, published, place_published, publisher | ⚠️ window-only, no retry; **missing `held_by`, `image_display`, `image_thumb`** |
+| 1 | MongoDB books → `books_catalog` | Hetzner `scripts/workers/sync-books-catalog.mjs` | every 5 min, watermark: `updated_at > max(books_catalog.updated_at)` (corrected 2026-08-31 — it is not a fixed window) | ~40 fields incl. `thumbnail`, `thumbnail_blob`, title, author, language, pages_count, pages_ocr/translated/blank, categories, collections, cover_image, summary_text, doi, published, place_published, publisher | ⚠️ window-only, no retry; **missing `held_by`, `image_display`, `image_thumb`** |
 | 2 | MongoDB books → `books_catalog` | PATCH `/api/books/[id]` → `mirrorBookToCatalog()` | on curator edit | ~11 fields: title, display_title, author, thumbnail, thumbnail_blob, language, published, categories, publisher, place_published, doi | ⚠️ **only fires from the PATCH route**; direct DB updates from `scripts/` bypass it |
 | 3 | MongoDB books → `bph_works.sl_book_id` | Vercel cron `/api/cron/sync-bph-sl-book-ids` | every 6h | `sl_book_id`, `sl_book_slug` | ✓ Honors `bph_catalog_link: false` opt-out (PR #1752, 2026-05-14) |
 | 4 | MongoDB pages → `pages_images` | Hetzner `scripts/workers/supabase-sync.mjs` | every 5 min, last-10-min window | id, book_id, page_number, archived_photo, display_photo, thumbnail_blob | ⚠️ window-only; no retry/backfill if a sync window misses a row |
@@ -131,9 +131,20 @@ Mitigations to consider:
 - Extract `mirrorBookToCatalog` to a shared module any maintenance script can import.
 - Or have the Hetzner sync use `supabase_synced_at < mongo updated_at` instead of a fixed 10-min window.
 
-### B. Hetzner sync uses a fixed last-10-min window with no retry
+### B. Hetzner sync selects on `updated_at` with no retry
 
-`scripts/workers/sync-books-catalog.mjs` and `supabase-sync.mjs` look at MongoDB documents whose `updated_at > now() - 10 min`. There's no record of which rows have been mirrored — if a tick fails mid-batch, the missed rows are stranded until *another* edit re-bumps `updated_at`. Same shape applies to `pages_images`.
+`supabase-sync.mjs` looks at MongoDB documents whose `updated_at > now() - 10 min`;
+`sync-books-catalog.mjs` uses a watermark instead — `updated_at > max(books_catalog.updated_at)`
+(`getLastSyncTime()`). Either way there's no record of which rows have been mirrored — if a tick
+fails mid-batch the missed rows are stranded until *another* edit re-bumps `updated_at`, and under
+the watermark the miss is permanent because the watermark still advances. Same shape applies to
+`pages_images`.
+
+**Corollary — a write that does not bump `updated_at` never reaches the mirror at all.** That is
+#4399: `$addToSet: { collections: slug }` tagged books in Mongo, and the collection's works grid
+(served from `books_catalog`) stayed empty. `books.collections` is now written only through
+`src/lib/collection-tagging.ts`, which owns the operator and the bump together. Read-side detector
+for both classes of drift: `node scripts/audit/collections-catalog-drift.mjs`.
 
 Mitigations to consider:
 - Track `supabase_synced_at` on MongoDB docs and pick the diff each tick.

--- a/scripts/audit/collections-catalog-drift.mjs
+++ b/scripts/audit/collections-catalog-drift.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Standing detector: books whose Mongo `collections` array disagrees with the
+ * Supabase `books_catalog.collections` mirror the collection grid reads.
+ *
+ * WHY (#4399). A collection page's works grid is served from Supabase —
+ * `browseBooks()` does `.contains('collections', [slug])` on `books_catalog`,
+ * filtered to `visible = true AND pages_count > 0`. The mirror is filled by
+ * `scripts/workers/sync-books-catalog.mjs`, which runs INCREMENTALLY over
+ * `{ updated_at: { $gt: lastSync } }`. Until #4399, every `$addToSet` /`$pull`
+ * of `books.collections` in `src/` left `updated_at` alone, so the tag never
+ * reached the mirror and the grid rendered empty — which reads as "we hold
+ * nothing", not as "the mirror never ran".
+ *
+ * The write side is now guarded (`src/lib/collection-tagging.ts` +
+ * `tests/unit/collection-tagging.test.ts`). This is the READ-side check, and it
+ * also catches rows stranded by a sync tick that failed mid-batch
+ * (`.claude/docs/supabase.md:136`) — a class of drift no write guard can see.
+ *
+ * READ-ONLY. It repairs nothing; the repair is a `--full` sync or a targeted
+ * `updated_at` bump, and that is a human decision.
+ *
+ * Exit 0 = no drift, 1 = drift found, 2 = a store was unreachable (never
+ * silently "clean").
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/collections-catalog-drift.mjs [--slug=alchemy] [--limit=20] [--json]
+ */
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+const args = process.argv.slice(2);
+const arg = (name) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : null;
+};
+const ONLY_SLUG = arg('slug');
+const SAMPLE_LIMIT = Number(arg('limit') || 20);
+const AS_JSON = args.includes('--json');
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!MONGODB_URI || !SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing MONGODB_URI, SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(2);
+}
+
+// ── Supabase side ──────────────────────────────────────────────────────────
+// supabase-js silently caps every response at 1,000 rows — no error, just a
+// truncated array. Page with .range() or this audit invents drift by the
+// tens of thousands.
+const PAGE = 1000;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+const catalog = new Map(); // book id -> Set(collection slugs)
+let offset = 0;
+for (;;) {
+  const { data, error } = await supabase
+    .from('books_catalog')
+    .select('id, collections')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .order('id', { ascending: true })
+    .range(offset, offset + PAGE - 1);
+  if (error) {
+    console.error(`Supabase read failed at offset ${offset}: ${error.message}`);
+    process.exit(2);
+  }
+  for (const row of data) catalog.set(row.id, new Set(row.collections || []));
+  if (data.length < PAGE) break;
+  offset += PAGE;
+}
+
+// ── Mongo side ─────────────────────────────────────────────────────────────
+let client;
+try {
+  client = new MongoClient(MONGODB_URI, { maxPoolSize: 2, serverSelectionTimeoutMS: 15000 });
+  await client.connect();
+} catch (err) {
+  console.error(`Cannot reach Mongo: ${err.message}`);
+  process.exit(2);
+}
+
+const books = client.db('bookstore').collection('books');
+// The grid's own filter: only these books can appear in a collection at all.
+const mongoFilter = { visible: true, pages_count: { $gt: 0 } };
+
+const cursor = books
+  .find(mongoFilter, { projection: { _id: 0, id: 1, collections: 1, updated_at: 1 } })
+  .batchSize(2000);
+
+/** slug -> { missingInCatalog: [], staleInCatalog: [], noRow: [] } */
+const bySlug = new Map();
+const bucket = (slug) => {
+  if (!bySlug.has(slug)) bySlug.set(slug, { missingInCatalog: [], staleInCatalog: [], noRow: [] });
+  return bySlug.get(slug);
+};
+
+let mongoBooks = 0;
+let booksWithDrift = 0;
+let booksWithoutRow = 0;
+// Positive control: how many tags each side actually carries. A clean report is
+// worthless if both sides read as empty — that would look identical to "no
+// drift" while proving only that the projection is wrong.
+let mongoTags = 0;
+let catalogTags = 0;
+for (const slugs of catalog.values()) catalogTags += slugs.size;
+const seen = new Set();
+
+for await (const book of cursor) {
+  mongoBooks += 1;
+  const id = book.id;
+  seen.add(id);
+  const mongoSlugs = new Set((book.collections || []).filter(Boolean));
+  mongoTags += mongoSlugs.size;
+  const row = catalog.get(id);
+
+  if (!row) {
+    // No mirror row at all — the book cannot appear in ANY of its collections.
+    if (mongoSlugs.size) {
+      booksWithoutRow += 1;
+      for (const slug of mongoSlugs) {
+        if (ONLY_SLUG && slug !== ONLY_SLUG) continue;
+        bucket(slug).noRow.push(id);
+      }
+    }
+    continue;
+  }
+
+  let drifted = false;
+  for (const slug of mongoSlugs) {
+    if (row.has(slug)) continue;
+    if (ONLY_SLUG && slug !== ONLY_SLUG) continue;
+    bucket(slug).missingInCatalog.push(id); // tagged in Mongo, invisible on the grid
+    drifted = true;
+  }
+  for (const slug of row) {
+    if (mongoSlugs.has(slug)) continue;
+    if (ONLY_SLUG && slug !== ONLY_SLUG) continue;
+    bucket(slug).staleInCatalog.push(id); // untagged in Mongo, still on the grid
+    drifted = true;
+  }
+  if (drifted) booksWithDrift += 1;
+}
+
+// Mirror rows for books the Mongo filter did not return (hidden, zero-page, or
+// deleted) are a different defect — the cleanup pass, not the tag bump. Counted,
+// not itemised per slug.
+const orphanRows = [...catalog.keys()].filter((id) => !seen.has(id)).length;
+
+await client.close();
+
+// ── Report ─────────────────────────────────────────────────────────────────
+const slugRows = [...bySlug.entries()]
+  .map(([slug, b]) => ({
+    slug,
+    missing: b.missingInCatalog.length,
+    stale: b.staleInCatalog.length,
+    noRow: b.noRow.length,
+    total: b.missingInCatalog.length + b.staleInCatalog.length + b.noRow.length,
+    sample: [...b.missingInCatalog, ...b.staleInCatalog, ...b.noRow].slice(0, 3),
+  }))
+  .sort((a, b) => b.total - a.total);
+
+const totals = slugRows.reduce(
+  (acc, r) => ({
+    missing: acc.missing + r.missing,
+    stale: acc.stale + r.stale,
+    noRow: acc.noRow + r.noRow,
+  }),
+  { missing: 0, stale: 0, noRow: 0 },
+);
+const totalDrift = totals.missing + totals.stale + totals.noRow;
+
+if (AS_JSON) {
+  console.log(
+    JSON.stringify(
+      {
+        checked_at: new Date().toISOString(),
+        mongo_books: mongoBooks,
+        catalog_rows: catalog.size,
+        mongo_tags: mongoTags,
+        catalog_tags: catalogTags,
+        books_with_drift: booksWithDrift,
+        books_without_row: booksWithoutRow,
+        orphan_catalog_rows: orphanRows,
+        totals,
+        collections: slugRows,
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  console.log(`Mongo books (visible, pages_count > 0): ${mongoBooks.toLocaleString()}`);
+  console.log(`books_catalog rows (same filter):       ${catalog.size.toLocaleString()}`);
+  console.log(
+    `Collection tags compared:               ${mongoTags.toLocaleString()} (Mongo)` +
+      ` vs ${catalogTags.toLocaleString()} (catalog)`,
+  );
+  if (mongoTags === 0 || catalogTags === 0) {
+    console.error('\nOne side carries no tags at all — the projection is wrong, not the data.');
+    process.exit(2);
+  }
+  console.log('');
+  console.log(`Books whose collections disagree:       ${booksWithDrift.toLocaleString()}`);
+  console.log(`Books tagged but with NO catalog row:   ${booksWithoutRow.toLocaleString()}`);
+  console.log(`Catalog rows for non-gridable books:    ${orphanRows.toLocaleString()}`);
+  console.log('');
+  console.log(`Tag-drift entries: ${totalDrift.toLocaleString()}`);
+  console.log(`  missing in catalog (grid too small): ${totals.missing.toLocaleString()}`);
+  console.log(`  stale in catalog (grid too big):     ${totals.stale.toLocaleString()}`);
+  console.log(`  no catalog row at all:               ${totals.noRow.toLocaleString()}`);
+
+  if (slugRows.length) {
+    console.log(`\nWorst ${Math.min(SAMPLE_LIMIT, slugRows.length)} collections:`);
+    for (const r of slugRows.slice(0, SAMPLE_LIMIT)) {
+      console.log(
+        `  ${r.slug.padEnd(34)} missing ${String(r.missing).padStart(5)}` +
+          `  stale ${String(r.stale).padStart(5)}  no-row ${String(r.noRow).padStart(5)}` +
+          `   e.g. ${r.sample.join(', ')}`,
+      );
+    }
+  }
+
+  if (totalDrift) {
+    console.log(
+      '\nRepair is a human decision: a `--full` books_catalog sync, or a targeted' +
+        '\n`updated_at` bump on the drifted ids so the incremental sync collects them.',
+    );
+  }
+}
+
+process.exit(totalDrift > 0 ? 1 : 0);

--- a/scripts/audit/collections-catalog-drift.mjs
+++ b/scripts/audit/collections-catalog-drift.mjs
@@ -175,6 +175,13 @@ const totals = slugRows.reduce(
 );
 const totalDrift = totals.missing + totals.stale + totals.noRow;
 
+// Positive control, before any verdict: "no drift" and "I compared nothing"
+// print identically otherwise.
+if (mongoTags === 0 || catalogTags === 0) {
+  console.error('One side carries no collection tags at all — the projection is wrong, not the data.');
+  process.exit(2);
+}
+
 if (AS_JSON) {
   console.log(
     JSON.stringify(
@@ -201,10 +208,6 @@ if (AS_JSON) {
     `Collection tags compared:               ${mongoTags.toLocaleString()} (Mongo)` +
       ` vs ${catalogTags.toLocaleString()} (catalog)`,
   );
-  if (mongoTags === 0 || catalogTags === 0) {
-    console.error('\nOne side carries no tags at all — the projection is wrong, not the data.');
-    process.exit(2);
-  }
   console.log('');
   console.log(`Books whose collections disagree:       ${booksWithDrift.toLocaleString()}`);
   console.log(`Books tagged but with NO catalog row:   ${booksWithoutRow.toLocaleString()}`);

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -4,6 +4,7 @@ import { ObjectId } from 'mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { createCollection } from '@/lib/create-collection';
+import { tagBooksIntoCollection } from '@/lib/collection-tagging';
 
 export const maxDuration = 30;
 
@@ -105,11 +106,10 @@ export const PATCH = withAuth(async (request) => {
         try { return new ObjectId(id); } catch { return null; }
       }).filter(Boolean);
 
-      const tagResult = await db.collection('books').updateMany(
-        { $or: [{ _id: { $in: bookObjectIds } }, { id: { $in: addBookIds } }] },
-        { $addToSet: { collections: slug } }
-      );
-      booksTagged = tagResult.modifiedCount;
+      const tagResult = await tagBooksIntoCollection(db, slug, {
+        $or: [{ _id: { $in: bookObjectIds } }, { id: { $in: addBookIds } }],
+      });
+      booksTagged = tagResult.changedCount;
 
       // Update book_count on collection (same filter as detail page)
       const bookCount = await db.collection('books').countDocuments({

--- a/src/app/api/editor/collections/route.ts
+++ b/src/app/api/editor/collections/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { authenticateEditor, checkCollectionOwnership } from '@/lib/editor-auth';
+import { tagBooksIntoCollection, untagBooksFromCollection } from '@/lib/collection-tagging';
 
 export const maxDuration = 30;
 
@@ -72,11 +73,11 @@ export async function POST(request: NextRequest) {
   const languages: { lang: string; count: number }[] = [];
 
   if (bookIds?.length) {
-    const result = await db.collection('books').updateMany(
-      { $or: [{ id: { $in: bookIds } }, { slug: { $in: bookIds } }], deleted: { $ne: true } },
-      { $addToSet: { collections: slug } }
-    );
-    booksTagged = result.modifiedCount;
+    const result = await tagBooksIntoCollection(db, slug, {
+      $or: [{ id: { $in: bookIds } }, { slug: { $in: bookIds } }],
+      deleted: { $ne: true },
+    });
+    booksTagged = result.changedCount;
 
     // Compute languages
     const langAgg = await db.collection('books').aggregate([
@@ -172,18 +173,17 @@ export async function PATCH(request: NextRequest) {
 
   // Add books
   if (addBookIds?.length) {
-    await db.collection('books').updateMany(
-      { $or: [{ id: { $in: addBookIds } }, { slug: { $in: addBookIds } }], deleted: { $ne: true } },
-      { $addToSet: { collections: slug } }
-    );
+    await tagBooksIntoCollection(db, slug, {
+      $or: [{ id: { $in: addBookIds } }, { slug: { $in: addBookIds } }],
+      deleted: { $ne: true },
+    });
   }
 
   // Remove books
   if (removeBookIds?.length) {
-    await db.collection('books').updateMany(
-      { $or: [{ id: { $in: removeBookIds } }, { slug: { $in: removeBookIds } }] },
-      { $pull: { collections: slug } as any }
-    );
+    await untagBooksFromCollection(db, slug, {
+      $or: [{ id: { $in: removeBookIds } }, { slug: { $in: removeBookIds } }],
+    });
   }
 
   // Recount

--- a/src/lib/collection-tagging.ts
+++ b/src/lib/collection-tagging.ts
@@ -1,0 +1,101 @@
+import type { Db, Document, Filter, UpdateFilter } from 'mongodb';
+
+/**
+ * The single place that writes `books.collections`.
+ *
+ * WHY THIS EXISTS (#4399). A collection's books grid is served from Supabase
+ * (`books_catalog`), not Mongo — `browseBooks()` does
+ * `.contains('collections', [slug])`. `scripts/workers/sync-books-catalog.mjs`
+ * runs incrementally, selecting `{ updated_at: { $gt: lastSync } }`.
+ *
+ * `$addToSet` does **not** touch `updated_at`. So a collection created through
+ * the API tagged its books in Mongo, computed a correct `book_count`, rendered
+ * its page — and showed an empty grid, until some unrelated edit re-bumped
+ * those books or someone ran the sync with `--full`. The emptiness reads as
+ * "we hold nothing" rather than "the mirror never ran", which is why it was
+ * rediscovered at least three times (the theosophy collection in May, the
+ * aldine-press script, and again while building #4398).
+ *
+ * `$pull` needs the bump for the same reason in the other direction: an
+ * untagged book that is never re-synced stays in the Supabase grid forever.
+ *
+ * The rule is therefore: **never write `books.collections` inline.** Route
+ * through these two functions, which own the operator *and* the
+ * `$currentDate: { updated_at: true }` bump together, so the two can never
+ * drift apart again. `tests/unit/collection-tagging.test.ts` pins both halves —
+ * the operator shape here, and the absence of inline writes elsewhere in
+ * `src/`.
+ */
+
+export interface CollectionTagResult {
+  /** Books the selector matched. */
+  matchedCount: number;
+  /** Books Mongo actually rewrote (always ≥ `changedCount`: the `updated_at` bump modifies every match). */
+  modifiedCount: number;
+  /**
+   * Books whose `collections` array actually gained (or lost) the slug.
+   * This is the number worth reporting to a caller — `modifiedCount` counts
+   * the `updated_at` bump too, so it would over-report a re-run as new work.
+   */
+  changedCount: number;
+}
+
+/**
+ * Add `slug` to `books.collections` for every book matching `selector`, and
+ * bump `updated_at` so the incremental `books_catalog` sync picks the books up.
+ *
+ * Books already carrying the slug are still bumped — that is deliberate, so
+ * re-running a tag operation repairs a book stranded by an earlier unbumped
+ * write or a sync tick that failed mid-batch.
+ */
+export async function tagBooksIntoCollection(
+  db: Db,
+  slug: string,
+  selector: Filter<Document>,
+): Promise<CollectionTagResult> {
+  return applyCollectionTag(db, slug, selector, 'add');
+}
+
+/**
+ * Remove `slug` from `books.collections` for every book matching `selector`,
+ * and bump `updated_at` so the untagging reaches the Supabase grid.
+ */
+export async function untagBooksFromCollection(
+  db: Db,
+  slug: string,
+  selector: Filter<Document>,
+): Promise<CollectionTagResult> {
+  return applyCollectionTag(db, slug, selector, 'remove');
+}
+
+async function applyCollectionTag(
+  db: Db,
+  slug: string,
+  selector: Filter<Document>,
+  mode: 'add' | 'remove',
+): Promise<CollectionTagResult> {
+  if (!slug) throw new Error('collection slug is required');
+
+  const books = db.collection('books');
+
+  // Count the books that will genuinely change membership BEFORE the write —
+  // afterwards `modifiedCount` includes every book whose `updated_at` moved.
+  const membership = mode === 'add' ? { $ne: slug } : slug;
+  const changedCount = await books.countDocuments({
+    $and: [selector, { collections: membership }],
+  } as Filter<Document>);
+
+  const update = (
+    mode === 'add'
+      ? { $addToSet: { collections: slug }, $currentDate: { updated_at: true } }
+      : { $pull: { collections: slug }, $currentDate: { updated_at: true } }
+  ) as UpdateFilter<Document>;
+
+  const result = await books.updateMany(selector, update);
+
+  return {
+    matchedCount: result.matchedCount,
+    modifiedCount: result.modifiedCount,
+    changedCount,
+  };
+}

--- a/src/lib/create-collection.ts
+++ b/src/lib/create-collection.ts
@@ -1,5 +1,6 @@
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { tagBooksIntoCollection } from '@/lib/collection-tagging';
 
 export interface CreateCollectionInput {
   slug: string;
@@ -32,7 +33,9 @@ export interface CreateCollectionResult {
  * (`POST /api/collection-proposals/[id]/approve`).
  *
  * Resolves the given book ids (accepting either Mongo `_id` strings or the
- * string `id` field), tags each book with the collection slug via `$addToSet`,
+ * string `id` field), tags each book with the collection slug (via
+ * `tagBooksIntoCollection`, which also bumps `updated_at` so the Supabase
+ * `books_catalog` mirror picks the books up — see #4399),
  * computes the language breakdown + visible book count, and inserts the
  * `collections` doc. Throws `{ code: 'exists' }` if the slug is taken so callers
  * can return a 409.
@@ -75,9 +78,7 @@ export async function createCollection(
 
   const bookMongoIds = books.map((b) => b._id);
   if (bookMongoIds.length > 0) {
-    await db
-      .collection('books')
-      .updateMany({ _id: { $in: bookMongoIds } }, { $addToSet: { collections: slug } });
+    await tagBooksIntoCollection(db, slug, { _id: { $in: bookMongoIds } });
   }
 
   // Language breakdown.

--- a/tests/unit/collection-tagging.test.ts
+++ b/tests/unit/collection-tagging.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tagging a book into a collection must reach the Supabase mirror.
+ *
+ * INCIDENT (#4399, and at least twice before it). A collection's books grid is
+ * served from Supabase `books_catalog` — `browseBooks()` does
+ * `.contains('collections', [slug])`. `scripts/workers/sync-books-catalog.mjs`
+ * runs incrementally, selecting `{ updated_at: { $gt: lastSync } }`.
+ * `$addToSet: { collections: slug }` does not touch `updated_at`, so every
+ * collection created through the API tagged its books in Mongo, computed a
+ * correct `book_count`, rendered its page — and served an EMPTY GRID until an
+ * unrelated edit re-bumped those books or someone ran the sync with `--full`.
+ *
+ * It reads as "we hold nothing", not as "the mirror never ran", which is why it
+ * was rediscovered three times: the theosophy collection in May, then
+ * `create-aldine-press-collection.mjs` (which fixed it locally, in a comment),
+ * then again while building #4398.
+ *
+ * THE RULE. `books.collections` is written in exactly one module —
+ * `src/lib/collection-tagging.ts` — which owns the array operator and the
+ * `updated_at` bump together, so the two cannot drift apart again.
+ *
+ * This file pins both halves:
+ *   1. BEHAVIOUR — a tagged (and an untagged) book satisfies the incremental
+ *      sync selector afterwards. Guarded by a negative control: a bare
+ *      `$addToSet` must NOT satisfy it, or the assertion proves nothing.
+ *   2. STRUCTURE — no other file under `src/` writes `collections` with
+ *      `$addToSet`/`$pull` inline. A behavioural test on the helper cannot see
+ *      a new call site that bypasses the helper; this can.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import type { Db } from 'mongodb';
+import { tagBooksIntoCollection, untagBooksFromCollection } from '@/lib/collection-tagging';
+
+// ── A fake `books` collection that honours the operators we care about ──────
+
+type Book = { id: string; collections?: string[]; updated_at: Date };
+
+/** Minimal filter evaluation — enough for `{ id: { $in: [...] } }`, `$and`,
+ *  `$or`, `$ne`, and a bare equality against an array field. */
+function matches(doc: Book, filter: Record<string, unknown>): boolean {
+  return Object.entries(filter).every(([key, cond]) => {
+    if (key === '$and') return (cond as Record<string, unknown>[]).every((f) => matches(doc, f));
+    if (key === '$or') return (cond as Record<string, unknown>[]).some((f) => matches(doc, f));
+    const value = (doc as Record<string, unknown>)[key];
+    if (cond && typeof cond === 'object' && !Array.isArray(cond)) {
+      const c = cond as Record<string, unknown>;
+      if ('$in' in c) {
+        const list = c.$in as unknown[];
+        return Array.isArray(value) ? value.some((v) => list.includes(v)) : list.includes(value);
+      }
+      if ('$ne' in c) {
+        return Array.isArray(value) ? !value.includes(c.$ne) : value !== c.$ne;
+      }
+    }
+    // Mongo matches a scalar against an array field by membership.
+    return Array.isArray(value) ? value.includes(cond) : value === cond;
+  });
+}
+
+function makeDb(books: Book[], now: Date) {
+  /** Every update document the helper handed to Mongo, for shape assertions. */
+  const updates: Record<string, unknown>[] = [];
+
+  const booksCollection = {
+    countDocuments: async (filter: Record<string, unknown>) =>
+      books.filter((b) => matches(b, filter)).length,
+    updateMany: async (filter: Record<string, unknown>, update: Record<string, unknown>) => {
+      updates.push(update);
+      const hits = books.filter((b) => matches(b, filter));
+      let modified = 0;
+      for (const book of hits) {
+        let touched = false;
+        const addToSet = update.$addToSet as Record<string, string> | undefined;
+        if (addToSet) {
+          for (const [field, value] of Object.entries(addToSet)) {
+            const arr = ((book as Record<string, unknown>)[field] as string[]) ?? [];
+            if (!arr.includes(value)) {
+              (book as Record<string, unknown>)[field] = [...arr, value];
+              touched = true;
+            }
+          }
+        }
+        const pull = update.$pull as Record<string, string> | undefined;
+        if (pull) {
+          for (const [field, value] of Object.entries(pull)) {
+            const arr = ((book as Record<string, unknown>)[field] as string[]) ?? [];
+            if (arr.includes(value)) {
+              (book as Record<string, unknown>)[field] = arr.filter((v) => v !== value);
+              touched = true;
+            }
+          }
+        }
+        const currentDate = update.$currentDate as Record<string, boolean> | undefined;
+        if (currentDate) {
+          for (const field of Object.keys(currentDate)) {
+            (book as Record<string, unknown>)[field] = now;
+            touched = true;
+          }
+        }
+        if (touched) modified += 1;
+      }
+      return { matchedCount: hits.length, modifiedCount: modified };
+    },
+  };
+
+  const db = {
+    collection: (name: string) => {
+      if (name !== 'books') throw new Error(`unexpected collection: ${name}`);
+      return booksCollection;
+    },
+  } as unknown as Db;
+
+  return { db, updates, booksCollection };
+}
+
+const LAST_SYNC = new Date('2026-08-31T10:00:00Z');
+const AFTER_SYNC = new Date('2026-08-31T10:05:00Z');
+
+/** The selector `scripts/workers/sync-books-catalog.mjs` builds for an
+ *  incremental run (`query = { updated_at: { $gt: lastSync } }`, :~180). */
+function incrementalSyncPicksUp(book: Book, lastSync = LAST_SYNC): boolean {
+  return book.updated_at > lastSync;
+}
+
+describe('collection tagging reaches the books_catalog mirror', () => {
+  it('a tagged book is picked up by the incremental sync selector', async () => {
+    const book: Book = { id: 'b1', collections: ['alchemy'], updated_at: LAST_SYNC };
+    const { db } = makeDb([book], AFTER_SYNC);
+
+    await tagBooksIntoCollection(db, 'hermetica', { id: { $in: ['b1'] } });
+
+    expect(book.collections).toContain('hermetica');
+    expect(incrementalSyncPicksUp(book)).toBe(true);
+  });
+
+  it('NEGATIVE CONTROL: a bare $addToSet is NOT picked up', async () => {
+    // Without this the assertion above could pass for the wrong reason. This is
+    // the exact write the three incidents shipped.
+    const book: Book = { id: 'b1', collections: ['alchemy'], updated_at: LAST_SYNC };
+    const { booksCollection } = makeDb([book], AFTER_SYNC);
+
+    await booksCollection.updateMany(
+      { id: { $in: ['b1'] } },
+      { $addToSet: { collections: 'hermetica' } },
+    );
+
+    expect(book.collections).toContain('hermetica'); // Mongo is right …
+    expect(incrementalSyncPicksUp(book)).toBe(false); // … and the grid stays empty.
+  });
+
+  it('an untagged book is picked up too, so it leaves the grid', async () => {
+    const book: Book = { id: 'b1', collections: ['alchemy', 'hermetica'], updated_at: LAST_SYNC };
+    const { db } = makeDb([book], AFTER_SYNC);
+
+    await untagBooksFromCollection(db, 'hermetica', { id: { $in: ['b1'] } });
+
+    expect(book.collections).toEqual(['alchemy']);
+    expect(incrementalSyncPicksUp(book)).toBe(true);
+  });
+
+  it('both writes carry $currentDate: { updated_at: true }', async () => {
+    const { db, updates } = makeDb(
+      [{ id: 'b1', collections: [], updated_at: LAST_SYNC }],
+      AFTER_SYNC,
+    );
+
+    await tagBooksIntoCollection(db, 'hermetica', { id: { $in: ['b1'] } });
+    await untagBooksFromCollection(db, 'hermetica', { id: { $in: ['b1'] } });
+
+    expect(updates).toHaveLength(2);
+    for (const update of updates) {
+      expect(update.$currentDate).toEqual({ updated_at: true });
+    }
+    expect(updates[0].$addToSet).toEqual({ collections: 'hermetica' });
+    expect(updates[1].$pull).toEqual({ collections: 'hermetica' });
+  });
+
+  it('reports newly tagged books, not the books the bump merely touched', async () => {
+    // `modifiedCount` now counts the `updated_at` bump, so it would report an
+    // already-tagged book as new work. Routes report `changedCount` instead.
+    const books: Book[] = [
+      { id: 'b1', collections: ['hermetica'], updated_at: LAST_SYNC },
+      { id: 'b2', collections: [], updated_at: LAST_SYNC },
+    ];
+    const { db } = makeDb(books, AFTER_SYNC);
+
+    const result = await tagBooksIntoCollection(db, 'hermetica', { id: { $in: ['b1', 'b2'] } });
+
+    expect(result.matchedCount).toBe(2);
+    expect(result.modifiedCount).toBe(2); // both bumped
+    expect(result.changedCount).toBe(1); // only b2 actually gained the slug
+    // The already-tagged book is re-synced on purpose: that repairs a row
+    // stranded by an earlier unbumped write or a half-failed sync tick.
+    expect(incrementalSyncPicksUp(books[0])).toBe(true);
+  });
+});
+
+// ── Structural half: nothing under src/ writes the array inline ─────────────
+
+const root = path.join(__dirname, '..', '..');
+const HELPER = path.join(root, 'src/lib/collection-tagging.ts');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** `$addToSet: { collections: ... }` / `$pull: { collections: ... }`, allowing
+ *  whitespace and a line break between the operator and the field. */
+const INLINE_WRITE = /\$(?:addToSet|pull)\s*:\s*\{\s*collections\s*:/;
+
+describe('books.collections is written in one place', () => {
+  const files = sourceFiles(path.join(root, 'src')).filter((f) => f !== HELPER);
+
+  it('finds the source tree it means to guard', () => {
+    // Guard the guard: a path change that empties this list must fail loudly.
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  it('no file outside src/lib/collection-tagging.ts writes the array inline', () => {
+    const offenders = files.filter((f) => INLINE_WRITE.test(readFileSync(f, 'utf8')));
+    expect(
+      offenders.map((f) => path.relative(root, f)),
+      'route these through tagBooksIntoCollection / untagBooksFromCollection — ' +
+        'an inline $addToSet leaves updated_at alone and the Supabase grid empty (#4399)',
+    ).toEqual([]);
+  });
+
+  it('the helper itself still pairs each operator with the bump', () => {
+    // Every line that writes the array must carry `$currentDate` on that same
+    // line — the pairing is the whole point of the module.
+    const writeLines = readFileSync(HELPER, 'utf8')
+      .split('\n')
+      .filter((line) => INLINE_WRITE.test(line) && !line.trimStart().startsWith('*'));
+    expect(writeLines).toHaveLength(2);
+    for (const line of writeLines) {
+      expect(line).toContain('$currentDate: { updated_at: true }');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #4399.

## The bug

A collection's works grid is served from **Supabase**, not Mongo: `browseBooks()` does `.contains('collections', [slug])` on `books_catalog`. That mirror is filled by `scripts/workers/sync-books-catalog.mjs`, which runs **incrementally** over `{ updated_at: { $gt: lastSync } }`.

`$addToSet: { collections: slug }` does not touch `updated_at`.

So every collection created through the API tagged its books in Mongo, computed a correct `book_count`, rendered its page — and served an **empty grid**, until an unrelated edit re-bumped those books or someone ran the sync with `--full`. Because it fails as *emptiness* rather than as an error, it reads as "we hold nothing" rather than "the mirror never ran". That is why it was rediscovered at least three times (the theosophy collection in May, `create-aldine-press-collection.mjs`, and again while building #4398).

`$pull` had the mirror-image defect: an untagged book that is never re-synced stays in the grid.

## The fix — a guard, not a doc

`src/lib/collection-tagging.ts` is now the **only** module under `src/` that writes `books.collections`. It owns the array operator and `$currentDate: { updated_at: true }` together, so the two cannot drift apart again.

Call sites found (`git grep`, the three named in the issue were a floor) and routed:

| Site | Op |
|---|---|
| `src/lib/create-collection.ts:80` — shared creation core, incl. propose→approve | `$addToSet` |
| `PATCH /api/collections` (`route.ts:108`) | `$addToSet` |
| `POST /api/editor/collections` (`route.ts:75`) | `$addToSet` |
| `PATCH /api/editor/collections` (`route.ts:175`) | `$addToSet` |
| `PATCH /api/editor/collections` (`route.ts:183`) | `$pull` |

Five sites in four files; a sweep for `$set`/`bulkWrite` writes to the field found no others in `src/`.

**One behaviour change worth reviewing:** the bump means `modifiedCount` now counts every matched book, including ones already in the collection, so it would over-report a re-run as new work. The helper returns `changedCount` — books that genuinely gained (or lost) the slug — and the routes report that in `books_tagged`. Already-tagged books are still bumped on purpose: re-running a tag operation then repairs a book stranded by an earlier unbumped write.

## The test

`tests/unit/collection-tagging.test.ts` (8 tests) pins both halves:

- **Behaviour** — a tagged, and an untagged, book satisfies the incremental sync selector afterwards, against a fake Mongo that honours `$addToSet`/`$pull`/`$currentDate`. Guarded by a **negative control**: the bare `$addToSet` the three incidents shipped must *not* satisfy the selector, or the assertion proves nothing.
- **Structure** — no file under `src/` outside the helper writes the array inline. A behavioural test on a helper cannot see a new call site that bypasses it; this can.

Full unit suite: 243 files, 3,309 tests, green. `npx tsc --noEmit` clean. (`npx eslint` is broken in this checkout — `@typescript-eslint/utils` throws `Class extends value undefined` on load — pre-existing and unrelated.)

## The audit

`scripts/audit/collections-catalog-drift.mjs` — read-only detector for books whose Mongo `collections` disagrees with `books_catalog.collections`, reported per slug (missing-in-catalog / stale-in-catalog / no-row-at-all). It also catches rows stranded by a sync tick that failed mid-batch, a class no write-side guard can see. Paginates with `.range()` because supabase-js silently caps at 1,000 rows. Exit 0 clean / 1 drift / 2 unreachable.

**Run against prod, 2026-08-31:**

```
Mongo books (visible, pages_count > 0): 31,716
books_catalog rows (same filter):       31,716
Collection tags compared:               52,097 (Mongo) vs 52,097 (catalog)

Books whose collections disagree:       0
Books tagged but with NO catalog row:   0
Tag-drift entries: 0
```

Zero drift, and the tag counters are the **positive control** — a report of "no drift" would look identical to "the projection is empty", so the script prints what it compared and exits 2 if either side carries no tags. 52,097 tags matching exactly on both sides means it really compared. The historical drift has been washed out by later edits and `--full` syncs; the detector is here for the next occurrence.

## In scope / out of scope

**In:** the `src/` write path, the test that pins it, the read-side audit, and a correction to `.claude/docs/supabase.md`, which described this sync as a fixed last-10-min window — it is a watermark (`max(books_catalog.updated_at)`), which matters because under a watermark a mid-batch miss is *permanent*, not merely delayed.

**Out, deliberately:**

- **Drift repair.** Nothing is repaired here; there is nothing to repair right now (0 rows), and the remedy for a future non-zero reading — a `--full` sync or a targeted `updated_at` bump — is a decision, not a side effect of a bug fix.
- **`scripts/` (28 files, 34 unbumped write sites).** Filed as #4452 with the site list. The two *recurring* writers there already bump correctly (`enrich-worker.mjs` phase 7.6 and `assign-collections-ai.mjs` both fold `updated_at` into a sibling `$set`), which is why prod drift is zero; the unbumped ones are one-off backfills. They cannot import the TS helper, so the enforceable property for scripts is operator/bump *pairing*, not routing — a different guard, and a different diff.
- **`create-aldine-press-collection.mjs` importing the helper** (issue item 5): not trivial. It is `.mjs`; the helper is TypeScript under `src/lib`. It already does the right thing inline, with a comment saying why. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd