### PR TITLE
feat(archive): one helper, five archivers, and the debt list shrinks 7 → 4 (#4406)

### DIFF
--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -435,3 +435,79 @@ export function shouldTileStitch(info, photoUrl) {
   if (info.maxArea && info.maxArea < info.width * info.height) return true;
   return false;
 }
+
+/**
+ * Fetch the best master a source will actually give us, and say what was available.
+ *
+ * `/full/full/` is a REQUEST, not a guarantee. The seven hosts in SILENT_CAP_HOSTS
+ * answer it with something smaller and no error — Kyoto at 1/8.69 of native, TU
+ * Delft 1/5.92, Manchester 1/3.25 — so an archiver that just fetches and stores is
+ * quietly banking a derivative as its master. Before #4406 the only callers that
+ * defeated that were archive-eap.mjs and the rearchive sweep; every other archiver
+ * was missing the same three lines, which is why this is a helper rather than a
+ * sixth copy of them.
+ *
+ * It deliberately does NOT own the download. Each archiver has its own retry,
+ * timeout and User-Agent policy tuned to its provider, and replacing those would be
+ * a larger and riskier change than the one being made — so the caller passes
+ * `download` and keeps its behaviour for the common path. The helper adds exactly
+ * two things: the tile-stitch route when a host is known to cap, and the native
+ * dimensions so the archiver can WRITE DOWN what was on offer.
+ *
+ * info.json is fetched ONLY for hosts already known to cap. That keeps request
+ * volume unchanged for the ~78% of pages from honest sources — three institutions
+ * blocked us inside 48 hours in August 2026, so an extra probe per page is not free.
+ * New cappers are found by scripts/audit/archive-coverage.mjs and added to
+ * SILENT_CAP_HOSTS, which is what makes them take effect here.
+ *
+ * @param {string} url - the page's source URL (any size form; upgraded internally)
+ * @param {{ download: (url: string) => Promise<Buffer>, info?: object }} opts
+ * @returns {Promise<{buffer: Buffer, nativeWidth: number|null, nativeHeight: number|null, stitchedTiles: number, url: string}>}
+ */
+export async function fetchPageMaster(url, opts = {}) {
+  const { download } = opts;
+  if (typeof download !== 'function') {
+    throw new Error('fetchPageMaster: opts.download is required (the caller owns its own retry/UA policy)');
+  }
+  const fullUrl = upgradeToFullRes(url);
+  const capSuspect = SILENT_CAP_HOSTS.some((h) => String(fullUrl).includes(h));
+  const info = opts.info ?? (capSuspect ? await fetchIiifInfo(fullUrl).catch(() => null) : null);
+
+  if (info && shouldTileStitch(info, fullUrl)) {
+    const stitch = await fetchIiifNativeRes(fullUrl, { info });
+    return {
+      buffer: stitch.buffer,
+      nativeWidth: stitch.width ?? info.width ?? null,
+      nativeHeight: stitch.height ?? info.height ?? null,
+      stitchedTiles: stitch.tiles || 0,
+      url: fullUrl,
+    };
+  }
+
+  return {
+    buffer: await download(fullUrl),
+    nativeWidth: info?.width ?? null,
+    nativeHeight: info?.height ?? null,
+    stitchedTiles: 0,
+    url: fullUrl,
+  };
+}
+
+/**
+ * The `$set` fields an archiver should write beside `archived_photo`, given what
+ * fetchPageMaster returned and the dimensions of what was actually stored.
+ *
+ * Centralised so six archivers cannot drift on field names — `image_width` vs
+ * `width` vs `iiif_info.width` is exactly the field sprawl this repo keeps paying
+ * for (#3969). Omits anything unknown rather than writing a zero: a wrong number
+ * here is worse than a missing one, because the MASTER tier trusts it.
+ */
+export function dimensionFields(stored, master) {
+  const out = {};
+  if (stored?.width) out.image_width = stored.width;
+  if (stored?.height) out.image_height = stored.height;
+  if (master?.nativeWidth) out['iiif_info.width'] = master.nativeWidth;
+  if (master?.nativeHeight) out['iiif_info.height'] = master.nativeHeight;
+  if (master?.stitchedTiles) out.stitched_tiles = master.stitchedTiles;
+  return out;
+}

--- a/scripts/maintenance/archive-unarchived-books.ts
+++ b/scripts/maintenance/archive-unarchived-books.ts
@@ -17,7 +17,7 @@
 import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
 import { storagePut } from '../../src/lib/storage';
-import { upgradeToFullRes, rateLimitedFetch } from '../lib/iiif-utils.mjs';
+import { upgradeToFullRes, rateLimitedFetch, fetchPageMaster, dimensionFields } from '../lib/iiif-utils.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = (() => {
@@ -52,13 +52,20 @@ async function archivePage(db, page) {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      let imageBuffer: Buffer;
-      try {
-        imageBuffer = await rateLimitedFetch(fullResUrl);
-      } catch (err) {
-        if (fullResUrl !== originalUrl) imageBuffer = await rateLimitedFetch(originalUrl);
-        else throw err;
-      }
+      // fetchPageMaster adds the tile-stitch route on the seven hosts that answer
+      // `/full/full/` with something smaller and no error, and reports what the
+      // source said was available so it can be recorded (#4406). The retry and
+      // full-res-then-original fallback stay this script's own.
+      const download = async (u: string): Promise<Buffer> => {
+        try {
+          return await rateLimitedFetch(u);
+        } catch (err) {
+          if (u !== originalUrl) return await rateLimitedFetch(originalUrl);
+          throw err;
+        }
+      };
+      const master = await fetchPageMaster(fullResUrl, { download });
+      const imageBuffer: Buffer = master.buffer;
 
       // Preserve native resolution. Only cap at 6000px to avoid pathological tiles.
       // Drops the previous 2000px down-resize that was discarding source detail.
@@ -76,8 +83,17 @@ async function archivePage(db, page) {
         access: 'public',
       });
 
-      // Update page in DB
-      const update = { $set: { archived_photo: blob.url } };
+      // Update page in DB. Record what we stored AND what the source said was
+      // available — the two numbers the MASTER tier compares. Stored dims come
+      // from the processed buffer we just wrote, not the pre-resize one, because
+      // the 6000px cap above means those can differ (#4406).
+      const storedMeta = await sharp(processed).metadata().catch(() => ({} as { width?: number; height?: number }));
+      const update = {
+        $set: {
+          archived_photo: blob.url,
+          ...dimensionFields({ width: storedMeta.width, height: storedMeta.height }, master),
+        } as Record<string, unknown>,
+      };
 
       // Also generate 150px thumbnail
       try {

--- a/scripts/workers/archive-gallica.mjs
+++ b/scripts/workers/archive-gallica.mjs
@@ -18,6 +18,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
+import { upgradeToFullRes, fetchPageMaster, dimensionFields } from '../lib/iiif-utils.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -78,12 +79,11 @@ async function waitForToken() {
   }
 }
 
-function upgradeToFullRes(url) {
-  if (url.includes('gallica') && url.match(/\/full\/\d+,?\d*\//)) {
-    return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-  }
-  return url;
-}
+// upgradeToFullRes is imported from ../lib/iiif-utils.mjs, not redefined here.
+// A private copy lived at this spot and was gallica-only (`url.includes('gallica')`),
+// so it silently no-op'd on every other host this worker touches — and, more to the
+// point, it is the shared version that knows about size caps. A local duplicate of a
+// shared helper is how a fix lands in one place and not the other (#4406).
 
 async function downloadImage(url, maxRetries = 4) {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -229,22 +229,24 @@ async function main() {
       const fullResUrl = upgradeToFullRes(originalUrl);
 
       try {
-        let buffer;
-        try {
-          buffer = await downloadImage(fullResUrl);
-        } catch (err) {
-          if (fullResUrl !== originalUrl) {
-            buffer = await downloadImage(originalUrl);
-          } else {
+        // fetchPageMaster owns only the cap-defeating route; this worker keeps its
+        // own retry + full-res-then-original fallback, passed through as `download`
+        // (#4406). It also records what the source said was available, so "did we
+        // get the master?" stops needing a second trip to the institution.
+        const download = async (u) => {
+          try {
+            return await downloadImage(u);
+          } catch (err) {
+            if (u !== originalUrl) return await downloadImage(originalUrl);
             throw err;
           }
-        }
+        };
+        const master = await fetchPageMaster(fullResUrl, { download });
+        const buffer = master.buffer;
 
         const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
 
-        const dimFields = {};
-        if (urls.width) dimFields.image_width = urls.width;
-        if (urls.height) dimFields.image_height = urls.height;
+        const dimFields = dimensionFields({ width: urls.width, height: urls.height }, master);
 
         await db.collection('pages').updateOne(
           { _id: page._id },

--- a/scripts/workers/archive-iiif-local.mjs
+++ b/scripts/workers/archive-iiif-local.mjs
@@ -50,6 +50,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
+import { fetchPageMaster, dimensionFields } from '../lib/iiif-utils.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -238,11 +239,13 @@ async function main() {
       await waitForToken();
       const url = page.photo_original || page.photo;
       try {
-        const buffer = await downloadImage(url);
-        const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
-        const dimFields = {};
-        if (urls.width) dimFields.image_width = urls.width;
-        if (urls.height) dimFields.image_height = urls.height;
+        // fetchPageMaster, not downloadImage directly: `/full/full/` is a request,
+        // and seven hosts answer it with something smaller and no error. It keeps
+        // THIS worker's retry/UA policy (downloadImage is passed straight through)
+        // and adds the tile-stitch route plus the native dimensions (#4406).
+        const master = await fetchPageMaster(url, { download: downloadImage });
+        const urls = await uploadPageVariants(master.buffer, page.book_id, page.page_number, uploadToR2);
+        const dimFields = dimensionFields({ width: urls.width, height: urls.height }, master);
         await db.collection('pages').updateOne({ _id: page._id }, {
           $set: {
             archived_photo: urls.archived, display_photo: urls.display, thumbnail_blob: urls.thumb,

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -15,7 +15,7 @@ import { MongoClient } from 'mongodb';
 import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
-import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
+import { upgradeToFullRes, fetchPageMaster, dimensionFields } from '../lib/iiif-utils.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 const MAX_PAGES = 10_000;
@@ -176,25 +176,25 @@ async function archivePage(page, db) {
   const pagesCol = page._collection || 'pages';
 
   try {
-    // Try full-res first, fall back to original URL if it fails (some sources reject /full/full/)
-    let result;
-    try {
-      result = await downloadImage(sourceUrl);
-    } catch (err) {
-      if (sourceUrl !== originalUrl) {
-        result = await downloadImage(originalUrl);
-      } else {
+    // Try full-res first, fall back to original URL if it fails (some sources reject /full/full/).
+    // This worker's downloadImage returns { buffer }, so it is adapted rather than
+    // replaced — fetchPageMaster owns only the cap-defeating route, never the
+    // provider-tuned retry policy (#4406).
+    const download = async (u) => {
+      try {
+        return (await downloadImage(u)).buffer;
+      } catch (err) {
+        if (u !== originalUrl) return (await downloadImage(originalUrl)).buffer;
         throw err;
       }
-    }
-    const { buffer } = result;
+    };
+    const master = await fetchPageMaster(sourceUrl, { download });
+    const buffer = master.buffer;
 
     // Upload full-res + generate and upload display (1200px) + thumbnail (150px)
     const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
 
-    const dimFields = {};
-    if (urls.width) dimFields.image_width = urls.width;
-    if (urls.height) dimFields.image_height = urls.height;
+    const dimFields = dimensionFields({ width: urls.width, height: urls.height }, master);
 
     await db.collection(pagesCol).updateOne(
       { _id: page._id },

--- a/scripts/workers/backfill-hires-illustrations.mjs
+++ b/scripts/workers/backfill-hires-illustrations.mjs
@@ -26,7 +26,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
-import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
+import { upgradeToFullRes, fetchPageMaster, dimensionFields } from '../lib/iiif-utils.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = (() => { const i = process.argv.indexOf('--limit'); return i !== -1 ? parseInt(process.argv[i+1]) : 0; })();
@@ -121,18 +121,31 @@ async function archivePageHires(page, db) {
   const domain = getDomain(fullRes);
   await waitForToken(domain);
 
-  let buffer;
+  // This worker exists to get HIGHER resolution for illustrated pages, so a
+  // silently-capped response defeats its whole purpose. fetchPageMaster adds the
+  // tile-stitch route on known cappers and reports what the source said was
+  // available; the retry + full-res-then-original fallback below stays this
+  // worker's own (#4406).
+  let master;
   try {
-    buffer = await downloadImage(fullRes);
+    const download = async (u) => {
+      try {
+        return await downloadImage(u);
+      } catch (err) {
+        if (u !== original) return await downloadImage(original);
+        throw err;
+      }
+    };
+    master = await fetchPageMaster(fullRes, { download });
   } catch (err) {
-    // Fallback to original URL if full-res rejected
-    try { buffer = await downloadImage(original); }
-    catch { return { fail: err.message }; }
+    return { fail: err.message };
   }
+  const buffer = master.buffer;
 
   if (!buffer || buffer.byteLength < 1000) return { fail: `tiny buffer (${buffer?.byteLength || 0}b)` };
 
   const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
+  const dimFields = dimensionFields({ width: urls.width, height: urls.height }, master);
 
   await db.collection('pages').updateOne(
     { _id: page._id },
@@ -140,8 +153,7 @@ async function archivePageHires(page, db) {
       archived_photo: urls.archived,
       display_photo: urls.display,
       thumbnail_blob: urls.thumb,
-      ...(urls.width ? { image_width: urls.width } : {}),
-      ...(urls.height ? { image_height: urls.height } : {}),
+      ...dimFields,
       'archive_metadata.archived_at': new Date(),
       'archive_metadata.source_url': fullRes,
       'archive_metadata.original_url': original,

--- a/tests/unit/archivers-record-dimensions.test.ts
+++ b/tests/unit/archivers-record-dimensions.test.ts
@@ -40,11 +40,6 @@ const PROJECT_ROOT = path.resolve(__dirname, '../..');
 const ARCHIVER_DIRS = ['scripts/workers', 'scripts/catalog-coverage', 'scripts/maintenance', 'scripts/migration'];
 
 /**
- * A file is an "archiver" if it writes a page image to storage. Detected by the
- * upload helpers rather than by filename, so a differently-named writer is
- * still caught.
- */
-/**
  * A file is a "page-master writer" if it constructs a page-master R2 key or goes
  * through the shared variant helper.
  *
@@ -73,7 +68,7 @@ const EXTRA_WRITERS = [
 ];
 
 /** Records the dimensions of the object it just wrote. */
-const RECORDS_STORED = /image_width|displayWidth/;
+const RECORDS_STORED = /image_width|displayWidth|dimensionFields\(/;
 
 /**
  * Records what the SOURCE said was available — the half that cannot be backfilled.
@@ -84,7 +79,7 @@ const RECORDS_STORED = /image_width|displayWidth/;
  * import is asserting that a symbol is in scope, not that a value is written.
  * See invariants/tests-that-are-not-guards.md.
  */
-const RECORDS_NATIVE = /['"`]?iiif_info\.width['"`]?\s*[:=]|iiif_info\.width'\]\s*=/;
+const RECORDS_NATIVE = /['"`]?iiif_info\.width['"`]?\s*[:=]|iiif_info\.width'\]\s*=|dimensionFields\(/;
 
 /**
  * Only writers that actually FETCH from a remote source can record a native
@@ -106,11 +101,6 @@ const FETCHES_FROM_SOURCE = /rateLimitedFetch|downloadImage|await fetch\(|downlo
 const NATIVE_WIDTH_DEBT = new Set([
   'scripts/workers/archive-bulk.mjs',
   'scripts/workers/archive-erara.mjs',      // PDF rasterization at PDF_DPI=200; no IIIF fetch at all
-  'scripts/workers/archive-gallica.mjs',
-  'scripts/workers/archive-iiif-local.mjs',
-  'scripts/workers/archive-ocr.mjs',
-  'scripts/workers/backfill-hires-illustrations.mjs',
-  'scripts/maintenance/archive-unarchived-books.ts',
   'scripts/maintenance/repair-bulk-jp2-offset.mjs',  // one-off #3368 repair; refetches, but records stored width only
   'scripts/maintenance/archive-ia-bulk.mjs',        // archive.org is not a silent capper: /full/full/ is the master, no native width to chase
 ]);


### PR DESCRIPTION
The remaining half of #4406. Writers that fetch from an institution now record **what the source said was available**, not just what we kept — the half no backfill can recover, because getting it later means asking the institution again, and on the seven `SILENT_CAP_HOSTS` the late answer is wrong anyway (the cap masquerades as native).

## One helper, five adoptions

`fetchPageMaster()` in `iiif-utils.mjs`, adopted by `archive-iiif-local`, `archive-ocr`, `archive-gallica`, `backfill-hires-illustrations`, `archive-unarchived-books`.

**It deliberately does not own the download.** Each archiver has retry, timeout and User-Agent policy tuned to its provider — MDZ at 2 req/s, Vatican at 0.1, Harvard MPS at 1 after 294 books got three-strike-blocked at 2. Replacing that would be a far riskier change than the one being made. The caller passes `download` and keeps its own behaviour, including its full-res-then-original fallback. The helper adds exactly two things:

- the **tile-stitch route** when a host is known to cap
- the **native dimensions**, so the archiver can write down what was on offer

`info.json` is fetched **only** for hosts already on `SILENT_CAP_HOSTS`, so request volume is unchanged for the ~78% of pages from honest sources.

`dimensionFields()` centralises the field names, so five archivers can't drift into `image_width` vs `width` vs `iiif_info.width` (#3969).

## Also: a private copy of a shared helper

`archive-gallica.mjs` had its own `upgradeToFullRes`, and it was gallica-only (`url.includes('gallica')`) — so it **silently no-op'd on every other host that worker touches**. Now imports the shared one. A local duplicate is precisely how a fix lands in one place and not the other.

## The guard drove this, and pushed back twice

Which is the point of having one:

1. It flagged all five newly-adopted files as **no longer recording** — the literal field names had become a helper call. Patterns widened to accept `dimensionFields(`.
2. Its stale-entry test then **demanded five names come off** `NATIVE_WIDTH_DEBT`.

**7 → 4**, and the four that remain have real reasons rather than excuses:

| file | why it stays |
|---|---|
| `archive-bulk.mjs` | reads local IA files, not a IIIF source |
| `archive-erara.mjs` | PDF rasterization at `PDF_DPI=200`; no IIIF fetch at all |
| `archive-ia-bulk.mjs` | archive.org does not cap — `/full/full/` is the master |
| `repair-bulk-jp2-offset.mjs` | one-off #3368 repair |

**Negative control re-run on the new shared path:** delete the `dimensionFields` call in `archive-gallica` → red; restore → green.

## Found while doing this, deliberately NOT fixed

`archive-bulk.mjs` has **`MAX_DIMENSION = 3000`**, no comment, and downsizes every master above it before storage.

That is a **third self-imposed resolution ceiling**, after e-rara's `PDF_DPI = 200` and the display-variant width. IA scans routinely exceed it — the Manchester master measured this week was 4782×7000, which would lose 57% of its width here. Raising it costs R2 storage, so it's a decision, not a bug fix, and it belongs with the other two on #4406.

## Verification

- `npx tsc --noEmit` clean
- 245 test files / 3,342 tests pass; 5 integration / 41 pass
- `node --check` on every changed script
- negative control both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrjrf5NFNsamfMBjpQFNhm
