### PR TITLE
Make book deletion structural, and book lookup two-keyed (#4450)

### DIFF
--- a/.claude/docs/invariants/book-deletion-and-identity.md
+++ b/.claude/docs/invariants/book-deletion-and-identity.md
@@ -1,0 +1,108 @@
+# Removing a book, and concluding one is missing
+
+**Read this when:** removing a document from `books`; writing a sweep that
+deletes, merges, or replaces book records; or investigating a report that a book
+has **vanished**.
+
+Materialized 2026-08-31 (#4450). Companion to
+[`../preservation-policy.md`](../preservation-policy.md), which governs whether a
+deletion should happen at all; this file governs how it happens and how you tell
+that one did.
+
+---
+
+## The two rules
+
+**1. `deleteBookArchived()` is the only way to remove a book.**
+`deleted_books` *is* the recovery path — `POST /api/books/restore/[id]` reads
+nothing else. A delete that skips it is unrecoverable **by design** and silent:
+nothing errors, no alarm fires, and the only way anyone finds out is a reader
+hitting a dead URL.
+
+- `src/lib/delete-book.ts` — `deleteBookArchived()`, `purgeBookUnarchived()`,
+  `findBookByEitherKey()`
+- `scripts/lib/delete-book.mjs` — the mirror for scripts (same arrangement as
+  `src/lib/r2-key.ts` / `scripts/lib/r2-key.mjs`; keep them in step by hand)
+
+The helper archives the book **and its pages**, re-reads the archive row, and
+only then deletes. If the archive is not readable it throws and leaves the book
+in place. `db.collection('books').deleteOne(...)` is the thing you don't call —
+a convention five scripts follow and one doesn't is not a guard.
+
+`purgeBookUnarchived()` exists for the deliberate, operator-confirmed permanent
+delete. It is named that way so an unrecoverable path cannot read like an
+ordinary `deleteOne` to the next person grepping.
+
+`moveToWarehouse()` in `src/lib/warehouse.ts` is the one bare `books.deleteOne`
+that is **not** a deletion — the record survives in `books_warehouse`. It now
+re-reads the warehouse copy before deleting, for the same reason.
+
+**2. A book has TWO keys. Look it up by both.**
+Importers mint them together — `{ _id: oid, id: oid.toHexString() }` — so `id`
+and `_id` normally agree. But a record that is **re-created** (restore,
+re-import, a recovery sweep) keeps its `id` and gets a **new `_id`**.
+
+Measured 2026-08-31: **16,343 books** are in that state, 14.6% of the corpus,
+concentrated on the days a recovery ran (5,000 on 2026-04-20, 2,051 on
+2026-03-24, 1,593 on 2026-04-12 …).
+
+`src/app/api/books/restore/[id]/route.ts` does this on purpose —
+`// Restore book (generate new _id to avoid conflicts)`. It is not a bug in the
+restore route; it is a fact about the corpus that every *reader* has to know.
+
+---
+
+## The tell — and why this needs a doc
+
+A book whose `_id` was re-minted is **invisible to an `_id`-only lookup while
+being alive, visible, fully paginated, and serving readers at its URL.** It
+reads as deletion without being one.
+
+That is exactly how **#4450** was filed: five books were reported "vanished from
+`books`, no `deleted_books` row, readers were on the pages." Every one of them
+was present the whole time — findable by `id`, four of them `visible: true`,
+all five with their complete page runs (352 / 246 / 520 / 1068 / 1046 pages).
+The lookup that declared them missing used `_id`. The absent ledger row was not
+evidence of a ledgerless delete; there had been no delete.
+
+The shape generalises: **a missing thing is not a missing behaviour.** Before
+reporting a record as lost, query it by every key it has, and check
+`books_warehouse` and `deleted_books` too. `findBookByEitherKey()` does all of
+this; use it rather than hand-rolling a lookup.
+
+---
+
+## The standing check
+
+`scripts/audit/books-delete-ledger-gap.mjs` — read-only, exits 1 on a real gap.
+
+It resolves every stored book reference that outlives the record —
+`entities.books[]`, `collections.sample_books[]`, `feedback.page`, and Supabase
+`books_catalog` — against **all** the keys, and reports three populations
+separately because they need opposite responses:
+
+| population | meaning | response |
+|---|---|---|
+| `live but _id-churned` | resolves by `id`, dead by `_id` | the record is fine, the *reader* of it is wrong |
+| `in deleted_books` | genuinely deleted, ledgered | recoverable via the restore route |
+| `UNRESOLVED` | no book under either key, no ledger row | possible real loss — investigate |
+
+Baseline, 2026-08-31: **0 unresolved** across 3,652,622 references.
+387,029 `entities.books[]` references and 16,413 Supabase catalog rows are
+`_id`-churned; 9,166 entity references point at properly ledgered deletions.
+
+Two things it deliberately does **not** do:
+
+- **Shortlinks are not covered.** `/q/…` codes are stateless — encoded in
+  `src/lib/shortlinks.ts`, never stored — so there is no set to enumerate.
+  Don't add a "shortlinks" lane expecting to find one.
+- **It does not fail on churn.** 16k records carry it historically; failing on
+  it would make the audit useless on its first run.
+
+**It confirms before it fails.** The first run reported 19 unresolved Supabase
+rows — all of which existed in Mongo, all imported during the twenty minutes the
+sweep was running. The key space is a snapshot; an active importer inserts books
+after the `books` cursor has passed and before Supabase is read. Every candidate
+is now re-checked individually against Mongo before being called a loss. Any
+audit that reads a large corpus while writers are live needs this pass, or it
+cries loss whenever an import is running and nobody trusts it again.

--- a/.claude/docs/invariants/book-deletion-and-identity.md
+++ b/.claude/docs/invariants/book-deletion-and-identity.md
@@ -47,8 +47,17 @@ concentrated on the days a recovery ran (5,000 on 2026-04-20, 2,051 on
 2026-03-24, 1,593 on 2026-04-12 …).
 
 `src/app/api/books/restore/[id]/route.ts` does this on purpose —
-`// Restore book (generate new _id to avoid conflicts)`. It is not a bug in the
-restore route; it is a fact about the corpus that every *reader* has to know.
+`// Restore book (generate new _id to avoid conflicts)` — and deletes the ledger
+row on success, which is why a re-created book leaves no trace in
+`deleted_books`. It is not a bug in that route; it is a fact about the corpus
+that every *reader* has to know.
+
+But **don't blame the restore route for the 16,343.** It stamps `restored_at`
+and `restored_from` on everything it writes, and only **15** books carry
+`restored_at` (all 2026-05-12). The rest were re-created by bulk recovery
+scripts and re-imports that preserved `created_at`, slug and pages while minting
+a fresh `_id`. The mechanism class is what matters — *any* path that re-creates a
+book document breaks every `_id`-keyed reference to it — not which script ran.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 
 **Data & corpus**
 - **Deleting anything, or "is it safe?" → `../preservation-policy.md`** (**TEXT is the irreplaceable half — 1.8% of bytes**)
+- Removing a book from `books`, or concluding one is MISSING → `book-deletion-and-identity.md` (**use `deleteBookArchived()`, never a raw `books.deleteOne`; and look a book up by `id` OR `_id` — 16,343 books have a re-minted `_id` and are invisible to an `_id`-only lookup while serving readers normally**)
 - Archivers/importers, `archived_photo`, "failed to fetch" triage → `archive-fetch-failures.md`
 - Quoting archive/R2 coverage, an archiver's "is this book done?" check, a new page-image field → `archive-coverage.md` (**"archived" is three questions — RECORD/FILE/MASTER; never sum them**)
 - Two artifacts that must line up (page images vs OCR, splits vs text) → `paired-artifacts.md`

--- a/scripts/audit/books-delete-ledger-gap.mjs
+++ b/scripts/audit/books-delete-ledger-gap.mjs
@@ -67,9 +67,6 @@ const JSON_OUT = args.includes('--json') ? args[args.indexOf('--json') + 1] : nu
 const NO_SUPABASE = args.includes('--no-supabase');
 const SAMPLE = args.includes('--sample');
 
-const uri = process.env.MONGODB_URI;
-if (!uri) { console.error('MONGODB_URI not set — cannot audit. This is UNKNOWN, not clean.'); process.exit(2); }
-
 const HEX24 = /^[0-9a-f]{24}$/;
 
 /** Pull one book-id-shaped token out of a reader path like /book/<id>/page/3. */
@@ -79,9 +76,15 @@ export function bookIdFromPath(path) {
   return m ? decodeURIComponent(m[1]) : null;
 }
 
-const client = new MongoClient(uri);
+let client;
 
 async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set — cannot audit. This is UNKNOWN, not clean.');
+    return 2;
+  }
+  client = new MongoClient(uri);
   await client.connect();
   const db = client.db('bookstore');
 
@@ -293,13 +296,21 @@ async function main() {
   return allUnresolved.size === 0 ? 0 : 1;
 }
 
-let code = 2;
-try {
-  code = await main();
-} catch (err) {
-  console.error('audit failed (UNKNOWN, not clean):', err.message);
-  code = 2;
-} finally {
-  await client.close().catch(() => {});
+// Run only when invoked directly. `bookIdFromPath` is exported for reuse, and
+// a module that sweeps the corpus and calls process.exit() the moment someone
+// imports it is not reusable — importing it once already cost a full run.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  let code = 2;
+  try {
+    code = await main();
+  } catch (err) {
+    console.error('audit failed (UNKNOWN, not clean):', err.message);
+    code = 2;
+  } finally {
+    await client?.close().catch(() => {});
+  }
+  process.exit(code);
 }
-process.exit(code);

--- a/scripts/audit/books-delete-ledger-gap.mjs
+++ b/scripts/audit/books-delete-ledger-gap.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * Audit: every stored reference to a book must still resolve, and every book
+ * that left `books` must have left a row in `deleted_books` (#4450).
+ *
+ * THE TWO INVARIANTS
+ *   1. LEDGER — a book removed from `books` is archived to `deleted_books`
+ *      first. That collection *is* the recovery path (`POST /api/books/restore/[id]`),
+ *      so a delete that skips it is unrecoverable by design and silent.
+ *      Route every removal through `deleteBookArchived()` (src/lib/warehouse.ts
+ *      `softDeleteBook`, or scripts/lib/delete-book.mjs) — never a raw
+ *      `books.deleteOne` / `deleteMany`.
+ *   2. IDENTITY — a book's Mongo `_id` is minted once and never changes.
+ *      Importers write `{ _id: oid, id: oid.toHexString() }`, so `id` and `_id`
+ *      agree for the life of the record. A document that comes back with a NEW
+ *      `_id` (restore, re-import, warehouse round-trip) keeps its `id` and
+ *      breaks every reference anyone stored as `_id`.
+ *
+ * WHY IT MATTERS — the incident this audit exists for (#4450)
+ *   Five books were reported "vanished from `books` with no `deleted_books`
+ *   row", found via feedback rows whose reader had been on the page. All five
+ *   were in fact ALIVE, visible, and fully paginated. They had simply been
+ *   re-created with a fresh `_id`, and the lookup that declared them missing
+ *   used `_id`. A book whose `_id` was re-minted is invisible to any `_id`
+ *   lookup while remaining perfectly readable at its URL — it reads as deletion
+ *   without being one, and no alarm can fire because nothing failed.
+ *
+ *   So the honest question is not "is it in `books`?" but "does every stored
+ *   reference still resolve, by EITHER key?" This audit answers that, and
+ *   separates the two populations, because they need opposite responses:
+ *     - unresolved by either key  -> possible real loss; check `deleted_books`.
+ *     - resolves by `id` but not `_id` -> identity churn; the record is fine,
+ *       the *reader* of it is wrong.
+ *
+ * WHAT IT MEASURES
+ *   Denominators, each read-only, over references that outlive the record:
+ *     (a) `entities.books[].book_id`
+ *     (b) `collections.sample_books[].id`
+ *     (c) `feedback` rows whose `page` path names a book
+ *     (d) Supabase `books_catalog` rows with no Mongo twin
+ *   Plus the corpus-wide identity-churn cohort and the `deleted_books` health
+ *   line (row count, newest `deleted_at`) that made the original report look
+ *   like a broken ledger.
+ *
+ *   Shortlinks (`/q/…`) are deliberately absent: they are stateless — encoded
+ *   in the code itself (`src/lib/shortlinks.ts`), never stored — so there is no
+ *   set of them to enumerate.
+ *
+ * USAGE
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/books-delete-ledger-gap.mjs
+ *   node scripts/audit/books-delete-ledger-gap.mjs --json out.json
+ *   node scripts/audit/books-delete-ledger-gap.mjs --no-supabase
+ *
+ * Exits 1 when a reference resolves by neither key (possible real loss),
+ * 0 otherwise. Identity churn is REPORTED, not failed — 16k+ records carry it
+ * historically, so failing on it would make the audit useless on day one.
+ * Exits 2 when it cannot reach the database: that is UNKNOWN, not clean.
+ *
+ * READ-ONLY — it never writes to Mongo, Supabase, or R2.
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import fs from 'fs';
+
+const args = process.argv.slice(2);
+const JSON_OUT = args.includes('--json') ? args[args.indexOf('--json') + 1] : null;
+const NO_SUPABASE = args.includes('--no-supabase');
+const SAMPLE = args.includes('--sample');
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set — cannot audit. This is UNKNOWN, not clean.'); process.exit(2); }
+
+const HEX24 = /^[0-9a-f]{24}$/;
+
+/** Pull one book-id-shaped token out of a reader path like /book/<id>/page/3. */
+export function bookIdFromPath(path) {
+  if (typeof path !== 'string') return null;
+  const m = path.match(/\/book\/([^/?#]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+const client = new MongoClient(uri);
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // ── The resolvable key space ────────────────────────────────────────────
+  // A reference resolves if it names a live book by ANY of its public keys.
+  // Warehoused books are live-but-parked, not deleted; deleted_books rows are
+  // recoverable. Both count as "accounted for", and are tracked separately so
+  // the report can say WHICH.
+  const live = { id: new Set(), _id: new Set(), slug: new Set() };
+  const warehouse = new Set();
+  const ledger = new Set();
+
+  for await (const b of db.collection('books').find({}, { projection: { id: 1, slug: 1 } })) {
+    if (b.id) live.id.add(String(b.id));
+    live._id.add(String(b._id));
+    if (b.slug) live.slug.add(String(b.slug));
+  }
+  for await (const b of db.collection('books_warehouse').find({}, { projection: { id: 1 } })) {
+    warehouse.add(String(b._id));
+    if (b.id) warehouse.add(String(b.id));
+  }
+  for await (const b of db.collection('deleted_books').find({}, { projection: { id: 1, original_id: 1 } })) {
+    ledger.add(String(b._id));
+    if (b.id) ledger.add(String(b.id));
+    if (b.original_id) ledger.add(String(b.original_id));
+  }
+
+  const classify = (ref) => {
+    const r = String(ref);
+    if (live.id.has(r) || live.slug.has(r)) return live._id.has(r) ? 'live' : 'live_id_only';
+    if (live._id.has(r)) return 'live';
+    if (warehouse.has(r)) return 'warehoused';
+    if (ledger.has(r)) return 'in_ledger';
+    return 'unresolved';
+  };
+
+  const sources = {};
+  const addRef = (source, ref, evidence) => {
+    if (!ref) return;
+    const s = (sources[source] ||= { total: 0, live: 0, live_id_only: 0, warehoused: 0, in_ledger: 0, unresolved: 0, unresolved_refs: new Map(), churn_refs: new Set() });
+    s.total++;
+    const verdict = classify(ref);
+    s[verdict]++;
+    if (verdict === 'unresolved') {
+      if (!s.unresolved_refs.has(String(ref))) s.unresolved_refs.set(String(ref), evidence || null);
+    } else if (verdict === 'live_id_only') {
+      s.churn_refs.add(String(ref));
+    }
+  };
+
+  // (a) entities.books[].book_id
+  const entCursor = db.collection('entities').find({}, { projection: { books: 1, name: 1 } });
+  for await (const e of entCursor) {
+    for (const b of e.books || []) addRef('entities.books[]', b.book_id, { entity: e.name, title: b.book_title });
+  }
+
+  // (b) collections.sample_books[].id
+  for await (const col of db.collection('collections').find({}, { projection: { sample_books: 1, slug: 1 } })) {
+    for (const b of col.sample_books || []) addRef('collections.sample_books[]', b.id, { collection: col.slug, title: b.title });
+  }
+
+  // (c) feedback rows naming a book in their page path
+  for await (const f of db.collection('feedback').find({}, { projection: { page: 1, created_at: 1, message: 1 } })) {
+    const ref = bookIdFromPath(f.page);
+    if (ref) addRef('feedback.page', ref, { created_at: f.created_at, page: f.page });
+  }
+
+  // (d) Supabase books_catalog rows with no Mongo twin
+  let supabase = { checked: false, reason: 'skipped (--no-supabase)' };
+  if (!NO_SUPABASE) {
+    const url = process.env.SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) {
+      supabase = { checked: false, reason: 'SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — UNKNOWN, not clean' };
+    } else {
+      const { createClient } = await import('@supabase/supabase-js');
+      const sb = createClient(url, key);
+      // supabase-js silently caps every response at 1,000 rows — paginate.
+      const PAGE = 1000;
+      let from = 0, rows = 0;
+      for (;;) {
+        const { data, error } = await sb.from('books_catalog').select('id,slug,title').range(from, from + PAGE - 1);
+        if (error) { supabase = { checked: false, reason: `supabase error: ${error.message}` }; break; }
+        if (!data || data.length === 0) break;
+        for (const r of data) addRef('supabase.books_catalog', r.id, { slug: r.slug, title: r.title });
+        rows += data.length;
+        if (data.length < PAGE) break;
+        from += PAGE;
+        if (SAMPLE && rows >= 5000) break;
+      }
+      if (supabase.checked !== false || !supabase.reason?.startsWith('supabase error')) {
+        supabase = { checked: true, rows };
+      }
+    }
+  }
+
+  // ── Corpus-wide identity churn ──────────────────────────────────────────
+  // `id` is a 24-hex ObjectId string that does NOT equal this document's own
+  // `_id`. Since importers mint them together, that means the document was
+  // re-created at some point and every reference stored as `_id` is now dead.
+  const churn = { total: 0, byRemintDay: {} };
+  for await (const b of db.collection('books').find(
+    { id: { $type: 'string' } }, { projection: { id: 1 } }
+  )) {
+    const id = String(b.id);
+    if (!HEX24.test(id)) continue;
+    if (id === String(b._id)) continue;
+    churn.total++;
+    const day = b._id.getTimestamp().toISOString().slice(0, 10);
+    churn.byRemintDay[day] = (churn.byRemintDay[day] || 0) + 1;
+  }
+  churn.topRemintDays = Object.entries(churn.byRemintDay).sort((a, b) => b[1] - a[1]).slice(0, 10);
+  delete churn.byRemintDay;
+
+  // ── deleted_books health ────────────────────────────────────────────────
+  const ledgerRows = await db.collection('deleted_books').countDocuments({});
+  const newest = await db.collection('deleted_books').find({}, { projection: { deleted_at: 1 } })
+    .sort({ deleted_at: -1 }).limit(1).next();
+
+  // ── CONFIRMATION PASS ───────────────────────────────────────────────────
+  // Re-check every apparently-unresolved reference against Mongo directly,
+  // BEFORE reporting.
+  //
+  // The key space above is a snapshot taken while the corpus was being written
+  // to. An import running during the sweep inserts books AFTER the `books`
+  // cursor has passed them but BEFORE Supabase is read, so its rows arrive
+  // looking like orphans. The first run of this audit produced exactly that:
+  // 19 "unresolved" catalog rows, all present in Mongo, all imported in the
+  // twenty minutes the sweep was running.
+  //
+  // An audit that cries loss whenever an importer is active is an audit nobody
+  // trusts. One query per candidate, and there should never be many.
+  const raced = new Set();
+  for (const s of Object.values(sources)) {
+    for (const ref of [...s.unresolved_refs.keys()]) {
+      if (raced.has(ref)) { s.unresolved--; s.unresolved_refs.delete(ref); continue; }
+      const or = [{ id: ref }, { slug: ref }];
+      if (HEX24.test(ref)) or.push({ _id: new ObjectId(ref) });
+      const found =
+        (await db.collection('books').findOne({ $or: or }, { projection: { _id: 1 } })) ||
+        (await db.collection('books_warehouse').findOne({ id: ref }, { projection: { _id: 1 } })) ||
+        (await db.collection('deleted_books').findOne({ id: ref }, { projection: { _id: 1 } }));
+      if (found) {
+        raced.add(ref);
+        s.unresolved--;
+        s.unresolved_refs.delete(ref);
+      }
+    }
+  }
+
+  // ── Report ──────────────────────────────────────────────────────────────
+  const report = {
+    generated_at: new Date().toISOString(),
+    books_live: live.id.size,
+    books_warehoused: warehouse.size,
+    deleted_books_rows: ledgerRows,
+    deleted_books_newest: newest?.deleted_at?.toISOString?.() || null,
+    identity_churn: churn,
+    supabase,
+    sources: {},
+  };
+
+  console.log('=== books delete-ledger + identity gap (#4450) ===\n');
+  console.log(`books (live):        ${live.id.size}`);
+  console.log(`books_warehouse:     ${warehouse.size / 2 | 0} (approx, keyed twice)`);
+  console.log(`deleted_books rows:  ${ledgerRows}  newest deleted_at: ${report.deleted_books_newest}`);
+  console.log(`\nidentity churn (books whose _id was re-minted): ${churn.total}`);
+  for (const [day, n] of churn.topRemintDays) console.log(`   ${day}  ${n}`);
+  console.log('\nreference resolution by source:');
+  for (const [name, s] of Object.entries(sources)) {
+    console.log(`\n  ${name}`);
+    console.log(`    references:            ${s.total}`);
+    console.log(`    live:                  ${s.live}`);
+    console.log(`    live but _id-churned:  ${s.live_id_only}   (resolve by \`id\`, dead by \`_id\`)`);
+    console.log(`    warehoused:            ${s.warehoused}`);
+    console.log(`    in deleted_books:      ${s.in_ledger}   (recoverable)`);
+    console.log(`    UNRESOLVED:            ${s.unresolved}`);
+    const sample = [...s.unresolved_refs.entries()].slice(0, 5);
+    for (const [ref, ev] of sample) console.log(`       e.g. ${ref} ${ev ? JSON.stringify(ev).slice(0, 160) : ''}`);
+    report.sources[name] = {
+      total: s.total, live: s.live, live_id_only: s.live_id_only,
+      warehoused: s.warehoused, in_ledger: s.in_ledger, unresolved: s.unresolved,
+      unresolved_sample: sample.map(([ref, ev]) => ({ ref, evidence: ev })),
+      churn_sample: [...s.churn_refs].slice(0, 20),
+    };
+  }
+
+  // Deduplicated corpus-wide count of references that resolve nowhere.
+  const allUnresolved = new Set();
+  for (const s of Object.values(sources)) for (const ref of s.unresolved_refs.keys()) allUnresolved.add(ref);
+  if (raced.size) {
+    console.log(`\nnote: ${raced.size} reference(s) looked unresolved in the snapshot but exist on re-check`);
+    console.log('      — a writer was active during the sweep; not loss.');
+  }
+  report.raced_recheck = raced.size;
+  report.unresolved_unique = allUnresolved.size;
+  report.unresolved_ids = [...allUnresolved];
+  console.log(`\nUNIQUE unresolved book references across all sources: ${allUnresolved.size}`);
+  console.log(
+    allUnresolved.size === 0
+      ? '\nOK — every stored reference resolves to a live, warehoused, or ledgered book.'
+      : '\nFAIL — the ids above name no book under either key and no ledger row. Investigate before re-import.'
+  );
+
+  if (JSON_OUT) {
+    fs.writeFileSync(JSON_OUT, JSON.stringify(report, null, 2));
+    console.log(`\nwrote ${JSON_OUT}`);
+  }
+  return allUnresolved.size === 0 ? 0 : 1;
+}
+
+let code = 2;
+try {
+  code = await main();
+} catch (err) {
+  console.error('audit failed (UNKNOWN, not clean):', err.message);
+  code = 2;
+} finally {
+  await client.close().catch(() => {});
+}
+process.exit(code);

--- a/scripts/lib/delete-book.mjs
+++ b/scripts/lib/delete-book.mjs
@@ -1,0 +1,136 @@
+/**
+ * The one way a SCRIPT removes a book from `books` (#4450).
+ *
+ * Mirror of `src/lib/delete-book.ts` — same rules, same shape, kept in step by
+ * hand (the two runtimes don't share a module graph; `scripts/lib/r2-key.mjs`
+ * and `src/lib/r2-key.ts` are the same arrangement).
+ *
+ * THE RULE
+ *   `deleted_books` IS the recovery path (`POST /api/books/restore/[id]`).
+ *   A delete that skips it is unrecoverable by design and silent. So archive
+ *   and delete are one call, and the delete does not happen until the archive
+ *   row has been read back.
+ *
+ *   Call `deleteBookArchived()`. `db.collection('books').deleteOne(...)` is the
+ *   thing you don't call.
+ *
+ * THE OTHER HALF — look a book up by EITHER key
+ *   A book has two identifiers: `_id`, and the `id` field holding its hex.
+ *   Importers mint them together, but a re-created record (restore, re-import,
+ *   recovery sweep) keeps `id` and gets a NEW `_id`; 16k+ books here are in
+ *   that state. A lookup keyed only on `_id` returns nothing for a book that is
+ *   alive and serving readers — which is exactly how #4450 came to be filed
+ *   against five books that had never left. Use `findBookByEitherKey()`.
+ */
+
+import { ObjectId } from 'mongodb';
+
+/**
+ * Find a book by `id` OR `_id`, in that order — `id` is the key that survives
+ * a re-create, so it is the one worth trusting first.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {string|ObjectId} ref
+ * @param {object} [scope] extra filter, e.g. `{ tenantId }`
+ * @returns {Promise<object|null>}
+ */
+export async function findBookByEitherKey(db, ref, scope = {}) {
+  const s = String(ref);
+  const byId = await db.collection('books').findOne({ ...scope, id: s });
+  if (byId) return byId;
+  if (ObjectId.isValid(s)) {
+    return db.collection('books').findOne({ ...scope, _id: new ObjectId(s) });
+  }
+  return null;
+}
+
+/**
+ * Archive a book and its pages to `deleted_books`, verify the archive row reads
+ * back, then remove the book and its pages from the live collections.
+ *
+ * Throws instead of deleting when the archive cannot be re-read — a failed
+ * archive must leave the book in place.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {string|ObjectId|object} ref  a book doc, or an `id`/`_id` naming one
+ * @param {string} reason  recorded on the archive row; say who and why
+ * @param {{scope?: object, stamp?: object}} [opts]
+ * @returns {Promise<{bookId: string, title?: string, pagesArchived: number, archiveId: ObjectId}|null>}
+ */
+export async function deleteBookArchived(db, ref, reason, opts = {}) {
+  if (!reason || typeof reason !== 'string') {
+    throw new Error(
+      'deleteBookArchived: a reason is required — it is the only record of why a book left the shelf.'
+    );
+  }
+  const scope = opts.scope ?? {};
+
+  const book =
+    ref && typeof ref === 'object' && '_id' in ref
+      ? ref
+      : await findBookByEitherKey(db, ref, scope);
+  if (!book) return null;
+
+  const bookId = book.id || String(book._id);
+
+  const pages = await db
+    .collection('pages')
+    .find({ ...scope, book_id: bookId })
+    .maxTimeMS(30000)
+    .toArray();
+
+  const archiveId = new ObjectId();
+  await db.collection('deleted_books').insertOne({
+    ...book,
+    ...(opts.stamp ?? {}),
+    _id: archiveId,
+    pages,
+    deleted_at: new Date(),
+    deletion_reason: reason,
+    original_id: book._id,
+  });
+
+  const archived = await db
+    .collection('deleted_books')
+    .findOne({ _id: archiveId }, { projection: { _id: 1 } });
+  if (!archived) {
+    throw new Error(
+      `deleteBookArchived: archive row for ${bookId} is not readable after insert — refusing to delete. The book is untouched.`
+    );
+  }
+
+  await db.collection('pages').deleteMany({ ...scope, book_id: bookId });
+  await db.collection('books').deleteOne({ ...scope, _id: book._id });
+
+  return { bookId, title: book.title, pagesArchived: pages.length, archiveId };
+}
+
+/**
+ * Remove a book WITHOUT archiving it. Unrecoverable.
+ *
+ * Named so the deliberate permanent-delete path is recognisable as such rather
+ * than looking like an ordinary `deleteOne`. Everything else wants
+ * `deleteBookArchived()`.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {string|ObjectId|object} ref
+ * @param {string} reason
+ * @param {{scope?: object}} [opts]
+ */
+export async function purgeBookUnarchived(db, ref, reason, opts = {}) {
+  if (!reason || typeof reason !== 'string') {
+    throw new Error('purgeBookUnarchived: a reason is required.');
+  }
+  const scope = opts.scope ?? {};
+  const book =
+    ref && typeof ref === 'object' && '_id' in ref
+      ? ref
+      : await findBookByEitherKey(db, ref, scope);
+  if (!book) return null;
+
+  const bookId = book.id || String(book._id);
+  const pagesResult = await db.collection('pages').deleteMany({ ...scope, book_id: bookId });
+  await db.collection('books').deleteOne({ ...scope, _id: book._id });
+
+  return { bookId, title: book.title, pagesDeleted: pagesResult.deletedCount ?? 0 };
+}

--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -10,6 +10,7 @@ import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { isBookReadable, hiddenBookMetadataCard } from '@/lib/book-access';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
+import { deleteBookArchived, purgeBookUnarchived } from '@/lib/delete-book';
 
 export const preferredRegion = 'fra1';
 
@@ -138,23 +139,18 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
 
     const bookId = book.id || book._id.toString();
 
-    // SOFT DELETE by default - archive to deleted_books collection
+    // SOFT DELETE by default - archive to deleted_books collection.
+    // Goes through deleteBookArchived() so the archive row is read back before
+    // anything is removed — `deleted_books` IS the recovery path (#4450).
+    // `scope` keeps every read and write tenant-bound, exactly as before.
     if (!confirmPermanent) {
-      // Get all pages for archival
-      const pages = await db.collection('pages').find({ book_id: bookId, tenantId }).maxTimeMS(30000).toArray();
-
-      // Archive book with its pages
-      await db.collection('deleted_books').insertOne({
-        ...book,
-        pages,
-        tenantId,
-        deleted_at: new Date(),
-        original_id: book._id
-      });
-
-      // Remove from active collections
-      await db.collection('pages').deleteMany({ book_id: bookId, tenantId });
-      await db.collection('books').deleteOne({ _id: book._id, tenantId });
+      const deleted = await deleteBookArchived(
+        db,
+        book,
+        `tenant admin delete via DELETE /api/${tenant}/books/${id} (${session?.user?.email ?? 'unknown'})`,
+        { scope: { tenantId }, stamp: { tenantId } }
+      );
+      const pagesArchived = deleted?.pagesArchived ?? 0;
 
       // A deleted book must leave every SERVING surface, not just Mongo —
       // stale embedding/catalog rows kept surfacing deleted books in search
@@ -167,13 +163,13 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
         action: 'book_deleted',
         book_id: bookId,
         book_title: book.title,
-        pages_affected: pages.length,
+        pages_affected: pagesArchived,
         metadata: { recoverable: true, search_rows_pruned: pruned.every(p => !p.error) },
       });
 
       return NextResponse.json({
         success: true,
-        message: `Archived "${book.title}" with ${pages.length} pages`,
+        message: `Archived "${book.title}" with ${pagesArchived} pages`,
         bookId,
         recoverable: true,
         hint: 'POST /api/books/restore/{id} to recover — a restored book needs re-embedding before it surfaces in semantic search'
@@ -218,9 +214,16 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
       });
     }
 
-    // Book is not archived - permanent delete from active (should be rare)
-    const pagesResult = await db.collection('pages').deleteMany({ book_id: bookId, tenantId });
-    await db.collection('books').deleteOne({ _id: book._id, tenantId });
+    // Book is not archived - permanent delete from active (should be rare).
+    // Named `purgeBookUnarchived` so this deliberate, unrecoverable path can
+    // never be mistaken for an ordinary deleteOne when read or grepped (#4450).
+    const purged = await purgeBookUnarchived(
+      db,
+      book,
+      `tenant operator purge via DELETE /api/${tenant}/books/${id}?confirm=PERMANENTLY_DELETE (${session?.user?.email ?? 'unknown'})`,
+      { scope: { tenantId } }
+    );
+    const pagesResult = { deletedCount: purged?.pagesDeleted ?? 0 };
 
     // Same serving-surface prune as the soft-delete path (#4216).
     await pruneSearchRowsForDeletedBook(bookId);

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -13,6 +13,7 @@ import { isBookReadable, hiddenBookMetadataCard } from '@/lib/book-access';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
+import { deleteBookArchived, purgeBookUnarchived } from '@/lib/delete-book';
 
 export const preferredRegion = 'fra1';
 
@@ -174,35 +175,29 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
 
     const bookId = book.id || book._id.toString();
 
-    // SOFT DELETE by default - archive to deleted_books collection
+    // SOFT DELETE by default - archive to deleted_books collection.
+    // Goes through deleteBookArchived() so the archive row is read back before
+    // anything is removed — `deleted_books` IS the recovery path (#4450).
     if (!confirmPermanent) {
-      // Get all pages for archival
-      const pages = await db.collection('pages').find({ book_id: bookId }).maxTimeMS(30000).toArray();
-
-      // Archive book with its pages
-      await db.collection('deleted_books').insertOne({
-        ...book,
-        pages,
-        deleted_at: new Date(),
-        original_id: book._id
-      });
-
-      // Remove from active collections
-      await db.collection('pages').deleteMany({ book_id: bookId });
-      await db.collection('books').deleteOne({ _id: book._id });
+      const deleted = await deleteBookArchived(
+        db,
+        book,
+        `admin delete via DELETE /api/books/${id} (${session?.user?.email ?? 'unknown'})`
+      );
+      const pagesArchived = deleted?.pagesArchived ?? 0;
 
       // Audit log (non-blocking)
       logAuditEvent({
         action: 'book_deleted',
         book_id: bookId,
         book_title: book.title,
-        pages_affected: pages.length,
+        pages_affected: pagesArchived,
         metadata: { recoverable: true },
       });
 
       return NextResponse.json({
         success: true,
-        message: `Archived "${book.title}" with ${pages.length} pages`,
+        message: `Archived "${book.title}" with ${pagesArchived} pages`,
         bookId,
         recoverable: true,
         hint: 'POST /api/books/restore/{id} to recover'
@@ -246,21 +241,26 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
       });
     }
 
-    // Book is not archived - permanent delete from active (should be rare)
-    const pagesResult = await db.collection('pages').deleteMany({ book_id: bookId });
-    await db.collection('books').deleteOne({ _id: book._id });
+    // Book is not archived - permanent delete from active (should be rare).
+    // Named `purgeBookUnarchived` so this deliberate, unrecoverable path can
+    // never be mistaken for an ordinary deleteOne when read or grepped (#4450).
+    const purged = await purgeBookUnarchived(
+      db,
+      book,
+      `operator purge via DELETE /api/books/${id}?confirm=PERMANENTLY_DELETE (${session?.user?.email ?? 'unknown'})`
+    );
 
     logAuditEvent({
       action: 'book_deleted_permanent',
       book_id: bookId,
       book_title: book.title,
-      pages_affected: pagesResult.deletedCount,
+      pages_affected: purged?.pagesDeleted ?? 0,
       metadata: { recoverable: false, source: 'active' },
     });
 
     return NextResponse.json({
       success: true,
-      message: `PERMANENTLY deleted "${book.title}" and ${pagesResult.deletedCount} pages`,
+      message: `PERMANENTLY deleted "${book.title}" and ${purged?.pagesDeleted ?? 0} pages`,
       bookId,
       recoverable: false,
       warning: 'This action cannot be undone'

--- a/src/lib/delete-book.ts
+++ b/src/lib/delete-book.ts
@@ -1,0 +1,170 @@
+/**
+ * The one way to remove a book from `books` (#4450).
+ *
+ * THE RULE
+ *   `deleted_books` IS the recovery path — `POST /api/books/restore/[id]` reads
+ *   nothing else. A delete that skips it is unrecoverable *by design* and
+ *   silent: nothing errors, no alarm fires, and the only way anyone finds out
+ *   is a reader hitting a dead URL. So the archive write and the delete are one
+ *   operation, not two steps a caller is trusted to remember.
+ *
+ *   Call `deleteBookArchived()`. Treat `db.collection('books').deleteOne(...)`
+ *   as the thing you don't call — the same shape as `assertBookScopedKey` for
+ *   R2 keys (#3362/#3365). A convention five scripts follow and one doesn't is
+ *   not a guard; a helper that refuses to delete until it has re-read the
+ *   archive row is.
+ *
+ * THE OTHER HALF — look a book up by EITHER key
+ *   A book carries two identifiers: the Mongo `_id`, and the `id` field that
+ *   holds its hex string. Importers mint them together
+ *   (`{ _id: oid, id: oid.toHexString() }`), so they normally agree — but a
+ *   record that is re-created (restore, re-import, a recovery sweep) keeps its
+ *   `id` and gets a NEW `_id`. 16k+ books in this corpus are in that state.
+ *
+ *   A lookup keyed only on `_id` therefore returns nothing for a book that is
+ *   alive, visible, and serving readers at its URL. That is exactly how #4450
+ *   was filed: five books reported "vanished, no ledger row" were all present
+ *   the whole time, findable by `id`. `findBookByEitherKey()` is the fix, and
+ *   every delete path here goes through it.
+ *
+ * The mirror for `scripts/` is `scripts/lib/delete-book.mjs`. Keep them in step.
+ */
+
+import { Db, Document, ObjectId } from 'mongodb';
+
+export interface DeleteBookOptions {
+  /** Extra filter applied to every read and write, e.g. `{ tenantId }`. */
+  scope?: Document;
+  /** Extra fields stamped onto the `deleted_books` row, e.g. `{ tenantId }`. */
+  stamp?: Document;
+}
+
+export interface DeleteBookResult {
+  bookId: string;
+  title?: string;
+  /** Pages copied into the archive row and then removed from `pages`. */
+  pagesArchived: number;
+  /** `_id` of the `deleted_books` row — the handle the restore route needs. */
+  archiveId: ObjectId;
+}
+
+/**
+ * Find a book by `id` OR `_id`, in that order.
+ *
+ * Order matters: `id` is the stable, reader-facing key that survives a
+ * re-create; `_id` does not. Checking `id` first means a churned record is
+ * found by the key that still means something.
+ */
+export async function findBookByEitherKey(
+  db: Db,
+  ref: string | ObjectId,
+  scope: Document = {}
+): Promise<Document | null> {
+  const s = String(ref);
+  const byId = await db.collection('books').findOne({ ...scope, id: s });
+  if (byId) return byId;
+  if (ObjectId.isValid(s)) {
+    return db.collection('books').findOne({ ...scope, _id: new ObjectId(s) });
+  }
+  return null;
+}
+
+/**
+ * Archive a book (with its pages) to `deleted_books`, verify the archive row is
+ * readable, and only then remove the book and its pages from the live
+ * collections.
+ *
+ * Throws rather than deleting if the archive write cannot be read back — a
+ * failed archive must leave the book in place, never half-removed. The caller
+ * is expected to surface that error, not swallow it.
+ *
+ * @param ref   a book document, or an `id` / `_id` naming one
+ * @param reason free text recorded on the archive row; say who and why
+ */
+export async function deleteBookArchived(
+  db: Db,
+  ref: string | ObjectId | Document,
+  reason: string,
+  opts: DeleteBookOptions = {}
+): Promise<DeleteBookResult | null> {
+  if (!reason || typeof reason !== 'string') {
+    throw new Error(
+      'deleteBookArchived: a reason is required — it is the only record of why a book left the shelf.'
+    );
+  }
+  const scope = opts.scope ?? {};
+
+  const book =
+    typeof ref === 'object' && ref !== null && '_id' in ref
+      ? (ref as Document)
+      : await findBookByEitherKey(db, ref as string | ObjectId, scope);
+  if (!book) return null;
+
+  const bookId: string = book.id || String(book._id);
+
+  const pages = await db
+    .collection('pages')
+    .find({ ...scope, book_id: bookId })
+    .maxTimeMS(30000)
+    .toArray();
+
+  const archiveId = new ObjectId();
+  await db.collection('deleted_books').insertOne({
+    ...book,
+    ...(opts.stamp ?? {}),
+    _id: archiveId,
+    pages,
+    deleted_at: new Date(),
+    deletion_reason: reason,
+    original_id: book._id,
+  });
+
+  // Read the archive back before destroying the original. An insert that
+  // reported success but cannot be read is the one case where deleting would
+  // be unrecoverable, so it is the one case worth a second round trip.
+  const archived = await db.collection('deleted_books').findOne(
+    { _id: archiveId },
+    { projection: { _id: 1, id: 1 } }
+  );
+  if (!archived) {
+    throw new Error(
+      `deleteBookArchived: archive row for ${bookId} is not readable after insert — refusing to delete. The book is untouched.`
+    );
+  }
+
+  await db.collection('pages').deleteMany({ ...scope, book_id: bookId });
+  await db.collection('books').deleteOne({ ...scope, _id: book._id });
+
+  return { bookId, title: book.title, pagesArchived: pages.length, archiveId };
+}
+
+/**
+ * Remove a book WITHOUT archiving it. Unrecoverable.
+ *
+ * This exists so the deliberate permanent-delete path has a name a reader can
+ * recognise, instead of looking like an ordinary `deleteOne`. Reach for it only
+ * where an operator has explicitly asked for destruction; everything else wants
+ * `deleteBookArchived()`.
+ */
+export async function purgeBookUnarchived(
+  db: Db,
+  ref: string | ObjectId | Document,
+  reason: string,
+  opts: DeleteBookOptions = {}
+): Promise<{ bookId: string; title?: string; pagesDeleted: number } | null> {
+  if (!reason || typeof reason !== 'string') {
+    throw new Error('purgeBookUnarchived: a reason is required.');
+  }
+  const scope = opts.scope ?? {};
+  const book =
+    typeof ref === 'object' && ref !== null && '_id' in ref
+      ? (ref as Document)
+      : await findBookByEitherKey(db, ref as string | ObjectId, scope);
+  if (!book) return null;
+
+  const bookId: string = book.id || String(book._id);
+  const pagesResult = await db.collection('pages').deleteMany({ ...scope, book_id: bookId });
+  await db.collection('books').deleteOne({ ...scope, _id: book._id });
+
+  return { bookId, title: book.title, pagesDeleted: pagesResult.deletedCount ?? 0 };
+}

--- a/src/lib/warehouse.ts
+++ b/src/lib/warehouse.ts
@@ -10,6 +10,7 @@
  */
 
 import { Db, Document } from 'mongodb';
+import { deleteBookArchived } from './delete-book';
 
 /** Statuses that belong in the warehouse */
 export const WAREHOUSE_STATUSES = ['archiving', 'archive_complete'] as const;
@@ -45,7 +46,22 @@ export async function moveToWarehouse(db: Db, bookId: string): Promise<boolean> 
     await db.collection('pages_warehouse').bulkWrite(bulkOps, { ordered: false });
   }
 
-  // Delete from live collections only after warehouse write succeeds
+  // Delete from live collections only after the warehouse copy is READABLE.
+  // This is the one bare `books.deleteOne` that is not a deletion — the record
+  // still exists, in `books_warehouse`. That makes it safe only for as long as
+  // the copy is really there, so re-read it rather than trusting the write
+  // (#4450). A book that vanishes from `books` with no warehouse row and no
+  // `deleted_books` row is unrecoverable and nothing downstream can tell.
+  const parked = await db.collection('books_warehouse').findOne(
+    { id: bookId },
+    { projection: { _id: 1 } }
+  );
+  if (!parked) {
+    throw new Error(
+      `moveToWarehouse: warehouse copy of ${bookId} is not readable after write — refusing to delete from books. The book is untouched.`
+    );
+  }
+
   await db.collection('pages').deleteMany({ book_id: bookId });
   await db.collection('books').deleteOne({ id: bookId });
 
@@ -109,8 +125,14 @@ export async function findBookAnywhere(
 
 /**
  * Soft-delete a book: archives to deleted_books, then removes from live.
- * ALWAYS use this instead of raw deleteOne/deleteMany on books.
- * Returns the deleted book document for verification.
+ *
+ * Thin wrapper over `deleteBookArchived()` (src/lib/delete-book.ts), which is
+ * the canonical archive-then-delete helper — see #4450. The archive row is read
+ * back before anything is removed, and the lookup accepts `id` OR `_id`, so a
+ * book whose `_id` was re-minted by a restore/re-import is still found.
+ *
+ * Kept as a named export because callers and docs refer to it; new code should
+ * call `deleteBookArchived()` directly. Returns the deleted book document.
  */
 export async function softDeleteBook(
   db: Db,
@@ -120,20 +142,7 @@ export async function softDeleteBook(
   const book = await db.collection('books').findOne({ id: bookId });
   if (!book) return null;
 
-  // Archive to deleted_books with metadata
-  await db.collection('deleted_books').replaceOne(
-    { id: bookId },
-    {
-      ...book,
-      deleted_at: new Date(),
-      deletion_reason: reason,
-    },
-    { upsert: true }
-  );
-
-  // Remove pages and book from live AFTER archive succeeds
-  await db.collection('pages').deleteMany({ book_id: bookId });
-  await db.collection('books').deleteOne({ id: bookId });
+  await deleteBookArchived(db, book, reason);
 
   // Audit log
   await db.collection('audit_log').insertOne({


### PR DESCRIPTION
Closes the investigation half of #4450 and ships the structural guard.

## The finding: the five books were never deleted

All five are alive in `books` right now. Four are `visible: true`. Every one has its complete page run.

| book | `id` (live) | pages | visible |
|---|---|---|---|
| Storia della letteratura italiana 15 | `69b51e2ccf111105c4297ca3` | 352 | yes |
| Poemander / Asclepius (e-rara) | `69bd9cdd6120d54bd0371648` | 246 | hidden (`unprocessed`) |
| Vossius, De universae Mathesios | `69b51e4d768235dc6598fc63` | 520 | yes |
| Böhme, Theosophia Revelata 2 | `69b51e98cf111105c42a0dd1` | 1068 | yes |
| Artis Cabalisticae 1 | `69b51e44768235dc6598e757` | 1046 | yes |

The issue looked them up by Mongo `_id`. Their reader-facing key is the **`id` field**. Those two agree at import (`{ _id: oid, id: oid.toHexString() }`) but diverge whenever a record is **re-created** — restore, re-import, recovery sweep. All five were re-created on **2026-04-12**, keeping `id`, getting a new `_id`.

**16,343 books** (14.6% of the corpus) are in that state, clustered on recovery days: 5,000 on 2026-04-20, 2,051 on 2026-03-24, 1,781 on 2026-03-27, 1,593 on 2026-04-12.

So the absent `deleted_books` row was not evidence of a ledgerless delete. There had been no delete. `src/app/api/books/restore/[id]/route.ts` mints the new `_id` on purpose (`// generate new _id to avoid conflicts`) and removes the ledger row on success — which is why the ledger looks quiet and the record looks gone.

## Measured scope: zero real losses

`scripts/audit/books-delete-ledger-gap.mjs`, run against production today:

```
                              refs        live   _id-churned   ledgered   UNRESOLVED
entities.books[]         3,540,139   3,143,299       387,029      9,166            0
collections.sample_books     1,224       1,193            31          0            0
feedback.page                  251         154            97          0            0
supabase.books_catalog     111,008      94,595        16,413          0            0
```

**0 unresolved** across 3,652,622 references. Not one stored reference names a book that exists nowhere.

The 9,166 ledgered entity references are ordinary recorded deletions, recoverable via the restore route. The 403,570 churned references are the real defect surface: they resolve fine by `id` and are dead by `_id`.

Shortlinks are absent as a denominator by design — `/q/…` codes are stateless, encoded in `src/lib/shortlinks.ts` and never stored, so there is no set to enumerate.

## In scope

- **`src/lib/delete-book.ts` + `scripts/lib/delete-book.mjs`** — `deleteBookArchived()` archives book + pages to `deleted_books`, **re-reads the archive row**, and only then deletes. If the archive is not readable it throws and leaves the book untouched. `purgeBookUnarchived()` names the deliberate unrecoverable path so it cannot read like an ordinary `deleteOne`. `findBookByEitherKey()` checks `id` first, `_id` second. Two runtimes, hand-mirrored — same arrangement as `src/lib/r2-key.ts` / `scripts/lib/r2-key.mjs`.
- **Routed through it**, behaviour-preserving: `softDeleteBook()` in `warehouse.ts`, and the soft-delete + permanent-from-active branches of both `DELETE /api/books/[id]` and `DELETE /api/[tenant]/books/[id]` (tenant scoping preserved via `opts.scope`).
- **`moveToWarehouse()`** keeps its bare `deleteOne` — the record survives in `books_warehouse`, so it isn't a deletion — but now re-reads the warehouse copy before deleting.
- **`scripts/audit/books-delete-ledger-gap.mjs`** — read-only standing check, exits 1 on a real gap, 2 when it can't reach the DB (UNKNOWN, not clean).
- **`.claude/docs/invariants/book-deletion-and-identity.md`** + one routing line in `CLAUDE.md`.

### The audit confirms before it fails

Its first run reported 19 unresolved Supabase rows. All 19 existed in Mongo, all imported during the twenty minutes the sweep was running (710 books were imported in the surrounding six hours). The key space is a snapshot built before Supabase is read, so an active importer manufactures phantom orphans. Every candidate is now re-checked individually against Mongo before being called a loss. An audit that cries loss whenever an import is running is an audit nobody trusts on the day it matters.

## Out of scope, deliberately

- **No data writes of any kind.** This was a read-only investigation; nothing was deleted, modified, or restored.
- **No recovery or re-import** — nothing is missing, so there is nothing to recover.
- **The 403,570 churned references are not repaired.** Rewriting stored `_id` references to `id` across `entities`, Supabase, and elsewhere is a data migration with its own blast radius, and it needs its own issue and its own review. This PR makes the condition *measurable and named*; it does not touch the rows.
- **The restore route still mints a new `_id`.** Changing that is a semantics decision about identity (and about `_id` collisions with a live record), not a guard. Worth an issue; not worth smuggling into this one.
- **28 scripts still `bare-insert`/bare-delete.** Only `src/` paths are routed through the helper here, where the swap is clean and behaviour-preserving. Migrating scripts is mechanical follow-up work that would have doubled this diff.
- **The seven feedback rows still need human replies.** Seven people asked for a translation and were told, in effect, nothing. They are owed a real answer — and the good news is that the pages they asked about are all live. No email was sent from this session.

## Verification

- `npx tsc --noEmit` clean.
- Audit run end-to-end against production: exit 0, numbers above.
- Every claim here is from a query whose output is quoted, not from a shape in the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd
