### PR TITLE
Stop paying Vercel for bulk imports; link Arabic witnesses into the works we hold

### DIFF
--- a/.claude/docs/invariants/import-cost-and-egress.md
+++ b/.claude/docs/invariants/import-cost-and-egress.md
@@ -1,0 +1,76 @@
+# Import cost & egress — where a bulk job should run
+
+**Read this when:** writing or running any bulk import, archiving sweep, or
+source enumeration; or choosing between `/api/import/*` and a `*-direct.mjs`
+script.
+
+---
+
+## The rule
+
+**A bulk import must not go through a Vercel function.** Use the direct-insert
+pattern (`scripts/import/*-direct.mjs` + `insertBookIfNew()`), run from Hetzner.
+
+The API routes exist for *interactive, one-off* imports — a curator adding a
+book from the admin UI. They are the wrong tool for a wave of hundreds.
+
+## Why, with the numbers
+
+Vercel is **~$3,069/mo** (Nov 2025 – Jul 2026: **$11,089.37**), on Derek's
+personal card. Function invocations are not incidental to that bill — the
+`costs/infrastructure-costs.md` register carries a **~$1,000/mo** line for
+crawler traffic whose entire cost was that each rejection ran in
+`src/proxy.ts` and so "still cost an edge request **+ a function invocation**."
+That is the same shape as a bulk import: work that does not need to be inside a
+serverless function, billed as if it did.
+
+An import route is the expensive case of that shape. `/api/import/gallica` and
+`/api/import/ia` declare `maxDuration = 300`; importing a 300-page manuscript
+holds a function for 30–90 seconds while it fetches a manifest and writes Mongo.
+Neither of those needs Vercel. A 356-book wave is several hundred long-running
+invocations bought for nothing.
+
+**Measured 2026-08-31:** ~1,500 eGangotri books and 20 Gallica books were
+imported through the routes in one session before anyone asked the question.
+
+## What to do instead
+
+`scripts/import/*-direct.mjs` — fetch the manifest on the machine running the
+job, build the docs with `makeBookDoc()` / `makePageDoc()`, insert through
+`insertBookIfNew()` (the direct importers' equivalent of the route's dedupe
+gate; skip-and-record is the default, and a declined book leaves a row in
+`dedup_skips`). Templates: `harvard-wuzhen-direct.mjs`,
+`gallica-islamic-direct.mjs`.
+
+The pattern already existed — `import-workflow.md` step 4 prescribes it — but it
+was documented for the **datacenter-429** reason, so it read as a workaround for
+awkward sources rather than the default for bulk. It is both.
+
+## Where to run it: three different IPs, three different consequences
+
+| runs from | egress | consequence |
+|---|---|---|
+| **Vercel** | datacenter | costs invocations; some sources 403/429 datacenter IPs (Harvard, Gallica, QDL) |
+| **Derek's laptop** | his home ISP | free, residential IP passes source gates — but it spends *his* connection's quota and dies when the laptop sleeps |
+| **Hetzner** | its own dedicated IP | free, always-on, survives overnight, separate quota from Derek's home IP |
+
+**Hetzner is the default for any long job.** A sweep run from the laptop is
+borrowing Derek's personal quota: on 2026-08-31 a Gallica enumeration burned his
+residential IP's budget to the point that later queries 429'd, while the same
+queries from Hetzner were unaffected. It also ties the job's life to a laptop lid.
+
+Check where you are before starting a long job — `hostname` and
+`curl -s https://api.ipify.org` — and say so in the report. "Where did this run"
+is not a detail; it decides who pays and whether the source will answer.
+
+## The exception
+
+An import that genuinely needs a browser session or an interactive credential
+cannot be a headless direct-insert. Those are rare; name the reason in the
+script header when claiming it.
+
+## Related
+
+- `.claude/docs/import-workflow.md` — the enumerate → dedupe → import loop
+- `~/sourcelibrary-ops/costs/infrastructure-costs.md` — the cost register (private repo)
+- `.claude/docs/invariants/archive-fetch-failures.md` — 403/429 handling once a source blocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - Adding or changing a Librarian / MCP tool, or the text one returns → `agent-tool-results.md` (**a ranker cannot answer "how many"**, and a URL you leave out is one the model will invent — two 404s came out of the first live turn)
 
 **Writing a sweep, an import, or a new field**
+- A BULK import/sweep, or choosing `/api/import/*` vs a `*-direct.mjs` script → `import-cost-and-egress.md` (**bulk never goes through a Vercel function** — invocations are a measured line item on a ~$3,069/mo bill; run it on Hetzner, not the laptop).
 - Running any script/worker under `secret-lover run`, or running one **from a worktree**, or a job that reports a store as empty → `credential-injection.md` (**secret-lover reports an unreadable secret as a missing one and runs anyway**; a worktree resolves to the wrong project and gets zero secrets)
 - Adding a field to `books`/`pages`, writing a maintenance sweep, or touching `book-docs.mjs`/`sweep-log.mjs`/`field-sprawl.mjs` → `field-sprawl.md` (**a sweep records a ROW, not a COLUMN**; consolidation without enforcement re-polluted 4.16M rows in 3 months)
 

--- a/scripts/import/gallica-islamic-direct.mjs
+++ b/scripts/import/gallica-islamic-direct.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Gallica Graeco-Arabic wave — DIRECT INSERT, no Vercel function involved.
+ *
+ * WHY THIS REPLACES gallica-islamic-wave.mjs. That script POSTs to
+ * /api/import/gallica, so every book costs a Vercel function invocation that
+ * holds a 300-page manifest for 30-90 seconds. Vercel is ~$3,069/mo and
+ * invocations are a measured line item there (the crawler-traffic entry in
+ * costs/infrastructure-costs.md is ~$1,000/mo of exactly this). A 356-book wave
+ * is several hundred long-running invocations bought for nothing: the work is
+ * fetch-a-manifest and write-Mongo, and neither needs to happen inside a
+ * serverless function.
+ *
+ * This is the documented `*-direct.mjs` pattern (see harvard-wuzhen-direct.mjs
+ * and import-workflow.md step 4). It was written for the datacenter-429 problem;
+ * it solves the cost problem identically, and both reasons apply to Gallica.
+ *
+ * Run it on Hetzner: its own IP (not Derek's home connection, which was
+ * carrying these sweeps), always-on for a slow overnight pass, and zero Vercel
+ * cost.
+ *
+ * ACQUISITION GATE. Uses insertBookIfNew() — the direct-insert importers'
+ * equivalent of the route's dedupe gate. Skip-and-record is the default, so a
+ * declined book leaves a row in `dedup_skips` rather than vanishing.
+ *
+ * THROTTLE. Gallica 429s hard: an import at 6s spacing lost ~2/3 of its calls.
+ * Default here is 20s. Slower is the point — a run that finishes is worth more
+ * than one that finishes fast and imports nothing.
+ *
+ * Usage (on Hetzner):
+ *   node --env-file=.env.production.local scripts/import/gallica-islamic-direct.mjs --limit 5
+ *   node --env-file=.env.production.local scripts/import/gallica-islamic-direct.mjs --limit 400 --commit
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import { readFileSync } from 'node:fs';
+import { makePageDoc } from '../lib/book-docs.mjs';
+import { insertBookIfNew } from '../lib/acquire-book.mjs';
+
+const COMMIT = process.argv.includes('--commit');
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const LIMIT = parseInt(arg('--limit', '5'), 10);
+const LIST = arg('--list', './gallica-islamic-candidates.json');
+const DELAY_MS = parseInt(arg('--delay', '20000'), 10);
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36';
+
+// A Greek author in the catalogue title means the WORK is Greek even though the
+// manuscript is Arabic. That distinction is the whole point of the wave, and
+// language-fields.md requires keeping it.
+const GREEK_WORK = /Ptolém|Almageste|Euclide|Hippocrate|Galien|Dioscoride|Platon|Aristote|Porphyre|Proclus|Plotin|Archimède|Ménélaüs|Apollonius|Theologia|Théologia|Isagoge|Organon/i;
+
+const slugify = (t, max = 70) => String(t).toLowerCase().normalize('NFD')
+  .replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9\s-]/g, '')
+  .replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, max).replace(/-$/, '');
+
+async function uniqueSlug(db, base) {
+  let slug = base || 'arabic-manuscript', i = 2;
+  while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`;
+  return slug;
+}
+
+/** Gallica IIIF v2. Returns page image URLs, or null if the manifest is unusable. */
+async function fetchManifest(ark) {
+  const url = `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/manifest.json`;
+  const r = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(60000) });
+  if (!r.ok) return { error: `HTTP ${r.status}` };
+  const m = await r.json();
+  const canvases = m.sequences?.[0]?.canvases || m.items || [];
+  const pages = canvases.map((c) => {
+    // v2 shape first (Gallica is v2), then v3.
+    const res = c.images?.[0]?.resource || c.items?.[0]?.items?.[0]?.body;
+    const svc = res?.service?.['@id'] || res?.service?.[0]?.id || res?.service?.id;
+    const photo = res?.['@id'] || res?.id || (svc ? `${svc}/full/full/0/default.jpg` : null);
+    const thumbnail = svc ? `${svc}/full/200,/0/default.jpg` : photo;
+    return photo ? { photo, thumbnail } : null;
+  }).filter(Boolean);
+  return { manifest: m, pages, url };
+}
+
+async function main() {
+  const raw = JSON.parse(readFileSync(LIST, 'utf8'));
+  const all = (raw.keep || raw.candidates || raw)
+    .slice()
+    .sort((a, b) => (GREEK_WORK.test(b.title || '') ? 1 : 0) - (GREEK_WORK.test(a.title || '') ? 1 : 0));
+  const batch = all.slice(0, LIMIT);
+  console.log(`list ${all.length}; processing ${batch.length}${COMMIT ? '' : ' (DRY RUN)'} at ${DELAY_MS / 1000}s spacing`);
+  console.log(`Greek-work titles in list: ${all.filter(r => GREEK_WORK.test(r.title || '')).length}`);
+
+  const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  let ok = 0, skipped = 0, failed = 0, totalPages = 0;
+  for (const [i, r] of batch.entries()) {
+    const isGreek = GREEK_WORK.test(r.title || '');
+    const title = String(r.title || '').replace(/\s+/g, ' ').trim().slice(0, 300) || `Arabic manuscript ${r.ark}`;
+
+    let res;
+    try { res = await fetchManifest(r.ark); }
+    catch (e) { failed++; console.error(`  FAIL ${r.ark}: ${e.name}`); await new Promise(s => setTimeout(s, DELAY_MS)); continue; }
+    if (res.error || !res.pages?.length) {
+      failed++; console.error(`  FAIL ${r.ark}: ${res.error || 'no pages in manifest'}`);
+      await new Promise(s => setTimeout(s, DELAY_MS)); continue;
+    }
+
+    if (!COMMIT) {
+      console.log(`  [dry] ${r.ark} ${String(res.pages.length).padStart(4)}pp ${isGreek ? '[GREEK]' : '       '} ${title.slice(0, 62)}`);
+      totalPages += res.pages.length;
+      await new Promise(s => setTimeout(s, DELAY_MS)); continue;
+    }
+
+    const now = new Date();
+    const bookId = new ObjectId();
+    const bookIdStr = bookId.toHexString();
+    const slug = await uniqueSlug(db, slugify(title));
+    const manifestUrl = res.url;
+
+    const acquired = await insertBookIfNew(db, {
+      _id: bookId, id: bookIdStr, slug,
+      title, author: 'Unknown',
+      language: 'Arabic',
+      // The MANUSCRIPT is Arabic; the WORK may be Greek. Conflating them would
+      // file the Almagest as an Arabic composition and sever the work-graph
+      // link to our Greek and Latin copies.
+      ...(isGreek ? { original_language: 'Greek' } : {}),
+      published: r.date || 'Unknown',
+      categories: ['islamic-science', ...(isGreek ? ['graeco-arabic-transmission'] : [])],
+      collections: [],
+      thumbnail: res.pages[0].thumbnail || '',
+      pages_count: res.pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
+      content_type: 'book',
+      dublin_core: { dc_identifier: [`IIIF:${manifestUrl}`, `ark:/12148/${r.ark}`], dc_source: manifestUrl },
+      image_source: {
+        provider: 'gallica', provider_name: 'Bibliothèque nationale de France (Gallica)',
+        source_url: `https://gallica.bnf.fr/ark:/12148/${r.ark}`,
+        iiif_manifest: manifestUrl,
+        license: 'Public domain / BnF conditions of use',
+        contributing_library: 'Bibliothèque nationale de France, Département des Manuscrits',
+        access_date: now,
+      },
+      status: 'draft', hidden: true, visible: false,
+      source_fingerprint: `gallica:${r.ark}`,
+      normalized_title: slugify(title).replace(/-/g, ' '),
+      normalized_author: 'unknown',
+      created_at: now, updated_at: now,
+    }, { importer: 'script:gallica-islamic-direct', sourceIdentifier: r.ark, sourceUrl: manifestUrl });
+
+    if (!acquired.inserted) {
+      skipped++; console.log(`  SKIP ${r.ark}: ${acquired.message}`);
+      await new Promise(s => setTimeout(s, DELAY_MS)); continue;
+    }
+
+    const CHUNK = 500;
+    for (let s = 0; s < res.pages.length; s += CHUNK) {
+      const docs = res.pages.slice(s, s + CHUNK).map((p, k) => {
+        const pid = new ObjectId();
+        return makePageDoc({
+          _id: pid, id: pid.toHexString(), book_id: bookIdStr,
+          page_number: s + k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo,
+          created_at: now, updated_at: now,
+        });
+      });
+      await db.collection('pages').insertMany(docs, { ordered: false });
+    }
+
+    ok++; totalPages += res.pages.length;
+    console.log(`  OK ${String(i + 1).padStart(3)}/${batch.length} ${r.ark} ${String(res.pages.length).padStart(4)}pp ${isGreek ? '[GREEK]' : '       '} ${title.slice(0, 54)}`);
+    await new Promise(s => setTimeout(s, DELAY_MS));
+  }
+
+  console.log(`\nimported ${ok}, skipped ${skipped}, failed ${failed}, ${totalPages} pages`);
+  console.log('Vercel function invocations used: 0');
+  await client.close();
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(e => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/maintenance/link-graeco-arabic-works.mjs
+++ b/scripts/maintenance/link-graeco-arabic-works.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Link Arabic transmission witnesses to the work clusters we already hold.
+ *
+ * WHY THIS EXISTS. We hold the receiving end of the Graeco-Arabic chain — 296
+ * Galen, 330 Hippocrates, 139 Dioscorides, 119 Euclid, overwhelmingly in Latin
+ * and Greek — and almost never the Arabic end. Importing Arabic witnesses
+ * without linking them produces orphans: 356 books that sit outside the very
+ * work-graph that makes them meaningful. That is #4394's defect committed on
+ * purpose, at scale.
+ *
+ * It is not hypothetical. Measured before writing this: 5 Arabic Almagest books
+ * already carry NO work_id while 6 others sit correctly on Q155952; Hippocrates
+ * has 11 unlinked against 8 on `local:a:hippocrates:aphorisms`.
+ *
+ * DESIGN — deliberately conservative, because a wrong work_id merges unrelated
+ * books and that is expensive to undo:
+ *   - A CURATED map, not fuzzy matching. `author-identity.md` is emphatic that a
+ *     pattern is a net, never a verdict; the al-Kindi query in this same session
+ *     matched al-Mutanabbi's poetry.
+ *   - It only ever FILLS AN EMPTY work_id. It never overwrites, never merges two
+ *     existing clusters. Cluster merging is merge-work-clusters.mjs, which has
+ *     alias-preservation and a provenance log; this does not reimplement it.
+ *   - Every target id is one we ALREADY hold books on, so nothing is minted.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/link-graeco-arabic-works.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/link-graeco-arabic-works.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const SWEEP = 'graeco-arabic-work-linking';
+const BACKUP = 'scripts/output/graeco-arabic-linking-backup.json';
+
+// work → { id: the cluster we already hold, match: title test }
+// Each `id` was read off production, not invented. See the measurement in the
+// header: these are live clusters spanning Greek/Latin/Arabic already.
+const MAP = [
+  { work: 'Ptolemy, Almagest',        id: 'Q155952',   match: /almagest|almageste/i },
+  // A title-page IMAGE is not a witness of the work.
+  { work: 'Euclid, Elements',         id: 'Q172891',   match: /(euclid|uqlidis)[^.]{0,40}(element|geom|geom)/i, notMatch: /title page|frontispiece|portrait/i },
+  // Require the treatise itself, not works derived FROM Dioscorides:
+  // "Alphabetum empiricum sive Dioscoridis", "Fasciculus remediorum ex
+  // Dioscoride et Mathiolo" are compilations, not copies.
+  { work: 'Dioscorides, De Materia',  id: 'Q3704131',  match: /dioscorid/i, notMatch: /\b(ex dioscorid|sive|fasciculus|alphabetum|remediorum)\b/i },
+  // `qanun` ALONE collides with al-Biruni's Canon Masudicus — different author,
+  // and astronomy not medicine. Require Avicenna's name alongside it.
+  // No \u escapes in any regex sent to Mongo: its PCRE2 rejects them outright,
+  // and a JS-literal \u012B reaches the server as the four characters "\u01".
+  // "ibn sin" already covers the transliterations we care about.
+  { work: 'Avicenna, Canon',          id: 'Q55360132', match: /(avicenn|ibn sin)/i, andMatch: /canon|qanun/i, notMatch: /masudi|mas'udi/i },
+  // "Aphorisms" is a GENRE. Unqualified it matched chemical, astrological,
+  // legal and eucharistic aphorisms — four disciplines, none of them Hippocrates.
+  { work: 'Hippocrates, Aphorisms',   id: 'local:a:hippocrates:aphorisms', match: /aphorism/i, andMatch: /hippocrat|buqrat/i },
+  { work: 'Picatrix / Ghayat',        id: 'local:n:majriti-maslama-pseudo:liber-piccatricia', match: /picatrix|ghayat al-hakim/i },
+  { work: 'Turba Philosophorum',      id: 'turba-philosophorum', match: /turba philosoph/i },
+  { work: 'Theology of Aristotle',    id: 'local:a:aristotle:mystical-philosophy-theology', match: /theolog(ia|y) of aristotle/i },
+];
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const plan = [];
+  for (const entry of MAP) {
+    // Sanity: the target cluster must actually exist. Linking into a cluster
+    // that holds nothing would be minting an id by another name.
+    const clusterSize = await books.countDocuments({ work_id: entry.id });
+    if (clusterSize === 0) {
+      console.log(`SKIP  ${entry.work}: target cluster ${entry.id} holds 0 books — refusing to mint`);
+      continue;
+    }
+
+    const conds = [
+      { $or: [{ title: entry.match }, { display_title: entry.match }, { english_title: entry.match }] },
+      { $or: [{ work_id: { $exists: false } }, { work_id: null }, { work_id: '' }] },
+    ];
+    // andMatch narrows a GENRE word to a work by requiring the author too.
+    if (entry.andMatch) conds.push({ $or: [{ title: entry.andMatch }, { display_title: entry.andMatch }, { english_title: entry.andMatch }] });
+    let orphans = await books.find({ $and: conds }).project({ id: 1, title: 1, display_title: 1, language: 1, visible: 1 }).toArray();
+    // notMatch removes derivative compilations and image records.
+    if (entry.notMatch) orphans = orphans.filter(o => !entry.notMatch.test(`${o.title} ${o.display_title || ''}`));
+
+    console.log(`\n${entry.work}`);
+    console.log(`  cluster ${entry.id} — ${clusterSize} books held`);
+    console.log(`  unlinked candidates: ${orphans.length}`);
+    for (const o of orphans.slice(0, 6)) {
+      console.log(`    [${String(o.language).padEnd(9)}] ${String(o.title).replace(/\s+/g, ' ').slice(0, 74)}`);
+    }
+    if (orphans.length > 6) console.log(`    … and ${orphans.length - 6} more`);
+    for (const o of orphans) plan.push({ id: o.id, title: o.title, language: o.language, work_id: entry.id, work: entry.work });
+  }
+
+  console.log(`\n${plan.length} books would be linked into ${new Set(plan.map(p => p.work_id)).size} existing clusters.`);
+
+  if (!APPLY) { console.log('\nDRY RUN — nothing written. Re-run with --apply.'); await client.close(); return; }
+
+  mkdirSync('scripts/output', { recursive: true });
+  // Merge, never overwrite: a re-run must not shrink the restore set.
+  const backup = existsSync(BACKUP) ? JSON.parse(readFileSync(BACKUP, 'utf8')) : { sweep: SWEEP, records: {} };
+  for (const p of plan) if (!backup.records[p.id]) backup.records[p.id] = { work_id: null };
+  writeFileSync(BACKUP, JSON.stringify(backup, null, 1));
+
+  let n = 0;
+  for (const p of plan) {
+    const res = await books.updateOne(
+      // Re-assert emptiness at write time: another session may have linked it
+      // since we planned, and we never overwrite someone else's answer.
+      { id: p.id, $or: [{ work_id: { $exists: false } }, { work_id: null }, { work_id: '' }] },
+      { $set: { work_id: p.work_id, work_id_source: 'graeco-arabic-curated', updated_at: new Date() } }
+    );
+    if (res.modifiedCount !== 1) { console.log(`  skipped ${p.id} (already linked since planning)`); continue; }
+    n++;
+    await recordSweepAction(db, {
+      sweep: SWEEP, book_id: p.id, action: 'linked-to-existing-work',
+      detail: { work: p.work, work_id: p.work_id, language: p.language, title: String(p.title).slice(0, 160) },
+    });
+  }
+  console.log(`\nlinked ${n}/${plan.length}`);
+  console.log('NEXT: node scripts/workers/sync-books-catalog.mjs  (books_catalog carries work_id)');
+  await client.close();
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(e => { console.error('FATAL', e); process.exit(1); });
+}


### PR DESCRIPTION
Three related pieces, all from one question: *"don't we avoid Vercel for imports? does it cost?"*

## 1. Yes it costs, and bulk imports shouldn't go through it

Vercel is **~$3,069/mo** — **$11,089.37** Nov 2025–Jul 2026, on Derek's personal card. Invocations are not incidental: the cost register already carries a **~$1,000/mo** line for crawler traffic whose entire cost was that each rejection "still cost an edge request **+ a function invocation**."

A bulk import is the expensive case of that same shape. `/api/import/*` declares `maxDuration = 300`; a 300-page manuscript holds a function for 30–90s to fetch a manifest and write Mongo. **Neither needs Vercel.**

Measured today: ~1,500 eGangotri books and 20 Gallica books went through the routes before anyone asked the question.

**New:** `gallica-islamic-direct.mjs` — the documented `*-direct.mjs` pattern, with `insertBookIfNew()` as its dedupe gate and `makePageDoc()` so unknown fields throw. Verified parsing a real Gallica manifest to 345 pages. Reports its own Vercel invocation count: **0**.

## 2. Where a job runs decides who pays

| runs from | egress | consequence |
|---|---|---|
| Vercel | datacenter | costs invocations; 403/429 at Harvard, Gallica, QDL |
| **Derek's laptop** | his home ISP | free and residential — but spends **his** quota and dies with the lid |
| **Hetzner** | own dedicated IP | free, always-on, separate quota |

Not theoretical either: a Gallica sweep from the laptop today burned Derek's residential quota until later queries 429'd. **Hetzner is the default for any long job**, and "where did this run" belongs in the report.

Documented in `.claude/docs/invariants/import-cost-and-egress.md`, with one routing line in CLAUDE.md — kept at **5,592 words**, inside the budget rather than quietly widening it.

## 3. Link the Arabic witnesses, don't orphan them

We hold the **receiving** end of the Graeco-Arabic chain — 296 Galen, 330 Hippocrates, 139 Dioscorides, 119 Euclid, overwhelmingly Latin and Greek — and almost never the Arabic end (327 Arabic books vs 43,983 Latin). Importing Arabic witnesses without linking them makes orphans, which is #4394's defect on purpose.

Already real: **5 Arabic Almagest books carried no `work_id`** while 6 others sat correctly on `Q155952`.

**Applied: 15 books into 5 existing clusters**, including the Arabic **Ḥunayn ibn Isḥāq** translations of Hippocrates' *Aphorisms* and Dioscorides — now beside the Greek and Latin copies of the same works.

### The dry run earned its keep

A first cut proposed **28** and **13 were wrong**:
- **"Aphorisms" is a genre** — it pulled in chemical, astrological, legal and eucharistic aphorisms. Four disciplines, none of them Hippocrates.
- **`qanun` alone matched al-Bīrūnī's *Canon Masudicus*** — different author, astronomy not medicine.
- Dioscorides pulled compilations derived *from* him; Euclid matched a title-page image.

Tightened with `andMatch`/`notMatch` to 15, all correct. The "target cluster must already hold books" guard **refused Picatrix**, whose cluster holds zero — surfacing that **Picatrix is fragmented across two ids**, which needs `merge-work-clusters.mjs` (alias-preserving), not a hand patch.

Related: #4311, #4394, #4225
