### PR TITLE
One dedup-key normalizer for scripts/, and a census that stops the next fork (#4444)

### DIFF
--- a/scripts/import/early-america-direct.mjs
+++ b/scripts/import/early-america-direct.mjs
@@ -11,6 +11,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+import { normalizeTitle, normalizeAuthor } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const BOOKS = [
@@ -52,8 +53,6 @@ const BOOKS = [
   { ia: 'oflawofnaturenat00pufe', title: 'Of the Law of Nature and Nations, Eight Books', author: 'Samuel von Pufendorf', language: 'English', published: '1729' },
 ];
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
-function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
 async function pageCountFor(ia,metadata){

--- a/scripts/import/founders-collected-direct.mjs
+++ b/scripts/import/founders-collected-direct.mjs
@@ -13,6 +13,11 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it is missing
+// the `born|died|fl|circa|ca` date strip — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -38,7 +43,6 @@ const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
   ia, title: `${s.work}, Vol. ${i + 1}`, author: s.author, language: s.lang, published: s.pub,
 })));
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/import/founding-chase.mjs
+++ b/scripts/import/founding-chase.mjs
@@ -12,13 +12,18 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it strips NO
+// honorifics and NO life dates at all (the third of the three author variants
+// #4444 measured) — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 const BOOKS = [
   { ia: 'bim_early-english-books-1641-1700_a-letter-concerning-tole_locke-john_1689', title: 'A Letter Concerning Toleration', author: 'John Locke', language: 'English', published: '1689' },
   { ia: 'bim_eighteenth-century_commentaries-on-the-laws_blackstone-william-sir_1765_2', title: 'Commentaries on the Laws of England, Vol. 2', author: 'William Blackstone', language: 'English', published: '1766' },
   { ia: 'bim_eighteenth-century_commentaries-on-the-laws_blackstone-william-sir_1765_3', title: 'Commentaries on the Laws of England, Vol. 3', author: 'William Blackstone', language: 'English', published: '1768' },
 ];
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/import/founding-docs-direct.mjs
+++ b/scripts/import/founding-docs-direct.mjs
@@ -21,6 +21,7 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+import { normalizeTitle, normalizeAuthor } from '../lib/dedup-normalize.mjs';
 
 const COMMIT = process.argv.includes('--commit');
 
@@ -46,20 +47,6 @@ const BOOKS = [
 
 const COLLECTIONS_TAG = []; // collection pages not built yet; leave untagged for now
 
-function normalizeTitle(title) {
-  return title.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i, '')
-    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
-    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-}
-function normalizeAuthor(author) {
-  const cleaned = author.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
-    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '').replace(/,\s*[\d\s\-–?.]+$/, '')
-    .replace(/[\[\]]/g, '').replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
-    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-  return cleaned.split(' ').filter(w => w.length > 0).sort().join(' ');
-}
 function slugify(text, maxLen = 70) {
   return text.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')

--- a/scripts/import/founding-enrich-direct.mjs
+++ b/scripts/import/founding-enrich-direct.mjs
@@ -20,6 +20,11 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it is missing
+// the `born|died|fl|circa|ca` date strip — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 const COLLECTION_TAG = 'american-founding';
 
@@ -111,7 +116,6 @@ const BOOKS = [
   })),
 ];
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/import/founding-influences2-direct.mjs
+++ b/scripts/import/founding-influences2-direct.mjs
@@ -15,6 +15,11 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it is missing
+// the `born|died|fl|circa|ca` date strip — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -62,7 +67,6 @@ const BOOKS = [
   ...SINGLES.map(s => ({ ia: s.ia, title: s.title, author: s.author, language: s.lang, published: s.pub })),
 ];
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/import/founding-tail-direct.mjs
+++ b/scripts/import/founding-tail-direct.mjs
@@ -12,6 +12,11 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it is missing
+// the `born|died|fl|circa|ca` date strip — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 const SETS = [
@@ -41,7 +46,6 @@ const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
   published: Array.isArray(s.published) ? s.published[i] : s.pub,
 })));
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/import/jefferson-canon-direct.mjs
+++ b/scripts/import/jefferson-canon-direct.mjs
@@ -17,6 +17,11 @@
  */
 import { MongoClient, ObjectId } from 'mongodb';
 import { makeBookDoc, makePageDoc } from '../lib/book-docs.mjs';
+// normalizeTitle is now the ONE shared dedup-key implementation (#4444). The
+// local normalizeAuthor below has DRIFTED from src/lib/dedup.ts — it is missing
+// the `born|died|fl|circa|ca` date strip — and is left in place deliberately:
+// swapping it would change this script's dedup keys. See #4444 for the plan.
+import { normalizeTitle } from '../lib/dedup-normalize.mjs';
 const COMMIT = process.argv.includes('--commit');
 
 // ===== TASK 1: Skipwith 1771 list — on-mission gaps =====
@@ -111,7 +116,6 @@ const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
   ia, title: s.ids.length > 1 ? `${s.work}, Vol. ${i + 1}` : s.work, author: s.author, language: s.lang, published: s.pub,
 })));
 
-function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
 function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
 function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
 async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}

--- a/scripts/lib/dedup-normalize.mjs
+++ b/scripts/lib/dedup-normalize.mjs
@@ -1,0 +1,63 @@
+/**
+ * Dedup normalizers — the scripts-side twin of `src/lib/dedup.ts`'s
+ * `normalizeTitle` / `normalizeAuthor` (#4444).
+ *
+ * These two functions compute the `normalized_title` / `normalized_author`
+ * DEDUP KEYS. If an import script normalizes even slightly differently from
+ * `src/lib/dedup.ts`, the same book gets two different keys and enters the
+ * corpus twice — silently, with no error and no skip row. That is not
+ * hypothetical: on 2026-08-31 there were 25 `normalizeTitle` and 25
+ * `normalizeAuthor` definitions in this repo, and the author halves had
+ * already drifted into three variants inside one family of import scripts.
+ *
+ * **Import from here in `scripts/`. Do not paste a copy.** Node scripts run
+ * under plain node on Hetzner and cannot import TypeScript, which is why a
+ * twin exists at all — the same reason as `r2-key.mjs`, `ngram-normalize.mjs`
+ * and `cover-scoring.mjs`. The TS side stays canonical; this file is a port;
+ * `tests/unit/dedup-normalizer-forks.test.ts` fails CI if the two ever
+ * disagree, and also census-checks that no NEW fork has appeared.
+ *
+ * Change BOTH sides or neither.
+ *
+ * Deliberate warts, preserved on purpose (improving them is #4270, which must
+ * not ride along with a consolidation or a regression there becomes
+ * indistinguishable from a consolidation bug):
+ *   - `[^\w\s]` is ASCII-only, so a wholly non-Latin title normalizes to ''.
+ *     `edition_key` (Unicode-aware) is what carries those records; see
+ *     `src/lib/edition-key.ts`.
+ *   - the leading-article alternation lists `la` twice — a no-op, kept so the
+ *     two sides stay literally comparable.
+ *   - `normalizeAuthor` sorts the words, so "Last, First" and "First Last"
+ *     collapse to the same key.
+ *
+ * Nullish input yields '' here (as in `src/lib/identity-fields.ts`, the
+ * canonical writer) rather than throwing.
+ */
+
+export function normalizeTitle(title) {
+  return String(title || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|la|gli|i|el|los|las)\s+/i, '')
+    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeAuthor(author) {
+  const cleaned = String(author || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
+    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '')
+    .replace(/,\s*[\d\s\-–?.]+$/, '')
+    .replace(/[\[\]]/g, '')
+    .replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned.split(' ').filter((w) => w.length > 0).sort().join(' ');
+}

--- a/scripts/lib/identity-fields.mjs
+++ b/scripts/lib/identity-fields.mjs
@@ -14,34 +14,12 @@
  */
 
 // ---- dedup.ts ports (ASCII semantics — deliberate, see TS header) ----------
+// The two dedup-key normalizers used to be pasted here as well. They now live
+// in ONE scripts-side module so every importer in scripts/ shares them
+// (#4444); re-exported so existing callers of this file are unaffected.
 
-export function normalizeTitle(title) {
-  return String(title || '')
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .toLowerCase()
-    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|la|gli|i|el|los|las)\s+/i, '')
-    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
-    .replace(/[^\w\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-export function normalizeAuthor(author) {
-  const cleaned = String(author || '')
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .toLowerCase()
-    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
-    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '')
-    .replace(/,\s*[\d\s\-–?.]+$/, '')
-    .replace(/[\[\]]/g, '')
-    .replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
-    .replace(/[^\w\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  return cleaned.split(' ').filter((w) => w.length > 0).sort().join(' ');
-}
+export { normalizeTitle, normalizeAuthor } from './dedup-normalize.mjs';
+import { normalizeTitle, normalizeAuthor } from './dedup-normalize.mjs';
 
 const LATIN_ORDINALS = {
   primus: 1, prima: 1, secundus: 2, secunda: 2, tertius: 3, tertia: 3,

--- a/scripts/research/kuleuven-gap-harvest.mjs
+++ b/scripts/research/kuleuven-gap-harvest.mjs
@@ -32,6 +32,8 @@ import { MongoClient } from 'mongodb';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+// Dedup-key normalizers: ONE implementation, shared with src/lib/dedup.ts (#4444).
+import { normalizeTitle, normalizeAuthor } from '../lib/dedup-normalize.mjs';
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const OUT = join(__dir, 'output');
@@ -47,23 +49,6 @@ const argNum = (flag, def) => { const i = args.indexOf(flag); return i >= 0 ? pa
 const FROM = argNum('--from', 1450);
 const TO = argNum('--to', 1700);
 
-// ---- normalization: mirror of src/lib/dedup.ts (keep in sync) ----
-function normalizeTitle(title = '') {
-  return title.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i, '')
-    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
-    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-}
-function normalizeAuthor(author = '') {
-  const cleaned = author.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
-    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
-    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '')
-    .replace(/,\s*[\d\s\-–?.]+$/, '')
-    .replace(/[\[\]]/g, '')
-    .replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
-    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-  return cleaned.split(' ').filter(w => w.length > 0).sort().join(' ');
-}
 const firstStr = (v) => Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
 
 // =====================================================================

--- a/tests/unit/dedup-normalizer-forks.test.ts
+++ b/tests/unit/dedup-normalizer-forks.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { normalizeTitle as tsTitle, normalizeAuthor as tsAuthor } from '@/lib/dedup';
+import { normalizeTitle as mjsTitle, normalizeAuthor as mjsAuthor } from '../../scripts/lib/dedup-normalize.mjs';
+
+/**
+ * #4444. `normalizeTitle` / `normalizeAuthor` compute DEDUP KEYS. A fork means
+ * import-time and detector-time hash the same book differently, and it enters
+ * the corpus twice — silently, no error, no skip row.
+ *
+ * Two guards here, and the second is the one that matters over time:
+ *
+ *  1. PARITY — the scripts-side twin must agree with `src/lib/dedup.ts`
+ *     character-for-character over a corpus that exercises every branch.
+ *  2. CENSUS — the set of files that define their own normalizer is pinned.
+ *     A new local definition fails this test; so does removing one without
+ *     updating the list (which is how a consolidation gets credited). This is
+ *     the "a check beats a sentence" half: doc prose did not stop the count
+ *     reaching 25 + 25.
+ *
+ * This suite must NOT be used to improve normalisation. Behaviour changes to
+ * these two functions are #4270, and land with their own before/after replay.
+ */
+
+// ---------------------------------------------------------------- 1. parity
+
+const TITLES = [
+  // leading articles, every language in the alternation
+  'The Chymical Wedding', 'A Vindication of the Rights of Woman', 'An Essay on Man',
+  'Der Weg zu Christo', 'Die Fama Fraternitatis', 'Das Kapital',
+  'De Mysteriis Aegyptiorum', 'Le Comte de Gabalis', 'La Somme théologique',
+  'Les Misérables', 'Il Principe', 'Lo Cunto de li Cunti', 'Gli Asolani',
+  'I Discorsi', 'El Criticón', 'Los Rios Profundos', 'Las Casas',
+  // volume markers, arabic / latin / abbreviated, bracketed and parenthesised
+  'Theatrum chemicum, Vol. 3', 'Opera omnia, Tomus II', 'Aristotelis Opera, Tomus primus',
+  'A Treatise of Human Nature (Vol. 1)', 'Böhmes Werke, Band 2',
+  'La Somme théologique, tome 3', 'Ars Magna, part 4', 'Anatomy [Vol 2]',
+  // diacritics, ligatures, punctuation, whitespace
+  "L'Alchimie et les alchimistes", 'De re metallica — libri XII',
+  'Chymische Hochzeit: Christiani Rosencreutz. Anno 1459',
+  'The  Works   of Plato', '   leading and trailing   ',
+  // non-Latin — ASCII normalizer yields '' here, deliberately (#4270)
+  '營造法式 (Yingzao Fashi) · 卷一~卷四', '營造法式', 'བཀའ་འགྱུར', 'كتاب الشفاء',
+  'Ἰλιάς', 'Тайная доктрина', 'حي بن يقظان / Philosophus Autodidactus',
+  // degenerate
+  'MS', 'untitled', '', '   ', '1776',
+];
+
+const AUTHORS = [
+  // honorifics — every token in the alternation
+  'Dr. John Dee', 'Prof. Isaac Newton', 'Rev. Robert Burton', 'Saint Augustine',
+  'St. Thomas Aquinas', 'Sir Francis Bacon', 'Fr. Marin Mersenne', 'Bp. Berkeley',
+  // life dates: parens, trailing comma, born/died/fl/circa/ca
+  'Andreae, Johann Valentin (1586-1654)', 'Newton, Isaac, 1642-1727',
+  'Kircher, Athanasius, 1602–1680', 'Dee, John, 1527-1608?',
+  'Paracelsus, born 1493', 'Agrippa, died 1535', 'Hermes Trismegistus, fl. 200',
+  'Boehme, Jacob, circa 1600', 'Bruno, ca. 1548', 'Ficino, c. 1433',
+  // bracketed annotations, word-order variants, diacritics
+  '[Meyer, Lodewijk]', 'Zetzner, Lazarus', 'Lazarus Zetzner',
+  'Thomas à Kempis', 'van Helmont, Jean Baptiste', 'Jakob Böhme',
+  // non-Latin and degenerate
+  'Li Jie (李誡)', '李誡', 'Ibn Sina', 'Blavatsky, Helena', 'Anon', '', '   ',
+];
+
+describe('dedup normalizers: scripts twin vs src/lib/dedup.ts', () => {
+  it('normalizeTitle agrees on every fixture', () => {
+    for (const t of TITLES) expect(mjsTitle(t), JSON.stringify(t)).toBe(tsTitle(t));
+  });
+
+  it('normalizeAuthor agrees on every fixture', () => {
+    for (const a of AUTHORS) expect(mjsAuthor(a), JSON.stringify(a)).toBe(tsAuthor(a));
+  });
+
+  it('the fixture corpus actually exercises the interesting branches', () => {
+    // A parity suite over inputs that all normalize to themselves proves
+    // nothing. Assert the corpus moves the needle before trusting it.
+    expect(TITLES.filter((t) => tsTitle(t) !== t.toLowerCase().trim()).length).toBeGreaterThan(25);
+    expect(AUTHORS.filter((a) => tsAuthor(a) !== a.toLowerCase().trim()).length).toBeGreaterThan(20);
+    // the deliberate ASCII wart (#4270) — pinned so a silent fix is visible
+    expect(tsTitle('營造法式')).toBe('');
+  });
+
+  it('the twin accepts nullish where the TS signature forbids it', () => {
+    expect(mjsTitle(null as unknown as string)).toBe('');
+    expect(mjsAuthor(undefined as unknown as string)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------- 2. census
+
+/**
+ * Files that still define a local `normalizeTitle` / `normalizeAuthor` instead
+ * of importing the shared one. Every entry is a KNOWN divergence documented in
+ * #4444 — none is byte-identical to `src/lib/dedup.ts`, so none can be swapped
+ * without changing that script's dedup keys.
+ *
+ * Shrinking this list is the work. GROWING it is the bug: a new local
+ * definition is a new dedup-key fork, and this test is where it gets caught.
+ *
+ * Note `git grep` sees TRACKED files only, so a brand-new clone is caught on
+ * the commit that adds it, not while it is still untracked on disk.
+ */
+const KNOWN_LOCAL_DEFINITIONS: Record<string, string> = {
+  // canonical + its parity-pinned twin
+  'src/lib/dedup.ts': 'canonical',
+  'scripts/lib/dedup-normalize.mjs': 'the scripts-side twin, pinned by this file',
+
+  // deliberately different jobs, not dedup keys
+  'scripts/lib/artwork-work-resolver.mjs':
+    'citation matcher: transliterates ligatures, punctuation -> space; own tests',
+  'scripts/import/kloss-enrich.mjs':
+    'normalizeAuthorString: a canonical-name LOOKUP, not a key normalizer',
+  'scripts/maintenance/hide-efm-duplicates.mjs':
+    'normalizeAuthor extracts a SURNAME, not a sorted full-name key',
+  'scripts/tmp-cluster-editions.mjs': 'scratch clustering script (tmp-)',
+
+  // drifted — swap one at a time, each with its own before/after replay
+  'scripts/catalog-coverage/build.mjs': 'ASCII-only; no article or volume strip',
+  'scripts/enrichment/backfill-work-ids.mjs': 'Unicode-aware, returns null, no word sort',
+  'scripts/enrichment/wikidata-books.mjs': 'punctuation -> space; no article or volume strip',
+  'scripts/iiif-discovery/dedupe-candidates.mjs': 'HTML entities, extra articles, D.O.M. prefix, length cap',
+  'scripts/iiif-discovery/import-leiden-artworks.mjs': 'bare lowercase+strip',
+  'scripts/iiif-discovery/import-leiden-books.mjs': 'bare lowercase+strip',
+  'scripts/import/bncf-aldine-direct.mjs': 'bare [^a-z0-9 ] strip',
+  'scripts/import/ccag-vii-pdf-direct.mjs': 'bare [^a-z0-9 ] strip',
+  'scripts/import/ia-bundle-import.mjs': 'bare [^a-z0-9 ] strip',
+  'scripts/import/shwep-curator-pass-import.mjs': 'bare [^a-z0-9 ] strip',
+  'scripts/import/import-artwork.mjs': 'bare lowercase+strip',
+  'scripts/import/import-met-egyptian.mjs': 'bare lowercase+strip',
+  'scripts/import/import-oraec.mjs': 'bare lowercase+strip',
+  'scripts/import/founders-collected-direct.mjs': 'normalizeAuthor: no born/died/fl/circa strip',
+  'scripts/import/founding-enrich-direct.mjs': 'normalizeAuthor: no born/died/fl/circa strip',
+  'scripts/import/founding-influences2-direct.mjs': 'normalizeAuthor: no born/died/fl/circa strip',
+  'scripts/import/founding-tail-direct.mjs': 'normalizeAuthor: no born/died/fl/circa strip',
+  'scripts/import/jefferson-canon-direct.mjs': 'normalizeAuthor: no born/died/fl/circa strip',
+  'scripts/import/founding-chase.mjs': 'normalizeAuthor: no honorific and no date strip at all',
+};
+
+describe('dedup normalizer fork census (#4444)', () => {
+  it('no undocumented local normalizeTitle/normalizeAuthor definition exists', () => {
+    const repoRoot = path.resolve(__dirname, '../..');
+    let out = '';
+    try {
+      out = execFileSync(
+        'git',
+        [
+          // POSIX ERE — git's regex engine does NOT understand `\s`, and a
+          // pattern it silently fails to match makes this whole guard inert.
+          'grep', '-l', '-E',
+          '(function|const)[[:space:]]+normalize(Title|Author)',
+          '--', '*.ts', '*.tsx', '*.mjs', '*.js',
+        ],
+        { cwd: repoRoot, encoding: 'utf8' },
+      );
+    } catch (e: unknown) {
+      // git grep exits 1 on no matches; anything else is a real failure
+      const err = e as { status?: number; stdout?: string };
+      if (err.status !== 1) throw e;
+      out = err.stdout || '';
+    }
+    const found = out.split('\n').map((s) => s.trim()).filter(Boolean)
+      .filter((f) => !f.startsWith('tests/'));
+
+    // Positive control: an empty result means the probe is broken, not that
+    // the repo is clean. It must at minimum find the canonical definition.
+    expect(found, 'git grep returned nothing — the census probe is broken')
+      .toContain('src/lib/dedup.ts');
+
+    const unexpected = found.filter((f) => !(f in KNOWN_LOCAL_DEFINITIONS));
+    expect(
+      unexpected,
+      'New local dedup-key normalizer(s). Import from scripts/lib/dedup-normalize.mjs '
+        + '(or src/lib/dedup.ts) instead — a fork means the same book gets two keys. '
+        + 'If the divergence is deliberate, add it to KNOWN_LOCAL_DEFINITIONS with a reason.',
+    ).toEqual([]);
+
+    const stale = Object.keys(KNOWN_LOCAL_DEFINITIONS).filter((f) => !found.includes(f));
+    expect(
+      stale,
+      'These files no longer define a local normalizer — remove them from '
+        + 'KNOWN_LOCAL_DEFINITIONS so the list keeps meaning what it says.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes part of #4444 (the inventory + the safe swaps). Split out of #3979 item 5.

`normalizeTitle` / `normalizeAuthor` compute the `normalized_title` / `normalized_author`
**dedup keys**. A fork means import-time and detector-time hash the same book differently
and it enters the corpus twice — silently, with no error and no skip row.

## What I did NOT do

**No normalisation behaviour changes.** One implementation of the *current* behaviour.
Improving the normalizer — especially the ASCII `[^\w\s]` that maps every wholly non-Latin
title to `''` — is #4270 and deliberately does not ride along, or a regression there would
be indistinguishable from a consolidation bug.

**No drifted copy is swapped.** 38 of the 50 definitions produce different keys from
canonical. Each needs its own before/after replay and its own commit; they are annotated
in place and enumerated below, and a checklist comment is on #4444.

---

## Inventory: 50 definitions, classified

Method: every definition was extracted from source, compiled, and replayed against
`src/lib/dedup.ts` over a corpus exercising each branch (all 17 leading articles, every
volume-marker form, all 8 honorifics, all 5 life-date forms, 6 scripts, degenerate input).

**Byte-comparison answers the wrong question here.** Most clones are minified one-liners;
some differ from canonical only by a duplicated `la` in the article alternation, which is a
no-op. What matters is whether two functions produce the same KEY, so the classification
below is **behavioural**, and "identical" means *identical output on every probe input*.

| | `normalizeTitle` | `normalizeAuthor` | total |
|---|---:|---:|---:|
| canonical + its parity-pinned twin | 2 | 2 | 4 |
| **identical to canonical → swapped in this PR** | **9** | **3** | **12** |
| drifted (produces different keys) | 12 | 16 | 28 |
| deliberately a different job | 2 | 4 | 6 |
| | **25** | **25** | **50** |

### Swapped — behaviourally identical (12 definitions, 9 files)

| file | swapped | note |
|---|---|---|
| `scripts/import/early-america-direct.mjs` | title + author | |
| `scripts/import/founding-docs-direct.mjs` | title + author | |
| `scripts/research/kuleuven-gap-harvest.mjs` | title + author | header already said "mirror of src/lib/dedup.ts (keep in sync)" |
| `scripts/import/founders-collected-direct.mjs` | title only | its author has drifted |
| `scripts/import/founding-chase.mjs` | title only | its author has drifted |
| `scripts/import/founding-enrich-direct.mjs` | title only | its author has drifted |
| `scripts/import/founding-influences2-direct.mjs` | title only | its author has drifted |
| `scripts/import/founding-tail-direct.mjs` | title only | its author has drifted |
| `scripts/import/jefferson-canon-direct.mjs` | title only | its author has drifted |

The nine `normalizeTitle` bodies differ from canonical by exactly one thing: canonical lists
`la` twice in the leading-article alternation (`…|le|la|les|il|lo|la|gli|…`). A duplicate
alternative the earlier branch already covers is inert; verified across the whole corpus.

### Drifted — NOT swapped (28 definitions)

Each of these currently produces different keys from `src/lib/dedup.ts`.

| file | fn | divergence | example: input → theirs / canonical |
|---|---|---|---|
| `scripts/import/founders-collected-direct.mjs` | author | **missing the `born\|died\|fl\|circa\|ca` date strip** | `Paracelsus, born 1493` → `1493 born paracelsus` / `paracelsus` |
| `scripts/import/founding-enrich-direct.mjs` | author | same | same |
| `scripts/import/founding-influences2-direct.mjs` | author | same | same |
| `scripts/import/founding-tail-direct.mjs` | author | same | same |
| `scripts/import/jefferson-canon-direct.mjs` | author | same | same |
| `scripts/import/founding-chase.mjs` | author | **strips no honorifics and no life dates at all** | `Dr. John Dee` → `dee dr john` / `dee john` |
| `scripts/import/bncf-aldine-direct.mjs` | title + author | bare `[^a-z0-9 ]`; no article strip, no volume strip, no word sort | `The Chymical Wedding…` → `the chymical wedding…` / `chymical wedding…` |
| `scripts/import/ccag-vii-pdf-direct.mjs` | title + author | same | same |
| `scripts/import/ia-bundle-import.mjs` | title + author | same | same |
| `scripts/import/shwep-curator-pass-import.mjs` | title + author | same | same |
| `scripts/import/import-artwork.mjs` | title + author | bare lowercase + punctuation strip | `Theatrum chemicum, Vol. 3` → `theatrum chemicum vol 3` / `theatrum chemicum` |
| `scripts/import/import-met-egyptian.mjs` | title + author | same | same |
| `scripts/import/import-oraec.mjs` | title + author | same | same |
| `scripts/iiif-discovery/import-leiden-books.mjs` | title + author | same (arrow one-liners) | same |
| `scripts/iiif-discovery/import-leiden-artworks.mjs` | title + author | same | same |
| `scripts/iiif-discovery/dedupe-candidates.mjs` | title + author | HTML-entity decode, 4 extra articles (`un\|une\|ein\|eine`), `D.O.M.`/`Dn.` prefix strip, `.slice(0,120)`; author drops 1-char tokens, `auteur du texte` strip, `.slice(0,60)`, **no volume strip** | `Böhmes Werke, Band 2` → `bohmes werke band 2` / `bohmes werke` |
| `scripts/catalog-coverage/build.mjs` | title | ASCII-only `[^a-z0-9\s]`, no NFD, no article or volume strip | 18/38 probe inputs differ |
| `scripts/enrichment/wikidata-books.mjs` | title | punctuation → **space** not empty; no article or volume strip | 19/38 differ |
| `scripts/enrichment/backfill-work-ids.mjs` | author | Unicode-aware `\p{L}\p{N}`, **returns `null`** for empty/`Unknown`, no honorific strip, **no word sort** | `Zetzner, Lazarus` → `zetzner lazarus` / `lazarus zetzner` |

### Deliberately a different job — leave alone (6 definitions)

| file | fn | why it is not a dedup key |
|---|---|---|
| `scripts/lib/artwork-work-resolver.mjs` | title | citation matcher: transliterates `æ œ ß ø þ ð ł đ ſ`, maps punctuation to **space**; has its own tests and its own header explaining the gate |
| `scripts/import/kloss-enrich.mjs` | `normalizeAuthorString` | a canonical-name **lookup** against `AUTHOR_CANONICAL`, not a key normalizer |
| `scripts/maintenance/hide-efm-duplicates.mjs` | author | extracts a **surname**, not a sorted full-name key |
| `scripts/tmp-cluster-editions.mjs` | title + author | scratch clustering script (`tmp-` prefix, untracked-by-convention scope) |
| `src/lib/dedup.ts` | title + author | **canonical** |
| `scripts/lib/dedup-normalize.mjs` | title + author | the scripts-side twin (this PR) |

---

## The shared implementation

`scripts/lib/dedup-normalize.mjs`.

**Prior art, found before building** (per the "search before you build" rule):
`scripts/lib/identity-fields.mjs` already held a parity-pinned `.mjs` twin of exactly these
two functions, pinned by `tests/unit/identity-fields-parity.test.ts`. So this PR does not
mint a third copy — it **moves** those two functions into the precisely-named module and
re-exports them from `identity-fields.mjs`, leaving every existing caller unaffected. Node
scripts run under plain node on Hetzner and cannot import TypeScript, which is why a twin
exists at all (same reason as `r2-key.mjs`, `ngram-normalize.mjs`, `cover-scoring.mjs`).

## Evidence the swap is inert

1. **Replay on the real inputs.** For each of the 9 files, the pre-change function text was
   taken from `git show HEAD:<file>` and replayed over **all 1,803 string literals in that
   same file**, against the shared implementation. **0 mismatches.**
2. `tests/unit/identity-fields-parity.test.ts` — the pre-existing twin suite — still passes.
3. Full unit suite: **242 files, 3,206 tests, all green.** `npx tsc --noEmit` clean.
4. `scripts/audit/dedup-replay-sample.ts` (read-only, no writes, no cost), 300 books, run twice:

   | run | same-source Latin / non-Latin | cross-source Latin / non-Latin | pos. control | neg. control |
   |---|---|---|---|---|
   | 1 | 99.3% / 100.0% | **97.3% / 100.0%** | 20/20 | 0/3 |
   | 2 | 100.0% / 100.0% | **98.7% / 99.3%** | 20/20 | 0/3 |

   Stated plainly rather than dressed up as a before/after: this script imports
   `src/lib/dedup.ts`, and **this PR does not touch `src/`** (`git diff HEAD -- src/` is
   empty), so the number cannot move. The two runs differ only by sampling noise (±1.4pp),
   which is useful in itself — it is the noise floor the drifted swaps will be judged
   against. Recorded here as that baseline.

## The durable half

`tests/unit/dedup-normalizer-forks.test.ts` has two guards:

1. **Parity** — the twin must equal `src/lib/dedup.ts` character-for-character over a corpus
   that exercises every branch, plus a meta-assertion that the corpus actually moves the
   needle (a parity suite over inputs that normalize to themselves proves nothing) and a
   pin on the deliberate non-Latin `''` wart, so a silent #4270 fix shows up as a failure.
2. **Census** — the set of files allowed to define a local normalizer is pinned. A new local
   definition fails CI; so does removing one without updating the list, which is how a
   consolidation gets silently credited. Prose did not stop the count reaching 25 + 25.

The census probe carries a **positive control**: an empty `git grep` reads exactly like a
clean repo. That is not hypothetical here — the first version of the probe matched *nothing*,
because git's ERE does not understand `\s`, and the guard was completely inert while
appearing to pass its own logic. It now asserts it can at minimum find `src/lib/dedup.ts`.

## Out of scope, deliberately

- **The 28 drifted swaps.** One at a time, each with its own replay. Checklist on #4444.
- **#4270** — normalizer behaviour, non-Latin handling. Must not ride along.
- **Issue item 4 (`authTokens` / `AUTH_STOP` fold): MOOT, not deferred.**
  `scripts/enrichment/shwep-cited-works.mjs` no longer exists — it was deleted in #3282
  (`chore(shwep): remove the scraped SHWEP episode data from the repo`), before #3979 was
  written. Neither `authTokens` nor `AUTH_STOP` appears anywhere in the repo
  (`git grep` exits 1). `scripts/lib/holdings-resolver.mjs` survived the deletion and does
  its own author de-noising inline. Nothing to fold. #3979's item 5 was written against a
  tree that had already lost the file.
- **The `~35 scripts/import/*-direct.mjs` bare-insert cohort** (`src/lib/acquisition-guard.ts`)
  — routing those through `acquisitionGate()` is a separate concern from normalizer identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
