### PR TITLE
One implementation of the OCR-result parser, parity-pinned (#4443)

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -65,7 +65,7 @@ function isDigitizerPage(pageType, ocrText) {
 // fork of it, and was deliberately left out of the #4443 consolidation. Measured
 // 2026-08-31: of 200 sampled pages holding a `<detected-images>` block, 200 were
 // JSON-shaped and 0 XML-shaped, so this returns [] on current-prompt output. See
-// #4445.
+// #4456.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];

--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -11,6 +11,7 @@ import { MongoClient } from 'mongodb';
 import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
+import { extractPageType, extractColumns, parseMultiPageOcr } from '../lib/ocr-result-parse.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -42,11 +43,7 @@ const abandonArg = args.find(a => a.startsWith('--abandon-stale='));
 const ABANDON_STALE_DAYS = abandonArg ? parseInt(abandonArg.split('=')[1], 10) : null;
 const DRY_RUN = args.includes('--dry-run');
 
-// --- OCR metadata extraction (mirrors defaults.ts) ---
-function extractPageType(text) {
-  const match = text.match(/<page-type>\s*(.*?)\s*<\/page-type>/i);
-  return match ? match[1].toLowerCase().trim() : null;
-}
+// --- OCR metadata extraction: shared with defaults.ts via scripts/lib/ocr-result-parse.mjs (#4443) ---
 
 /** Check if this page is a digitizer insert — via OCR tag, body-text, or meta-descriptor fallback. */
 function isDigitizerPage(pageType, ocrText) {
@@ -62,13 +59,13 @@ function isDigitizerPage(pageType, ocrText) {
   return false;
 }
 
-function extractColumns(text) {
-  const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
-  if (!match) return null;
-  const n = parseInt(match[1], 10);
-  return n >= 2 ? n : null;
-}
-
+// NOTE: this parses `<image>` sub-tags, which the CURRENT OCR prompt does not
+// emit — it asks for a JSON array inside `<detected-images>`. It is therefore a
+// different parser from the canonical `parseDetectedImages` in defaults.ts, not a
+// fork of it, and was deliberately left out of the #4443 consolidation. Measured
+// 2026-08-31: of 200 sampled pages holding a `<detected-images>` block, 200 were
+// JSON-shaped and 0 XML-shaped, so this returns [] on current-prompt output. See
+// #4445.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];
@@ -97,19 +94,6 @@ function parseDetectedImages(text) {
     images.push(image);
   }
   return images;
-}
-
-function parseMultiPageOcr(text) {
-  const results = new Map();
-  const regex = /<page\s+id="([^"]+)">([\s\S]*?)(?=<page\s+id="|$)/g;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    const pageId = match[1];
-    let content = match[2].trim();
-    content = content.replace(/<\/page>\s*$/, '').trim();
-    if (content) results.set(pageId, content);
-  }
-  return results;
 }
 
 // --- Gemini API ---
@@ -210,7 +194,7 @@ async function processOneJob(db, job) {
         const text = result.response?.candidates?.[0]?.content?.parts?.[0]?.text;
         if (!text) { failCount++; continue; }
         const usage = result.response?.usageMetadata;
-        const parsed = parseMultiPageOcr(text);
+        const parsed = parseMultiPageOcr(text, { lenient: true });
         for (const [pageId, ocrText] of parsed) {
           pageResults.push({ pageId, text: ocrText, usage });
         }
@@ -257,7 +241,7 @@ async function processOneJob(db, job) {
       if (text.length > 25000) { failCount++; continue; }
 
       if (job.type === 'ocr') {
-        const pageType = extractPageType(text);
+        const pageType = extractPageType(text, { validate: false });
         const columns = extractColumns(text);
         const detectedImages = parseDetectedImages(text);
 

--- a/scripts/batch/collect-multipage-ocr.mjs
+++ b/scripts/batch/collect-multipage-ocr.mjs
@@ -9,39 +9,26 @@
 import { MongoClient } from 'mongodb';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
+import { extractPageType, extractColumns, parseMultiPageOcr } from '../lib/ocr-result-parse.mjs';
 
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const DRY_RUN = process.argv.includes('--dry-run');
 
-// Prompt version and helpers inlined to avoid build issues
-const PROMPT_VERSION = 'v4.2026-02';
+/**
+ * Provenance fallback for legacy jobs only — NOT the current prompt version.
+ *
+ * Jobs submitted since early 2026 record their own `prompt_version` (see
+ * `pipeline-orchestrator.mjs`, `bulk-reocr-*.mjs`), and that is what gets
+ * stamped. This value is what a job predating that field was actually run with,
+ * so it must NOT be bumped to `PROMPT_VERSION` from ocr-result-parse.mjs:
+ * restamping an old job with today's prompt version fabricates provenance.
+ * Previously named PROMPT_VERSION, which read as "the current prompt" (#4443).
+ */
+const LEGACY_JOB_PROMPT_VERSION = 'v4.2026-02';
 
-function extractPageType(text) {
-  const match = text.match(/<page-type>([\s\S]*?)<\/page-type>/);
-  return match ? match[1].trim().toLowerCase() : null;
-}
-
-function extractColumns(text) {
-  const match = text.match(/<columns>(\d+)<\/columns>/);
-  if (!match) return null;
-  const n = parseInt(match[1]);
-  return n >= 2 ? n : null;
-}
-
-function parseMultiPageOcr(text) {
-  const results = new Map();
-  const regex = /<page\s+id="([^"]+)">([\s\S]*?)(?=<page\s+id="|$)/g;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    const pageId = match[1];
-    let content = match[2].trim();
-    // Remove closing </page> tag if present
-    content = content.replace(/<\/page>\s*$/, '').trim();
-    if (content) results.set(pageId, content);
-  }
-  return results;
-}
-
+// NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
+// a different parser from the canonical `parseDetectedImages`, not a fork of it.
+// Deliberately out of scope for #4443; see #4445.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];
@@ -160,7 +147,7 @@ async function main() {
         if (r.error) { console.log(`  Response error: ${JSON.stringify(r.error).slice(0, 100)}`); continue; }
         const text = r.response?.candidates?.[0]?.content?.parts?.[0]?.text;
         if (!text) { console.log('  Empty response'); continue; }
-        const parsed = parseMultiPageOcr(text);
+        const parsed = parseMultiPageOcr(text, { lenient: true });
         pageCount += parsed.size;
         console.log(`  Response: ${parsed.size} pages parsed from ${text.length} chars`);
       }
@@ -189,7 +176,7 @@ async function main() {
         continue;
       }
       const usage = result.response?.usageMetadata;
-      const parsed = parseMultiPageOcr(text);
+      const parsed = parseMultiPageOcr(text, { lenient: true });
       console.log(`  Response ${ri}: ${parsed.size} pages`);
 
       for (const [pageId, ocrText] of parsed) {
@@ -199,7 +186,7 @@ async function main() {
           continue;
         }
 
-        const pageType = extractPageType(ocrText);
+        const pageType = extractPageType(ocrText, { validate: false });
         const columns = extractColumns(ocrText);
         const detectedImages = parseDetectedImages(ocrText);
 
@@ -221,7 +208,7 @@ async function main() {
               'ocr.model': job.model,
               'ocr.language': job.language,
               'ocr.source': 'batch_api',
-              'ocr.prompt_version': job.prompt_version || PROMPT_VERSION,
+              'ocr.prompt_version': job.prompt_version || LEGACY_JOB_PROMPT_VERSION,
               'ocr.prompt_name': job.prompt_name || 'Standard OCR',
               'ocr.batch_job_id': String(job._id),
               'ocr.pages_per_request': job.pages_per_request,

--- a/scripts/batch/collect-multipage-ocr.mjs
+++ b/scripts/batch/collect-multipage-ocr.mjs
@@ -28,7 +28,7 @@ const LEGACY_JOB_PROMPT_VERSION = 'v4.2026-02';
 
 // NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
 // a different parser from the canonical `parseDetectedImages`, not a fork of it.
-// Deliberately out of scope for #4443; see #4445.
+// Deliberately out of scope for #4443; see #4456.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -33,6 +33,7 @@ import fs from 'node:fs';
 import { MongoClient } from 'mongodb';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { extractPageType, extractColumns } from '../lib/ocr-result-parse.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -219,11 +220,7 @@ async function callGemini(imageBase64, mimeType, promptText, apiKey) {
   };
 }
 
-// --- Extract metadata from OCR text ---
-function extractPageType(text) {
-  const match = text.match(/<page-type>\s*(.*?)\s*<\/page-type>/i);
-  return match ? match[1].toLowerCase().trim() : null;
-}
+// --- Extract metadata from OCR text: shared via scripts/lib/ocr-result-parse.mjs (#4443) ---
 
 /** Check if this page is a digitizer insert — via OCR tag, body-text, or meta-descriptor fallback. */
 function isDigitizerPage(pageType, ocrText) {
@@ -237,13 +234,9 @@ function isDigitizerPage(pageType, ocrText) {
   return false;
 }
 
-function extractColumns(text) {
-  const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
-  if (!match) return null;
-  const n = parseInt(match[1], 10);
-  return n >= 2 ? n : null;
-}
-
+// NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
+// a different parser from the canonical `parseDetectedImages`, not a fork of it.
+// Deliberately out of scope for #4443; see #4445.
 function parseDetectedImages(text) {
   const imageBlocks = text.match(/<detected-images>[\s\S]*?<\/detected-images>/gi);
   if (!imageBlocks) return [];
@@ -292,7 +285,7 @@ async function processPage(page, promptText, db) {
       return { pageId: page.id, status: 'skip', reason: 'hallucination (>25k chars)', durationMs };
     }
 
-    const pageType = extractPageType(result.text);
+    const pageType = extractPageType(result.text, { validate: false });
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
 

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -236,7 +236,7 @@ function isDigitizerPage(pageType, ocrText) {
 
 // NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
 // a different parser from the canonical `parseDetectedImages`, not a fork of it.
-// Deliberately out of scope for #4443; see #4445.
+// Deliberately out of scope for #4443; see #4456.
 function parseDetectedImages(text) {
   const imageBlocks = text.match(/<detected-images>[\s\S]*?<\/detected-images>/gi);
   if (!imageBlocks) return [];

--- a/scripts/batch/realtime-reocr-efm.mjs
+++ b/scripts/batch/realtime-reocr-efm.mjs
@@ -19,6 +19,7 @@
 import { MongoClient } from 'mongodb';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { extractPageType, extractColumns } from '../lib/ocr-result-parse.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -139,19 +140,11 @@ async function callGemini(imageBase64, mimeType, promptText, apiKey) {
   };
 }
 
-// --- Extract metadata from OCR text ---
-function extractPageType(text) {
-  const match = text.match(/<page-type>\s*(.*?)\s*<\/page-type>/i);
-  return match ? match[1].toLowerCase().trim() : null;
-}
+// --- Extract metadata from OCR text: shared via scripts/lib/ocr-result-parse.mjs (#4443) ---
 
-function extractColumns(text) {
-  const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
-  if (!match) return null;
-  const n = parseInt(match[1], 10);
-  return n >= 2 ? n : null;
-}
-
+// NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
+// a different parser from the canonical `parseDetectedImages`, not a fork of it.
+// Deliberately out of scope for #4443; see #4445.
 function parseDetectedImages(text) {
   const imageBlocks = text.match(/<detected-images>[\s\S]*?<\/detected-images>/gi);
   if (!imageBlocks) return [];
@@ -199,7 +192,7 @@ async function processPage(page, promptText, db) {
     }
 
     // Extract metadata
-    const pageType = extractPageType(result.text);
+    const pageType = extractPageType(result.text, { validate: false });
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
 

--- a/scripts/batch/realtime-reocr-efm.mjs
+++ b/scripts/batch/realtime-reocr-efm.mjs
@@ -144,7 +144,7 @@ async function callGemini(imageBase64, mimeType, promptText, apiKey) {
 
 // NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
 // a different parser from the canonical `parseDetectedImages`, not a fork of it.
-// Deliberately out of scope for #4443; see #4445.
+// Deliberately out of scope for #4443; see #4456.
 function parseDetectedImages(text) {
   const imageBlocks = text.match(/<detected-images>[\s\S]*?<\/detected-images>/gi);
   if (!imageBlocks) return [];

--- a/scripts/lib/ocr-result-parse.mjs
+++ b/scripts/lib/ocr-result-parse.mjs
@@ -1,0 +1,113 @@
+/**
+ * JS twin of the OCR-result parsers in `src/lib/types/prompts/defaults.ts` (#4443).
+ *
+ * Why a separate copy: pipeline scripts run as plain `.mjs` and cannot import the
+ * `@/`-aliased TS module. Same reason as `scripts/lib/page-image-url.mjs`, and the
+ * same guarantee — `tests/unit/ocr-result-parse.test.ts` runs both implementations
+ * over one fixture corpus and fails if they disagree, so an edit to either side
+ * breaks CI instead of drifting.
+ *
+ * Before this file existed, six scripts each carried a private copy that imported
+ * nothing:
+ *
+ *   scripts/batch/collect-batch-results.mjs     scripts/split-book.mjs
+ *   scripts/batch/collect-multipage-ocr.mjs     scripts/workers/batch-collector.mjs
+ *   scripts/batch/realtime-ocr.mjs              scripts/batch/realtime-reocr-efm.mjs
+ *
+ * They had drifted into five mutually incompatible behaviours — two screened the
+ * model's page type against separately-stale vocabularies, four screened it not at
+ * all, and one had lost the `i` flag. Because the failure mode is *missing
+ * metadata* rather than an error, nothing ever went red. These are the collectors
+ * that read batch output we have already spent money to generate.
+ *
+ * KEEP IN LOCKSTEP WITH `src/lib/types/prompts/defaults.ts`.
+ */
+
+/**
+ * Bump in `defaults.ts`; this mirrors it. Pinned by the parity test.
+ *
+ * NOTE for collectors: this is the version of the prompt *this checkout* would
+ * send, not the version any given batch job was submitted with. To stamp
+ * `ocr.prompt_version` on a collected page, read it off the job record — a job
+ * submitted months ago did not use this prompt, and stamping it with today's
+ * value fabricates provenance.
+ */
+export const PROMPT_VERSION = 'v6.1.2026-05';
+
+/** Page-type vocabulary accepted from the model. Mirrors VALID_PAGE_TYPES in defaults.ts. */
+export const VALID_PAGE_TYPES = new Set([
+  'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
+  'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
+  'digitizer-insert', 'exlibris', 'bookplate',
+]);
+
+/**
+ * Extract <page-type> from OCR text. Returns undefined if not found or invalid.
+ *
+ * `validate: false` returns whatever the model emitted (trimmed, lower-cased)
+ * without screening it against VALID_PAGE_TYPES. That is not a preference — it is
+ * what four batch collectors have always done, and the two vocabularies genuinely
+ * disagree: the OCR prompt offers `musical-score`, `table` and `cover`, none of
+ * which VALID_PAGE_TYPES lists. Flipping those callers to validating would
+ * silently stop three prompt-sanctioned types from being recorded, so the
+ * divergence is a parameter rather than a fork. See #4444 for the gap itself.
+ *
+ * Unlike the TS canonical this tolerates a non-string argument, because
+ * `split-book.mjs` passes `page.ocr`, which is null on an un-OCR'd page.
+ */
+export function extractPageType(ocrText, { validate = true } = {}) {
+  const match = ocrText?.match(/<page-type>([\s\S]*?)<\/page-type>/i);
+  if (!match) return undefined;
+  const type = match[1].trim().toLowerCase();
+  if (!validate) return type || undefined;
+  return VALID_PAGE_TYPES.has(type) ? type : undefined;
+}
+
+/** Extract <columns>N</columns> from OCR text. Returns undefined if not found or 1. */
+export function extractColumns(ocrText) {
+  const match = ocrText?.match(/<columns>\s*(\d+)\s*<\/columns>/i);
+  if (!match) return undefined;
+  const n = parseInt(match[1], 10);
+  return n > 1 ? n : undefined;
+}
+
+/** Extract <script>printed|handwritten|mixed</script> from OCR text. */
+export function extractScriptType(ocrText) {
+  const match = ocrText?.match(/<script>([\s\S]*?)<\/script>/i);
+  if (!match) return undefined;
+  const type = match[1].trim().toLowerCase();
+  if (type === 'handwritten' || type === 'mixed' || type === 'printed') return type;
+  return undefined;
+}
+
+/**
+ * Parse a multi-page OCR response into a Map of pageId → OCR text.
+ *
+ * `lenient: true` is the batch-collector dialect, and it differs in four ways that
+ * all exist for one reason — a truncated Gemini batch response drops the final
+ * `</page>`, and the strict parser silently discards that page's text even though
+ * we already paid to generate it:
+ *   1. accepts any whitespace in `<page   id="…">`, not one literal space;
+ *   2. does not require `</page>` — a block runs to the next `<page id=` or EOF;
+ *   3. strips a trailing `</page>` left over from (2);
+ *   4. omits pages whose content is empty after trimming.
+ * Callers on the request path keep the strict default.
+ */
+export function parseMultiPageOcr(text, { lenient = false } = {}) {
+  const results = new Map();
+  if (lenient) {
+    const regex = /<page\s+id="([^"]+)">([\s\S]*?)(?=<page\s+id="|$)/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const content = match[2].trim().replace(/<\/page>\s*$/, '').trim();
+      if (content) results.set(match[1], content);
+    }
+    return results;
+  }
+  const regex = /<page id="([^"]+)">([\s\S]*?)<\/page>/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    results.set(match[1], match[2].trim());
+  }
+  return results;
+}

--- a/scripts/lib/ocr-result-parse.mjs
+++ b/scripts/lib/ocr-result-parse.mjs
@@ -50,7 +50,7 @@ export const VALID_PAGE_TYPES = new Set([
  * disagree: the OCR prompt offers `musical-score`, `table` and `cover`, none of
  * which VALID_PAGE_TYPES lists. Flipping those callers to validating would
  * silently stop three prompt-sanctioned types from being recorded, so the
- * divergence is a parameter rather than a fork. See #4444 for the gap itself.
+ * divergence is a parameter rather than a fork. See #4455 for the gap itself.
  *
  * Unlike the TS canonical this tolerates a non-string argument, because
  * `split-book.mjs` passes `page.ocr`, which is null on an un-OCR'd page.

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -20,6 +20,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import sharp from 'sharp';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { extractPageType } from './lib/ocr-result-parse.mjs';
 
 // --- Config ---
 const OVERLAP = 0.03;        // 3% overlap on each crop (#1491 lesson #6: 1% clipped tight gutters)
@@ -92,14 +93,11 @@ async function uploadFullImage(buf, bookId, pageNum) {
   return { fullUrl, dispUrl, thumbUrl, width: fm.width, height: fm.height };
 }
 
-// --- Page type extraction ---
-const VALID_PAGE_TYPES = new Set(['title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index', 'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text', 'digitizer-insert']);
-function extractPageType(text) {
-  const m = text?.match(/<page-type>([\s\S]*?)<\/page-type>/i);
-  if (!m) return undefined;
-  const t = m[1].trim().toLowerCase();
-  return VALID_PAGE_TYPES.has(t) ? t : undefined;
-}
+// --- Page type extraction: shared via scripts/lib/ocr-result-parse.mjs (#4443) ---
+// Validating, as this script's private copy always did — but against the current
+// vocabulary rather than the 15-value set it had frozen at (which predated
+// `exlibris` and `bookplate`). The shared function is equally null-tolerant,
+// which matters here: `p.ocr` is null on an un-OCR'd page.
 
 // --- Fetch image with retries ---
 async function fetchImage(url) {

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -27,6 +27,7 @@ import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-r
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 import { shouldRefuseOcrWrite, recordRefusal, guardEnabled } from '../lib/blank-page-guard.mjs';
+import { extractPageType, extractColumns, parseMultiPageOcr } from '../lib/ocr-result-parse.mjs';
 
 /**
  * Save current page content as a revision before overwriting — delegates to the
@@ -89,26 +90,11 @@ function calculateCost(model, inputTokens, outputTokens) {
   return Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000;
 }
 
-// ── OCR metadata extraction (mirrors defaults.ts) ──
+// ── OCR metadata extraction: shared with defaults.ts via scripts/lib/ocr-result-parse.mjs (#4443) ──
 
-function extractPageType(text) {
-  const match = text.match(/<page-type>\s*(.*?)\s*<\/page-type>/i);
-  if (!match) return null;
-  const type = match[1].toLowerCase().trim();
-  const valid = new Set([
-    'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
-    'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
-  ]);
-  return valid.has(type) ? type : null;
-}
-
-function extractColumns(text) {
-  const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
-  if (!match) return null;
-  const n = parseInt(match[1], 10);
-  return n >= 2 ? n : null;
-}
-
+// NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
+// a different parser from the canonical `parseDetectedImages`, not a fork of it.
+// Deliberately out of scope for #4443; see #4445.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];
@@ -176,19 +162,6 @@ function normalizeBbox(raw) {
     };
   }
   return { x, y, width, height };
-}
-
-function parseMultiPageOcr(text) {
-  const results = new Map();
-  const regex = /<page\s+id="([^"]+)">([\s\S]*?)(?=<page\s+id="|$)/g;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    const pageId = match[1];
-    let content = match[2].trim();
-    content = content.replace(/<\/page>\s*$/, '').trim();
-    if (content) results.set(pageId, content);
-  }
-  return results;
 }
 
 // ── Gemini API ──
@@ -377,7 +350,7 @@ async function processOneJob(db, job) {
         if (candidate?.finishReason === 'RECITATION') { recitationCount++; failCount++; continue; }
         const text = candidate?.content?.parts?.[0]?.text;
         if (!text) { failCount++; continue; }
-        const parsed = parseMultiPageOcr(text);
+        const parsed = parseMultiPageOcr(text, { lenient: true });
         // One response covers N pages and reports one usageMetadata — split it
         // evenly for the per-page stamp so pages.ocr.input_tokens doesn't claim
         // the whole request's tokens N times over.
@@ -553,6 +526,10 @@ async function processOneJob(db, job) {
           blankRefusedCount++;
           continue;
         }
+        // Validating, as this collector's private copy always did — but against
+        // the current vocabulary rather than the 14-value set it had frozen at.
+        // That set had lost `digitizer-insert`, so this collector could not
+        // record the one page type the digitizer guards downstream read (#4443).
         const pageType = extractPageType(text);
         const columns = extractColumns(text);
         const detectedImages = parseDetectedImages(text);

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -94,7 +94,7 @@ function calculateCost(model, inputTokens, outputTokens) {
 
 // NOTE: parses `<image>` sub-tags, which the current OCR prompt does not emit —
 // a different parser from the canonical `parseDetectedImages`, not a fork of it.
-// Deliberately out of scope for #4443; see #4445.
+// Deliberately out of scope for #4443; see #4456.
 function parseDetectedImages(text) {
   const match = text.match(/<detected-images>([\s\S]*?)<\/detected-images>/);
   if (!match) return [];

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -44,7 +44,7 @@ export const IMAGE_CANDIDATE_PAGE_TYPES = [
  * `cover`, which VALID_PAGE_TYPES does not list. Flipping those callers to
  * validating would silently stop three prompt-sanctioned types from being
  * recorded, so the divergence is a parameter here rather than a fork out there.
- * See #4444 for closing the vocabulary gap itself.
+ * See #4455 for closing the vocabulary gap itself.
  */
 export function extractPageType(
   ocrText: string,

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -5,7 +5,14 @@ import { VALID_IMAGE_TYPES } from "../../gallery-image-types";
 // Bump this when DEFAULT_PROMPTS change. Stored on every page record for audit trail.
 export const PROMPT_VERSION = 'v6.1.2026-05';
 
-const VALID_PAGE_TYPES = new Set([
+/**
+ * Page-type vocabulary accepted from the model.
+ *
+ * Exported so the scripts-side twin (`scripts/lib/ocr-result-parse.mjs`) can be
+ * pinned against it — six scripts each carried a private, separately-drifted copy
+ * of this set until #4443.
+ */
+export const VALID_PAGE_TYPES = new Set([
   'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
   'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
   'digitizer-insert', 'exlibris', 'bookplate',
@@ -27,17 +34,38 @@ export const IMAGE_CANDIDATE_PAGE_TYPES = [
   'illustration', 'diagram', 'map', 'frontispiece', 'mixed',
 ];
 
-/** Extract <page-type> from OCR text. Returns undefined if not found or invalid. */
-export function extractPageType(ocrText: string): string | undefined {
-  const match = ocrText.match(/<page-type>([\s\S]*?)<\/page-type>/i);
+/**
+ * Extract <page-type> from OCR text. Returns undefined if not found or invalid.
+ *
+ * `validate: false` returns whatever the model emitted (trimmed, lower-cased)
+ * without screening it against VALID_PAGE_TYPES. That is not a preference — it
+ * is what four batch collectors have always done (#4443), and the vocabularies
+ * genuinely disagree: the OCR prompt offers `musical-score`, `table` and
+ * `cover`, which VALID_PAGE_TYPES does not list. Flipping those callers to
+ * validating would silently stop three prompt-sanctioned types from being
+ * recorded, so the divergence is a parameter here rather than a fork out there.
+ * See #4444 for closing the vocabulary gap itself.
+ */
+export function extractPageType(
+  ocrText: string,
+  { validate = true }: { validate?: boolean } = {},
+): string | undefined {
+  const match = ocrText?.match(/<page-type>([\s\S]*?)<\/page-type>/i);
   if (!match) return undefined;
   const type = match[1].trim().toLowerCase();
+  if (!validate) return type || undefined;
   return VALID_PAGE_TYPES.has(type) ? type : undefined;
 }
 
-/** Extract <columns>N</columns> from OCR text. Returns undefined if not found or 1. */
+/**
+ * Extract <columns>N</columns> from OCR text. Returns undefined if not found or 1.
+ *
+ * The `\s*` padding matches what every scripts-side copy accepted; without it
+ * `<columns> 2 </columns>` parses as single-column. Strictly wider than the
+ * pre-#4443 pattern — every input that matched before still matches.
+ */
 export function extractColumns(ocrText: string): number | undefined {
-  const match = ocrText.match(/<columns>(\d+)<\/columns>/i);
+  const match = ocrText?.match(/<columns>\s*(\d+)\s*<\/columns>/i);
   if (!match) return undefined;
   const n = parseInt(match[1], 10);
   return n > 1 ? n : undefined;
@@ -124,9 +152,31 @@ export function parseDetectedImages(ocrText: string): DetectedImage[] {
 /**
  * Parse multi-page OCR response. Expects <page id="PAGE_ID">...</page> blocks.
  * Returns a Map of pageId → OCR text.
+ *
+ * `lenient: true` is the batch-collector dialect (#4443), and it differs in four
+ * ways that all exist for one reason — a truncated Gemini batch response drops
+ * the final `</page>`, and the strict parser silently discards that page's text
+ * even though we already paid to generate it:
+ *   1. accepts any whitespace in `<page   id="…">`, not one literal space;
+ *   2. does not require `</page>` — a block runs to the next `<page id=` or EOF;
+ *   3. strips a trailing `</page>` left over from (2);
+ *   4. omits pages whose content is empty after trimming.
+ * Callers on the request path keep the strict default.
  */
-export function parseMultiPageOcr(text: string): Map<string, string> {
+export function parseMultiPageOcr(
+  text: string,
+  { lenient = false }: { lenient?: boolean } = {},
+): Map<string, string> {
   const results = new Map<string, string>();
+  if (lenient) {
+    const regex = /<page\s+id="([^"]+)">([\s\S]*?)(?=<page\s+id="|$)/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const content = match[2].trim().replace(/<\/page>\s*$/, '').trim();
+      if (content) results.set(match[1], content);
+    }
+    return results;
+  }
   const regex = /<page id="([^"]+)">([\s\S]*?)<\/page>/g;
   let match;
   while ((match = regex.exec(text)) !== null) {

--- a/tests/unit/ocr-result-parse.test.ts
+++ b/tests/unit/ocr-result-parse.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The scripts-side OCR parser must not drift from the TS canonical.
+ *
+ * `src/lib/types/prompts/defaults.ts` is the canonical OCR-result parser. Until
+ * #4443 `scripts/lib/` had no twin of it, so six pipeline scripts each carried a
+ * private copy and imported nothing — and those copies had drifted into five
+ * mutually incompatible behaviours:
+ *
+ *   - `collect-batch-results.mjs`, `realtime-ocr.mjs`, `realtime-reocr-efm.mjs`,
+ *     `collect-multipage-ocr.mjs` — wrote the model's page-type string with no
+ *     vocabulary screening at all;
+ *   - `workers/batch-collector.mjs` — screened against a 14-value set that had
+ *     lost `digitizer-insert`, so the collector could not record the very type
+ *     the digitizer-page guards read;
+ *   - `split-book.mjs` — screened against a different 15-value set;
+ *   - `collect-multipage-ocr.mjs` — had also lost the `i` flag, so `<PAGE-TYPE>`
+ *     did not match.
+ *
+ * None of it errors. A dropped `<page-type>` is *missing metadata*, and these are
+ * the collectors that read batch output we have already paid to generate. This
+ * test is the report that never existed: it runs both implementations over one
+ * fixture corpus and fails if they disagree.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PROMPT_VERSION,
+  VALID_PAGE_TYPES,
+  extractPageType,
+  extractColumns,
+  extractScriptType,
+  parseMultiPageOcr,
+} from '@/lib/types/prompts/defaults';
+import {
+  PROMPT_VERSION as PROMPT_VERSION_JS,
+  VALID_PAGE_TYPES as VALID_PAGE_TYPES_JS,
+  extractPageType as extractPageTypeJs,
+  extractColumns as extractColumnsJs,
+  extractScriptType as extractScriptTypeJs,
+  parseMultiPageOcr as parseMultiPageOcrJs,
+} from '../../scripts/lib/ocr-result-parse.mjs';
+
+/** One fixture per real-world shape the six copies disagreed on. */
+const pageTypeFixtures: Record<string, string> = {
+  plain: 'body text\n<page-type>title-page</page-type>\n<vocab>x</vocab>',
+  padded: '<page-type>  Frontispiece  </page-type>',
+  uppercaseTag: '<PAGE-TYPE>blank</PAGE-TYPE>',
+  multiline: '<page-type>\ntext\n</page-type>',
+  // Offered by the OCR prompt, absent from VALID_PAGE_TYPES — see #4444.
+  promptOnly: '<page-type>musical-score</page-type>',
+  promptOnlyTable: '<page-type>table</page-type>',
+  promptOnlyCover: '<page-type>cover</page-type>',
+  // The type batch-collector.mjs's stale set could not record.
+  digitizer: '<page-type>digitizer-insert</page-type>',
+  exlibris: '<page-type>exlibris</page-type>',
+  garbage: '<page-type>a page of some kind</page-type>',
+  empty: '<page-type></page-type>',
+  absent: 'just body text with no tags at all',
+};
+
+const columnsFixtures: Record<string, string> = {
+  two: '<columns>2</columns>',
+  padded: '<columns> 3 </columns>',
+  single: '<columns>1</columns>',
+  uppercase: '<COLUMNS>4</COLUMNS>',
+  absent: 'no columns tag',
+};
+
+const scriptFixtures: Record<string, string> = {
+  printed: '<script>printed</script>',
+  handwritten: '<script>  Handwritten  </script>',
+  mixed: '<script>mixed</script>',
+  bogus: '<script>engraved</script>',
+  absent: 'no script tag',
+};
+
+const multiPageFixtures: Record<string, string> = {
+  wellFormed: '<page id="a1">alpha</page>\n<page id="a2">beta</page>',
+  // Gemini truncates a long batch response mid-stream: the last page loses its
+  // closing tag. The strict parser drops it; the collector dialect keeps it.
+  truncatedTail: '<page id="a1">alpha</page>\n<page id="a2">beta but never closed',
+  extraWhitespaceInTag: '<page   id="a1">alpha</page>',
+  emptyBlock: '<page id="a1"></page>\n<page id="a2">beta</page>',
+  interleaved: 'preamble\n<page id="a1">alpha</page>\ntrailing prose\n<page id="a2">beta</page>',
+  none: 'no page blocks here',
+};
+
+describe('TS canonical and scripts JS twin agree — extractPageType', () => {
+  it('validating mode returns identical results for every fixture', () => {
+    for (const [name, text] of Object.entries(pageTypeFixtures)) {
+      expect(extractPageTypeJs(text), name).toBe(extractPageType(text));
+    }
+  });
+
+  it('validate:false mode returns identical results for every fixture', () => {
+    for (const [name, text] of Object.entries(pageTypeFixtures)) {
+      expect(extractPageTypeJs(text, { validate: false }), name)
+        .toBe(extractPageType(text, { validate: false }));
+    }
+  });
+
+  it('the two vocabulary sets are the same set', () => {
+    expect([...VALID_PAGE_TYPES_JS].sort()).toEqual([...VALID_PAGE_TYPES].sort());
+  });
+});
+
+describe('TS canonical and scripts JS twin agree — the rest', () => {
+  it('extractColumns', () => {
+    for (const [name, text] of Object.entries(columnsFixtures)) {
+      expect(extractColumnsJs(text), name).toBe(extractColumns(text));
+    }
+  });
+
+  it('extractScriptType', () => {
+    for (const [name, text] of Object.entries(scriptFixtures)) {
+      expect(extractScriptTypeJs(text), name).toBe(extractScriptType(text));
+    }
+  });
+
+  it('parseMultiPageOcr, strict and lenient', () => {
+    for (const [name, text] of Object.entries(multiPageFixtures)) {
+      for (const lenient of [false, true]) {
+        expect([...parseMultiPageOcrJs(text, { lenient })], `${name}/lenient=${lenient}`)
+          .toEqual([...parseMultiPageOcr(text, { lenient })]);
+      }
+    }
+  });
+
+  it('PROMPT_VERSION is mirrored', () => {
+    expect(PROMPT_VERSION_JS).toBe(PROMPT_VERSION);
+  });
+});
+
+/**
+ * Behaviour the parity assertions above would pass while both sides were wrong
+ * together. These pin what the functions actually do.
+ */
+describe('extractPageType behaviour', () => {
+  it('screens the model output against the vocabulary by default', () => {
+    expect(extractPageType(pageTypeFixtures.garbage)).toBeUndefined();
+    expect(extractPageType(pageTypeFixtures.plain)).toBe('title-page');
+  });
+
+  it('validate:false passes the model string through, screening nothing', () => {
+    expect(extractPageType(pageTypeFixtures.garbage, { validate: false }))
+      .toBe('a page of some kind');
+  });
+
+  it('the three prompt-only types are the measured vocabulary gap (#4444)', () => {
+    // The OCR prompt offers musical-score / table / cover and the reader renders
+    // them (tests/unit/page-type-vocabulary.test.ts), but VALID_PAGE_TYPES does
+    // not list them — which is why the four unvalidated collectors could NOT be
+    // flipped to validating in #4443 without silently dropping all three.
+    for (const t of ['musical-score', 'table', 'cover']) {
+      expect(VALID_PAGE_TYPES.has(t), `${t} unexpectedly in VALID_PAGE_TYPES`).toBe(false);
+      expect(extractPageType(`<page-type>${t}</page-type>`)).toBeUndefined();
+      expect(extractPageType(`<page-type>${t}</page-type>`, { validate: false })).toBe(t);
+    }
+  });
+
+  it('digitizer-insert survives — the type batch-collector could not record', () => {
+    expect(extractPageType(pageTypeFixtures.digitizer)).toBe('digitizer-insert');
+  });
+
+  it('matches case-insensitively and across newlines', () => {
+    expect(extractPageType(pageTypeFixtures.uppercaseTag)).toBe('blank');
+    expect(extractPageType(pageTypeFixtures.multiline)).toBe('text');
+  });
+
+  it('an empty tag is undefined, never the empty string', () => {
+    expect(extractPageType(pageTypeFixtures.empty, { validate: false })).toBeUndefined();
+  });
+});
+
+describe('extractColumns behaviour', () => {
+  it('tolerates whitespace inside the tag (every scripts copy did)', () => {
+    expect(extractColumns('<columns> 3 </columns>')).toBe(3);
+  });
+  it('single-column is undefined, not 1', () => {
+    expect(extractColumns('<columns>1</columns>')).toBeUndefined();
+  });
+});
+
+describe('parseMultiPageOcr behaviour', () => {
+  it('strict mode drops a page whose closing tag was truncated away', () => {
+    const strict = parseMultiPageOcr(multiPageFixtures.truncatedTail);
+    expect([...strict.keys()]).toEqual(['a1']);
+  });
+
+  it('lenient mode recovers it — that page was already paid for', () => {
+    const lenient = parseMultiPageOcr(multiPageFixtures.truncatedTail, { lenient: true });
+    expect([...lenient.keys()]).toEqual(['a1', 'a2']);
+    expect(lenient.get('a2')).toBe('beta but never closed');
+  });
+
+  it('lenient mode omits an empty block; strict mode keeps it', () => {
+    expect([...parseMultiPageOcr(multiPageFixtures.emptyBlock, { lenient: true }).keys()])
+      .toEqual(['a2']);
+    expect([...parseMultiPageOcr(multiPageFixtures.emptyBlock).keys()])
+      .toEqual(['a1', 'a2']);
+  });
+
+  it('lenient mode absorbs prose that follows a closed block, tag and all', () => {
+    // A wart of the dialect, pinned rather than fixed: because a block runs to
+    // the next `<page id=`, anything printed between two pages is appended to the
+    // earlier one — and since the `</page>` is no longer trailing, it survives
+    // the strip and lands in the stored text. Strict mode does not have this
+    // problem. Changing it would rewrite what the collectors store, so #4443
+    // records it instead.
+    const lenient = parseMultiPageOcr(multiPageFixtures.interleaved, { lenient: true });
+    expect(lenient.get('a1')).toBe('alpha</page>\ntrailing prose');
+    expect(lenient.get('a2')).toBe('beta');
+    expect(parseMultiPageOcr(multiPageFixtures.interleaved).get('a1')).toBe('alpha');
+  });
+
+  it('strict mode requires exactly one space before id=', () => {
+    expect(parseMultiPageOcr(multiPageFixtures.extraWhitespaceInTag).size).toBe(0);
+    expect(parseMultiPageOcr(multiPageFixtures.extraWhitespaceInTag, { lenient: true }).size).toBe(1);
+  });
+});
+
+/**
+ * Scripts-only hardening: `split-book.mjs` calls extractPageType with `page.ocr`,
+ * which is null on an un-OCR'd page. The twin must not throw there.
+ */
+describe('twin tolerates the nullish input scripts actually pass', () => {
+  it('extractPageType(null) is undefined, not a TypeError', () => {
+    expect(extractPageTypeJs(null)).toBeUndefined();
+    expect(extractPageTypeJs(undefined)).toBeUndefined();
+  });
+  it('extractColumns(null) is undefined', () => {
+    expect(extractColumnsJs(null)).toBeUndefined();
+  });
+});

--- a/tests/unit/ocr-result-parse.test.ts
+++ b/tests/unit/ocr-result-parse.test.ts
@@ -45,7 +45,7 @@ const pageTypeFixtures: Record<string, string> = {
   padded: '<page-type>  Frontispiece  </page-type>',
   uppercaseTag: '<PAGE-TYPE>blank</PAGE-TYPE>',
   multiline: '<page-type>\ntext\n</page-type>',
-  // Offered by the OCR prompt, absent from VALID_PAGE_TYPES — see #4444.
+  // Offered by the OCR prompt, absent from VALID_PAGE_TYPES — see #4455.
   promptOnly: '<page-type>musical-score</page-type>',
   promptOnlyTable: '<page-type>table</page-type>',
   promptOnlyCover: '<page-type>cover</page-type>',
@@ -145,7 +145,7 @@ describe('extractPageType behaviour', () => {
       .toBe('a page of some kind');
   });
 
-  it('the three prompt-only types are the measured vocabulary gap (#4444)', () => {
+  it('the three prompt-only types are the measured vocabulary gap (#4455)', () => {
     // The OCR prompt offers musical-score / table / cover and the reader renders
     // them (tests/unit/page-type-vocabulary.test.ts), but VALID_PAGE_TYPES does
     // not list them — which is why the four unvalidated collectors could NOT be


### PR DESCRIPTION
Closes #4443.

`src/lib/types/prompts/defaults.ts` is the canonical OCR-result parser and `scripts/lib/` had no
twin of it, so six pipeline scripts each carried a private copy and imported nothing. This adds
the twin, pins it with a parity test, and swaps all six.

## Verification of the claim

Confirmed on `origin/main`. All six files carried a private copy; none imported the canonical.

**Every copy was diffed against the canonical before anything was swapped.** Not one was
byte-identical — they had drifted into five mutually incompatible behaviours:

| file | `extractPageType` vocabulary | miss returns | other drift |
|---|---|---|---|
| `batch/collect-batch-results.mjs` | **none — no screening** | `null` | `.*?` instead of `[\s\S]*?` |
| `batch/collect-multipage-ocr.mjs` | **none — no screening** | `null` | **lost the `i` flag** |
| `batch/realtime-ocr.mjs` | **none — no screening** | `null` | `.*?` instead of `[\s\S]*?` |
| `batch/realtime-reocr-efm.mjs` | **none — no screening** | `null` | `.*?` instead of `[\s\S]*?` |
| `split-book.mjs` | stale 15-value set | `undefined` | null-tolerant (`text?.match`) |
| `workers/batch-collector.mjs` | stale 14-value set | `null` | — |
| **canonical** | 17-value set | `undefined` | — |

`extractColumns` was consistent across the copies but **wider than the canonical**: every copy
accepted `<columns> 2 </columns>`, the canonical did not. `parseMultiPageOcr` was identical in
all three copies that had it, and differed from the canonical in four ways at once.

None of this errors. A dropped `<page-type>` is *missing metadata*, which is why it survived
months on the collectors that read output we have already paid to generate.

## Per-copy drift classification and how each was handled

**Reconciled as options on the shared function, not forks:**

- `extractPageType(text, { validate: false })` — the four unscreened collectors keep their exact
  behaviour. This is not laziness: the vocabularies genuinely disagree. The OCR prompt offers
  `musical-score`, `table` and `cover`; `VALID_PAGE_TYPES` lists none of them. Flipping those
  four to validating would have silently stopped three prompt-sanctioned types from ever being
  recorded — the exact bug class this issue exists to prevent. Filed as **#4455**; every
  `{ validate: false }` call site is a marker that disappears when that lands.
- `parseMultiPageOcr(text, { lenient: true })` — the batch-collector dialect. It does not require
  a closing `</page>`, because a truncated Gemini batch response drops the final tag and the
  strict parser then discards that page's text. Request-path callers keep the strict default.

**Widened in the shared function (strict supersets — nothing that matched before stops matching):**

- `extractColumns` gains the `\s*` padding every scripts copy had. Without it a padded tag parses
  as single-column.
- `extractPageType` is null-tolerant, which `split-book.mjs` relies on: it passes `p.ocr`, null on
  an un-OCR'd page.
- `collect-multipage-ocr.mjs` regains the `i` flag it had lost.

**Deliberate behaviour change, in the two files where the drift *was* the bug:**

- `workers/batch-collector.mjs` was frozen at 14 values and **had lost `digitizer-insert`** — so
  this collector could not record the one page type the digitizer guards downstream read, while
  `collect-batch-results.mjs`, reading the same tag, both recorded it and set `hidden: true`.
- `split-book.mjs` was frozen at 15, predating `exlibris` and `bookplate`.

Both now validate against the current vocabulary. Both are widenings — every value either copy
accepted before is still accepted.

Return type: the copies returned `null` where the shared function returns `undefined`. Every one
of the ten call sites tests the result for truthiness (`if (pageType)`, `...(columns && {…})`), so
this is not observable. Checked individually rather than assumed.

## Stale prompt versions (issue scope item 4)

The issue notes `collect-multipage-ocr.mjs` pinned to v4 while live was v5. Live is now
**v6.1.2026-05**, and the picture is not what the name suggested:

- `collect-multipage-ocr.mjs` had `const PROMPT_VERSION = 'v4.2026-02'`, `collect-batch-results.mjs`
  a `'v4.2026-02'` literal, `workers/batch-collector.mjs` `'v5.2026-02'`.
- All three are used only as `job.prompt_version || <literal>` — a fallback for jobs predating the
  `prompt_version` field on the job record. Submitters have recorded it for some time
  (`pipeline-orchestrator.mjs`, `bulk-reocr-*.mjs`).
- **These must NOT be bumped.** Restamping a job submitted under v4 with today's version fabricates
  provenance. The value is right; only the *name* was wrong, so
  `collect-multipage-ocr.mjs`'s constant is renamed `LEGACY_JOB_PROMPT_VERSION` and documented.

The twin exports the real `PROMPT_VERSION`, mirrored from the canonical and pinned by the parity
test, so a future bump can no longer be missed on the scripts side.

## Test

`tests/unit/ocr-result-parse.test.ts` runs both implementations over one fixture corpus, in both
option modes, and compares the vocabulary sets and `PROMPT_VERSION` directly. It runs under
`npm test`, which is what `.github/workflows/unit-tests.yml` invokes.

**The guard was verified firing**, not merely observed passing: reverting the twin's `i` flag and
dropping one vocabulary entry — the two drifts that actually existed in the real copies — fails 3
tests. It also pins behaviour the parity assertions alone would let both sides get wrong together,
including one wart of the lenient dialect that is recorded rather than fixed (prose printed between
two page blocks is appended to the earlier one, `</page>` marker included).

`npx tsc --noEmit` clean. Full suite: **243 files, 3,323 tests passing.**

## Out of scope

- **`parseDetectedImages` is not consolidated.** The scripts copies parse `<image>` sub-tags; the
  canonical parses JSON, which is what the current prompt asks for. These are different parsers,
  not a fork. Verified against production: of 200 sampled pages holding a `<detected-images>`
  block, **200 were JSON-shaped and 0 XML-shaped** — so the script-side function returns `[]` on
  every current-prompt page and the collectors silently record no detected images. Real bug, filed
  as **#4456**; a comment at each of the five copies now says so.
- **The page-type vocabulary gap itself** (#4455) — fixing it changes what the collectors write,
  which is a data decision, not a refactor.
- No batch collector was run against production. Verification was code diffing plus one read-only
  sample query.
- The other four items on the #3979 map. #3979 stays as the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd