### PR TITLE
docs(invariants): spend-controls, paid for by demoting corpus stats

### DIFF
--- a/.claude/docs/invariants/spend-controls.md
+++ b/.claude/docs/invariants/spend-controls.md
@@ -1,0 +1,85 @@
+# Spend controls — the dial, and the four ways it has failed
+
+**Read this when** you are adding or changing anything that calls Gemini from a
+worker, cron, or scheduled job; adding a line to `infrastructure/hetzner-crontab`
+or `vercel.json` crons; touching `scripts/lib/spend-guard.mjs`; or asking "why
+did the daily budget not hold?"
+
+The dial is `system_config.processing_control.daily_budget_usd`, changed **only**
+via `scripts/maintenance/set-dial.mjs` (versioned — it snapshots the prior doc).
+Unset/0 means no paid dispatch: default-closed on purpose.
+
+There is a standing check — `scripts/audit/spend-perimeter.mjs`, wired to CI on
+changes to workers, the crontab, or `vercel.json`. It fails on an ungated
+spending phase, an unclassified schedule, or a worker whose `main()` does not
+gate. **If you are adding a spender, that check is what will catch you; this doc
+is for the part it cannot check.**
+
+## The four failure modes
+
+They are indistinguishable from outside — all of them present as "I set a limit
+and it didn't hold." Name the mode before fixing anything.
+
+**1. Wrong meter** (#3826, fixed #3835). The guard summed Mongo `gemini_usage`
+while the logger wrote Supabase. It read $9.00 on a day that billed ~$2.3K
+against a $15 dial. `getTodaySpendUsd` now sums BOTH stores and **fails closed**
+when the primary is unreadable — an unreadable meter must stop the line, not
+green-light it.
+
+**2. Ungated paths** (#4436). A perfect meter cannot stop a path that never calls
+the gate. Five of seven orchestrator spending phases never asked — including
+Phase 1.5, which the crontab runs every two minutes, so the phase that ran most
+often was the one the ceiling could not stop. Separately, import-time preview OCR
+spent ~$392 in four days straight through a **pause** (#4432).
+
+**3. Dispatch is not consumption** (#4446). `translate-worker` gated
+`selfDispatch()` — which creates work — but `main()` also drained
+already-queued jobs and asked nothing. Caught live on the 2026-08-31 relight:
+5,011 orphaned jobs / 107,938 pages draining while the guard truthfully logged
+`CEILING REACHED — no new dispatch`. Both statements were correct at once.
+
+> **A queue is stored spend.** Anything that turns a queued job into Gemini
+> calls has to ask, or the ceiling only limits how fast you ENQUEUE money.
+
+Corollary: **removing a producer does not empty its queue.** #4432 deleted the
+feature that created those jobs; the jobs kept running for days.
+
+**4. Committed but unpriced — OPEN.** A batch job writes its usage row at SUBMIT
+with `cost_usd: 0`; the true cost lands only when the collector picks it up.
+Between submit and collect the spend is invisible, so the dial over-dispatches by
+whatever is in flight. Measured 2026-08-31: dial $5, cut off at $5.08 *visible*,
+settled at **$6.32** (26% over) once 13 batches / 2,350 pages / $2.87 were
+priced. Scales with in-flight batch size.
+
+## Judgment, which no check asserts
+
+- **Presence of a guard is not coverage by it.** The first version of
+  `spend-perimeter.mjs` passed `translate-worker` because the *file* mentioned
+  `budgetAllowsDispatch` — in a helper off the spending path. Hours later that
+  worker drained a queue through the ceiling. Check the **path**, not the file.
+- **A per-call cost is a rate, not an amount.** "Preview OCR is not free… ~$2.73"
+  was written three weeks before the same code cost $392. Multiply by the
+  acquisition rate before calling something negligible.
+- **Verify a relight by watching the CALL COUNT freeze, not the dollar figure.**
+  Dollars keep climbing after the ceiling as batch accounting catches up; a
+  frozen call count is what proves dispatch actually stopped.
+- **Silence is not proof a watcher is working.** A monitor that only reports
+  movement looks identical when the line is quiet and when the monitor is dead.
+  Positive-control it against a live query before trusting six hours of calm.
+
+## Known holes, deliberately
+
+- **Traffic-driven Vercel routes are outside the dial by construction** — chat,
+  ask, explain, identify, ai-expand, transliterate, detect-split,
+  contribute/process. No live route in `src/` reads `processing_control` at all.
+  Measured ~$1.61/day against ~$75/day of gateable pipeline spend; it scales with
+  visitors and bots, not with the pipeline.
+- `cron-caller.mjs` → `/api/cron/social-post` → `tweet-generator` (Gemini),
+  fixed-rate 8/day.
+- **`cost_usd` is COMPUTED, never billed** (#3576 open). Billed ran ~3x computed
+  on runaway-heavy days, and ~110 rows/day carry no `cost_usd` at all — the guard
+  prints that count every cycle. **A $5 computed dial is not a $5 invoice.**
+  Treat the ceiling as a strong brake, not an accounting system.
+- **Phase 2's cross-book pool routes every small book to flash-lite regardless of
+  script** — the defect #4436 fixed for preview only. See `language-fields.md`
+  for why that matters on non-Latin scripts.

--- a/.claude/docs/invariants/visibility-and-stats.md
+++ b/.claude/docs/invariants/visibility-and-stats.md
@@ -22,3 +22,24 @@ Lessons from PR #2055 (see `.claude/handoffs/`). The homepage and most public su
 - **`gallery_images.book_visible` drifts in BOTH directions, and only one direction is a leak.** It is denormalised from `books.visible` and refreshed by the sync worker only when a book's **pages** change, so a bare visibility flip never reaches it. Measured 2026-08-18: 1,217 rows claimed `book_visible: true` for a hidden book (art leaking, fixed), and **6,760 claimed `false` for a visible book** (art suppressed that should show, left alone). Repair the leak direction freely; the suppressed direction *publishes* images and is a curation decision, not a data fix. Don't "correct" both in one sweep and call it hygiene.
 - **Authored prose inside a collection doc is a takedown surface.** The Kloss takedown swept books, Supabase, `gallery_images.book_visible`, collection `visible` flags, the tenant and code references — but not `description` / `expanded_description` / `highlighted_books` / `featured_images` / `hero_image`, which are hand-written and cite specific books by id. `/collections/freemasonry` therefore stayed live for six weeks naming "the Kloss Library, one of the most important Masonic research collections ever assembled" and linking 13 removed books, every link dead. **Any removal has to grep the authored fields, not just the flags** — a hidden book stops rendering, but a sentence *about* it does not.
 - **A card must count what its TARGET page renders, not what the collection holds.** `collections` carries three counters — `book_count` (translated/readable), `total_book_count` (all visible member texts, #3176), `artwork_count` — and nothing ties a counter to the view that consumes it, so a card is free to pick the wrong one. A `collection_type: 'visual_art'` collection renders artworks and *nothing else* (`isArtCollection`), so its book counters describe texts the reader can never reach from it. Until #4106 the sub-collection child cards on `/collections/[id]` showed `total_book_count ?? book_count`, inherited their noun from the **parent** collection, and sorted the grid by `book_count` — so `school-of-athens` advertised **"518 books"** above a page showing **30 works**, and sorted second in Classical Philosophy. Measured across all 284 child cards, **19 art children were mislabelled**; School of Athens was the only over-count and the rest simply vanished (`esoteric-engravers` showing 0 against ~1,600 artworks, `portraits-tradition` 0 against ~1,600). The fix is per-child, not global: `childCardCount()` labels and sorts by the child's own `collection_type`, and `collectionCountLabel()` takes an optional third `collectionType` that drops the text half for `visual_art`. **Before adding a count to any card, open the page it links to and ask which query fills it** — `/collections` and the homepage grids escaped this only because they exclude `visual_art` at the query level, not because they got the counter right. Corollary, still open as a curation call (#4107): the 518 texts tagged `school-of-athens` are legitimate editions that no surface lists, so a counter can also be *honest about data that no page will ever show*. Second instance, 2026-08-30: on a newly built collection `book_count` counted every tagged, visible, paginated member (33) while the grid rendered 32, because the grid is `browseBooks` over Supabase and serves *readable* books — Carey's *Principles of Social Science* (497pp, 300 OCR'd, **0 translated**) is a legitimate member that no page will show. `book_count` is the readable subset, `total_book_count` is the membership; computing the former as "live members" silently overstates it by however many members are untranslated. Caught only by diffing the live grid against Mongo membership after the write, which is the check worth running: **do not validate a counter against the query you just wrote, validate it against the read path**.
+
+## Corpus counts (demoted from `CLAUDE.md` 2026-08-31)
+
+**Measured 2026-08-30 — re-measure before quoting; these drift by thousands a
+month.** The 2026-05-26 vintage of this paragraph was off by up to 5x
+(`pages_count > 0` read ~15K against a true 74.7K) and sat wrong for months
+because nobody re-ran it.
+
+- **109,567** total docs in `bookstore`
+- **47,483** `visible: true` — but **15,752 are artwork records with
+  `pages_count: 0`**, so the honest "books you can read" figure is **31,731**
+  (`visible: true && pages_count > 0`)
+- **84,574** with `pages_count > 0` (actually processed)
+- **61,829** with `pages_ocr > 0` — 20.2M pages ingested, 6.45M transcribed,
+  5.05M translated
+
+The canonical "live" filter across all public APIs is
+`visible: true && pages_count > 0` (see `/api/books/library`). The `tier` field
+is **legacy** — its only remaining reader is `src/app/page.tsx` homepage ranking
+via `highlighted_books` collection entries.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,12 +115,12 @@ it makes needs a person. Related: `.claude/docs/invariants/first-translation-cla
 
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
-- Production database: `bookstore`, NOT `sourcelibrary_research`. Measured 2026-08-30: **109,567** total docs, **47,483** `visible: true` — but **15,752 of those are artwork records with `pages_count: 0`, so the honest "books you can read" number is 31,731** (`visible: true && pages_count > 0`). Also **84,574** with `pages_count > 0` (actually processed), **61,829** with `pages_ocr > 0` (20.2M pages ingested, 6.45M transcribed, 5.05M translated). Re-measure before quoting — these drift by thousands a month, and the 2026-05-26 vintage of this line was off by up to 5× (`pages_count > 0` read ~15K against a true 74.7K) before anyone noticed. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking via `highlighted_books` collection entries); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
+- Production database: `bookstore`, NOT `sourcelibrary_research`. **Re-measure before quoting any corpus count** — the 2026-05-26 vintage of this line was off by up to 5x before anyone noticed, and `visible: true` alone overstates readable books by ~15.7K artwork records. Canonical "live" filter: `visible: true && pages_count > 0`. Current figures and the `tier` legacy note -> `.claude/docs/invariants/visibility-and-stats.md`.
 - **supabase-js silently caps every response at 1,000 rows** — no error, no warning, just a truncated array (truncation order follows the query plan, so it can look systematic, e.g. alphabetical). Any `.select()` that can exceed 1K rows needs `.range()` pagination or must be split into per-key queries. This zeroed whole corpora on `/api/ngrams` while reporting `found=true` (PR #3208) — the bug shape is "some keys work, others silently empty."
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
-- OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
+- OCR/Translation routing (`getModelForBook`): `gemini-3-flash-preview` for BPH, **non-Latin scripts, and unknown/absent language**; `gemini-3.1-flash-lite` only for the Latin-script allowlist. The cheap model does not fail on low-resource scripts — it invents plausible text. See `src/lib/types/ai-models.ts`.
 - **Grounded search: flash-lite does NOT ground** (0/189 measured 2026-08-10 — empty `groundingMetadata` while the prose claims "extensive searches"). Use `gemini-3-flash-preview` with an explicit positive `thinkingBudget` (512 → 6/6 grounded, ~$0.003/book; unbounded ≈ $0.19/book; `-1` silently suppresses grounding). Verify groundedness from `queries[]` on written rows, never from response prose.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
@@ -185,6 +185,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - Adding or changing a Librarian / MCP tool, or the text one returns → `agent-tool-results.md` (**a ranker cannot answer "how many"**, and a URL you leave out is one the model will invent — two 404s came out of the first live turn)
 
 **Writing a sweep, an import, or a new field**
+- Anything that calls Gemini from a worker or cron, a new `hetzner-crontab`/`vercel.json` line, or "why didn't the daily budget hold?" -> `spend-controls.md` (**a queue is stored spend**; the dial has failed four distinct ways, and they look identical from outside)
 - Running any script/worker under `secret-lover run`, or running one **from a worktree**, or a job that reports a store as empty → `credential-injection.md` (**secret-lover reports an unreadable secret as a missing one and runs anyway**; a worktree resolves to the wrong project and gets zero secrets)
 - Adding a field to `books`/`pages`, writing a maintenance sweep, or touching `book-docs.mjs`/`sweep-log.mjs`/`field-sprawl.mjs` → `field-sprawl.md` (**a sweep records a ROW, not a COLUMN**; consolidation without enforcement re-polluted 4.16M rows in 3 months)
 


### PR DESCRIPTION
The `/gnite` reflection pass from the spend-ceiling session. Both directions of the ratchet.

## Up

New `.claude/docs/invariants/spend-controls.md`, with one routing line in `CLAUDE.md`.

Last night found **four distinct ways a spend ceiling fails**, and the reason they need writing down is that they are indistinguishable from outside — all four present as "I set a limit and it didn't hold":

1. **Wrong meter** (#3826) — guard read one store, logger wrote the other
2. **Ungated paths** (#4436) — 5 of 7 orchestrator spending phases never asked
3. **Dispatch ≠ consumption** (#4446) — gated creating work, not draining a queue
4. **Committed but unpriced** — OPEN; batch cost is invisible between submit and collect (26% overshoot measured)

`scripts/audit/spend-perimeter.mjs` already fails CI on the mechanical cases. This doc carries only what a check cannot assert — chiefly that **presence of a guard is not coverage by it**, which is how the audit's own first version passed the worker that then drained a queue through the ceiling.

## Fixed in place

The OCR routing line claimed flash-lite was for "everything else", omitting the **non-Latin and unknown-language** branches. That is the *safety* half of the rule — flash-lite doesn't fail on low-resource scripts, it invents plausible text — and the omission is roughly why 4,281 non-Latin books (Chinese, Tibetan, Parthian, Sogdian) were about to be routed to it.

## Down

The corpus-stats paragraph moves to `visibility-and-stats.md`. It's a measurement snapshot that says of itself "re-measure before quoting", it only fires when someone quotes a count, and that doc already owns the subsystem. `CLAUDE.md` keeps the rule and the canonical filter.

**The figures were appended to the target before the pointer went in.** A demotion whose destination doesn't hold the content is deletion with a citation — and I'd just spent a night on exactly that failure shape, so I checked rather than assumed (the pointer *was* dead when I first wrote it).

Net **5,554 → 5,543** words: a routing line added, a wrong line corrected, and still under where it started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HCFx8VPFrhmBMGVbcpYQW