### PR TITLE
fix(scripts): revalidation callers send CRON_SECRET (#4470 follow-up)

### DIFF
--- a/scripts/create-proposed-collections-2026-08.mjs
+++ b/scripts/create-proposed-collections-2026-08.mjs
@@ -368,7 +368,7 @@ async function main() {
     console.log('');
     console.log('2. Revalidate ISR + purge the CDN for the new paths:');
     console.log('     curl -s -X POST https://sourcelibrary.org/api/admin/revalidate \\');
-    console.log('       -H "x-revalidate-secret: $REVALIDATE_SECRET" -H "Content-Type: application/json" \\');
+    console.log('       -H "x-revalidate-secret: $CRON_SECRET" -H "Content-Type: application/json" \\');
     console.log('       --data \'{"collections": true, "paths": ["/collections", "/collections/harmonia-mundi-economic-order", "/collections/picturing-the-world-1450-1750"]}\'');
     console.log('');
     console.log('3. Verify the GRID is non-empty, not just book_count. A correct book_count');

--- a/scripts/lib/triage-apply.mjs
+++ b/scripts/lib/triage-apply.mjs
@@ -96,7 +96,7 @@ export async function finalizeCaches({ paths, execute }) {
   if (!execute) {
     console.log('\nNOW RUN (finalize was not requested):');
     console.log('  node scripts/workers/sync-books-catalog.mjs');
-    console.log(`  curl -s -X POST https://sourcelibrary.org/api/admin/revalidate -H "x-revalidate-secret: $REVALIDATE_SECRET" -H "Content-Type: application/json" --data '${body}'`);
+    console.log(`  curl -s -X POST https://sourcelibrary.org/api/admin/revalidate -H "x-revalidate-secret: $CRON_SECRET" -H "Content-Type: application/json" --data '${body}'`);
     return;
   }
   console.log('\nfinalize: syncing Supabase catalog…');
@@ -108,7 +108,7 @@ export async function finalizeCaches({ paths, execute }) {
   const res = await fetch('https://sourcelibrary.org/api/admin/revalidate', {
     method: 'POST',
     headers: {
-      'x-revalidate-secret': process.env.REVALIDATE_SECRET || '',
+      'x-revalidate-secret': process.env.REVALIDATE_SECRET || process.env.CRON_SECRET || '',
       'Content-Type': 'application/json',
       'User-Agent': 'Mozilla/5.0 (sourcelibrary maintenance; triage-apply)',
     },

--- a/scripts/split-book-v2.mjs
+++ b/scripts/split-book-v2.mjs
@@ -596,8 +596,17 @@ if (book.tenantId && book.tenantId !== 'default') {
 
 for (const path of revalidatePaths) {
   try {
-    const revalUrl = `https://sourcelibrary.org/api/admin/revalidate?path=${encodeURIComponent(path)}&secret=${process.env.REVALIDATION_SECRET || ''}`;
-    const resp = await fetch(revalUrl, { signal: AbortSignal.timeout(10000) });
+    // POST with the shared secret — the old form (GET + ?secret= query param)
+    // hit a POST-only route and never revalidated anything (#4470).
+    const resp = await fetch('https://sourcelibrary.org/api/admin/revalidate', {
+      method: 'POST',
+      headers: {
+        'x-revalidate-secret': process.env.CRON_SECRET || '',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ paths: [path] }),
+      signal: AbortSignal.timeout(10000),
+    });
     console.log(`  Revalidated ${path}: ${resp.status}`);
   } catch (e) {
     console.log(`  Revalidation failed for ${path}: ${e.message?.slice(0, 40)}`);


### PR DESCRIPTION
The caller sweep promised on #4470. Three files change; two named there need no change (already Bearer CRON_SECRET). Notable: split-book-v2's revalidation call has never worked — GET with a query-param secret against a POST-only route — now a real POST. Scripts-only: no Vercel deploy owed; Hetzner picks it up on the hourly pull.

In scope: the caller migration only. Out of scope: any route change (done in #4470).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd