### PR TITLE
Fix the slug fallback that published 112 books at /book/unknown-N (#4389)

### DIFF
--- a/.claude/docs/invariants/content-urls-and-libraries.md
+++ b/.claude/docs/invariants/content-urls-and-libraries.md
@@ -46,7 +46,26 @@ encodes that:
    main checkout. Don't recreate them (`create-all-provider-tenants.mjs` is
    the legacy writer — don't run it). New contributing libraries go in
    `LIBRARY_PARTNERS`, not in the `tenants` collection.
-5. **Segment 0 of a URL is shared by three namespaces, and ownership is
+5. **Renaming a slug needs the alias AND the redirect, and until #4389 only
+   the alias existed.** A repair sweep pushes the old slug onto
+   `slug_aliases`, and `findBookByIdOrSlug` resolves it on its miss path — so
+   the old URL keeps *resolving*. It did not keep *canonicalising*: the 301
+   was supposed to come from the proxy's book-slug resolver, and the proxy
+   only routes `/book/<segment>` there when `looksLikeBookId(segment)` — which
+   is `false` for anything containing a hyphen, i.e. for **every slug-shaped
+   alias a rename creates**. The ~276 books renamed by earlier sweeps
+   therefore each had two fully-rendering URLs, each emitting a
+   self-referential canonical. It read as working because the artwork half of
+   that batch *did* 308, via the unrelated `/artwork` canonicalisation.
+   `/book/[id]/page.tsx` now 308s any resolved-but-non-canonical segment to
+   `/book/<slug>` (English only; the localized twin has its own branch just
+   above it). It lives in the page, not the proxy, because the decision needs
+   the resolved book and the proxy would otherwise pay a DB lookup on every
+   book page view. **When you rename a public URL, verify the 301 by curling
+   it** — an old URL that renders is not an old URL that redirects, and the
+   difference is invisible from the database. Reader URLs
+   (`/book/<alias>/page/<pageId>`) still resolve without redirecting.
+6. **Segment 0 of a URL is shared by three namespaces, and ownership is
    decided by an ALLOWLIST of tenants — never by a denylist of routes.**
    `/bph/…` (tenant), `/es/…` (locale prefix) and `/book/…`, `/upload`,
    `/encyclopedia/…` (~90 global route roots) all compete for the same

--- a/.claude/docs/invariants/non-latin-text-operations.md
+++ b/.claude/docs/invariants/non-latin-text-operations.md
@@ -48,6 +48,41 @@ it into either verdict — a missing flag must not read as a clean one.
   against 校正 / 註, Arabic تأليف and لـ against حققه and the scribe's كتبه, and
   the Sanskrit and Tibetan colophon forms.
 
+## The unjudgeable input is not always empty — sometimes it is a sentinel
+
+*Added 2026-08-31 after #4389.*
+
+Every case above fails **loudly-ish**: the operation returns nothing, and the
+bug is that nothing got read as a negative. There is a worse shape, because it
+never returns nothing at all.
+
+An ETCSL import built each book's slug from an English-title field that held
+the literal string `"Unknown"` wherever the English title had not been
+resolved. `slugify("Unknown")` is `"unknown"` — a well-formed, readable,
+entirely legal slug. No fallback branch fired. Nothing was empty, nothing threw,
+nothing looked wrong at any point downstream. The importer's own dedupe counter
+finished the job, and **112 books went live at `/book/unknown-1` …
+`/book/unknown-111`** with good titles sitting one field over, for six months,
+until an MCP client noticed.
+
+**The rule.** A catalogue sentinel — `Unknown`, `Untitled`, `n/a`, `?`,
+`Onbekend`, `[no title]` — is the ABSENCE of a value written in the shape of
+one. Test for it *before* the value reaches a normaliser, because after
+normalisation it is indistinguishable from data. `isNonTitle()` in
+`src/lib/slugify.ts` is the reference list; reuse it rather than growing a
+second one.
+
+**The tell**: an output that is perfectly well-formed and identical across many
+records. Sameness at scale is the signature — 112 slugs sharing one stem is not
+a coincidence, and no shape check can find it, because each one is individually
+valid.
+
+**The corollary for detectors.** A guard written against the empty case will not
+fire here. `isPlaceholderSlug` had caught `-10` and `untitled-3` for months and
+was blind to `unknown-7`, because that string has letters, no leading hyphen,
+and reads like English. If a rule exists to catch "nothing usable got through",
+enumerate the sentinels it must also catch.
+
 ## The test that would have caught all six
 
 A unit fixture of the same assertion in Chinese, Arabic, Hebrew and Devanagari,

--- a/.github/workflows/corpus-integrity-watch.yml
+++ b/.github/workflows/corpus-integrity-watch.yml
@@ -109,3 +109,51 @@ jobs:
         run: |
           echo "::error::bulk-archive-alignment could not run (exit ${{ steps.run.outputs.fired }}) — no sample was measured. Check the MONGODB_URI repo secret."
           exit 1
+
+  placeholder-slugs:
+    # Daily cron + manual runs. A book's slug IS its public address, and #4389
+    # showed the failure is silent by construction: the fallback produces a
+    # string that looks exactly like a real slug, so 111 books sat at
+    # /book/unknown-N for six months with good titles one field over.
+    if: github.event.schedule != '0 7 * * 1'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci --ignore-scripts
+      - name: Check for placeholder book slugs
+        id: run
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          set +e
+          npx tsx scripts/audit/book-slug-placeholders.ts > report.txt 2>&1
+          echo "fired=$?" >> "$GITHUB_OUTPUT"
+          cat report.txt
+      # One open issue at a time. The finding is deterministic and stays true
+      # until someone repairs it, so filing daily would bury the first report
+      # under 30 copies of itself.
+      - name: File findings
+        if: steps.run.outputs.fired == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Placeholder book slugs are live"
+          OPEN=$(gh issue list --state open --search "in:title $TITLE" --json title --jq "[.[] | select(.title == \"$TITLE\")] | length")
+          if [ "$OPEN" != "0" ]; then
+            echo "An open '$TITLE' issue already exists — not filing another."
+            exit 0
+          fi
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "A visible book is published at a URL that says nothing about it (/book/unknown-7, /book/untitled-3, /book/-9). The slug is the public, citable address, so this is a broken page address, not a cosmetic issue. Repair with scripts/maintenance/repair-book-slugs.ts (dry run by default) — it preserves the old slug as an alias. See #4389." \
+            "$(cat report.txt)")
+          gh issue create --title "$TITLE" --body "$BODY" --label data-quality
+      # Exit 2 means the detector never reached the database. A silent green run
+      # is indistinguishable from "checked, found nothing".
+      - name: Fail if the detector could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::book-slug-placeholders could not run (exit ${{ steps.run.outputs.fired }}) — no finding was measured. Check the MONGODB_URI repo secret."
+          exit 1

--- a/scripts/audit/book-slug-placeholders.ts
+++ b/scripts/audit/book-slug-placeholders.ts
@@ -1,0 +1,120 @@
+/**
+ * book-slug-placeholders — is any live book published at a placeholder URL?
+ *
+ * WHY THIS EXISTS (#4389)
+ * A book's slug IS its public address. On 2026-08-30 an MCP client found 111
+ * visible books sitting at /book/unknown-1 … /book/unknown-111 — shareable,
+ * citable, indexable URLs — while every one of them carried a perfectly good
+ * title one field over. They had been live since 2026-03-10. Nothing surfaced
+ * them because nothing was looking: the slug generator has a fallback, the
+ * fallback produced a string that *looks* like a slug, and a string that looks
+ * like a slug passes every check downstream.
+ *
+ * That is the class this detector exists for. A slug fallback reaching
+ * production should be a failing check, not a doc.
+ *
+ * WHAT IT MEASURES
+ * Every book, tested with the same `isPlaceholderSlug` the repair sweeps and
+ * the import path use — imported, not reimplemented, so the detector cannot
+ * drift away from the rule it is watching. Findings are split by reachability:
+ *
+ *   visible: true   → public URLs. This is the finding.
+ *   hidden          → reported for context; a hidden book with a bad slug
+ *                     becomes a public one the day it is unhidden.
+ *
+ * EXIT CONTRACT (.claude/docs/invariants/measurement-instruments.md)
+ *   0  ran, clean
+ *   1  ran, found placeholder slugs on visible books
+ *   2  could not run — no measurement was taken. Never read as clean.
+ *
+ * USAGE
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/audit/book-slug-placeholders.ts [--json] [--limit=50]
+ */
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+import { isPlaceholderSlug } from '../../src/lib/slugify';
+
+const argv = process.argv.slice(2);
+const JSON_OUT = argv.includes('--json');
+const LIMIT = parseInt(argv.find((a) => a.startsWith('--limit='))?.split('=')[1] || '50', 10);
+
+interface Row {
+  id: string;
+  slug: string;
+  title: string;
+  visible: boolean;
+}
+
+async function main(): Promise<number> {
+  const uri = process.env.MONGODB_URI || process.env.MONGODB_URL;
+  if (!uri) {
+    console.error('Missing MONGODB_URI — no measurement taken.');
+    return 2;
+  }
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 20000 });
+  try {
+    await client.connect();
+    const db = client.db(process.env.DB_NAME || 'bookstore');
+
+    // Scope: EVERY book with a slug, not just the ones a listing surface shows.
+    // A count that excludes the failure reports clean forever (#4146), and a
+    // hidden book's slug is one `visible: true` away from being public.
+    const cursor = db.collection('books').find(
+      {},
+      { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, visible: 1 } },
+    );
+
+    let scanned = 0;
+    let slugged = 0;
+    const visibleHits: Row[] = [];
+    const hiddenHits: Row[] = [];
+
+    for await (const doc of cursor) {
+      scanned += 1;
+      const slug = doc.slug as string | undefined;
+      // No slug at all is a different (and older) problem — /book/<objectid>
+      // still resolves, so it is ugly, not broken. repair-book-slugs.ts owns it.
+      if (!slug) continue;
+      slugged += 1;
+      if (!isPlaceholderSlug(slug)) continue;
+      const row: Row = {
+        id: (doc.id as string) || '',
+        slug,
+        title: ((doc.display_title as string) || (doc.title as string) || '').slice(0, 70),
+        visible: doc.visible === true,
+      };
+      (row.visible ? visibleHits : hiddenHits).push(row);
+    }
+
+    if (JSON_OUT) {
+      console.log(JSON.stringify({ scanned, slugged, visible: visibleHits, hidden: hiddenHits }, null, 2));
+    } else {
+      // Print the denominator. "Clean" means nothing until you can see what was
+      // actually in scope.
+      console.log(`Scanned ${scanned} books, ${slugged} of them with a slug.`);
+      console.log(`Placeholder slugs: ${visibleHits.length} visible, ${hiddenHits.length} hidden.`);
+      if (visibleHits.length) {
+        console.log('\nPublic URLs that say nothing about the book:');
+        for (const r of visibleHits.slice(0, LIMIT)) {
+          console.log(`  /book/${r.slug}  ←  "${r.title}"  (${r.id})`);
+        }
+        if (visibleHits.length > LIMIT) console.log(`  … and ${visibleHits.length - LIMIT} more`);
+        console.log('\nRepair: npx tsx scripts/maintenance/repair-book-slugs.ts   (dry run by default)');
+      }
+    }
+
+    return visibleHits.length > 0 ? 1 : 0;
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+// An uncaught throw is an instrument failure (2), never a finding (1).
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error('book-slug-placeholders could not run:', err instanceof Error ? err.message : err);
+    process.exit(2);
+  });

--- a/scripts/maintenance/repair-unknown-slugs-4389.ts
+++ b/scripts/maintenance/repair-unknown-slugs-4389.ts
@@ -1,0 +1,249 @@
+/**
+ * repair-unknown-slugs-4389 — move 112 books off /book/unknown-N.
+ *
+ * WHAT HAPPENED (#4389)
+ * On 2026-03-10 an ETCSL import slugged each book from an English-title field
+ * that held the literal string "Unknown" for records whose English title had
+ * not been resolved. "Unknown" sanitizes to "unknown" — a legal, readable-
+ * looking slug — so no fallback branch fired and nothing looked wrong. The
+ * importer's own dedupe counter did the rest: one book at /book/unknown and
+ * 111 at /book/unknown-1 … /book/unknown-111, all `visible: true`, all with a
+ * perfectly good `display_title` sitting one field over.
+ *
+ * The generator fix is in src/lib/slugify.ts (sentinel titles are treated as
+ * absent, and isPlaceholderSlug now recognises the family). The standing check
+ * is scripts/audit/book-slug-placeholders.ts. This script repairs the records.
+ *
+ * SCOPE IS DELIBERATELY NARROW
+ * Only `slug` matching ^unknown(-\d+)?$. The wider placeholder classes —
+ * /book/-9, /book/216, the `untitled-N` family — are older, have different
+ * causes, and mostly cannot be repaired without a display_title first.
+ * `repair-book-slugs.ts` owns those; do not widen this one.
+ *
+ * URLs ARE PUBLIC, SO NOTHING IS DROPPED
+ * The old slug is pushed onto `slug_aliases` in the SAME update.
+ * findBookByIdOrSlug resolves aliases on its miss path, and /book/[id] now
+ * 308s an alias to the canonical slug (added in the same PR), so existing
+ * links, citations and indexed results keep working and consolidate onto the
+ * new URL.
+ *
+ * `updated_at` is bumped with the slug. /book/[id] reads the Supabase
+ * books_catalog mirror BEFORE Atlas, and that mirror syncs incrementally on
+ * `{ updated_at: { $gt: lastSync } }`. A slug written without the bump is
+ * invisible to it, and the page keeps serving the OLD slug as canonical until
+ * the weekly full rebuild.
+ *
+ * ORDER MATTERS: run this only AFTER the redirect is deployed. Renaming first
+ * turns 112 live URLs into pages that render but never point anywhere new.
+ *
+ * USAGE
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/maintenance/repair-unknown-slugs-4389.ts            # dry run
+ *   npx tsx scripts/maintenance/repair-unknown-slugs-4389.ts --apply
+ *   npx tsx scripts/maintenance/repair-unknown-slugs-4389.ts --json     # plan as JSON
+ */
+import 'dotenv/config';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { MongoClient, type Db } from 'mongodb';
+import { generateBookSlug, appendSlugSuffix, isPlaceholderSlug } from '../../src/lib/slugify';
+
+const APPLY = process.argv.includes('--apply');
+const JSON_OUT = process.argv.includes('--json');
+const OUT_DIR = join(process.cwd(), 'scripts', 'output');
+
+/** The exact family this script owns. Nothing else is touched. */
+const UNKNOWN_SLUG_RE = '^unknown(-\\d+)?$';
+
+interface BookRow {
+  _id: unknown;
+  id?: string;
+  slug?: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  visible?: boolean;
+}
+
+interface PlanRow {
+  id: string;
+  from: string;
+  to: string;
+  title: string;
+  visible: boolean;
+  filter: Record<string, unknown>;
+}
+
+/**
+ * Claim a slug against the database AND against the slugs minted earlier in
+ * this same run — generateUniqueBookSlug only knows about the database, which
+ * would hand two books the same slug in a bulk sweep. `slug_aliases` is checked
+ * too: a freed-up old slug still redirects and must not be reissued.
+ *
+ * The candidate ladder matters here. Eleven of these books are "A Balbale to
+ * Inana"; their display titles are genuinely identical and only the original
+ * `title` carries the ETCSL number that tells them apart. So try the original
+ * title before falling back to a bare counter — "a-balbale-to-inana-etcsl-4-08-08"
+ * tells a reader something, "a-balbale-to-inana-anonymous-7" does not.
+ */
+async function reserveSlug(db: Db, candidates: string[], taken: Set<string>): Promise<string> {
+  const isFree = async (candidate: string) => {
+    if (taken.has(candidate)) return false;
+    const hit = await db.collection('books').findOne(
+      { $or: [{ slug: candidate }, { slug_aliases: candidate }] },
+      { projection: { _id: 1 } },
+    );
+    return !hit;
+  };
+
+  const ladder = candidates.filter((c, i) => c && candidates.indexOf(c) === i);
+  for (const candidate of ladder) {
+    if (await isFree(candidate)) {
+      taken.add(candidate);
+      return candidate;
+    }
+  }
+
+  const base = ladder[0];
+  let n = 1;
+  for (;;) {
+    n += 1;
+    const candidate = appendSlugSuffix(base, n);
+    if (await isFree(candidate)) {
+      taken.add(candidate);
+      return candidate;
+    }
+    if (n > 200) throw new Error(`could not find a free slug for "${base}"`);
+  }
+}
+
+async function main(): Promise<number> {
+  const uri = process.env.MONGODB_URI || process.env.MONGODB_URL;
+  if (!uri) {
+    console.error('MONGODB_URI not set. Run: set -a; source .env.production.local; set +a');
+    return 2;
+  }
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 20000 });
+  await client.connect();
+  const db = client.db(process.env.DB_NAME || 'bookstore');
+
+  try {
+    const broken = (await db.collection('books')
+      .find({ slug: { $regex: UNKNOWN_SLUG_RE } })
+      .project({ _id: 1, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1 })
+      .sort({ created_at: 1 })
+      .toArray()) as unknown as BookRow[];
+
+    if (!JSON_OUT) {
+      console.log(`Books at /book/unknown[-N]: ${broken.length} (${broken.filter((b) => b.visible === true).length} visible)`);
+    }
+    if (broken.length === 0) return 0;
+
+    const taken = new Set<string>();
+    const plan: PlanRow[] = [];
+    const skipped: string[] = [];
+
+    for (const book of broken) {
+      const displayTitle = book.display_title || '';
+      const title = book.title || '';
+      const author = book.author || '';
+
+      // Candidate 1: the generator's own answer (display_title preferred).
+      // Candidate 2: built from the original title, which in this corpus carries
+      // the ETCSL catalogue number and so disambiguates identical hymn titles.
+      const fromDisplay = generateBookSlug(title, author, displayTitle || null);
+      const fromTitle = generateBookSlug(title, author, null);
+
+      // If the generator itself can only produce a placeholder, this book has
+      // nothing to build a URL from and needs metadata, not a rename. Leaving it
+      // at /book/unknown-N is worse than nothing, but moving it to another
+      // meaningless URL is not better — and it would burn the redirect.
+      const usable = [fromDisplay, fromTitle].filter((c) => c && !isPlaceholderSlug(c));
+      if (usable.length === 0) {
+        skipped.push(`${book.id} — nothing to build a slug from: "${(displayTitle || title).slice(0, 50)}"`);
+        continue;
+      }
+
+      const to = await reserveSlug(db, usable, taken);
+      plan.push({
+        id: book.id || String(book._id),
+        from: book.slug || '',
+        to,
+        title: (displayTitle || title).slice(0, 70),
+        visible: book.visible === true,
+        // Books carry both a string `id` and a Mongo `_id`; prefer `id` (indexed,
+        // and what every other writer keys on). A stringified ObjectId never
+        // matches an ObjectId, and the update would silently no-op.
+        //
+        // The old slug is part of the selector, which makes the write idempotent
+        // and concurrency-safe: if another session already renamed this book,
+        // the update matches nothing instead of overwriting their result. A
+        // worktree isolates files, never production.
+        filter: book.id
+          ? { id: book.id, slug: book.slug }
+          : { _id: book._id, slug: book.slug },
+      });
+    }
+
+    if (JSON_OUT) {
+      console.log(JSON.stringify(plan.map(({ filter: _f, ...rest }) => rest), null, 2));
+    } else {
+      if (skipped.length) {
+        console.log(`\nSkipped (left exactly as they are): ${skipped.length}`);
+        for (const line of skipped) console.log(`  ${line}`);
+      }
+      console.log(`\nPlanned renames: ${plan.length}${APPLY ? '' : ' (DRY RUN — nothing written)'}\n`);
+      for (const p of plan) {
+        console.log(`  /book/${p.from}  →  /book/${p.to}`);
+        console.log(`      ${p.title}`);
+      }
+    }
+
+    if (!APPLY) {
+      if (!JSON_OUT) {
+        console.log('\nRe-run with --apply to write. Old slugs are preserved as aliases.');
+        console.log('Do NOT apply before the /book/[id] alias redirect is deployed (#4389).');
+      }
+      return 0;
+    }
+
+    // Backup BEFORE the first write, so a bad sweep is reversible from disk.
+    mkdirSync(OUT_DIR, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = join(OUT_DIR, `unknown-slugs-backup-${stamp}.json`);
+    writeFileSync(backupPath, JSON.stringify(plan.map(({ filter: _f, ...rest }) => rest), null, 2));
+    console.log(`\nBackup written: ${backupPath}`);
+
+    let written = 0;
+    const misses: string[] = [];
+    for (const p of plan) {
+      const res = await db.collection('books').updateOne(p.filter, {
+        $set: { slug: p.to, updated_at: new Date() },
+        $addToSet: { slug_aliases: p.from },
+      });
+      if (res.matchedCount !== 1) {
+        misses.push(`${p.id} — selector matched ${res.matchedCount} docs, slug NOT written`);
+        continue;
+      }
+      written += 1;
+    }
+
+    console.log(`\nDone. ${written}/${plan.length} slugs repaired, ${written} old slugs kept as aliases.`);
+    for (const m of misses) console.error(`  MISS ${m}`);
+    console.log('\nNext:');
+    console.log('  1. Purge Cloudflare + revalidate the affected /book paths (.claude/docs/invariants/deploy-and-caching.md).');
+    console.log('  2. The Supabase books_catalog sync picks these up on updated_at (:45, every odd hour).');
+    console.log('  3. Re-run scripts/audit/book-slug-placeholders.ts — the unknown family should be gone.');
+    return misses.length ? 1 : 0;
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });

--- a/scripts/maintenance/repair-unknown-slugs-4389.ts
+++ b/scripts/maintenance/repair-unknown-slugs-4389.ts
@@ -156,9 +156,9 @@ async function main(): Promise<number> {
       const fromTitle = generateBookSlug(title, author, null);
 
       // If the generator itself can only produce a placeholder, this book has
-      // nothing to build a URL from and needs metadata, not a rename. Leaving it
-      // at /book/unknown-N is worse than nothing, but moving it to another
-      // meaningless URL is not better — and it would burn the redirect.
+      // nothing to build a URL from: it needs metadata, not a rename. Moving it
+      // from one meaningless URL to another buys nothing and spends the one
+      // redirect the old address gets.
       const usable = [fromDisplay, fromTitle].filter((c) => c && !isPlaceholderSlug(c));
       if (usable.length === 0) {
         skipped.push(`${book.id} — nothing to build a slug from: "${(displayTitle || title).slice(0, 50)}"`);

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2601,8 +2601,10 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
     // working at the OLD address: the proxy only sends a /book/<segment> to the
     // book-slug resolver when `looksLikeBookId(segment)` is true, and that is
     // false for every slug-shaped segment — which is every alias a slug repair
-    // creates. So the ~276 books renamed by earlier sweeps, and the 111 renamed
+    // creates. So the ~276 books renamed by earlier sweeps, and the 112 renamed
     // by #4389, each had two live URLs emitting self-referential canonicals.
+    // Confirmed against production before the change: /book/1-10, a real alias
+    // on a real book, returned 200 rather than a redirect.
     // The redirect belongs here rather than in the proxy because deciding it
     // needs the resolved book, and the proxy would have to pay a DB lookup on
     // every book page view to learn what one string compare answers here.

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -2595,6 +2595,33 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
     // authority to /artwork rather than keep indexing both. redirect() defaults to
     // a temporary 307, which consolidates nothing — the whole point of the change.
     if (artSlug) permanentRedirect(`/artwork/${artSlug}`);
+
+    // A slug that was RENAMED keeps working through `slug_aliases`
+    // (findBookByIdOrSlug resolves them on its miss path), but until now it kept
+    // working at the OLD address: the proxy only sends a /book/<segment> to the
+    // book-slug resolver when `looksLikeBookId(segment)` is true, and that is
+    // false for every slug-shaped segment — which is every alias a slug repair
+    // creates. So the ~276 books renamed by earlier sweeps, and the 111 renamed
+    // by #4389, each had two live URLs emitting self-referential canonicals.
+    // The redirect belongs here rather than in the proxy because deciding it
+    // needs the resolved book, and the proxy would have to pay a DB lookup on
+    // every book page view to learn what one string compare answers here.
+    //
+    // 308, for the same reason as the artwork case above: this is a permanent
+    // canonicalisation and search engines must move authority to the new URL.
+    // Costs one string comparison on the canonical path, where it is false.
+    // Localized twins are handled by their own branch above (307/308 there).
+    //
+    // The shape guard is a loop guard: a slug carrying a character that the
+    // router re-encodes would never compare equal to the incoming segment, so
+    // the redirect would fire again on its own target. Only redirect TO a
+    // segment that survives a round trip unchanged.
+    if (lang === 'en') {
+      const canonicalSlug = (earlyBook as { slug?: string }).slug;
+      if (canonicalSlug && id !== canonicalSlug && /^[a-z0-9][a-z0-9._~-]*$/i.test(canonicalSlug)) {
+        permanentRedirect(`/book/${canonicalSlug}`);
+      }
+    }
   }
 
   return (

--- a/src/lib/metadata-enrichment.ts
+++ b/src/lib/metadata-enrichment.ts
@@ -492,7 +492,24 @@ export async function enrichBookMetadata(
         db, book.title as string, (updates.author || book.author) as string, updates.display_title as string
       );
       if (newSlug !== currentSlug) {
-        await db.collection('books').updateOne({ id: bookId }, { $set: { slug: newSlug } });
+        // A rename here changes a PUBLIC URL, so it owes the same two things
+        // every other slug writer owes (#4389):
+        //
+        //   slug_aliases — the old address keeps resolving and now 308s to the
+        //     new one. Without it the old URL 404s. This writer had been
+        //     skipping it since the leading-hyphen class was added to
+        //     isPlaceholderSlug; it only did not bite because a placeholder URL
+        //     is rarely linked. Widening the rule again (to the "unknown-N"
+        //     family) would have made a silent 404 the common case.
+        //   updated_at — /book/[id] reads the Supabase books_catalog mirror
+        //     BEFORE Atlas, and that mirror syncs on { updated_at: { $gt } }.
+        //     A slug written without the bump is invisible to it, and the page
+        //     keeps serving the OLD slug as canonical until the weekly rebuild.
+        //
+        // A previous slug of '' has no URL to preserve — nothing to alias.
+        const slugUpdate: Record<string, unknown> = { $set: { slug: newSlug, updated_at: new Date() } };
+        if (currentSlug) slugUpdate.$addToSet = { slug_aliases: currentSlug };
+        await db.collection('books').updateOne({ id: bookId }, slugUpdate);
         changes.push({ field: 'slug', previous: currentSlug, new_value: newSlug });
       }
     }

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -16,7 +16,13 @@ export function generateBookSlug(
   author: string,
   displayTitle?: string | null
 ): string {
-  const titleSource = displayTitle || title;
+  // A sentinel is the ABSENCE of a title, not a title. Reading it as text is
+  // what put 112 ETCSL books at /book/unknown-N (#4389): the importer slugged a
+  // record whose English title field held the literal string "Unknown", which
+  // sanitizes to the perfectly legal-looking slug "unknown", so no fallback
+  // branch ever fired and nothing looked broken. Skipping the sentinel here
+  // means the next source (the original title, then the author) gets its turn.
+  const titleSource = isNonTitle(displayTitle) ? (isNonTitle(title) ? '' : title) : displayTitle || '';
   const slugTitle = slugifyText(titleSource, 60);
   const authorLast = extractLastName(author);
   const slugAuthor = slugifyText(authorLast, 20);
@@ -41,21 +47,71 @@ export function generateBookSlug(
 }
 
 /**
+ * Catalogue sentinels that mean "we do not have a title", written into a title
+ * field as if they were one. Every one of these sanitizes to a legal-looking
+ * slug, which is exactly why they are dangerous: nothing downstream can tell
+ * `/book/unknown-7` from a book actually called "Unknown".
+ *
+ * Compared after lowercasing, trimming, and stripping wrapping brackets and
+ * trailing punctuation — catalogues write "[unknown]", "Unknown.", "n/a".
+ */
+const NON_TITLE_SENTINELS = new Set([
+  'unknown', 'unknown title', 'title unknown', 'untitled', 'no title',
+  // 'n a' is the slug form of 'n/a' — isPlaceholderSlug hyphen-splits before
+  // testing, so both spellings have to be here.
+  'none', 'na', 'n/a', 'n a', 'nil', 'null', 'undefined', 'missing', 'not known',
+  'onbekend', 'sans titre', 'ohne titel', 'senza titolo', 'sin titulo',
+  '?', '??', '???', '-', '--', '.', '_',
+]);
+
+/**
+ * Is this string a "we do not know" marker rather than a title?
+ *
+ * Empty/absent counts too, so callers can use it as a single "nothing usable
+ * here" test. See NON_TITLE_SENTINELS and #4389.
+ */
+export function isNonTitle(text: string | null | undefined): boolean {
+  if (!text) return true;
+  const normalized = text
+    .trim()
+    .replace(/^[[({<"'\s]+|[\])}>"'.,;:\s]+$/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return true;
+  return NON_TITLE_SENTINELS.has(normalized);
+}
+
+/**
+ * The base of a slug, with a dedupe suffix removed: "unknown-7" → "unknown",
+ * "atalanta-fugiens-maier-5" → "atalanta-fugiens-maier".
+ */
+function slugBase(slug: string): string {
+  return slug.replace(/-\d+$/, '');
+}
+
+/**
  * Is this slug a placeholder or a malformed leftover rather than a real,
  * readable URL segment?
  *
  * Catches: missing/empty, the literal string "undefined", the "untitled"
- * family, and anything with no Latin letter at all — the class that produced
- * ~85 visible books sitting at URLs like /book/-10 and /book/-13, written by
- * an import that bypassed generateBookSlug entirely.
+ * family, a sentinel base with a dedupe counter on it ("unknown-7" — #4389),
+ * and anything with no Latin letter at all — the class that produced ~85
+ * visible books sitting at URLs like /book/-10 and /book/-13, written by an
+ * import that bypassed generateBookSlug entirely.
  *
- * Used by the repair sweep and by the enrichment path that regenerates a slug
- * once a book finally has a display_title.
+ * The counter is stripped before the sentinel test, but only a NUMERIC one:
+ * "unknown-pleasures" is a real title and stays a real slug.
+ *
+ * Used by the repair sweeps, by scripts/audit/book-slug-placeholders.ts, and
+ * by the enrichment path that regenerates a slug once a book finally has a
+ * display_title.
  */
 export function isPlaceholderSlug(slug: string | null | undefined): boolean {
   if (!slug) return true;
   if (slug === 'undefined' || slug === 'null') return true;
   if (/^untitled(-|$)/.test(slug)) return true;
+  if (NON_TITLE_SENTINELS.has(slugBase(slug).replace(/-/g, ' '))) return true;
   return !/[a-z]/.test(slug);
 }
 
@@ -131,7 +187,13 @@ function extractLastName(author: string): string {
   if (!author || /^unknown\b/i.test(author.trim())) {
     return 'unknown';
   }
-  if (author === 'Anonymous') {
+  // "Anonymous Sumerian", "Anonymous (Egyptian)", "Anonymous Yucatec Maya
+  // scribes" — 661 books carry a qualified anonymity marker, and the last-word
+  // rule below reads the qualifier as a surname: /book/a-balbale-to-inana-sumerian
+  // presents a language as the author. Same defect as "Unknown artist" →
+  // "-artist" above, one word over. The bare "Anonymous" case is unchanged and
+  // deliberate — an anonymous early-modern imprint is a real attribution.
+  if (/^anonymous\b/i.test(author.trim())) {
     return 'anonymous';
   }
 

--- a/tests/unit/book-slug-quality.test.ts
+++ b/tests/unit/book-slug-quality.test.ts
@@ -11,7 +11,7 @@
  * and Sanskrit titles, so that path is load-bearing, not theoretical.
  */
 import { describe, it, expect } from 'vitest';
-import { generateBookSlug, isPlaceholderSlug, readerPageUrl } from '@/lib/slugify';
+import { generateBookSlug, isNonTitle, isPlaceholderSlug, readerPageUrl } from '@/lib/slugify';
 
 describe('generateBookSlug', () => {
   it('builds title-author for the ordinary case', () => {
@@ -79,6 +79,60 @@ describe('readerPageUrl', () => {
   });
 });
 
+/**
+ * #4389 — 111 visible books published at /book/unknown-1 … /book/unknown-111.
+ *
+ * The importer slugged an English-title field whose value was the literal
+ * string "Unknown". "Unknown" sanitizes to "unknown" — a legal, readable-looking
+ * slug — so no fallback branch fired, the dedupe counter did the rest, and the
+ * books shipped with perfectly good titles sitting unused one field over.
+ *
+ * The lesson is the one in .claude/docs/invariants/non-latin-text-operations.md,
+ * displaced by one step: an operation whose input means "we cannot judge" must
+ * not produce a confident output. Here the unjudgeable input was not an empty
+ * string but a sentinel that LOOKS like data.
+ */
+describe('title sentinels never become the slug (#4389)', () => {
+  it('recognises the sentinel family, and only it', () => {
+    for (const sentinel of ['Unknown', 'unknown', ' UNKNOWN ', '[unknown]', 'Untitled',
+      'No title', 'n/a', 'N/A', '?', '-', 'null', 'undefined', 'Onbekend', 'Sans titre', '']) {
+      expect(isNonTitle(sentinel), `"${sentinel}" should read as absent`).toBe(true);
+    }
+    for (const real of ['Unknown Pleasures', 'The Unknown God', 'Titles of Honour', 'Nada', 'Nihil']) {
+      expect(isNonTitle(real), `"${real}" is a real title`).toBe(false);
+    }
+  });
+
+  it('falls through a sentinel display_title to the real title', () => {
+    // The exact production shape: english_title "Unknown", display_title good.
+    expect(generateBookSlug("Ninurta's Return to Nibru (ETCSL 1.6.1)", 'Anonymous Sumerian', 'Unknown'))
+      .toBe('ninurta-s-return-to-nibru-etcsl-1-6-1-anonymous');
+  });
+
+  it('never mints a slug whose body is a sentinel', () => {
+    for (const [title, displayTitle] of [['Unknown', null], ['Unknown', 'Unknown'], ['', 'unknown'], ['n/a', '[unknown]']] as Array<[string, string | null]>) {
+      const slug = generateBookSlug(title, 'Anonymous Sumerian', displayTitle);
+      expect(isPlaceholderSlug(slug), `"${title}"/"${displayTitle}" → ${slug}`).toBe(false);
+      expect(slug).toBe('anonymous');
+    }
+  });
+
+  it('flags the shipped URLs so the repair sweep and the audit can see them', () => {
+    expect(isPlaceholderSlug('unknown')).toBe(true);
+    expect(isPlaceholderSlug('unknown-1')).toBe(true);
+    expect(isPlaceholderSlug('unknown-111')).toBe(true);
+    expect(isPlaceholderSlug('no-title')).toBe(true);
+    expect(isPlaceholderSlug('n-a')).toBe(true);
+    // A numeric dedupe suffix is stripped before the test; a word is not.
+    expect(isPlaceholderSlug('unknown-pleasures')).toBe(false);
+    expect(isPlaceholderSlug('the-unknown-god-anonymous')).toBe(false);
+  });
+
+  it('a title that is only a sentinel does not out-rank the author', () => {
+    expect(generateBookSlug('Unknown', 'Mousouros, Markos (ed.)')).toBe('mousouros');
+  });
+});
+
 describe('unknown authors', () => {
   it('does not suffix a slug with "artist" for "Unknown artist"', () => {
     // /book/…-setsubun-oni-yari-ritual-at-osu-kannon-artist was a real
@@ -86,6 +140,13 @@ describe('unknown authors', () => {
     expect(generateBookSlug('大須観音 節分会', 'Unknown artist', 'Setsubun Oni-yari Ritual at Ōsu Kannon'))
       .toBe('setsubun-oni-yari-ritual-at-osu-kannon');
     expect(generateBookSlug('A Title', 'unknown')).toBe('a-title');
+  });
+
+  it('does not read the qualifier of a qualified anonymity marker as a surname', () => {
+    // /book/a-balbale-to-inana-sumerian presents a language as the author.
+    expect(generateBookSlug('A Balbale to Inana', 'Anonymous Sumerian')).toBe('a-balbale-to-inana-anonymous');
+    expect(generateBookSlug('A Hymn', 'Anonymous (Egyptian)')).toBe('a-hymn-anonymous');
+    expect(generateBookSlug('A Hymn', 'Anonymous Yucatec Maya scribes')).toBe('a-hymn-anonymous');
   });
 
   it('still keeps "Anonymous", which is a real attribution in this corpus', () => {


### PR DESCRIPTION
Closes #4389.

## What was wrong

Not a code branch — a **data sentinel that slugifies to a legal slug**.

The 2026-03-10 ETCSL import built each slug from an English-title field that held the literal string `"Unknown"` wherever the English title had not been resolved. `slugify("Unknown") === "unknown"` — readable, well-formed, indistinguishable from a real slug — so no fallback fired and nothing failed. The importer's own dedupe counter produced the rest: **one book at `/book/unknown` and 111 at `/book/unknown-1` … `/book/unknown-111`** (the issue counted 111; the un-suffixed first member makes 112). All `visible: true`, all carrying a good `display_title` one field over, live since March.

Verified read-only against prod: 112 docs match `^unknown(-\d+)?$`, 112 visible, every one `contributing_library: "ETCSL (University of Oxford)"`, every one `english_title: "Unknown"`. The 261 ETCSL siblings with a resolved English title all have proper slugs — which is why the damage looked patternless.

The diacritics in the issue's examples are a **correlation, not the cause**: Š and ĝ decompose under NFD and slug fine (`enki-and-ninhursaga` came from "Enki and Ninḫursaĝa"). What those records share is that their English title was never resolved, and the transliteration-heavy hymn genres are simply where that happened.

Still the `non-latin-text-operations.md` lesson, displaced by one step: an input meaning "we cannot judge" must not produce a confident output. There the unjudgeable input was an empty string; here it is a sentinel that *looks* like data — worse, because an empty result at least invites a check.

## In scope

**Generator** — `src/lib/slugify.ts`
- `isNonTitle()`: the sentinel family (`Unknown`, `[untitled]`, `n/a`, `sans titre`, `?`, …), bracket- and punctuation-tolerant. `generateBookSlug` falls through a sentinel `display_title` to the real title, then to the author.
- `isPlaceholderSlug()`: flags a sentinel base carrying a **numeric** dedupe counter, so `unknown-7` is visible to the repair sweeps and the audit while `unknown-pleasures` stays a real slug.
- `extractLastName()`: a qualified anonymity marker is anonymity. 661 books are bylined "Anonymous Sumerian" / "Anonymous (Egyptian)" / "Anonymous Yucatec Maya scribes", and the last-word rule read the qualifier as a surname — `/book/a-balbale-to-inana-sumerian` presents a language as the author. Same defect as the existing "Unknown artist" → `-artist` scar, one word over; without it this PR would publish 112 new URLs carrying it. Bare "Anonymous" is unchanged and still pinned.

**Redirect** — `src/app/book/[id]/page.tsx`
A renamed slug already kept *working* via `slug_aliases`, but it kept working at the **old address**. `repair-book-slugs.ts` says "the caller 301s to the canonical slug" — the caller never does: the proxy only routes `/book/<segment>` to the book-slug resolver when `looksLikeBookId(segment)`, which is `false` for every hyphenated, slug-shaped segment — i.e. for **every alias a slug repair creates**. So the ~276 books renamed by earlier sweeps each had two live URLs emitting self-referential canonicals. (Spot-checked in prod: `/book/-10` and `/book/-2` do 308 today, but only because they are artworks and hit the *artwork* canonicalisation.)

`/book/[id]` now 308s an alias to the canonical slug, immediately after the artwork redirect and on the same reasoning. It costs one string comparison on the canonical path, where it is false. It lives in the page rather than the proxy because deciding it needs the resolved book, and the proxy would pay a DB lookup on every book page view to learn what a string compare answers here. A shape guard (`^[a-z0-9][a-z0-9._~-]*$`) prevents a re-encoded slug redirecting to its own target.

**Standing check** — `scripts/audit/book-slug-placeholders.ts`, wired into `corpus-integrity-watch.yml`
Imports the same `isPlaceholderSlug` the writers use, so it cannot drift from the rule it watches. 0/1/2 exit contract, prints its denominator, one open issue at a time. **Verified by making it fail**: with `MONGODB_URI` removed it exits 2, not 0.

Current reading: `Scanned 111779 books, 111774 with a slug. Placeholder slugs: 158 visible, 31 hidden.` — the 112 here plus older classes (`untitled-N` on CJK titles, `/book/-9`, `/book/216`) that `repair-book-slugs.ts` owns and that mostly need a `display_title` before they can be repaired at all.

Unit tests pin the generator (`tests/unit/book-slug-quality.test.ts`); 3207/3207 pass, `tsc --noEmit` clean.


**Second writer, found by the widening** — `src/lib/metadata-enrichment.ts`
Widening `isPlaceholderSlug` pointed an existing writer at these 112 live URLs. The enrichment path regenerates a slug the moment a book finally gets a `display_title`, and it wrote the new slug **alone**: no `slug_aliases` (so the old public URL would 404 rather than 308) and no `updated_at` (so the Supabase mirror that decides the rendered canonical never learns about it). Pre-existing for the `-10` class, where it rarely bit because nobody links those; it would have bitten hard here, and this writer runs unattended from the post-import cron. Fixed in the same PR — the read rule widened, so every hit had to be classified reader / writer / detector.

**Docs** — `non-latin-text-operations.md` gains the sentinel shape (every case in that file fails by returning *nothing*; this one never returns nothing, which is worse). `content-urls-and-libraries.md` gains the rename rule: an old URL that renders is not an old URL that redirects, and the difference is invisible from the database — curl it.

## Out of scope (deliberately)

- **Running the repair.** `scripts/maintenance/repair-unknown-slugs-4389.ts` is committed and dry-run only. Renaming before the redirect is deployed turns 112 working URLs into pages that point nowhere new.
- **The other 46 visible placeholder slugs.** Different causes, and most need metadata first. The audit reports them; `repair-book-slugs.ts` owns them.
- **Reader URLs** `/book/<alias>/page/<pageId>`. They still resolve and render via the alias; only the book-level URL 308s. Worth a follow-up.
- **Two drifted `.mjs` copies of the slug algorithm** (`populate-book-slugs.mjs`, `repair-object-object-authors-3770.mjs`). `populate-book-slugs.mjs` still carries the pre-#4127 `extractLastName`. Not touched here; worth consolidating.
- Filed as `.ts`, not `.mjs`, precisely so the repair and the audit **import** `@/lib/slugify` instead of reimplementing it — the drift above is what a fourth copy would become.

## Dry run — 112 renames, 112 unique targets, 0 bare numeric suffixes

20 of 112 (14 in creation order, then 6 showing the disambiguation ladder). Eleven of these books are all called "A Balbale to Inana"; only the original `title` carries the ETCSL number, so the script tries the title-derived slug before a counter — `a-balbale-to-inana-etcsl-4-08-01` says something, `…-anonymous-7` does not.

| old | new | title |
|---|---|---|
| `/book/unknown` | `/book/inana-and-bilulu-an-ulila-to-inana-anonymous` | Inana and Bilulu: An Ulila to Inana |
| `/book/unknown-1` | `/book/ninurta-s-return-to-nibru-a-sir-gida-to-ninurta-anonymous` | Ninurta's Return to Nibru: A Šir-gida to Ninurta |
| `/book/unknown-2` | `/book/ninurta-s-exploits-a-sir-sud-to-ninurta-anonymous` | Ninurta's Exploits: A Šir-sud to Ninurta |
| `/book/unknown-3` | `/book/the-sumunda-grass-anonymous` | The Šumunda Grass |
| `/book/unknown-4` | `/book/an-adab-to-bau-for-luma-luma-a-anonymous` | An Adab to Bau for Luma (Luma A) |
| `/book/unknown-5` | `/book/a-tigi-to-bau-for-gudea-gudea-a-anonymous` | A Tigi to Bau for Gudea (Gudea A) |
| `/book/unknown-6` | `/book/a-tigi-to-enlil-for-ur-namma-ur-namma-b-anonymous` | A Tigi to Enlil for Ur-Namma (Ur-Namma B) |
| `/book/unknown-7` | `/book/a-sir-namsub-to-nanna-for-ur-namma-ur-namma-e-anonymous` | A Šir-namšub to Nanna for Ur-Namma (Ur-Namma E) |
| `/book/unknown-8` | `/book/a-sir-namsub-to-nanna-for-ur-namma-ur-namma-f-anonymous` | A Šir-namšub to Nanna for Ur-Namma (Ur-Namma F) |
| `/book/unknown-9` | `/book/a-balbale-to-enlil-for-ur-namma-ur-namma-g-anonymous` | A Balbale to Enlil for Ur-Namma (Ur-Namma G) |
| `/book/unknown-10` | `/book/an-adab-to-enlil-for-sulgi-sulgi-g-anonymous` | An Adab to Enlil for Šulgi (Šulgi G) |
| `/book/unknown-11` | `/book/a-tigi-for-sulgi-sulgi-l-anonymous` | A Tigi for Šulgi (Šulgi L) |
| `/book/unknown-13` | `/book/an-adab-to-utu-for-sulgi-sulgi-q-anonymous` | An Adab to Utu for Šulgi (Šulgi Q) |
| `/book/unknown-14` | `/book/sulgi-and-ninlil-s-barge-a-tigi-to-ninlil-sulgi-r-anonymous` | Šulgi and Ninlil's Barge: A Tigi to Ninlil (Šulgi R) |
| `/book/unknown-59` | `/book/a-balbale-to-inana-etcsl-4-07-6-anonymous` | A Balbale to Inana |
| `/book/unknown-62` | `/book/a-sir-namsub-to-inana-etcsl-4-07-9-anonymous` | A Šir-namšub to Inana |
| `/book/unknown-63` | `/book/a-balbale-to-inana-etcsl-4-08-01-anonymous` | A Balbale to Inana |
| `/book/unknown-64` | `/book/a-balbale-to-inana-etcsl-4-08-02-anonymous` | A Balbale to Inana |
| `/book/unknown-65` | `/book/a-balbale-to-inana-etcsl-4-08-03-anonymous` | A Balbale to Inana |
| `/book/unknown-66` | `/book/a-balbale-to-inana-etcsl-4-08-04-anonymous` | A Balbale to Inana |

_(full plan: `npx tsx scripts/maintenance/repair-unknown-slugs-4389.ts --json`)_

## Post-merge, in this order

1. `set -a; source .env.production.local; set +a` then `npx tsx scripts/maintenance/repair-unknown-slugs-4389.ts --apply` (backs up to `scripts/output/` before the first write; guarded on the old slug so a concurrent session cannot be clobbered).
2. Purge Cloudflare + revalidate the affected `/book` paths per `.claude/docs/invariants/deploy-and-caching.md`.
3. The Supabase `books_catalog` sync picks the renames up from the `updated_at` bump (:45, every odd hour) — that mirror is what decides the rendered canonical, so a slug written without it would keep serving the old URL until the weekly full rebuild.
4. Re-run `npx tsx scripts/audit/book-slug-placeholders.ts` — the `unknown` family should be gone and the count should drop 158 → 46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd
