### PR TITLE
Language filters on semantic search are a post-filter over HNSW candidates (#4439)

### DIFF
--- a/.claude/docs/embeddings.md
+++ b/.claude/docs/embeddings.md
@@ -32,9 +32,10 @@ language is a key, not a feature.
 - **The vector index is PARTIAL, one per language** (`page_texts_embedding_es_idx`).
   HNSW returns the globally nearest N and filters afterwards, so a shared index
   plus `WHERE lang = 'es'` would strip results to zero whenever the true
-  neighbours are in another language — the same cross-lingual bug fixed in
-  `match_semantic` in May 2026. A partial index makes it structurally
-  impossible. **Adding a language means running
+  neighbours are in another language — the same cross-lingual bug `match_semantic`
+  was believed to have fixed in May 2026 and had not (#4439). A partial index
+  makes it structurally impossible, which is why this half is sound and the
+  branch-based half was not. **Adding a language means running
   `scripts/migration/add-page-texts-table.mjs --lang=<iso>` again**; until you
   do, that language is searched by sequential scan (correct, just slower).
 - **There is a lexical lane too**, which the English store does not have here:
@@ -108,6 +109,36 @@ Baseline at 2026-05-26 (after first cleanup pass): 338 truly orphaned rows total
 - Page-level: `node scripts/workers/embed-gemini.mjs --book <id>` re-embeds a specific book.
 - Book-level: enrich-worker Phase 6.5 handles it during enrichment. To force, re-run enrichment for the book.
 - Artwork / gallery / clip: idempotent backfill scripts in `scripts/migration/` — delete the row(s) and re-run the cron.
+
+### A language filter over an HNSW index is a post-filter until proven otherwise (#4439)
+
+**Rule: an `ORDER BY embedding <=> q LIMIT n` with a WHERE predicate is a
+post-filter, whatever the surrounding code says.** The predicate runs on
+candidates the index already chose, so the filter's recall tracks that value's
+share of the table rather than the query. `match_semantic`, `match_page_texts`
+and `match_books_semantic` all have this shape, and `match_semantic` carried a
+comment claiming it had been fixed in May 2026 — a plpgsql `IF` branch that ends
+in the same `ORDER BY`. A branch is not a plan.
+
+**Tell:** the dominant language works perfectly and a non-dominant one returns
+zero — *fast*. 60ms is not a scan of 4.5M rows; it is an index scan whose
+candidates all failed the filter. Measured 2026-08-31: Chinese (2.2% of
+`page_translations`), Arabic (1.2%) and Sanskrit (3.2%) filters returned 0 rows
+on queries the corpus answers well, while Latin (36%) returned a full page.
+
+**How to test it:** never with the dominant value. Assert that a filter for a
+NON-dominant value returns rows on a query whose unfiltered hits are all
+elsewhere — `scripts/audit/semantic-language-filter-recall.mjs`. And control the
+instrument: check the rows exist in the TABLE, and that the unfiltered arm
+returns something, before reading an empty filtered result as a defect.
+
+**The two structural fixes**, in preference order: a PARTIAL index per value, so
+the predicate matches the index predicate and the scan happens inside it (what
+`page_texts` does for `lang`); or pgvector's `hnsw.iterative_scan` (≥ 0.8.0),
+which keeps walking the graph until enough rows survive the filter. A
+fenced exact pre-filter (`OFFSET 0` + `enable_indexscan = off`) is correct on any
+version but costs a scan of everything the predicate admits — 47.6s measured for
+an `exclude_languages` query. Migration: `scripts/migration/fix-semantic-language-prefilter.sql`.
 
 ### Index health
 The HNSW index has to be present and the planner has to choose it — `CREATE INDEX` succeeds silently even when it produces an unusable index above the dim cap. Always `EXPLAIN ANALYZE` a real `match_*` query after touching a vector column or index. See `lesson_pgvector_hnsw_dim_cap.md` and `lesson_silent_probe_failures.md`.

--- a/.claude/docs/invariants/search-filters-and-lanes.md
+++ b/.claude/docs/invariants/search-filters-and-lanes.md
@@ -121,3 +121,46 @@ Three traps, all of which bit during the fix:
 Corollary for counting, not just serving: any aggregate over `books` inflates
 unless it excludes artworks. A naive author query for "William Blake" returns
 777 records, of which **776 are prints and drawings**.
+
+---
+
+## A filter over a vector index is a post-filter until proven otherwise (#4439)
+
+`ORDER BY embedding <=> query LIMIT n` plus a WHERE predicate does not filter
+then rank. It ranks — via the HNSW index — then filters what the index handed
+back. So the predicate's **recall tracks that value's share of the table, not
+the query**. On `page_translations` that means Latin (36% of rows) filters
+perfectly and Chinese (2.2%) returns nothing, on the same query, in 60ms.
+
+Three things generalise past this table:
+
+- **A branch is not a plan.** `match_semantic` had carried, since 2026-05-17, a
+  correct diagnosis of this exact bug and an `IF has_language_filter THEN`
+  branch written to avoid it. Both branches ended in the same `ORDER BY … LIMIT`,
+  so both used the index. The comment said sequential scan; the planner had
+  never heard of the comment. **Verify a plan change with `EXPLAIN ANALYZE`, or
+  by a latency that could only come from the plan you intended.**
+- **Fast zero is the tell.** No scan of 4.5M rows returns in 60ms. When a filter
+  returns empty far quicker than the work it claims to have done, it did not do
+  that work.
+- **Test with the rare value, never the common one.** A test that asserts
+  `language: 'Latin'` returns rows passes against the broken function. The
+  mechanism-pinning form is: a filter for a NON-dominant value must return rows
+  on a query whose unfiltered hits are all dominant —
+  `scripts/audit/semantic-language-filter-recall.mjs`. Control the instrument
+  too (do the rows exist in the table? does the unfiltered arm return anything?)
+  or you cannot tell a broken filter from an honest absence.
+
+Structural fixes, in preference order: a **partial index per value** so the
+predicate matches the index predicate (`page_texts` does this for `lang`);
+pgvector **`hnsw.iterative_scan`** (≥ 0.8.0), which keeps walking until enough
+rows survive; or a fenced exact pre-filter, which is correct on any version and
+costs a scan of everything the predicate admits. Details, measurements and the
+migration: `scripts/migration/fix-semantic-language-prefilter.sql` and
+`.claude/docs/embeddings.md`.
+
+This is at minimum a partial cause of #3514 — retrieval reproducing the very
+narrowing the library exists to undo. `exclude_languages` is documented on
+`search_concept` and `search_translations` as the way "to surface non-Western
+sources"; until this is fixed it does the opposite of that more reliably than
+it does it.

--- a/scripts/audit/semantic-language-filter-recall.mjs
+++ b/scripts/audit/semantic-language-filter-recall.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Does a language filter on semantic page search actually PRE-filter? (#4439)
+ *
+ * This pins a MECHANISM, not an output. The bug it exists to catch is not "a
+ * query returned nothing" — it is "the language predicate is applied to
+ * candidates an HNSW index has already chosen, so a filter's recall tracks that
+ * language's share of the table rather than the query." Under that failure the
+ * dominant language keeps working perfectly, which is why the defect survived a
+ * fix, a comment claiming the fix, and three months of use.
+ *
+ * The assertion is therefore deliberately awkward: for a query whose UNFILTERED
+ * top hits are all Western, filtering to a NON-DOMINANT language must still
+ * return rows. A test that only exercises Latin (36% of the table) passes
+ * against the broken function.
+ *
+ * There is also a positive control on the instrument itself, because "0 rows"
+ * from a filter and "0 rows" from a query nothing matches are the same shape:
+ *   - the unfiltered arm must return rows (the query works at all), and
+ *   - the target language must have rows in the corpus at all (checked against
+ *     the table, not inferred from the search returning nothing).
+ * If either control fails the run reports UNKNOWN and exits 2. An audit that
+ * cannot tell "broken" from "nothing there" is not measuring anything.
+ *
+ * Read-only. Runs one Gemini embedding call per probe query (~$0.000002 each).
+ *
+ *   node --env-file=.env.production.local scripts/audit/semantic-language-filter-recall.mjs
+ *   node --env-file=.env.production.local scripts/audit/semantic-language-filter-recall.mjs --rpc=match_semantic_prefilter_v2
+ *   node --env-file=.env.production.local scripts/audit/semantic-language-filter-recall.mjs --sweep
+ *   node --env-file=.env.production.local scripts/audit/semantic-language-filter-recall.mjs --dump-defs   # needs SUPABASE_DB_URL
+ *
+ * Exit codes: 0 pass, 1 fail (the defect is present), 2 unknown (a control failed).
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const args = process.argv.slice(2);
+const val = (f) => { const m = args.find((a) => a.startsWith(`${f}=`)); return m ? m.slice(f.length + 1) : undefined; };
+const RPC = val('--rpc') || 'match_semantic';
+const SWEEP = args.includes('--sweep');
+const DUMP_DEFS = args.includes('--dump-defs');
+const LIMIT = parseInt(val('--limit') || '15', 10);
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+
+/**
+ * Probes. Each pairs a query whose global nearest neighbours are Western with a
+ * language whose corpus demonstrably covers that subject — so an empty result is
+ * a retrieval failure, not an honest absence.
+ *
+ * `evidence` is the human reason we expect the corpus to answer; it goes in the
+ * report so a future reader can re-judge the probe rather than trust it.
+ */
+const PROBES = [
+  {
+    query: 'the stone that draws iron, the south-pointing needle, magnetic attraction',
+    language: 'Chinese',
+    evidence: 'Shen Kuo describes the compass needle; the Bencao Gangmu treats loadstone as materia medica. Verified reachable at similarity 0.704 by scanning past the HNSW candidate set (#4439).',
+  },
+  {
+    query: 'pitch pipes, bells and the tuning of musical tones',
+    language: 'Chinese',
+    evidence: 'Zhu Zaiyu on equal temperament; the lülü pitch-pipe literature is a core Chinese subject.',
+  },
+  {
+    query: 'distillation of spirits, the alembic and the calcination of metals',
+    language: 'Arabic',
+    evidence: 'The apparatus is Arabic by descent — "alembic" is al-anbīq — and Jabir and al-Razi are the tradition the Latin alchemists were reading in translation.',
+  },
+  {
+    query: 'grammar, the roots of words and the rules that generate speech',
+    language: 'Sanskrit',
+    evidence: 'Panini\'s Ashtadhyayi and its commentary literature are the densest grammatical corpus in any language we hold; Sanskrit is 3.2% of the table.',
+  },
+];
+
+/**
+ * Probes deliberately NOT used, and why — a rejected probe is as informative as
+ * a kept one, and re-deriving this costs a Gemini call each time:
+ *   "breath, the subtle body and the channels of vital force" / Sanskrit — the
+ *     unfiltered top hits are already Sanskrit/Tibetan, so the filter has
+ *     nothing to prove and the probe passes against the broken function.
+ *   "the physician examines the pulse and prescribes a compound remedy" /
+ *     Arabic — unfiltered hits include Chinese and Tibetan, so the candidate
+ *     set is not Western-dominated; it returned 1 row of a requested 15, which
+ *     is candidate exhaustion showing through rather than a clean failure.
+ */
+
+function fail(msg) { console.error(`\n  ERROR  ${msg}`); process.exit(2); }
+
+if (!SUPABASE_URL || !SUPABASE_KEY) fail('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set.');
+if (!GEMINI_KEY && !DUMP_DEFS) fail('GEMINI_API_KEY not set — the probe needs a query embedding.');
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function embed(query) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:batchEmbedContents?key=${GEMINI_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [{
+          model: 'models/gemini-embedding-2-preview',
+          content: { parts: [{ text: query }] },
+          outputDimensionality: 768,
+        }],
+      }),
+    },
+  );
+  if (!res.ok) fail(`Gemini embedding failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+  const data = await res.json();
+  const v = data?.embeddings?.[0]?.values;
+  if (!Array.isArray(v)) fail('Gemini returned no embedding.');
+  return v;
+}
+
+async function search(emb, { languages = null } = {}) {
+  const t0 = Date.now();
+  const { data, error } = await sb.rpc(RPC, {
+    query_embedding: JSON.stringify(emb),
+    match_threshold: 0.3,
+    match_count: LIMIT,
+    filter_tenant_id: null,
+    filter_language: null,
+    filter_year_min: null,
+    filter_year_max: null,
+    filter_languages: languages,
+    filter_exclude_languages: null,
+  });
+  if (error) fail(`${RPC} failed: ${error.message}`);
+  return { rows: data || [], ms: Date.now() - t0 };
+}
+
+/**
+ * Control: does the corpus hold embedded rows in this language at all? Asked of
+ * the TABLE, never inferred from the search — that inference is the bug.
+ */
+async function corpusRows(language) {
+  const { count, error } = await sb
+    .from('page_translations')
+    .select('page_id', { count: 'exact', head: true })
+    .eq('book_language', language)
+    .not('embedding', 'is', null);
+  if (error) fail(`corpus control query failed: ${error.message}`);
+  return count ?? 0;
+}
+
+// ── --dump-defs: what is ACTUALLY deployed ───────────────────────────────────
+// A committed migration is not evidence of production. Requires a direct
+// Postgres connection (SUPABASE_DB_URL); PostgREST cannot read pg_catalog.
+if (DUMP_DEFS) {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) fail('--dump-defs needs SUPABASE_DB_URL (a direct Postgres connection). PostgREST cannot read pg_get_functiondef.');
+  const { default: pg } = await import('pg');
+  const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  const { rows: ext } = await client.query(`SELECT extversion FROM pg_extension WHERE extname = 'vector'`);
+  console.log(`pgvector: ${ext[0]?.extversion ?? '(not installed)'}\n`);
+  const { rows } = await client.query(
+    `SELECT p.proname, pg_get_function_identity_arguments(p.oid) AS sig, pg_get_functiondef(p.oid) AS def
+       FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname IN ('match_semantic','match_page_texts','match_books_semantic',
+                          'match_semantic_prefilter_v2','match_page_texts_prefilter_v2',
+                          'match_books_semantic_prefilter_v2')
+      ORDER BY p.proname`,
+  );
+  for (const r of rows) console.log(`── ${r.proname}(${r.sig})\n${r.def}\n`);
+  await client.end();
+  process.exit(0);
+}
+
+// ── The audit ────────────────────────────────────────────────────────────────
+
+console.log(`# Semantic language-filter recall (#4439)\n`);
+console.log(`RPC under test: **${RPC}**   match_count: ${LIMIT}\n`);
+
+let failures = 0;
+let unknown = 0;
+const probes = SWEEP ? PROBES : PROBES.slice(0, 2);
+
+for (const probe of probes) {
+  const emb = await embed(probe.query);
+
+  const base = await search(emb, {});
+  const filtered = await search(emb, { languages: [probe.language] });
+  const inCorpus = await corpusRows(probe.language);
+
+  const baseLangs = [...new Set(base.rows.map((r) => r.book_language))];
+  const baseIsWestern = baseLangs.every((l) => l !== probe.language);
+
+  console.log(`## ${probe.query}`);
+  console.log(`- target language: **${probe.language}** (${inCorpus.toLocaleString()} embedded rows in corpus)`);
+  console.log(`- unfiltered: ${base.rows.length} rows in ${base.ms}ms — languages: ${baseLangs.join(', ') || '(none)'}`);
+  console.log(`- filtered to ${probe.language}: **${filtered.rows.length} rows** in ${filtered.ms}ms`);
+  if (filtered.rows.length) {
+    const top = filtered.rows[0];
+    console.log(`  - top hit: ${Number(top.similarity).toFixed(4)} — ${top.book_title} (p.${top.page_number})`);
+  }
+  console.log(`- why this language should answer: ${probe.evidence}`);
+
+  // Controls first — an assertion on an instrument that did not fire is noise.
+  if (base.rows.length === 0) {
+    console.log(`\n  **UNKNOWN** — the unfiltered arm returned nothing, so this probe cannot`);
+    console.log(`  distinguish a filter defect from a dead search path.\n`);
+    unknown++;
+    continue;
+  }
+  if (inCorpus === 0) {
+    console.log(`\n  **UNKNOWN** — the corpus holds no embedded ${probe.language} rows, so an`);
+    console.log(`  empty filtered result is honest, not a defect.\n`);
+    unknown++;
+    continue;
+  }
+  if (!baseIsWestern) {
+    console.log(`\n  **UNKNOWN** — ${probe.language} already appears in the unfiltered top hits,`);
+    console.log(`  so this probe no longer discriminates. Pick a query whose global`);
+    console.log(`  neighbours are elsewhere.\n`);
+    unknown++;
+    continue;
+  }
+
+  if (filtered.rows.length === 0) {
+    console.log(`\n  **FAIL** — ${inCorpus.toLocaleString()} embedded ${probe.language} rows exist and the`);
+    console.log(`  filter reached none of them, while the same query unfiltered returned`);
+    console.log(`  ${base.rows.length}. The predicate is being applied after ranking, not before.\n`);
+    failures++;
+  } else {
+    console.log(`\n  **PASS** — the filter reached ${probe.language} material on a query whose`);
+    console.log(`  global neighbours are ${baseLangs.join('/')}.\n`);
+  }
+}
+
+console.log(`---\n`);
+if (failures > 0) {
+  console.log(`**${failures} of ${probes.length} probes FAILED.** Language filtering on \`${RPC}\` is a`);
+  console.log(`post-filter over ranked candidates. See scripts/migration/fix-semantic-language-prefilter.sql.`);
+  process.exit(1);
+}
+if (unknown > 0) {
+  console.log(`**${unknown} of ${probes.length} probes returned UNKNOWN** — a control failed, so this run`);
+  console.log(`measured nothing. Do not read it as a pass.`);
+  process.exit(2);
+}
+console.log(`**PASS** — every probe reached its non-dominant language.`);

--- a/scripts/migration/add-match-semantic-rpc.sql
+++ b/scripts/migration/add-match-semantic-rpc.sql
@@ -8,6 +8,12 @@
 -- catches the error and returns []. Discovered 2026-05-15 while shipping the
 -- MCP search_concept tool that depends on this.
 --
+-- ⚠️ THE "FIX" DESCRIBED BELOW IS INERT. See issue #4439 and the replacement in
+-- `fix-semantic-language-prefilter.sql`. The paragraph is kept verbatim because
+-- it is the most useful thing in this file: it is a correct diagnosis attached
+-- to a change that does not implement it, and reading the two together is the
+-- fastest way to understand how that happens.
+--
 -- Cross-lingual gotcha (fixed 2026-05-17): HNSW + post-filter returns 0 rows
 -- when filter_language scopes the result set to a language that doesn't appear
 -- in the top-N nearest neighbors of the query. Example: an English query for
@@ -21,6 +27,18 @@
 -- accept arrays for multi-language queries (e.g. ["Chinese","Sanskrit","Arabic"]
 -- or excluding ["Latin","German","English","French"] to focus on non-Western
 -- traditions). Both also branch to seq scan to avoid the HNSW post-filter gotcha.
+--
+-- WHY IT IS INERT (2026-08-31, #4439): the branch does not force a sequential
+-- scan. Both branches below end in `ORDER BY p.embedding <=> query_embedding
+-- LIMIT match_count`, which is exactly the shape pgvector's HNSW index serves,
+-- so the planner takes the index in the "seq scan" branch too and the language
+-- predicate is applied to candidates the index already chose. A branch is not a
+-- plan. Measured: Chinese/Arabic/Sanskrit filters return 0 rows in 60–230ms —
+-- and 60ms is itself the tell, since no scan of 4.5M rows finishes that fast.
+-- Raise match_count to 10,000 and the planner abandons the index, the same
+-- query takes 47.6s, and it returns 1,000 Chinese rows topping out at
+-- similarity 0.704 against a global unfiltered top of 0.728. The material was
+-- always there.
 --
 -- Tenant filter: page_translations doesn't currently carry a tenant_id column,
 -- so we accept the parameter for API compatibility but ignore it.
@@ -55,6 +73,12 @@ DECLARE
     OR (filter_exclude_languages IS NOT NULL AND array_length(filter_exclude_languages, 1) > 0);
 BEGIN
   IF has_language_filter THEN
+    -- ⚠️ THIS COMMENT IS WRONG — #4439. It describes an intent the SQL below
+    -- does not carry out: the ORDER BY still matches the HNSW operator, so the
+    -- planner takes the vector index here too and the language predicate runs
+    -- on candidates it already picked. Left in place, marked, because the gap
+    -- between this comment and the query under it IS the bug.
+    --
     -- Language-scoped path: filter first, sort by distance after.
     -- Avoids the HNSW post-filter gotcha where the index returns top-N
     -- nearest vectors globally and a language filter strips them all.

--- a/scripts/migration/add-page-texts-table.sql
+++ b/scripts/migration/add-page-texts-table.sql
@@ -22,10 +22,20 @@
 -- HNSW returns the globally nearest N vectors and a WHERE clause filters them
 -- AFTERWARDS, so a `lang = 'es'` predicate against one shared index would strip
 -- the result set to zero whenever the query's true neighbours are in another
--- language. That is exactly the cross-lingual bug fixed in match_semantic in
--- May 2026 (see add-match-semantic-rpc.sql), and a partial index per language
--- makes it structurally impossible: `WHERE lang = 'es'` matches the index
--- predicate, so the scan happens inside that language.
+-- language. That is exactly the cross-lingual bug match_semantic was BELIEVED
+-- to have fixed in May 2026 — it was not; the fix was inert until #4439 (see
+-- add-match-semantic-rpc.sql). A partial index per language makes it
+-- structurally impossible instead of relying on a branch: `WHERE lang = 'es'`
+-- matches the index predicate, so the scan happens inside that language. That
+-- distinction is the lesson of #4439 — this design was right for the right
+-- reason, and it is the pattern to reach for if `page_translations` ever needs
+-- a per-language index of its own.
+--
+-- NOTE (#4439): the protection above covers `filter_lang` (which TEXT to read)
+-- and nothing else. `match_page_texts` also takes filter_language /
+-- filter_languages / filter_exclude_languages — the BOOK's language — and those
+-- are post-filtered over the partial index's candidates, with the same silent
+-- zero. Fixed in fix-semantic-language-prefilter.sql.
 --
 -- Adding a language therefore means running the runner again with --lang=<iso>;
 -- until you do, that language's rows are searched by sequential scan (correct,

--- a/scripts/migration/apply-semantic-language-prefilter.sql
+++ b/scripts/migration/apply-semantic-language-prefilter.sql
@@ -1,0 +1,298 @@
+-- HELD FOR HUMAN APPROVAL — issue #4439.
+--
+-- This file replaces the THREE LIVE serving RPCs. Running it changes what
+-- sourcelibrary.org, /api/search and the public MCP tools return, on the
+-- request path, immediately. It is deliberately a separate file from
+-- `fix-semantic-language-prefilter.sql` (which only creates `*_prefilter_v2`
+-- shadows and is safe to run) so that no sweep, script or half-read
+-- instruction can apply it by accident.
+--
+-- Do not run it until all four of these are true:
+--
+--   1. `fix-semantic-language-prefilter.sql` has been applied and
+--      `scripts/audit/semantic-language-filter-recall.mjs
+--       --rpc=match_semantic_prefilter_v2` PASSES against production.
+--   2. `EXPLAIN (ANALYZE, BUFFERS)` on the filtered branch of the shadow shows
+--      no plain `Index Scan using page_translations_embedding_idx` — reading
+--      the SQL and believing it is exactly how the 2026-05-17 fix shipped
+--      inert.
+--   3. The measured p95 latency of the filtered path is acceptable for the
+--      request path. It will NOT be, on pgvector < 0.8.0, for
+--      `exclude_languages` — a full scan of 4.5M rows measured 47.6s. See the
+--      cost section in `fix-semantic-language-prefilter.sql`.
+--   4. Someone has diffed the CURRENT production definitions against the
+--      committed ones. `scripts/audit/semantic-language-filter-recall.mjs
+--      --dump-defs` prints `pg_get_functiondef` for all three; a committed
+--      migration is not evidence of what is deployed.
+--
+-- Rollback is `add-match-semantic-rpc.sql`, `add-page-texts-table.sql` and
+-- `book-embeddings-schema.sql` — the previous bodies are still in the repo, so
+-- reverting is re-running those files. Keep the shadows around until this has
+-- been live for a while; they cost nothing and they are the A/B.
+--
+-- The bodies below are byte-identical in behaviour to the `*_prefilter_v2`
+-- shadows; only the names differ. Read the rationale there, not here — one
+-- explanation, so the two cannot drift.
+
+-- ── page_translations ────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION match_semantic(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_tenant_id TEXT DEFAULT NULL,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_languages TEXT[] DEFAULT NULL,
+  filter_exclude_languages TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  has_language_filter BOOLEAN := filter_language IS NOT NULL
+    OR (filter_languages IS NOT NULL AND array_length(filter_languages, 1) > 0)
+    OR (filter_exclude_languages IS NOT NULL AND array_length(filter_exclude_languages, 1) > 0);
+  can_iterate BOOLEAN := pgvector_supports_iterative_scan();
+BEGIN
+  IF NOT has_language_filter THEN
+    RETURN QUERY
+    SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           1 - (p.embedding <=> query_embedding) AS similarity
+    FROM page_translations p
+    WHERE p.embedding IS NOT NULL
+      AND 1 - (p.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    ORDER BY p.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  IF can_iterate THEN
+    PERFORM set_config('hnsw.iterative_scan', 'relaxed_order', true);
+    PERFORM set_config('hnsw.max_scan_tuples', '50000', true);
+    PERFORM set_config('hnsw.ef_search', '100', true);
+
+    RETURN QUERY
+    SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+           s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+    FROM (
+      SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+             p.book_author, p.book_language, p.book_year,
+             (p.embedding <=> query_embedding) AS dist
+      FROM page_translations p
+      WHERE p.embedding IS NOT NULL
+        AND (filter_language IS NULL OR p.book_language = filter_language)
+        AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+             OR p.book_language = ANY(filter_languages))
+        AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+             OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+        AND 1 - (p.embedding <=> query_embedding) > match_threshold
+        AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+        AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+      ORDER BY p.embedding <=> query_embedding
+      LIMIT match_count
+    ) s
+    ORDER BY s.dist;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+         s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+  FROM (
+    SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           (p.embedding <=> query_embedding) AS dist
+    FROM page_translations p
+    WHERE p.embedding IS NOT NULL
+      AND (filter_language IS NULL OR p.book_language = filter_language)
+      AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+           OR p.book_language = ANY(filter_languages))
+      AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+           OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    OFFSET 0
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;
+
+-- ── page_texts ───────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION match_page_texts(
+  query_embedding vector(768),
+  filter_lang TEXT,
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_languages TEXT[] DEFAULT NULL,
+  filter_exclude_languages TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  has_language_filter BOOLEAN := filter_language IS NOT NULL
+    OR (filter_languages IS NOT NULL AND array_length(filter_languages, 1) > 0)
+    OR (filter_exclude_languages IS NOT NULL AND array_length(filter_exclude_languages, 1) > 0);
+  can_iterate BOOLEAN := pgvector_supports_iterative_scan();
+BEGIN
+  IF NOT has_language_filter THEN
+    RETURN QUERY
+    SELECT p.page_id, p.book_id, p.page_number, p.text, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           1 - (p.embedding <=> query_embedding) AS similarity
+    FROM page_texts p
+    WHERE p.lang = filter_lang
+      AND p.embedding IS NOT NULL
+      AND 1 - (p.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    ORDER BY p.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  IF can_iterate THEN
+    PERFORM set_config('hnsw.iterative_scan', 'relaxed_order', true);
+    PERFORM set_config('hnsw.max_scan_tuples', '50000', true);
+    PERFORM set_config('hnsw.ef_search', '100', true);
+
+    RETURN QUERY
+    SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+           s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+    FROM (
+      SELECT p.page_id, p.book_id, p.page_number, p.text AS translation,
+             p.book_title, p.book_author, p.book_language, p.book_year,
+             (p.embedding <=> query_embedding) AS dist
+      FROM page_texts p
+      WHERE p.lang = filter_lang
+        AND p.embedding IS NOT NULL
+        AND (filter_language IS NULL OR p.book_language = filter_language)
+        AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+             OR p.book_language = ANY(filter_languages))
+        AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+             OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+        AND 1 - (p.embedding <=> query_embedding) > match_threshold
+        AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+        AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+      ORDER BY p.embedding <=> query_embedding
+      LIMIT match_count
+    ) s
+    ORDER BY s.dist;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+         s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+  FROM (
+    SELECT p.page_id, p.book_id, p.page_number, p.text AS translation,
+           p.book_title, p.book_author, p.book_language, p.book_year,
+           (p.embedding <=> query_embedding) AS dist
+    FROM page_texts p
+    WHERE p.lang = filter_lang
+      AND p.embedding IS NOT NULL
+      AND (filter_language IS NULL OR p.book_language = filter_language)
+      AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+           OR p.book_language = ANY(filter_languages))
+      AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+           OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    OFFSET 0
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;
+
+-- ── book_embeddings ──────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION match_books_semantic(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 20,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL
+)
+RETURNS TABLE (
+  book_id TEXT,
+  title TEXT,
+  author TEXT,
+  year INT,
+  language TEXT,
+  summary_text TEXT,
+  metadata JSONB,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF filter_language IS NULL THEN
+    RETURN QUERY
+    SELECT b.book_id, b.title, b.author, b.year, b.language, b.summary_text,
+           b.metadata, 1 - (b.embedding <=> query_embedding) AS similarity
+    FROM book_embeddings b
+    WHERE 1 - (b.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR b.year >= filter_year_min)
+      AND (filter_year_max IS NULL OR b.year <= filter_year_max)
+    ORDER BY b.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.book_id, s.title, s.author, s.year, s.language, s.summary_text,
+         s.metadata, 1 - s.dist AS similarity
+  FROM (
+    SELECT b.book_id, b.title, b.author, b.year, b.language, b.summary_text,
+           b.metadata, (b.embedding <=> query_embedding) AS dist
+    FROM book_embeddings b
+    WHERE b.language = filter_language
+      AND (filter_year_min IS NULL OR b.year >= filter_year_min)
+      AND (filter_year_max IS NULL OR b.year <= filter_year_max)
+    OFFSET 0
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;

--- a/scripts/migration/fix-semantic-language-prefilter.sql
+++ b/scripts/migration/fix-semantic-language-prefilter.sql
@@ -1,0 +1,485 @@
+-- Shadow functions for issue #4439 — language filters are a post-filter over an
+-- HNSW candidate set, so a non-dominant language returns 0 rows.
+--
+-- ADDITIVE AND SAFE TO RUN. Nothing in this file touches a live RPC. It creates
+-- three `*_prefilter_v2` twins of the serving functions so the fix can be
+-- EXPLAINed, timed and recall-tested against production data before anyone
+-- replaces the functions the site actually calls. The replacement lives in
+-- `apply-semantic-language-prefilter.sql` and is held for a human.
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- WHAT IS ACTUALLY WRONG
+--
+-- `add-match-semantic-rpc.sql` claims a fix landed 2026-05-17: "when
+-- filter_language(s) is set, branch to a sequential-scan path that filters by
+-- language FIRST then sorts by similarity." The branch exists. It does not
+-- force a sequential scan. Both branches end in the same two lines:
+--
+--     ORDER BY p.embedding <=> query_embedding
+--     LIMIT match_count;
+--
+-- That is precisely the shape pgvector's HNSW index serves, so the planner
+-- takes the index in BOTH branches and the language predicate is applied to
+-- candidates the index has already chosen. Recall then tracks the language's
+-- share of the table rather than the query: Latin at 36% survives, Chinese at
+-- 2.2% does not.
+--
+-- Measured against production 2026-08-31 (query: "the stone that draws iron,
+-- the south-pointing needle, magnetic attraction"):
+--
+--   filter                        match_count      rows   latency
+--   ────────────────────────────  ───────────  ────────  ────────
+--   none                                   15        15     940ms   (Latin/English/Greek)
+--   language = 'Latin'                     15        15      69ms
+--   languages = ['Chinese']                15         0     210ms
+--   languages = ['Chinese']                40         0     228ms
+--   languages = ['Chinese']               100         0      60ms
+--   languages = ['Chinese']               500         0      73ms
+--   languages = ['Chinese']              2000         0      91ms
+--   languages = ['Chinese']             10000      1000    47579ms
+--
+-- The last row is the positive control on the mechanism, and it is the whole
+-- proof. At match_count = 10000 the planner abandons the HNSW index (a LIMIT
+-- that large costs more through the graph than a scan), falls back to a real
+-- sequential scan, and the SAME query returns Chinese rows whose top
+-- similarity is 0.7040 — against a global unfiltered top of 0.728. The
+-- material was always there, at competitive similarity. Only the plan stood
+-- between the query and it. 60–230ms for an alleged scan of 4.5M rows was
+-- the tell all along.
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- THE FIX, AND WHY IT HAS TWO PATHS
+--
+-- Path A — iterative index scan (pgvector >= 0.8.0). `hnsw.iterative_scan`
+-- makes the index keep walking the graph until `match_count` rows have
+-- survived the WHERE clause, bounded by `hnsw.max_scan_tuples`. This is the
+-- mechanism pgvector added for exactly this problem. It stays sub-second and
+-- it works for `exclude_languages` too, which a pre-filter does not (see
+-- below). `relaxed_order` may emit rows slightly out of distance order, so the
+-- inner scan is wrapped and re-sorted over at most `match_count` rows.
+--
+-- Path B — exact pre-filter, for pgvector < 0.8.0. Two independent things stop
+-- the HNSW index being chosen, because one of them being subtly wrong is how
+-- the 2026-05-17 "fix" became inert:
+--
+--   1. The distance is computed inside a subquery fenced with `OFFSET 0`, so
+--      the outer `ORDER BY s.dist` is an ordering over a subquery output
+--      column and cannot be matched to the `<=>` operator on an indexed
+--      column. `OFFSET 0` blocks subquery pull-up; without it the planner
+--      flattens the subquery and we are back where we started.
+--   2. `enable_indexscan = off` for the duration of the transaction. pgvector
+--      HNSW is only reachable as a plain (ordered) index scan, so this removes
+--      it outright, while leaving BITMAP index scans available — which is what
+--      we want the partial `page_translations_lang_idx` on `book_language` to
+--      serve. `set_config(..., true)` is transaction-local; PostgREST runs one
+--      transaction per request, so it cannot leak into another query.
+--
+-- Which path a call takes is decided by reading `pg_extension.extversion`, not
+-- by probing a GUC. Setting an unknown `hnsw.*` parameter can silently succeed
+-- as a placeholder on some builds, which would make the probe report success
+-- and take the wrong branch — a check that cannot fail is not a check.
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- VERIFIED, NOT ASSUMED
+--
+-- The plans below come from a local pgvector 0.8.6 (docker pgvector/pgvector:pg17)
+-- loaded with 60,000 rows at the corpus's real language proportions (Latin 36.0%,
+-- English 11.8%, Sanskrit 3.2%, Chinese 2.2%, Arabic 1.2%), each language's
+-- vectors drawn around its own centroid so the query's true neighbours really
+-- are Latin. The language btree was dropped and the planner pushed toward the
+-- vector index (`enable_seqscan = off`, `enable_bitmapscan = off`) — the most
+-- index-favouring conditions obtainable. If a shape cannot reach HNSW there, it
+-- cannot reach it in production.
+--
+--   A. OLD SHAPE (as committed)
+--        Limit
+--          ->  Index Scan using page_translations_embedding_idx
+--                Order By: (embedding <=> $q)
+--                Filter: (book_language = ANY ('{Chinese}'))
+--      → 0 rows.   The bug, reproduced.
+--
+--   B. OFFSET 0 fence alone
+--        Limit -> Sort -> Subquery Scan on s -> Seq Scan on page_translations
+--      → 15 rows.  The fence alone defeats the index even under maximum
+--                  index-favouring pressure.
+--
+--   C. OFFSET 0 fence + enable_indexscan = off
+--        identical plan to B.
+--      → 15 rows.  The GUC is belt to the fence's braces; neither is load-
+--                  bearing alone, which is the point — the 2026-05-17 fix had
+--                  exactly one mechanism and it was the wrong one.
+--
+-- End-to-end through the functions themselves, same forcing:
+--
+--   match_semantic (live)          0 Chinese rows
+--   v2, Path A (iterative scan)   15 rows, top similarity 0.7916
+--   v2, Path B (fenced)           15 rows, top similarity 0.7950
+--   v2, exclude 3 languages       15 rows
+--   v2, unfiltered                15 rows  (HNSW path, unchanged)
+--
+-- Path A's slightly lower top similarity is `relaxed_order` doing what it says:
+-- approximate ordering in exchange for staying on the index. Path B is exact.
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- KNOWN COST, STATED UP FRONT
+--
+-- Path B is exact and slow, and how slow depends entirely on how many rows the
+-- language predicate admits:
+--
+--   * An INCLUDE filter on a non-dominant language (Chinese 100,613 rows,
+--     Arabic 54,352, Sanskrit 142,513) can use the partial btree on
+--     `book_language` via a bitmap scan. Expect ~1–4s: bounded, correct, and
+--     the honest price of exact search.
+--   * An EXCLUDE filter (`NOT (book_language = ANY(...))`) has no usable
+--     index and degrades to a full scan of 4.5M rows. That is the 47.6s
+--     measured above. It is a correct answer nobody will wait for.
+--
+-- So on pgvector < 0.8.0 this fix turns "confidently wrong in 100ms" into
+-- "right, eventually" — an improvement, but not a finished one. On >= 0.8.0
+-- Path A gives both. If production is on < 0.8.0 the follow-up is either an
+-- extension upgrade or per-language PARTIAL HNSW indexes, which is already the
+-- pattern `page_texts` uses (`page_texts_embedding_es_idx`; see
+-- `.claude/docs/embeddings.md`).
+--
+-- NOT MEASURED, AND SOMEONE MUST: production p95 for either path on the real
+-- 4.5M-row table. The local box is 60,000 rows and every variant there runs in
+-- under 55ms, which tells you the ordering of the costs and nothing about the
+-- absolute numbers. The one real production data point is the 47.6s above, and
+-- that is a full scan with no index help at all — the pessimistic bound for
+-- Path B on an exclude filter, not an estimate for the include filters. Take
+-- the timings from `EXPLAIN (ANALYZE)` against the shadow before replacing
+-- anything; the tolerance that matters is the MCP request path, not a psql
+-- prompt.
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- HOW TO VERIFY (do this, do not read the SQL and believe it — that is the
+-- exact mistake of 2026-05-17)
+--
+--   \timing on
+--   SET hnsw.ef_search = 40;
+--   EXPLAIN (ANALYZE, BUFFERS)
+--   SELECT * FROM match_semantic_prefilter_v2(
+--     (SELECT embedding FROM page_translations WHERE book_language = 'Latin'
+--        AND embedding IS NOT NULL LIMIT 1),
+--     0.3, 15, NULL, NULL, NULL, NULL, ARRAY['Chinese'], NULL);
+--
+-- A plan containing `Index Scan using page_translations_embedding_idx` in the
+-- FILTERED branch means the fix did not take. What you want to see is either a
+-- Bitmap Heap Scan on `page_translations_lang_idx` (Path B) or an Index Scan
+-- reporting far more tuples touched than returned (Path A, iterating).
+--
+-- The end-to-end recall test — the one that pins the MECHANISM rather than an
+-- output — is `scripts/audit/semantic-language-filter-recall.mjs`, which
+-- asserts that a non-dominant language filter returns rows on a query whose
+-- unfiltered top hits are all Western. Point it at either function:
+--
+--   node --env-file=.env.production.local \
+--     scripts/audit/semantic-language-filter-recall.mjs --rpc=match_semantic_prefilter_v2
+--
+-- Related: `.claude/docs/invariants/search-filters-and-lanes.md`, and the
+-- lesson this issue is the origin of — a ranked filter's recall tracks the
+-- base rate, so positive-control the mechanism, never the output.
+
+-- ── Version probe ────────────────────────────────────────────────────────────
+-- Read the extension version rather than probing a GUC: setting an unknown
+-- `hnsw.*` parameter can succeed as a placeholder on builds that do not
+-- reserve the prefix, so a probe that "works" proves nothing. Array comparison
+-- is element-wise, which gives correct numeric ordering (0.10.0 > 0.8.0), where
+-- a string compare would not.
+
+CREATE OR REPLACE FUNCTION pgvector_supports_iterative_scan()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(
+    (SELECT string_to_array(split_part(extversion, '-', 1), '.')::INT[] >= ARRAY[0, 8, 0]
+     FROM pg_extension WHERE extname = 'vector'),
+    FALSE
+  );
+$$;
+
+-- Read-callable by the same roles as the functions it serves, so the
+-- verification script can reach it with the service role.
+GRANT EXECUTE ON FUNCTION pgvector_supports_iterative_scan() TO anon, authenticated, service_role;
+
+-- ── page_translations (English page store) ───────────────────────────────────
+
+CREATE OR REPLACE FUNCTION match_semantic_prefilter_v2(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_tenant_id TEXT DEFAULT NULL,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_languages TEXT[] DEFAULT NULL,
+  filter_exclude_languages TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  has_language_filter BOOLEAN := filter_language IS NOT NULL
+    OR (filter_languages IS NOT NULL AND array_length(filter_languages, 1) > 0)
+    OR (filter_exclude_languages IS NOT NULL AND array_length(filter_exclude_languages, 1) > 0);
+  can_iterate BOOLEAN := pgvector_supports_iterative_scan();
+BEGIN
+  IF NOT has_language_filter THEN
+    -- Unfiltered: the HNSW index is exactly right here and always was.
+    RETURN QUERY
+    SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           1 - (p.embedding <=> query_embedding) AS similarity
+    FROM page_translations p
+    WHERE p.embedding IS NOT NULL
+      AND 1 - (p.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    ORDER BY p.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  IF can_iterate THEN
+    -- Path A: let the index keep walking until match_count rows survive the
+    -- filter. Inner LIMIT drives the index; outer sort repairs relaxed_order.
+    PERFORM set_config('hnsw.iterative_scan', 'relaxed_order', true);
+    PERFORM set_config('hnsw.max_scan_tuples', '50000', true);
+    PERFORM set_config('hnsw.ef_search', '100', true);
+
+    RETURN QUERY
+    SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+           s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+    FROM (
+      SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+             p.book_author, p.book_language, p.book_year,
+             (p.embedding <=> query_embedding) AS dist
+      FROM page_translations p
+      WHERE p.embedding IS NOT NULL
+        AND (filter_language IS NULL OR p.book_language = filter_language)
+        AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+             OR p.book_language = ANY(filter_languages))
+        AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+             OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+        AND 1 - (p.embedding <=> query_embedding) > match_threshold
+        AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+        AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+      ORDER BY p.embedding <=> query_embedding
+      LIMIT match_count
+    ) s
+    ORDER BY s.dist;
+    RETURN;
+  END IF;
+
+  -- Path B: exact pre-filter. Two fences, deliberately redundant.
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+         s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+  FROM (
+    SELECT p.page_id, p.book_id, p.page_number, p.translation, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           (p.embedding <=> query_embedding) AS dist
+    FROM page_translations p
+    WHERE p.embedding IS NOT NULL
+      AND (filter_language IS NULL OR p.book_language = filter_language)
+      AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+           OR p.book_language = ANY(filter_languages))
+      AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+           OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    OFFSET 0  -- optimization fence: stops the outer ORDER BY reaching the index
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;
+
+-- ── page_texts (language-keyed page store, #4095) ────────────────────────────
+-- Same defect, same shape. `filter_lang` (which TEXT to read) is unaffected —
+-- it is served by a partial HNSW index per language, which is structurally
+-- immune. The BOOK-language filters below are not.
+
+CREATE OR REPLACE FUNCTION match_page_texts_prefilter_v2(
+  query_embedding vector(768),
+  filter_lang TEXT,
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL,
+  filter_languages TEXT[] DEFAULT NULL,
+  filter_exclude_languages TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  has_language_filter BOOLEAN := filter_language IS NOT NULL
+    OR (filter_languages IS NOT NULL AND array_length(filter_languages, 1) > 0)
+    OR (filter_exclude_languages IS NOT NULL AND array_length(filter_exclude_languages, 1) > 0);
+  can_iterate BOOLEAN := pgvector_supports_iterative_scan();
+BEGIN
+  IF NOT has_language_filter THEN
+    RETURN QUERY
+    SELECT p.page_id, p.book_id, p.page_number, p.text, p.book_title,
+           p.book_author, p.book_language, p.book_year,
+           1 - (p.embedding <=> query_embedding) AS similarity
+    FROM page_texts p
+    WHERE p.lang = filter_lang
+      AND p.embedding IS NOT NULL
+      AND 1 - (p.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    ORDER BY p.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  IF can_iterate THEN
+    PERFORM set_config('hnsw.iterative_scan', 'relaxed_order', true);
+    PERFORM set_config('hnsw.max_scan_tuples', '50000', true);
+    PERFORM set_config('hnsw.ef_search', '100', true);
+
+    RETURN QUERY
+    SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+           s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+    FROM (
+      SELECT p.page_id, p.book_id, p.page_number, p.text AS translation,
+             p.book_title, p.book_author, p.book_language, p.book_year,
+             (p.embedding <=> query_embedding) AS dist
+      FROM page_texts p
+      WHERE p.lang = filter_lang
+        AND p.embedding IS NOT NULL
+        AND (filter_language IS NULL OR p.book_language = filter_language)
+        AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+             OR p.book_language = ANY(filter_languages))
+        AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+             OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+        AND 1 - (p.embedding <=> query_embedding) > match_threshold
+        AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+        AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+      ORDER BY p.embedding <=> query_embedding
+      LIMIT match_count
+    ) s
+    ORDER BY s.dist;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.page_id, s.book_id, s.page_number, s.translation, s.book_title,
+         s.book_author, s.book_language, s.book_year, 1 - s.dist AS similarity
+  FROM (
+    SELECT p.page_id, p.book_id, p.page_number, p.text AS translation,
+           p.book_title, p.book_author, p.book_language, p.book_year,
+           (p.embedding <=> query_embedding) AS dist
+    FROM page_texts p
+    WHERE p.lang = filter_lang
+      AND p.embedding IS NOT NULL
+      AND (filter_language IS NULL OR p.book_language = filter_language)
+      AND (filter_languages IS NULL OR array_length(filter_languages, 1) IS NULL
+           OR p.book_language = ANY(filter_languages))
+      AND (filter_exclude_languages IS NULL OR array_length(filter_exclude_languages, 1) IS NULL
+           OR p.book_language IS NULL OR NOT (p.book_language = ANY(filter_exclude_languages)))
+      AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+      AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
+    OFFSET 0
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;
+
+-- ── book_embeddings (book-level discovery) ───────────────────────────────────
+-- Same ORDER BY shape, same defect, but ~36K rows rather than 4.5M, so the
+-- exact pre-filter is cheap here (a full scan of 36K vectors is tens of ms) and
+-- there is no reason to reach for the iterative path at all. Worth fixing even
+-- so: `semanticBookSearch` passes `filter_language`, and a Chinese-language
+-- book search on a Western-leaning query has exactly the same silent zero.
+
+CREATE OR REPLACE FUNCTION match_books_semantic_prefilter_v2(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 20,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL
+)
+RETURNS TABLE (
+  book_id TEXT,
+  title TEXT,
+  author TEXT,
+  year INT,
+  language TEXT,
+  summary_text TEXT,
+  metadata JSONB,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF filter_language IS NULL THEN
+    RETURN QUERY
+    SELECT b.book_id, b.title, b.author, b.year, b.language, b.summary_text,
+           b.metadata, 1 - (b.embedding <=> query_embedding) AS similarity
+    FROM book_embeddings b
+    WHERE 1 - (b.embedding <=> query_embedding) > match_threshold
+      AND (filter_year_min IS NULL OR b.year >= filter_year_min)
+      AND (filter_year_max IS NULL OR b.year <= filter_year_max)
+    ORDER BY b.embedding <=> query_embedding
+    LIMIT match_count;
+    RETURN;
+  END IF;
+
+  PERFORM set_config('enable_indexscan', 'off', true);
+
+  RETURN QUERY
+  SELECT s.book_id, s.title, s.author, s.year, s.language, s.summary_text,
+         s.metadata, 1 - s.dist AS similarity
+  FROM (
+    SELECT b.book_id, b.title, b.author, b.year, b.language, b.summary_text,
+           b.metadata, (b.embedding <=> query_embedding) AS dist
+    FROM book_embeddings b
+    WHERE b.language = filter_language
+      AND (filter_year_min IS NULL OR b.year >= filter_year_min)
+      AND (filter_year_max IS NULL OR b.year <= filter_year_max)
+    OFFSET 0
+  ) s
+  WHERE 1 - s.dist > match_threshold
+  ORDER BY s.dist
+  LIMIT match_count;
+END;
+$$;
+
+-- Shadow functions are callable by the service role only — they exist for
+-- verification, not for serving. Nothing in `src/` references them.
+GRANT EXECUTE ON FUNCTION match_semantic_prefilter_v2(vector, FLOAT, INT, TEXT, TEXT, INT, INT, TEXT[], TEXT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION match_page_texts_prefilter_v2(vector, TEXT, FLOAT, INT, TEXT, INT, INT, TEXT[], TEXT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION match_books_semantic_prefilter_v2(vector, FLOAT, INT, TEXT, INT, INT) TO service_role;


### PR DESCRIPTION
Fixes the retrieval half of #4439.

## What is wrong

`match_semantic` has carried, since 2026-05-17, a correct diagnosis of the cross-lingual HNSW post-filter bug **and** an `IF has_language_filter THEN` branch written to avoid it. Both branches end in the same two lines:

```
ORDER BY p.embedding <=> query_embedding
LIMIT match_count;
```

That is exactly the shape pgvector's HNSW index serves, so the planner takes the index in the "sequential scan" branch too, and the language predicate is applied to candidates the index has already chosen. **A branch is not a plan.** The recall of a language filter is therefore a function of that language's share of the table, not of the query.

## Verifying the defect (production, 2026-08-31)

Query: `"the stone that draws iron, the south-pointing needle, magnetic attraction"`, via `match_semantic` with the service role.

| filter | match_count | rows | latency |
|---|---:|---:|---:|
| none | 15 | 15 | 940ms |
| `language = 'Latin'` | 15 | 15 | 69ms |
| `languages = ['Chinese']` | 15 | **0** | 210ms |
| `languages = ['Chinese']` | 100 | **0** | 60ms |
| `languages = ['Chinese']` | 2000 | **0** | 91ms |
| `languages = ['Chinese']` | 10000 | **1000** | 47,579ms |

The last row is the positive control on the *mechanism*, and it is the whole proof. At `match_count = 10000` the planner abandons the index (a LIMIT that large costs more through the graph than a scan), the same query takes 47.6s, and it returns 1,000 Chinese rows topping out at similarity **0.7040** — against a global unfiltered top of 0.728. The material was always there at competitive similarity; only the plan stood between the query and it. And 60ms was the tell all along: no scan of 4.5M rows finishes that fast.

Four probes through `scripts/audit/semantic-language-filter-recall.mjs --sweep` fail against the live RPC — Chinese x2, Arabic (54,351 embedded rows, 0 reached), Sanskrit (142,513 rows, 0 reached).

## Verifying the fix — EXPLAIN, not reading the SQL

Reproduced on a local pgvector **0.8.6** (`pgvector/pgvector:pg17`), 60,000 rows at the corpus's real language proportions (Latin 36.0%, English 11.8%, Sanskrit 3.2%, Chinese 2.2%, Arabic 1.2%), each language's vectors drawn around its own centroid so the query's true neighbours really are Latin. Language btree dropped and the planner pushed toward the vector index (`enable_seqscan = off`, `enable_bitmapscan = off`) — the most index-favouring conditions obtainable.

**A. Old shape (as committed):**

```
Limit
  ->  Index Scan using page_translations_embedding_idx on page_translations p
        Order By: (embedding <=> $q)
        Filter: ((embedding IS NOT NULL) AND (book_language = ANY ('{Chinese}')))
```

-> **0 rows.** The bug, reproduced.

**B. `OFFSET 0` fence alone:**

```
Limit
  ->  Sort  (Sort Key: s.dist)
        ->  Subquery Scan on s
              Filter: ((1 - s.dist) > 0.3)
              ->  Seq Scan on page_translations p
                    Filter: ((embedding IS NOT NULL) AND (book_language = ANY ('{Chinese}')))
```

-> **15 rows.** The fence alone defeats the index under maximum index-favouring pressure.

**C. Fence + `enable_indexscan = off`:** identical plan, **15 rows**. The GUC is belt to the fence's braces — deliberately redundant, because the 2026-05-17 fix had exactly one mechanism and it was the wrong one.

End to end through the functions themselves, same forcing:

| function | Chinese rows | top similarity |
|---|---:|---:|
| `match_semantic` (live) | **0** | — |
| `..._prefilter_v2` Path A (iterative scan) | 15 | 0.7916 |
| `..._prefilter_v2` Path B (fenced pre-filter) | 15 | 0.7950 |
| `..._prefilter_v2` exclude 3 languages | 15 | — |
| `..._prefilter_v2` unfiltered | 15 | unchanged |

Path A's slightly lower top similarity is `relaxed_order` doing what it says: approximate ordering in exchange for staying on the index.

## The fix, and why it has two paths

- **Path A — `hnsw.iterative_scan` (pgvector >= 0.8.0).** The index keeps walking the graph until `match_count` rows survive the WHERE clause, bounded by `hnsw.max_scan_tuples`. Sub-second, and it works for `exclude_languages` too, which a pre-filter does not.
- **Path B — exact pre-filter, for older pgvector.** Distance computed in a subquery fenced with `OFFSET 0` (blocks subquery pull-up, so the outer `ORDER BY` cannot be matched to the `<=>` operator on an indexed column), plus `enable_indexscan = off` (HNSW is only reachable as a plain ordered index scan; bitmap index scans on `book_language` stay available). `set_config(..., true)` is transaction-local and PostgREST runs one transaction per request.

Which path a call takes is decided by reading `pg_extension.extversion`, **not** by probing a GUC — setting an unknown `hnsw.*` parameter can silently succeed as a placeholder on builds that don't reserve the prefix, and a check that cannot fail is not a check.

## Latency, stated plainly

Path B is exact and its cost is whatever the predicate admits. Include filters on a non-dominant language can use the partial `page_translations_lang_idx` via a bitmap scan; **exclude filters have no usable index and degrade to a full scan — 47.6s measured on production.** On pgvector < 0.8.0 this turns "confidently wrong in 100ms" into "right, eventually", which is an improvement and not a finished one. On >= 0.8.0 Path A gives both.

**Not measured, and someone must: production p95 for either path on the real 4.5M-row table.** See the blocker below.

## Sibling-RPC audit

Audited from the committed SQL (see blocker — production definitions could not be read):

- **`match_page_texts`** (`add-page-texts-table.sql`) — **same defect.** `filter_lang` (which *text* to read) is safe: it is served by a partial HNSW index per language, structurally immune, and that design is right for the right reason. But `filter_language` / `filter_languages` / `filter_exclude_languages` — the *book's* language — are post-filtered over that partial index's candidates, with the same silent zero. Shadow + fix included.
- **`match_books_semantic`** (`book-embeddings-schema.sql`) — **same shape, same defect, much smaller blast radius.** `book_embeddings` is ~36K rows, so an exact pre-filter is tens of ms and there is no reason to reach for the iterative path. `semanticBookSearch` passes `filter_language`, so a Chinese-language book search on a Western-leaning query has the identical silent zero. Shadow + fix included.
- **`match_pages_in_books` / `match_page_texts_in_books`** — not affected. They scope by `book_id = ANY(...)` with no language predicate, and the caller has already chosen the books.
- **`search_page_texts`** — not affected. Lexical (GIN/tsvector), not a vector index.

## In scope

- `scripts/migration/fix-semantic-language-prefilter.sql` — three `*_prefilter_v2` shadow functions plus a `pgvector_supports_iterative_scan()` version probe. **Additive. Touches no live RPC.** Safe to run.
- `scripts/audit/semantic-language-filter-recall.mjs` — the mechanism-pinning test. Asserts that a filter for a **non-dominant** language returns rows on a query whose unfiltered hits are all Western. Controls the instrument in both directions: the target language must have rows in the *table* (asked of the table, never inferred from the search), and the unfiltered arm must return something; either control failing reports UNKNOWN and exits 2 rather than a misleading pass or fail. `--rpc=` points it at either function; `--dump-defs` prints `pg_get_functiondef` for all six.
- Comment corrections in `add-match-semantic-rpc.sql` and `add-page-texts-table.sql`. The wrong claims are marked in place rather than deleted — the gap between the comment and the query under it *is* the bug, and it is the most useful thing in the file.
- `.claude/docs/embeddings.md` + `.claude/docs/invariants/search-filters-and-lanes.md` — the generalised rule: **a filter over a vector index is a post-filter until proven otherwise**; fast-zero is the tell; test with the rare value, never the common one.

## Out of scope, deliberately

- **`scripts/migration/apply-semantic-language-prefilter.sql` is NOT applied and must not be by this PR.** It replaces the three live serving RPCs, which is actuation on the request path. Its header lists four preconditions, all of which need production DB access. **This is the post-merge step awaiting @JDerekLomas.**
- No change to `src/` — the RPC contract is unchanged, so `semantic-search.ts` and the MCP tools need no edit. This PR is one concern: the plan the filter runs under.
- **Partial HNSW indexes per language on `page_translations`** — the structurally-immune option, and the pattern `page_texts` already uses. It is the right follow-up if production turns out to be on pgvector < 0.8.0, and it is an index-build decision on a 4.5M-row table, so it belongs in its own issue.
- The other items split out of the #4439 report (work_language/text_role, truncated-ingest badges, work_id in results) are separate issues already.

## Blocker: production verification is incomplete, and here is exactly what is missing

Everything above that says "production" was measured through the **PostgREST RPC** with the service-role key. What I could **not** do is reach Postgres directly, which means these three things are unverified:

1. `EXPLAIN ANALYZE` against the real 4.5M-row table (the plans above are from the local 60K reproduction).
2. Production p95 latency for either path.
3. `pg_get_functiondef` on the three live RPCs — so the audit above is against the **committed** SQL, and per `lesson_committed_migration_may_not_match_production` that is not evidence of what is deployed.

Why: `SUPABASE_DB_URL` / `SUPABASE_DB_PASSWORD` live only in the macOS Keychain behind `secret-lover`, whose `keychain-helper` needs an interactive LocalAuthentication approval that a non-interactive session cannot give. `secret-lover run` then reports the unreadable secrets as **"not in Keychain (skipping)"** and proceeds with them empty — the failure mode already recorded in `credential-injection.md`, observed again here. They are also not in `.env.production.local`, any of its backups, or the Vercel project env; and PostgREST's `application/vnd.pgrst.plan` media type is disabled on this project (406 `PGRST107`), so plans cannot be read through the API either.

**To finish it**, from an interactive terminal:

```bash
# 1. Apply the shadows (additive — creates only *_prefilter_v2, touches no live RPC).
#    run-supabase-sql.mjs reads PGPASSWORD, which secret-lover supplies as
#    SUPABASE_DB_PASSWORD, so map it:
secret-lover run -- sh -c 'PGPASSWORD=$SUPABASE_DB_PASSWORD node \
  scripts/migration/run-supabase-sql.mjs scripts/migration/fix-semantic-language-prefilter.sql'

# 2. Read what is ACTUALLY deployed, and the pgvector version (decides Path A vs B).
secret-lover run -- node scripts/audit/semantic-language-filter-recall.mjs --dump-defs

# 3. The mechanism test against the shadow. Must PASS (exit 0); it exits 1 today
#    against match_semantic and 2 if a control fails.
node --env-file=.env.production.local scripts/audit/semantic-language-filter-recall.mjs \
  --rpc=match_semantic_prefilter_v2 --sweep
```

Then read the EXPLAIN and the timings before anything goes near `apply-semantic-language-prefilter.sql`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd
