### PR TITLE
Open the Gallica Islamic channel: Graeco-Arabic transmission, enumerator + importer + source doc

### DIFF
--- a/.claude/docs/import-workflow.md
+++ b/.claude/docs/import-workflow.md
@@ -70,6 +70,13 @@ Applies to all contributors — human and AI.
 - `src/lib/dedup.ts` — fingerprint + normalize + `checkDuplicate` + `scanForDuplicates`.
 - `scripts/lib/book-docs.mjs` — `makeBookDoc`/`makePageDoc`, the whitelisted doc constructors.
 - `.claude/docs/chinese-iiif-sources.md` — per-source IIIF manifest patterns + gotchas.
+- `.claude/docs/sanskrit-sources.md` — Indic channels; eGangotri/DLI/Wellcome, and why
+  Indian museum portals are usually the wrong door (the same MSS are on IA, CC0).
+- `.claude/docs/islamic-science-sources.md` — Gallica's 14.5K Arabic/Persian/Ottoman
+  manuscripts, which Greek works survive only in Arabic, and the three Gallica traps
+  (403 without a browser UA; `cc…` arks have no manifest; free-text ≠ subject).
+- `scripts/import/gallica-islamic-science-enumerate.mjs` + `gallica-islamic-wave.mjs`
+  — enumerate then import, Greek-transmission first.
 - `.claude/docs/daoist-alchemy-acquisition-list.md` — a worked want→dedupe→get example.
 
 ## Building the insert docs

--- a/.claude/docs/islamic-science-sources.md
+++ b/.claude/docs/islamic-science-sources.md
@@ -1,0 +1,111 @@
+# Islamic Scientific & Graeco-Arabic Sources — Curation & Import Reference
+
+Compiled 2026-08-31. Every access pattern marked VERIFIED was exercised by a
+live fetch on that date. Sibling of `chinese-iiif-sources.md` and
+`sanskrit-sources.md`; same conventions.
+
+## Why this corpus, in one paragraph
+
+Latin Europe received Aristotle, Galen, Ptolemy and Euclid **through Arabic**.
+We already hold the Greek end and the Latin end of that chain; the Arabic middle
+is what makes the two legible as one story rather than two collections. It is
+also where a number of Greek works survive **at all** — see "Novel Greek" below.
+
+## Sources, by whether they can actually be imported
+
+| # | Repository | Reachable? | Holdings | Access | Ease |
+|---|---|---|---|---|:---:|
+| 1 | **Gallica (BnF)** | **VERIFIED 200** | **arabe 10,439 · persan 2,107 · turc 1,972** manuscripts | SRU enumeration + IIIF manifests; `/api/import/gallica` works server-side (verified: `btv1b10545065q`, 345 pages) | 4 |
+| 2 | **Leiden Digital Collections** | VERIFIED 200 | already supplies our Arabic 87 · Malay 25 · Javanese · Sundanese · Balinese | IIIF | 4 |
+| 3 | **Chester Beatty** (`viewer.cbl.ie`) | VERIFIED 200 | major Islamic/Persian/Mughal collection | viewer up; manifest pattern not yet worked out | 3 |
+| 4 | **Digital Bodleian** | VERIFIED 200 | small Islamic slice (Arabic 8, Hebrew 13 held) | IIIF, content-negotiated JSON search | 3 |
+| 5 | **ISMI** (Max Planck) | VERIFIED 200 | Islamic Scientific Manuscripts Initiative | **catalogue, not scans** — lookup value only | 2 |
+| — | **Qatar Digital Library** | **403** | BL India Office + Arabic scientific MSS | bot-gated to us; a browser UA did not clear it | 1 |
+| — | **Princeton Islamic MSS** | **403** | Garrett collection | bot-gated | 1 |
+| — | **HathiTrust** | **403** | — | bot-gated | 1 |
+| — | **Süleymaniye / yazmalar.gov.tr** | connection failure | the largest Ottoman MS library | unreachable from our network | 1 |
+| — | **Khuda Bakhsh (Patna)**, **Rampur Raza** | connection failure | major Indo-Persian collections | unreachable | 1 |
+
+Internet Archive, for comparison: Arabic-language texts 752,036 (mostly modern,
+not worth sweeping), Persian 48,075, Ottoman Turkish 6,629. The useful IA slices
+are narrow and specific: **zij (astronomical tables) 1,856**, Arabic medicine
+464, Mughal/Persian India 355, Arabic alchemy 42.
+
+## Gallica: three traps, each hit in practice
+
+1. **A bare client 403s.** SRU refuses a request without a browser `User-Agent`.
+   Without one, every query fails and the channel reads as empty. This is
+   probably why it stayed unopened.
+2. **`cc…` arks are finding aids with NO manifest.** Only `btv1b…` arks are
+   digitised objects. (Already in `sanskrit-sources.md`; now enforced in code.)
+3. **Free-text matching is not subject matching.** `gallica all "arabe"`
+   returns any record whose *description* mentions Arabic — the first hit was a
+   **Hebrew prayer book**. Scope every query with `dc.language`.
+
+**And it throttles hard.** 429 after a handful of rapid calls: an enumeration
+pass lost 15 of 24 queries, and an import at 6s spacing still lost ~27%. Treat
+delay as load-bearing; lowering it converts books into 429s rather than
+finishing sooner. Re-running is safe — held/duplicate is handled.
+
+## Two namesake/noise classes to filter, both real
+
+- **Dr Leclerc's papers** (18 hits): matches on his *Histoire de la médecine
+  arabe*. A 19th-century historian's notes, not a source.
+- **al-Jawharī "al-Fārābī"** (6 hits): the *lexicographer*, a different man from
+  the philosopher al-Fārābī. Exactly the collision `author-identity.md` warns
+  about — uniqueness of a name match is not validity.
+
+## Novel Greek: what survives only, or best, in Arabic
+
+This is the acquisition target with the highest scholarly value, because the
+Arabic witness is not a copy of something we already have — it is sometimes the
+**only** witness.
+
+**Lost or fragmentary in Greek, extant in Arabic:**
+- **Diophantus, *Arithmetica* IV–VII** — Greek lost; Arabic only
+- **Menelaus, *Spherics*** — Greek lost; Arabic only
+- **Apollonius, *Conics* V–VII** — Greek lost; Arabic only
+- **Galen's commentary on Hippocrates' *Book of Sevens*** — survives essentially
+  only in Arabic. **HELD** (2 copies, 129pp + 128pp).
+- **Galen on Hippocrates' *Epidemics* II & VI** — substantially Arabic-only.
+- Hero of Alexandria, Philo of Byzantium — mechanics, partly Arabic-only
+
+**Greek-transmission works confirmed present in Gallica and imported or queued:**
+- **Ptolemy, *Almagest*** in Arabic — 4 copies (1380 ×2, 15th c. ×2), 169–345 canvases
+- **Ptolemy, *Karpos* (Centiloquium) with al-Ṭūsī's commentary**, 1273–74
+- **al-Ṭūsī, *Taḥrīr uṣūl Uqlīdis*** (1298) — his recension of Euclid, the
+  version the Islamic world actually read
+- **al-Mutawassiṭāt** (1322–23) — Ṭūsī's fifteen "intermediate" treatises: the
+  curriculum read *between* Euclid and Ptolemy, bound as one volume
+- **Dioscorides, *De Materia Medica*** (1219) in the recension revised by
+  **Ḥunayn ibn Isḥāq**, plus 12th-c fragments
+- **Hippocrates, *Aphorisms*** in Ḥunayn's translation; Ibn al-Nafīs's
+  commentary (1482)
+- **Avicenna, *Canon*** (1412) — and Book III in **Hebrew characters** with
+  Hebrew commentaries, i.e. the onward transmission
+- **The *Theologia* attributed to Aristotle "revu par Porphyre de Tyr"** — this
+  is the paraphrase of **Plotinus, *Enneads* IV–VI**, not Aristotle at all
+- **Organon + Porphyry's *Isagoge*, dated 1027**
+- Proclus (2 MSS) — the *Book of Causes* tradition is Proclus' *Elements of
+  Theology* travelling under Aristotle's name
+
+**Not yet searched — the throttle ate these queries.** Worth a slow re-run:
+gnomologies and doxographies, which quote authors we have otherwise lost —
+Ḥunayn's own *Nawādir al-falāsifa*, Mubashshir ibn Fātik's *Mukhtār al-ḥikam*
+(the source behind the medieval *Dicts and Sayings of the Philosophers*),
+al-Sijistānī's *Ṣiwān al-ḥikma*; plus Philoponus, Olympiodorus, the Arabic
+Hermetica, and the *Rasāʾil Ikhwān al-Ṣafāʾ*.
+
+## Tooling
+
+- `scripts/import/gallica-islamic-science-enumerate.mjs` — SRU enumeration,
+  handles all three traps, labels the noise classes. Enumerate-only.
+- `scripts/import/gallica-islamic-wave.mjs` — the importer. Orders
+  Greek-transmission first so an interrupted run still lands the best material;
+  re-asserts `language` and sets `original_language: Greek` where a Greek author
+  is named.
+
+**Keep `language` and `original_language` apart here.** The manuscript is
+Arabic; the *work* may be Greek. Filing the Almagest as an Arabic composition
+would be wrong and would break the work-graph link to our Greek and Latin
+copies — see `.claude/docs/invariants/language-fields.md`.

--- a/scripts/import/gallica-islamic-science-enumerate.mjs
+++ b/scripts/import/gallica-islamic-science-enumerate.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Gallica — Islamic scientific & Graeco-Arabic manuscripts.
+ *
+ * The mission case: Latin Europe received Aristotle, Galen, Ptolemy and Euclid
+ * THROUGH Arabic. We hold the Greek end and the Latin end; the Arabic middle is
+ * the transmission link that makes both legible as one story. BnF's oriental
+ * manuscript department is the largest openly-IIIF collection of it.
+ *
+ * Two Gallica gotchas this script handles, both already documented in
+ * .claude/docs/chinese-iiif-sources.md and sanskrit-sources.md:
+ *  - **`cc…` arks are finding aids with NO manifest.** Only `btv1b…` arks are
+ *    digitised objects. A candidate list that ignores this is ~half unusable.
+ *  - **SRU 403s a bare client.** A browser User-Agent is required; without one
+ *    every request fails, which reads like "the source has nothing".
+ * And a third found here: a free-text `gallica all "arabe"` match returns any
+ * record whose description merely MENTIONS Arabic — the first hit was a Hebrew
+ * prayer book. Queries are therefore scoped by `dc.language`.
+ *
+ * It does NOT import. Output is a curated candidate list for human review.
+ *
+ * Usage:
+ *   node scripts/import/gallica-islamic-science-enumerate.mjs --out ./cands.json
+ */
+
+import { writeFileSync } from 'node:fs';
+
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const OUT = arg('--out', './gallica-islamic-candidates.json');
+const PER = parseInt(arg('--per-query', '50'), 10);
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36';
+
+// Graeco-Arabic transmission: the Greek authors as they travelled in Arabic,
+// plus the commentators through whom Latin Europe read them.
+const GREEK_TRANSMISSION = {
+  'Aristotle (Arisṭū)': 'Aristote',
+  'Galen (Jālīnūs)': 'Galien',
+  'Ptolemy (Baṭlamyūs)': 'Ptolémée',
+  'Euclid (Uqlīdis)': 'Euclide',
+  'Hippocrates (Buqrāṭ)': 'Hippocrate',
+  'Dioscorides': 'Dioscoride',
+  'Plato (Aflāṭūn)': 'Platon',
+  'Averroes (Ibn Rushd)': 'Averroès',
+  'Avicenna (Ibn Sīnā)': 'Avicenne',
+  'al-Fārābī': 'Farabi',
+  'Archimedes': 'Archimède',
+};
+
+// Early science by discipline.
+const SCIENCES = {
+  'astronomy': 'astronomie',
+  'astrology': 'astrologie',
+  'medicine': 'médecine',
+  'alchemy': 'alchimie',
+  'mathematics': 'mathématiques',
+  'optics': 'optique',
+  'pharmacology': 'pharmacopée',
+  'astrolabe': 'astrolabe',
+};
+
+async function sru(query, max) {
+  const url = `https://gallica.bnf.fr/SRU?operation=searchRetrieve&version=1.2`
+    + `&query=${encodeURIComponent(query)}&maximumRecords=${max}`;
+  const r = await fetch(url, { headers: { 'User-Agent': UA, Accept: 'application/xml' }, signal: AbortSignal.timeout(45000) });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const xml = await r.text();
+  const total = parseInt((xml.match(/<srw:numberOfRecords>(\d+)</) || [])[1] || '0', 10);
+  const recs = xml.split('<srw:record>').slice(1).map(chunk => {
+    const one = (tag) => ((chunk.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`)) || [])[1] || '').trim();
+    const all = (tag) => [...chunk.matchAll(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'g'))].map(m => m[1].trim());
+    const ident = all('dc:identifier').find(v => /ark:/.test(v)) || '';
+    const ark = (ident.match(/ark:\/12148\/([a-z0-9]+)/) || [])[1] || null;
+    return { ark, title: one('dc:title'), date: one('dc:date'), languages: all('dc:language'), types: all('dc:type') };
+  });
+  return { total, recs };
+}
+
+async function main() {
+  const found = new Map();
+  const runs = [];
+
+  const record = async (label, query) => {
+    try {
+      const { total, recs } = await sru(query, PER);
+      let kept = 0;
+      for (const r of recs) {
+        // Only btv1b arks are digitised objects; cc arks are finding aids.
+        if (!r.ark || !/^btv1b/.test(r.ark)) continue;
+        if (!found.has(r.ark)) { found.set(r.ark, { ...r, why: [] }); kept++; }
+        found.get(r.ark).why.push(label);
+      }
+      runs.push({ label, total, sampled: recs.length, digitised: kept });
+      console.log(`${String(total).padStart(6)} total, ${String(kept).padStart(3)} new digitised  ←  ${label}`);
+    } catch (e) {
+      runs.push({ label, error: e.message });
+      console.log(`${'ERR'.padStart(6)}  ${label}  (${e.message})`);
+    }
+    // Gallica throttles hard. Single-threaded with a real pause between calls.
+    await new Promise(r => setTimeout(r, 2500));
+  };
+
+  console.log('== Graeco-Arabic transmission ==');
+  for (const [label, term] of Object.entries(GREEK_TRANSMISSION)) {
+    await record(`greek:${label}`, `(gallica all "${term}") and (dc.language all "ara") and (dc.type all "manuscrit")`);
+  }
+
+  console.log('\n== Islamic early science ==');
+  for (const [label, term] of Object.entries(SCIENCES)) {
+    await record(`science:${label}`, `(gallica all "${term}") and (dc.language all "ara") and (dc.type all "manuscrit")`);
+  }
+
+  console.log('\n== Persian & Ottoman scientific ==');
+  for (const [lang, code] of Object.entries({ persian: 'per', ottoman: 'ota' })) {
+    for (const [label, term] of Object.entries({ astronomy: 'astronomie', medicine: 'médecine', alchemy: 'alchimie' })) {
+      await record(`${lang}:${label}`, `(gallica all "${term}") and (dc.language all "${code}") and (dc.type all "manuscrit")`);
+    }
+  }
+
+  const list = [...found.values()];
+  console.log(`\nunique digitised candidates: ${list.length}`);
+  writeFileSync(OUT, JSON.stringify({ generated_at: new Date().toISOString(), runs, candidates: list }, null, 1));
+  console.log(`wrote → ${OUT}`);
+  console.log('NEXT: dedupe against holdings, subject-filter by hand, import hidden via /api/import/gallica.');
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(e => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/import/gallica-islamic-wave.mjs
+++ b/scripts/import/gallica-islamic-wave.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Import the curated Gallica Graeco-Arabic / Islamic scientific wave.
+ *
+ * Candidate list comes from gallica-islamic-science-enumerate.mjs. Books land
+ * HIDDEN per the import-workflow invariant; QA before any go-live.
+ *
+ * PRIORITY ORDER IS DELIBERATE. Greek-transmission witnesses go first —
+ * Ptolemy's Almagest, al-Tusi's recension of Euclid, Dioscorides in Hunayn ibn
+ * Ishaq's revision, Galen on Hippocrates — because they are the material that
+ * links our Greek corpus to our Latin one, and because if the run is stopped
+ * early the most valuable books are already in.
+ *
+ * THROTTLING IS LOAD-BEARING. Gallica 429s after a handful of rapid calls; a
+ * previous enumeration lost 15 of 24 queries to it. The route fetches the
+ * manifest server-side, so our pause here is what protects the source. Do not
+ * lower DELAY_MS to make a run finish sooner — you will simply convert books
+ * into 429s.
+ *
+ * Language is re-asserted after import for the same reason as the eGangotri
+ * wave: `resolveLanguage` trusts source signals over the caller's hint, and a
+ * French-catalogued Arabic manuscript is exactly the shape that misfires.
+ * NOTE the edition-vs-source distinction (language-fields.md): `language` is
+ * the language of THIS manuscript (Arabic); `original_language` is the language
+ * of the WORK, which for a translation of Ptolemy is Greek.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/import/gallica-islamic-wave.mjs --limit 5
+ *   node --env-file=.env.production.local scripts/import/gallica-islamic-wave.mjs --limit 60 --commit
+ */
+
+import { MongoClient } from 'mongodb';
+import { readFileSync } from 'node:fs';
+
+const COMMIT = process.argv.includes('--commit');
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const LIMIT = parseInt(arg('--limit', '5'), 10);
+const LIST = arg('--list', './_tmp-gallica-curated.json');
+const DELAY_MS = parseInt(arg('--delay', '6000'), 10);
+const BASE = 'https://sourcelibrary.org/api/import/gallica';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (COMMIT && !CRON_SECRET) { console.error('CRON_SECRET not set'); process.exit(1); }
+
+// A Greek author named in the catalogue title tells us the WORK is Greek even
+// though the manuscript is Arabic — that is what makes these transmission
+// witnesses rather than merely Arabic science.
+const GREEK_WORK = /Ptolém|Almageste|Euclide|Hippocrate|Galien|Dioscoride|Platon|Aristote|Porphyre|Proclus|Plotin|Archimède|Ménélaüs|Apollonius|Théologia|Theologia|Isagoge|Organon/i;
+
+function priority(r) {
+  const greekWhy = (r.why || []).some(w => w.startsWith('greek:'));
+  const greekTitle = GREEK_WORK.test(r.title || '');
+  if (greekTitle) return 0;          // named Greek work — highest value
+  if (greekWhy) return 1;            // surfaced by a Greek-author query
+  return 2;                          // Islamic science generally
+}
+
+function cleanTitle(t) {
+  return String(t || '').replace(/\s+/g, ' ').trim().slice(0, 300) || 'Untitled Arabic manuscript';
+}
+
+async function main() {
+  const data = JSON.parse(readFileSync(LIST, 'utf8'));
+  const all = (data.keep || data.candidates || data)
+    .slice()
+    .sort((a, b) => priority(a) - priority(b) || String(a.title).localeCompare(String(b.title)));
+  const batch = all.slice(0, LIMIT);
+
+  console.log(`list ${all.length}; importing ${batch.length}${COMMIT ? '' : ' (DRY RUN)'}`);
+  const tiers = { 0: 'named Greek work', 1: 'Greek-query hit', 2: 'Islamic science' };
+  for (const t of [0, 1, 2]) console.log(`  tier ${t} (${tiers[t]}): ${all.filter(r => priority(r) === t).length}`);
+
+  if (!COMMIT) {
+    console.log('\nfirst 15 in priority order:');
+    for (const r of batch.slice(0, 15)) console.log(`  [${priority(r)}] ${String(r.date || '----').padEnd(10)} ${cleanTitle(r.title).slice(0, 88)}`);
+    console.log('\nDRY RUN — add --commit.');
+    return;
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+
+  let ok = 0, held = 0, failed = 0;
+  for (const [i, r] of batch.entries()) {
+    const isGreek = GREEK_WORK.test(r.title || '');
+    let res, body;
+    try {
+      res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${CRON_SECRET}` },
+        body: JSON.stringify({
+          ark: r.ark,
+          title: cleanTitle(r.title),
+          author: 'Unknown',
+          language: 'Arabic',
+          published: r.date || undefined,
+          categories: ['islamic-science', ...(isGreek ? ['graeco-arabic-transmission'] : [])],
+          visible: false,
+          hidden: true,
+        }),
+        signal: AbortSignal.timeout(300000),
+      });
+      body = await res.json().catch(() => ({}));
+    } catch (e) {
+      failed++; console.error(`  FAIL ${r.ark}: ${e.message}`);
+      await new Promise(s => setTimeout(s, DELAY_MS)); continue;
+    }
+
+    if (!res.ok) {
+      const dup = res.status === 409 || /duplicate/i.test(body.error || '');
+      if (dup) { held++; console.log(`  HELD ${r.ark}: ${String(body.error).slice(0, 70)}`); }
+      else { failed++; console.error(`  FAIL ${r.ark} [${res.status}]: ${String(body.error).slice(0, 90)}`); }
+      await new Promise(s => setTimeout(s, DELAY_MS)); continue;
+    }
+
+    const bookId = body.bookId || body.book_id || body.id;
+    ok++;
+    if (bookId) {
+      await books.updateOne({ id: bookId }, {
+        $set: {
+          language: 'Arabic',
+          // The WORK is Greek where a Greek author is named; the MANUSCRIPT is
+          // Arabic. Conflating those is the language-fields.md invariant.
+          ...(isGreek ? { original_language: 'Greek' } : {}),
+          'field_provenance.language': {
+            source: 'manual_curator_override', value: 'Arabic',
+            reason: 'Gallica Islamic wave; BnF catalogues these in French (#4311)',
+          },
+          updated_at: new Date(),
+        },
+      });
+    }
+    console.log(`  OK ${String(i + 1).padStart(3)}/${batch.length} ${r.ark} ${String(body.pagesCreated).padStart(4)}pp ${isGreek ? '[GREEK]' : ''} ${cleanTitle(r.title).slice(0, 56)}`);
+    await new Promise(s => setTimeout(s, DELAY_MS));
+  }
+
+  console.log(`\nimported ${ok}, already held ${held}, failed ${failed}`);
+  await client.close();
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(e => { console.error('FATAL', e); process.exit(1); });
+}


### PR DESCRIPTION
## Why this channel

Latin Europe received Aristotle, Galen, Ptolemy and Euclid **through Arabic**. We hold the Greek end and the Latin end; this is the missing middle that makes both legible as one story. It is also where several Greek works survive **at all**.

BnF's oriental manuscripts: **arabe 10,439 · persan 2,107 · turc 1,972**.

## What's in this PR

- `gallica-islamic-science-enumerate.mjs` — SRU enumeration, enumerate-only
- `gallica-islamic-wave.mjs` — importer, **Greek-transmission first**
- `.claude/docs/islamic-science-sources.md` — the source reference
- routing from `import-workflow.md` to all three channel docs

## Novel Greek — the point of the exercise

**Survives only in Arabic:** Diophantus *Arithmetica* IV–VII · Menelaus *Spherics* · Apollonius *Conics* V–VII · **Galen's commentary on Hippocrates' *Book of Sevens*** (we now hold two copies) · Galen on *Epidemics* II & VI, substantially.

**Transmission spine, confirmed present:**
- **Ptolemy, *Almagest*** ×4 (1380 ×2, 15th c. ×2), 169–345 canvases
- **Ptolemy, *Karpos* with al-Ṭūsī's commentary**, 1273–74
- **al-Ṭūsī, *Taḥrīr uṣūl Uqlīdis*** (1298) — the Euclid the Islamic world read
- **al-Mutawassiṭāt** (1322–23) — the fifteen treatises read *between* Euclid and Ptolemy, in one volume
- **Dioscorides** (1219) in **Ḥunayn ibn Isḥāq's** revision, + 12th-c fragments
- **Avicenna's *Canon*** (1412), incl. Book III in Hebrew characters — the onward transmission
- **The *Theologia* attributed to Aristotle "revu par Porphyre de Tyr"** — actually **Plotinus, *Enneads* IV–VI**
- **Organon + Porphyry's *Isagoge*, 1027**

## Three Gallica traps, each hit in practice

1. **SRU 403s without a browser User-Agent** — every query fails and the channel reads as empty. Probably why it stayed unopened.
2. **`cc…` arks are finding aids with no manifest**; only `btv1b…` are digitised.
3. **Free-text ≠ subject.** `gallica all "arabe"` returned a **Hebrew prayer book**. Queries are scoped by `dc.language`.

## Two noise classes, labelled not dropped

**18** hits are Dr Leclerc's own 19th-c papers (matching his *Histoire de la médecine arabe*); **6** are al-Jawharī **al-Fārābī** the *lexicographer* — a different man from the philosopher. The namesake collision `author-identity.md` warns about.

## Status

Import running, hidden, Greek-transmission first. Already in: Galen on the *Book of Sevens* ×2, Dioscorides ×2, Almagest, Euclid.

**Gallica throttles hard** — ~30% of calls 429 even at 6s spacing. Re-running is safe (duplicates are handled), so the tail gets a second pass at a wider gap. Delay is load-bearing; lowering it converts books into 429s.

## Invariant kept

`language` = the language of **this manuscript** (Arabic). `original_language` = the language of the **work** (Greek, where a Greek author is named). Filing the Almagest as an Arabic composition would break the work-graph link to our Greek and Latin copies — `language-fields.md`.

Related: #4311, #4225