### PR TITLE
fix(security): revalidation routes fail closed — unset REVALIDATE_SECRET disabled auth entirely

### DIFF
--- a/src/app/api/admin/revalidate-book/[id]/route.ts
+++ b/src/app/api/admin/revalidate-book/[id]/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from 'next/cache';
 import { getDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
+import { isRevalidateAuthorized } from '@/lib/revalidate-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,10 +13,8 @@ export async function POST(
 ) {
   const { id } = await params;
 
-  // Optional: verify a simple shared secret for pipeline calls
-  const authHeader = request.headers.get('x-revalidate-secret');
-  const secret = process.env.REVALIDATE_SECRET;
-  if (secret && authHeader !== secret) {
+  // Shared secret for pipeline calls — fail-closed (see src/lib/revalidate-auth.ts).
+  if (!isRevalidateAuthorized(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/revalidate/route.ts
+++ b/src/app/api/admin/revalidate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 import { getDb } from '@/lib/mongodb';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
+import { isRevalidateAuthorized } from '@/lib/revalidate-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -18,12 +19,11 @@ export const maxDuration = 60;
  *   or { "collections": true }  — revalidate all collection pages
  *   or { "all": true }          — revalidate all content pages
  *
- * Auth: x-revalidate-secret header or admin session
+ * Auth: x-revalidate-secret header or Bearer secret (REVALIDATE_SECRET or
+ * CRON_SECRET) — fail-closed, see src/lib/revalidate-auth.ts.
  */
 export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get('x-revalidate-secret');
-  const secret = process.env.REVALIDATE_SECRET;
-  if (secret && authHeader !== secret) {
+  if (!isRevalidateAuthorized(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/lib/revalidate-auth.ts
+++ b/src/lib/revalidate-auth.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+
+/**
+ * Auth for the on-demand revalidation routes (/api/admin/revalidate,
+ * /api/admin/revalidate-book/[id]).
+ *
+ * Fail-closed: a request is authorized only when it presents a secret matching
+ * REVALIDATE_SECRET or CRON_SECRET, via the `x-revalidate-secret` header or
+ * `Authorization: Bearer <secret>`. If neither env var is set, nothing is
+ * authorized.
+ *
+ * History: the previous check was `if (secret && header !== secret) 401` —
+ * with REVALIDATE_SECRET unset in production that skipped auth entirely,
+ * leaving an unauthenticated cache-invalidation lever on the public site
+ * (each accepted call forces origin re-renders, i.e. someone else's compute
+ * bill). Found 2026-08-31 during the #4389 slug repair. CRON_SECRET is
+ * accepted so every existing pipeline caller already holds a working secret.
+ */
+export function isRevalidateAuthorized(request: NextRequest): boolean {
+  const bearer = (request.headers.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  const presented = [request.headers.get('x-revalidate-secret'), bearer].filter(
+    (p): p is string => typeof p === 'string' && p.length > 0
+  );
+  const secrets = [process.env.REVALIDATE_SECRET, process.env.CRON_SECRET].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  return secrets.length > 0 && presented.some((p) => secrets.includes(p));
+}

--- a/tests/unit/revalidate-auth.test.ts
+++ b/tests/unit/revalidate-auth.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The revalidation routes must FAIL CLOSED.
+ *
+ * INCIDENT (2026-08-31, found during the #4389 slug repair): the auth check in
+ * /api/admin/revalidate and /api/admin/revalidate-book/[id] was
+ * `if (secret && header !== secret) 401` — so with REVALIDATE_SECRET unset in
+ * production the check was skipped entirely, and an unauthenticated POST could
+ * force origin re-renders of arbitrary paths (a cache-busting lever anyone on
+ * the internet could pull; each accepted call spends origin compute). The call
+ * that discovered it carried no secret and no session and was accepted.
+ *
+ * This pins the replacement: no configured secret ⇒ nothing is authorized;
+ * a configured secret must actually match; CRON_SECRET is accepted so every
+ * existing pipeline caller keeps working.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { isRevalidateAuthorized } from '@/lib/revalidate-auth';
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('https://sourcelibrary.org/api/admin/revalidate', {
+    method: 'POST',
+    headers,
+  });
+}
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved.REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
+  saved.CRON_SECRET = process.env.CRON_SECRET;
+  delete process.env.REVALIDATE_SECRET;
+  delete process.env.CRON_SECRET;
+});
+
+afterEach(() => {
+  for (const k of ['REVALIDATE_SECRET', 'CRON_SECRET'] as const) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('isRevalidateAuthorized fails closed', () => {
+  it('refuses everything when no secret is configured — the incident shape', () => {
+    expect(isRevalidateAuthorized(req())).toBe(false);
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': 'anything' }))).toBe(false);
+    expect(isRevalidateAuthorized(req({ authorization: 'Bearer anything' }))).toBe(false);
+  });
+
+  it('refuses a missing or wrong secret when one is configured', () => {
+    process.env.REVALIDATE_SECRET = 'right';
+    expect(isRevalidateAuthorized(req())).toBe(false);
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': 'wrong' }))).toBe(false);
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': '' }))).toBe(false);
+  });
+
+  it('accepts a matching x-revalidate-secret', () => {
+    process.env.REVALIDATE_SECRET = 'right';
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': 'right' }))).toBe(true);
+  });
+
+  it('accepts CRON_SECRET via header or Bearer — pipeline callers keep working', () => {
+    process.env.CRON_SECRET = 'cron';
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': 'cron' }))).toBe(true);
+    expect(isRevalidateAuthorized(req({ authorization: 'Bearer cron' }))).toBe(true);
+  });
+
+  it('an empty configured secret authorizes nothing', () => {
+    process.env.REVALIDATE_SECRET = '';
+    expect(isRevalidateAuthorized(req({ 'x-revalidate-secret': '' }))).toBe(false);
+  });
+});
+
+describe('the routes actually use the guard (structural)', () => {
+  it.each([
+    'src/app/api/admin/revalidate/route.ts',
+    'src/app/api/admin/revalidate-book/[id]/route.ts',
+  ])('%s imports isRevalidateAuthorized and has no fail-open check', async (rel) => {
+    const { readFileSync } = await import('fs');
+    const path = await import('path');
+    const src = readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+    expect(src).toContain('isRevalidateAuthorized');
+    // The incident shape: a check guarded on the secret existing.
+    expect(src).not.toMatch(/if\s*\(\s*secret\s*&&/);
+  });
+});


### PR DESCRIPTION
Found live during the #4389 post-merge work: `POST /api/admin/revalidate` accepted a request with **no secret and no session** (112 paths revalidated, 200). The guard was `if (secret && header !== secret) 401` — with `REVALIDATE_SECRET` unset in production, auth was skipped entirely. Same shape in `revalidate-book/[id]`. (`revalidate-authors` is fine — it uses `withAdminAuth`.)

**Impact:** anyone could force origin re-renders of arbitrary paths — a cache-busting lever that spends our compute and could bury the origin under a purge loop. No data exposure.

**Fix:** shared `isRevalidateAuthorized()` in `src/lib/revalidate-auth.ts`, fail-closed: no configured secret ⇒ nothing authorized. Accepts `REVALIDATE_SECRET` **or** `CRON_SECRET` (header or Bearer), so every existing pipeline caller keeps working — the scripts that pass `$REVALIDATE_SECRET` today are passing it empty (it's unset locally too) and were riding the fail-open; they should switch to `$CRON_SECRET`, which they all have.

In scope: the two routes + guard + unit/structural tests (7 passing; the structural half fails CI if the fail-open shape returns). Out of scope: setting REVALIDATE_SECRET in Vercel (unnecessary once CRON_SECRET is accepted), updating script call sites to pass CRON_SECRET (they work today only because of the hole; after merge they need the header — listed in the follow-up comment).

⚠️ Merging this deploys production and immediately 401s any caller not sending a secret. Known callers all have CRON_SECRET available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd