### PR TITLE
feat(archive): stop imposing resolution ceilings on masters (#4406)

### DIFF
--- a/scripts/maintenance/rearchive-iiif-manifest.mjs
+++ b/scripts/maintenance/rearchive-iiif-manifest.mjs
@@ -69,7 +69,12 @@ const CONCURRENCY = parseInt(ARG('--concurrency', '2'));
 const PAGE_CONCURRENCY = parseInt(ARG('--page-concurrency', '4'));
 const LIMIT = parseInt(ARG('--limit', '0'));
 const MIN_UPGRADE_RATIO = parseFloat(ARG('--min-upgrade-ratio', '1.5'));
-const SHARP_MAX_WIDTH = parseInt(ARG('--max-width', '6000'));
+// Safety valve, not a quality ceiling (#4406). This is a RE-ARCHIVE path whose
+// entire purpose is recovering resolution, so a default that quietly caps the
+// result works against the job. Raised 6000 -> 30000: high enough that no real
+// scan is touched, low enough to stop sharp exhausting memory on a pathological
+// one. Pass --max-width to lower it deliberately for a constrained run.
+const SHARP_MAX_WIDTH = parseInt(ARG('--max-width', '30000'));
 const JPEG_QUALITY = parseInt(ARG('--jpeg-quality', '90'));
 
 if (!BOOK_ID && !PROVIDER) {

--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -43,7 +43,24 @@ const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '8', 10);
 const DRY_RUN = hasFlag('dry-run');
 const TARGET_BOOK_ID = getArg('book-id') || null;  // one-off: archive a single book, bypassing the queue
 const JPEG_QUALITY = 85;
-const MAX_DIMENSION = 3000;
+/**
+ * We do not impose resolution ceilings on masters (#4406).
+ *
+ * This was `MAX_DIMENSION = 3000`, applied with a silent
+ * `.resize(3000, 3000, { fit: 'inside' })` to every page above it — so any scan
+ * larger than 3000px on its long edge was permanently downsized before storage,
+ * with nothing recorded to say it had happened. IA scans routinely exceed that;
+ * a Manchester master measured 2026-08-30 was 4782x7000, which would have lost
+ * 57% of its width here. The loss is unrecoverable once the source is gone, and
+ * it was invisible because the stored file is a perfectly good JPEG.
+ *
+ * What remains is a SAFETY VALVE, not a quality decision: sharp will happily try
+ * to decode a pathological image and exhaust memory. Above this we SKIP the page
+ * and say so loudly, rather than quietly shrinking it — the same pattern
+ * deepzoom-harvest-page-masters.mjs already uses. A skipped page is a visible
+ * gap someone can act on; a downsized one looks like success forever.
+ */
+const PATHOLOGICAL_DIMENSION = 30000;
 // Pages sampled to verify the zip-leaf mapping before writing a book (#3368).
 const ALIGN_SAMPLES = parseInt(getArg('align-samples') || '3', 10);
 // Escape hatch for backfills over items already proven aligned. Never default
@@ -260,10 +277,12 @@ async function jp2ToJpeg(jp2Path) {
   } catch (err) {
     if (!fs.existsSync(bmpPath)) throw new Error(`opj_decompress failed: ${err.stderr?.slice(0, 200) || err.message}`);
   }
-  let sharpPipeline = sharp(bmpPath);
+  const sharpPipeline = sharp(bmpPath);
   const meta = await sharpPipeline.metadata();
-  if (meta.width > MAX_DIMENSION || meta.height > MAX_DIMENSION) {
-    sharpPipeline = sharp(bmpPath).resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true });
+  // No downsize: store the JP2 at the resolution the source actually holds.
+  if (meta.width > PATHOLOGICAL_DIMENSION || meta.height > PATHOLOGICAL_DIMENSION) {
+    try { fs.unlinkSync(bmpPath); } catch {}
+    throw new Error(`pathological dimensions ${meta.width}x${meta.height} — skipped, not downsized (#4406)`);
   }
   const jpegBuffer = await sharpPipeline.jpeg({ quality: JPEG_QUALITY }).toBuffer();
   try { fs.unlinkSync(bmpPath); } catch {}
@@ -475,10 +494,11 @@ async function processBook(book, db) {
           if (format === 'jp2') {
             jpegBuffer = await jp2ToJpeg(srcFile);
           } else {
-            let sharpInst = sharp(srcFile);
+            const sharpInst = sharp(srcFile);
             const meta = await sharpInst.metadata();
-            if (meta.width > MAX_DIMENSION || meta.height > MAX_DIMENSION) {
-              sharpInst = sharp(srcFile).resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true });
+            // No downsize: store what the source holds. See PATHOLOGICAL_DIMENSION.
+            if (meta.width > PATHOLOGICAL_DIMENSION || meta.height > PATHOLOGICAL_DIMENSION) {
+              throw new Error(`pathological dimensions ${meta.width}x${meta.height} — skipped, not downsized (#4406)`);
             }
             jpegBuffer = await sharpInst.jpeg({ quality: JPEG_QUALITY }).toBuffer();
           }

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -36,8 +36,35 @@ const BOOK_CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
 const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '8', 10);
 const DRY_RUN = hasFlag('dry-run');
 const JPEG_QUALITY = 85;
-const MAX_DIMENSION = 3000;
-const PDF_DPI = 200;  // Good balance of quality vs size
+/**
+ * Safety valve, not a quality ceiling (#4406). Was `MAX_DIMENSION = 3000` with a
+ * silent downsize; now we store what the rasterization produced and SKIP loudly
+ * above a pathological size, so a gap is visible instead of a shrink being silent.
+ */
+const PATHOLOGICAL_DIMENSION = 30000;
+
+/**
+ * PDF rasterization density.
+ *
+ * Was 200, commented "Good balance of quality vs size" — a trade of preservation
+ * quality for file size, made once and inherited by 1.92M pages, everything OCR
+ * read, everything translated from it, and everything a reader can zoom into.
+ * Measured 2026-08-30: e-rara pages sampled 0/14 at full resolution against the
+ * source's own info.json, median ratio 0.667 — we held ~44% of the pixels.
+ *
+ * 400 is the preservation floor for printed text (FADGI/Metamorfoze both treat
+ * 400 ppi as the working minimum for reformatted print), and it doubles the
+ * linear resolution of what we captured before. It is not a free change — the
+ * files are roughly 4x the pixels — but a master is the thing you cannot
+ * re-derive, and e-rara is a partner whose IIIF endpoint we do not currently
+ * use for archiving.
+ *
+ * THE REAL FIX IS UPSTREAM OF THIS NUMBER. Rasterizing a PDF is a lossy path we
+ * chose for convenience; e-rara serves IIIF, which tile-stitching can pull at
+ * true native resolution (see fetchPageMaster). Raising the DPI narrows the gap;
+ * it does not close it. Tracked on #4406 alongside #3186's parked e-rara lane.
+ */
+const PDF_DPI = parseInt(process.env.ERARA_PDF_DPI || '400', 10);
 const DELAY_BETWEEN_DOWNLOADS_MS = 2000;  // Polite delay between PDF downloads
 
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -235,12 +262,11 @@ async function processBook(book, db) {
         if (idx >= workItems.length) break;
         const { page, srcFile } = workItems[idx];
         try {
-          let sharpInst = sharp(srcFile);
+          const sharpInst = sharp(srcFile);
           const meta = await sharpInst.metadata();
-          if (meta.width > MAX_DIMENSION || meta.height > MAX_DIMENSION) {
-            sharpInst = sharp(srcFile).resize(MAX_DIMENSION, MAX_DIMENSION, {
-              fit: 'inside', withoutEnlargement: true,
-            });
+          // No downsize: store what the rasterization produced. See PATHOLOGICAL_DIMENSION.
+          if (meta.width > PATHOLOGICAL_DIMENSION || meta.height > PATHOLOGICAL_DIMENSION) {
+            throw new Error(`pathological dimensions ${meta.width}x${meta.height} — skipped, not downsized (#4406)`);
           }
           const jpegBuffer = await sharpInst.jpeg({ quality: JPEG_QUALITY }).toBuffer();
 

--- a/scripts/workers/batch-split-bph.mjs
+++ b/scripts/workers/batch-split-bph.mjs
@@ -35,7 +35,24 @@ import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 // --- Config ---
 const ASPECT_RATIO_THRESHOLD = 1.2; // w/h > 1.2 = spread
 const OVERLAP_PX = 10; // pixels of overlap at split point (0-1000 scale)
-const CROPPED_MAX_WIDTH = 2000; // max width for cropped halves
+/**
+ * The cropped half IS the master for a split book — do not cap it (#4406).
+ *
+ * This was `CROPPED_MAX_WIDTH = 2000`, applied to both halves. That is not a
+ * derivative cap: `getPageSource()` returns `cropped_photo` FIRST, and the
+ * splitter overwrites `archived_photo` with the half, so for a split book the
+ * 2000px crop is the highest-resolution copy the system holds.
+ *
+ * It matters most here of anywhere. BPH is tier 0 — no public re-acquisition
+ * path, no `ia_identifier`, nothing to re-fetch from if the crop is all we kept
+ * (see .claude/docs/preservation-policy.md). Halving a spread and capping each
+ * half at 2000px turns a 6000px scan into two ~2000px ones and discards the rest
+ * permanently.
+ *
+ * Now: crop and keep. `extract()` alone, no resize. The display and thumb
+ * variants generated below are still sized — those are derivatives and are
+ * supposed to be small.
+ */
 const CROPPED_QUALITY = 90;
 const DISPLAY_WIDTH = 1200;
 const DISPLAY_QUALITY = 85;
@@ -316,14 +333,12 @@ async function processBook(r2, db, book) {
       // Crop left half
       const leftBuf = await sharp(buf)
         .extract({ left: 0, top: 0, width: splitX + Math.round(OVERLAP_PX * imgWidth / 1000), height: imgHeight })
-        .resize(CROPPED_MAX_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
         .jpeg({ quality: CROPPED_QUALITY, progressive: true })
         .toBuffer();
 
       // Crop right half
       const rightBuf = await sharp(buf)
         .extract({ left: Math.max(0, splitX - Math.round(OVERLAP_PX * imgWidth / 1000)), top: 0, width: imgWidth - splitX + Math.round(OVERLAP_PX * imgWidth / 1000), height: imgHeight })
-        .resize(CROPPED_MAX_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
         .jpeg({ quality: CROPPED_QUALITY, progressive: true })
         .toBuffer();
 

--- a/tests/unit/no-master-resolution-ceilings.test.ts
+++ b/tests/unit/no-master-resolution-ceilings.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+/**
+ * We do not impose resolution ceilings on masters (#4406).
+ *
+ * A master is the copy that cannot be re-derived. Silently downsizing one before
+ * storage is the only mistake in this system that is both permanent and
+ * invisible: the stored file is a perfectly good JPEG, nothing errors, no counter
+ * moves, and the discarded pixels are gone the moment the source is.
+ *
+ * Three of these were found in one afternoon, each individually reasonable and
+ * none of them ever revisited:
+ *
+ *   archive-bulk.mjs      MAX_DIMENSION = 3000    (no comment at all)
+ *   archive-erara.mjs     PDF_DPI = 200           "Good balance of quality vs size"
+ *   batch-split-bph.mjs   CROPPED_MAX_WIDTH = 2000 — and the crop IS the master
+ *                          for a split book, on BPH, which is tier 0 with no
+ *                          re-acquisition path at all.
+ *
+ * The distinction this test encodes: a DERIVATIVE may be capped — that is what a
+ * display variant or a thumbnail is for. A MASTER may not. So it only inspects
+ * the resize that produces the bytes written to a master key.
+ *
+ * A pathological-size guard is fine and expected — but it must SKIP loudly, not
+ * shrink quietly. A gap someone can see beats a success that is silently worse.
+ */
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const ARCHIVER_DIRS = ['scripts/workers', 'scripts/catalog-coverage', 'scripts/maintenance', 'scripts/migration'];
+
+/** Writers that produce a page master. Same shape as archivers-record-dimensions. */
+const WRITES_PAGE_IMAGES = /uploadPageVariants|storagePut\(\s*`?pages\/|uploadToR2\(\s*`?(archived|pages)\//;
+
+/**
+ * A downsize applied to the master path: `.resize(` with a literal number, where
+ * that number is small enough to cut a real scan.
+ *
+ * DERIVATIVE_WIDTHS are the sizes this codebase uses for display copies,
+ * thumbnails and model inputs. They are legitimate and deliberately ignored —
+ * catching them would flag every thumbnail generator and the guard would be
+ * allowlisted into meaninglessness within a week.
+ */
+const DERIVATIVE_WIDTHS = new Set([150, 200, 256, 300, 400, 500, 512, 1024, 1200, 1500]);
+
+/** Above this, a resize is a safety valve rather than a quality ceiling. */
+const SAFETY_VALVE_FLOOR = 10000;
+
+/**
+ * Master writers whose upload key is a variable, so the pattern above cannot see
+ * them. Same blind spot, and same remedy, as archivers-record-dimensions.test.ts:
+ * name it rather than let the file be silently exempt.
+ */
+const EXTRA_WRITERS = [
+  'scripts/workers/batch-split-bph.mjs',       // uploadToR2(r2, key, buf) — key is arg 2
+  'scripts/maintenance/archive-ia-bulk.mjs',   // key built into a const first
+];
+
+function listMasterWriters(): string[] {
+  const found: string[] = [];
+  for (const dir of ARCHIVER_DIRS) {
+    let entries: string[];
+    try {
+      entries = readdirSync(path.join(PROJECT_ROOT, dir), { recursive: true } as never) as string[];
+    } catch {
+      continue;
+    }
+    for (const rel of entries) {
+      if (!/\.(mjs|ts)$/.test(String(rel))) continue;
+      if (String(rel).includes('lib/')) continue;
+      const repoPath = path.posix.join(dir, String(rel).split(path.sep).join('/'));
+      let src: string;
+      try {
+        src = readFileSync(path.join(PROJECT_ROOT, repoPath), 'utf8');
+      } catch {
+        continue;
+      }
+      if (WRITES_PAGE_IMAGES.test(src)) found.push(repoPath);
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Strip comments before scanning.
+ *
+ * Without this the guard flags its own documentation: the comment explaining that
+ * archive-bulk USED to call `.resize(3000, 3000, …)` matches the very pattern it
+ * is describing. A guard that goes red on prose is one someone disables.
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** Literal-number resizes in a file that look like a ceiling on a master. */
+function ceilingResizes(src: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripComments(src).matchAll(/\.resize\(\s*(\d{3,5})/g)) {
+    const n = Number(m[1]);
+    if (DERIVATIVE_WIDTHS.has(n)) continue;   // a display/thumb/model size
+    if (n >= SAFETY_VALVE_FLOOR) continue;    // a pathological-size guard
+    hits.push(n);
+  }
+  return hits;
+}
+
+const writers = [...new Set([...listMasterWriters(), ...EXTRA_WRITERS])].sort();
+const read = (f: string) => readFileSync(path.join(PROJECT_ROOT, f), 'utf8');
+
+describe('no resolution ceilings on masters (#4406)', () => {
+  it('finds the master writers at all (guards the guard)', () => {
+    expect(writers.length).toBeGreaterThan(5);
+    expect(writers).toContain('scripts/workers/archive-bulk.mjs');
+    expect(writers).toContain('scripts/workers/batch-split-bph.mjs');
+  });
+
+  it('no master writer downsizes to a fixed sub-10000px width', () => {
+    const offenders: string[] = [];
+    for (const f of writers) {
+      const hits = ceilingResizes(read(f));
+      if (hits.length) offenders.push(`${f} → .resize(${[...new Set(hits)].join(', ')})`);
+    }
+    expect(
+      offenders,
+      'These downsize an image on a path that writes a page MASTER. A master is the copy\n' +
+      'that cannot be re-derived, so capping it discards pixels permanently and invisibly —\n' +
+      'the stored file is still a valid JPEG and nothing reports a loss.\n\n' +
+      'If this is a DERIVATIVE (display/thumb/model input), add its width to\n' +
+      'DERIVATIVE_WIDTHS. If it is a pathological-size guard, raise it above\n' +
+      `${SAFETY_VALVE_FLOOR} and make it SKIP rather than shrink.\n\n  ` +
+      offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('the e-rara PDF rasterization is not back below the preservation floor', () => {
+    // pdftoppm -r <dpi> is a resolution ceiling that no .resize() call reveals.
+    // 200 was the shipped value across 1.92M pages; 400 ppi is the FADGI /
+    // Metamorfoze working minimum for reformatted print.
+    const src = read('scripts/workers/archive-erara.mjs');
+    const m = src.match(/const PDF_DPI = parseInt\(process\.env\.ERARA_PDF_DPI \|\| '(\d+)'/);
+    expect(m, 'PDF_DPI is no longer declared in the expected form — re-check this guard').toBeTruthy();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(400);
+  });
+});


### PR DESCRIPTION
> "We shouldn't impose ceilings like that"

Agreed, and it's the right call. A master is the copy that cannot be re-derived, so capping one is the only mistake in this system that is both **permanent and invisible** — the stored file is a perfectly good JPEG, nothing errors, no counter moves, and the discarded pixels are gone the moment the source is.

## The audit found more than the two we knew about

| file | ceiling | note |
|---|---|---|
| `archive-bulk.mjs` | `MAX_DIMENSION = 3000` | no comment at all, two sites |
| `archive-erara.mjs` | `MAX_DIMENSION = 3000` | same |
| `archive-erara.mjs` | `PDF_DPI = 200` | *"Good balance of quality vs size"* |
| `batch-split-bph.mjs` | `CROPPED_MAX_WIDTH = 2000` | **the worst one** |
| `rearchive-iiif-manifest.mjs` | `--max-width 6000` default | on a *recovery* path |

**`batch-split-bph` was hiding in plain sight.** That 2000px crop is not a derivative: `getPageSource()` returns `cropped_photo` **first**, and the splitter overwrites `archived_photo` with the half — so for a split book the crop **is** the highest-resolution copy we hold. It runs on BPH: **tier 0, no `ia_identifier`, nothing to re-fetch from**. Halving a 6000px spread and capping each half at 2000px discarded two thirds of irreplaceable partner material, permanently.

## What replaces them

A **safety valve, not a quality decision.** Above `PATHOLOGICAL_DIMENSION` (30000) the page is **skipped and says so**, instead of being quietly shrunk — the same pattern `deepzoom-harvest-page-masters` already used. A visible gap can be acted on; a silent downsize looks like success forever.

**`PDF_DPI` 200 → 400** (env-overridable), the FADGI/Metamorfoze working minimum for reformatted print. Not free — roughly 4× the pixels — but e-rara measured **0/14 at full resolution** against the source's own `info.json`, median ratio 0.667.

The comment there is honest about what it doesn't fix: rasterizing a PDF is a lossy path we chose for convenience, when e-rara serves IIIF that tile-stitching can pull natively. **Raising the DPI narrows the gap; it doesn't close it.**

## Guarded, not just fixed

`tests/unit/no-master-resolution-ceilings.test.ts` fails on any sub-10000px literal `.resize()` in a master-writing path, and on `PDF_DPI` dropping below 400. Derivative widths (150/512/1200/…) are exempt **by name** — a guard that flags every thumbnail generator gets allowlisted into meaninglessness within a week.

**It caught two of its own defects before shipping:**

1. It flagged the comment *describing* the removed resize. Now strips comments first — a test that goes red on prose is one someone disables.
2. It couldn't see `batch-split-bph` at all, whose upload key is an argument rather than a literal. Blind spot named, same as in `archivers-record-dimensions`.

**Negative controls, both directions:** reintroduce the 2000px crop → red. Drop `PDF_DPI` to 200 → red. Restore → green.

## Cost

This increases R2 storage — that's the trade, made deliberately. It applies to **future** archiving; existing masters are unchanged. Re-acquiring what was already capped is the separate #3186 question.

## Verification

- `npx tsc --noEmit` clean
- 246 test files / 3,345 tests pass
- `node --check` on every changed script
- negative controls above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrjrf5NFNsamfMBjpQFNhm
