### PR TITLE
fix(reader): the transliterate wall reads as a sign-in prompt, not a failure

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { anonActionGate } from '@/lib/anon-gate';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { performTransliteration } from '@/lib/ai';
 import { resolveTenantId } from '@/lib/tenant-context';
 
@@ -109,7 +109,16 @@ export async function POST(
     const gate = await anonActionGate(request, { name: 'transliterate', limit: 15, allowBotBypass: false });
     if (!gate.allowed) {
       return NextResponse.json(
-        { error: 'Transliteration limit reached. Sign in (free) to keep going.', retry_after: gate.retryAfter },
+        {
+          error: 'Transliteration limit reached. Sign in (free) to keep going.',
+          // Machine-readable so the reader UI can render a sign-in CTA instead
+          // of an error toast. The panel auto-fires this route, so a wall that
+          // only says something in prose shows readers a failure for something
+          // they did nothing wrong to hit. Same shape as search/unified.
+          code: 'SIGNIN_REQUIRED',
+          sign_in: SIGNIN_URL,
+          retry_after: gate.retryAfter,
+        },
         { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
       );
     }

--- a/src/app/api/pages/[id]/transliterate/route.ts
+++ b/src/app/api/pages/[id]/transliterate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { anonActionGate } from '@/lib/anon-gate';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { performTransliteration } from '@/lib/ai';
 const TRANSLITERATION_MODEL = 'gemini-3-flash-preview';
 import { logGeminiCall } from '@/lib/gemini-logger';
@@ -100,7 +100,16 @@ export async function POST(
     const gate = await anonActionGate(request, { name: 'transliterate', limit: 15, allowBotBypass: false });
     if (!gate.allowed) {
       return NextResponse.json(
-        { error: 'Transliteration limit reached. Sign in (free) to keep going.', retry_after: gate.retryAfter },
+        {
+          error: 'Transliteration limit reached. Sign in (free) to keep going.',
+          // Machine-readable so the reader UI can render a sign-in CTA instead
+          // of an error toast. The panel auto-fires this route, so a wall that
+          // only says something in prose shows readers a failure for something
+          // they did nothing wrong to hit. Same shape as search/unified.
+          code: 'SIGNIN_REQUIRED',
+          sign_in: SIGNIN_URL,
+          retry_after: gate.retryAfter,
+        },
         { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
       );
     }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,6 +29,7 @@ import {
   type IndexSearchResult,
   type GalleryItem,
   type Collection,
+  type ApiClientError,
 } from '@/lib/api-client';
 import { tenantBookUrl } from '@/lib/slugify';
 import { matchKnownEntity } from '@/lib/known-entities';
@@ -601,10 +602,15 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
             if (oldest) searchCache.current.delete(oldest[0]);
           }
         } catch (err) {
+          const apiErr = err as ApiClientError;
           const msg = err instanceof Error ? err.message : String(err);
           // Anonymous free-search allowance exhausted — show the sign-in wall
           // and stop (don't fire the parallel agents or report an error).
-          if (/free searches this hour/i.test(msg) || /SIGNIN_REQUIRED/.test(msg)) {
+          // Keyed on the machine-readable code the route sends, not on the
+          // wording of the copy: the api-client interceptor carries `code`
+          // through now, and a regex over user-facing prose silently stops
+          // matching the first time that prose is reworded.
+          if (apiErr?.code === 'SIGNIN_REQUIRED') {
             setSignInRequired(true);
             setBookResults([]); setBookTotal(0);
             setIndexResults([]); setIndexTotal(0);

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo, type ReactNode } from 'react';
 import { useParams, usePathname } from 'next/navigation';
+import Link from 'next/link';
 import { useStableSession } from '@/hooks/useStableSession';
 import { resolveImprintPlace } from '@/lib/imprint';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
@@ -50,6 +51,7 @@ import { isNativeEdition, localizedTitle } from '@/lib/localized';
 import ShareButton from '@/components/ui/ShareButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
+import type { ApiClientError } from '@/lib/api-client';
 import LikeButton from '@/components/ui/LikeButton';
 import { getShortUrl } from '@/lib/shortlinks';
 import { getPageDisplayUrl, getPageThumbUrl, isUsableImageUrl } from '@/lib/utils';
@@ -61,6 +63,28 @@ import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import { shouldShowTranslationRequestCta } from '@/lib/translation-request-cta';
 import { hasNonLatinScript } from '@/lib/non-latin-scripts';
 
+
+/** Set when the anon-gate walls a signed-out reader; null otherwise. */
+type TransliterationGate = { message: string } | null;
+
+/**
+ * Both transliteration call sites — the panel's auto-fire effect and the
+ * explicit button — share this. Generating a transliteration is a paid Gemini
+ * call, so anonymous volume is capped per hour and the route answers 429 with
+ * `code: 'SIGNIN_REQUIRED'` at the cap. That is a prompt, not a failure: the
+ * panel renders a sign-in CTA rather than an error toast, and nothing retries.
+ * Any other error keeps the existing toast.
+ */
+function handleTransliterationError(
+  err: ApiClientError,
+  setGate: (gate: TransliterationGate) => void,
+): void {
+  if (err?.code === 'SIGNIN_REQUIRED') {
+    setGate({ message: err.message });
+    return;
+  }
+  toast.error(`Transliteration failed: ${err?.message || 'Unknown error'}`);
+}
 
 // Helper to format edit source info
 // EditSourceBadge removed — source info folded into RevisionHistory trigger
@@ -630,6 +654,10 @@ export default function TranslationEditor({
   const [showGermanSourcePanel, setShowGermanSourcePanel] = useState(false);
   const [transliterationText, setTransliterationText] = useState('');
   const [transliterationLoading, setTransliterationLoading] = useState(false);
+  // Set when the anon-gate walls a signed-out reader. The panel auto-fires the
+  // route, so hitting the hourly cap must read as a sign-in prompt, never as a
+  // failure the reader caused — and nothing may retry into the wall.
+  const [transliterationGate, setTransliterationGate] = useState<TransliterationGate>(null);
   const [showPageMetadata, setShowPageMetadata] = useState(false); // Toggle for page metadata panel
   const [showFontControls, setShowFontControls] = useState(false);
   // Liked state of the CURRENT page, reported by the LikeButtons (#4126) so
@@ -884,12 +912,13 @@ export default function TranslationEditor({
     }
     let cancelled = false;
     setTransliterationLoading(true);
+    setTransliterationGate(null);
     pagesApi.transliterate(page.id)
       .then((res) => {
         if (!cancelled) setTransliterationText(res.transliteration || '');
       })
-      .catch((err) => {
-        if (!cancelled) toast.error(`Transliteration failed: ${err.message || 'Unknown error'}`);
+      .catch((err: ApiClientError) => {
+        if (!cancelled) handleTransliterationError(err, setTransliterationGate);
       })
       .finally(() => {
         if (!cancelled) setTransliterationLoading(false);
@@ -897,9 +926,12 @@ export default function TranslationEditor({
     return () => { cancelled = true; };
   }, [showTransliterationPanel, page.id, isNonLatin, page.ocr?.data, page.transliteration?.data]);
 
-  // Reset transliteration text when page changes
+  // Reset transliteration text when page changes. The gate clears too: it is
+  // per-request state, and a page whose transliteration is already cached is
+  // served free — leaving a stale wall up would hide text we have paid for.
   useEffect(() => {
     setTransliterationText(page.transliteration?.data || '');
+    setTransliterationGate(null);
   }, [page.id, page.transliteration?.data]);
 
   // Detect multi-column structure in OCR (either <column-break/> or ## Column N headers)
@@ -1993,6 +2025,24 @@ export default function TranslationEditor({
                       <div className="prose-manuscript leading-relaxed" style={{ color: 'var(--text-secondary)' }} lang="und-Latn">
                         <NotesRenderer text={cleanTransliteration} showNotes={false} showMetadata={false} columns={effectiveColumns} />
                       </div>
+                    ) : transliterationGate ? (
+                      // The anon-gate wall. Deliberately NOT an error state: the
+                      // reader has done nothing wrong, and nothing retries.
+                      // Ordered after the cached-text branch so a page we have
+                      // already paid for still renders while the wall is up.
+                      <div className="h-full flex flex-col items-center justify-center text-center px-4">
+                        <Type className="w-8 h-8 mb-3" style={{ color: 'var(--text-faint)' }} />
+                        <p className="text-sm mb-4" style={{ color: 'var(--text-muted)' }}>
+                          {transliterationGate.message}
+                        </p>
+                        <Link
+                          href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname || `/book/${book.id}/page/${page.id}`)}&reason=limit`}
+                          className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-all hover:opacity-90"
+                          style={{ background: 'var(--accent-rust)' }}
+                        >
+                          Sign in — free
+                        </Link>
+                      </div>
                     ) : page.ocr?.data ? (
                       <div className="h-full flex flex-col items-center justify-center text-center px-4">
                         <Type className="w-8 h-8 mb-3" style={{ color: 'var(--text-faint)' }} />
@@ -2002,9 +2052,10 @@ export default function TranslationEditor({
                         <button
                           onClick={() => {
                             setTransliterationLoading(true);
+                            setTransliterationGate(null);
                             pagesApi.transliterate(page.id)
                               .then((res) => setTransliterationText(res.transliteration || ''))
-                              .catch((err) => toast.error(`Transliteration failed: ${err.message || 'Unknown error'}`))
+                              .catch((err: ApiClientError) => handleTransliterationError(err, setTransliterationGate))
                               .finally(() => setTransliterationLoading(false));
                           }}
                           className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white transition-all hover:opacity-90"

--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -116,10 +116,43 @@ apiClient.interceptors.response.use(
     }
 
     // Extract error message from response
-    const message = (error.response?.data as any)?.error || error.message || 'Request failed';
-    throw new Error(message);
+    const data = error.response?.data as ApiErrorBody | undefined;
+    const message = data?.error || error.message || 'Request failed';
+
+    // Carry the machine-readable fields through instead of collapsing the
+    // response to a prose string. Anon-gate walls answer with
+    // `code: 'SIGNIN_REQUIRED'` (see src/lib/anon-gate.ts), and a caller that
+    // can only read `err.message` has to regex the copy to recognise one —
+    // which breaks the moment the wording changes. `message` is unchanged, so
+    // every existing caller keeps working.
+    throw Object.assign(new Error(message), {
+      status: error.response?.status,
+      code: data?.code,
+      signIn: data?.sign_in,
+      retryAfter: data?.retry_after,
+    });
   }
 );
+
+/** The JSON body our API routes return on error. */
+interface ApiErrorBody {
+  error?: string;
+  code?: string;
+  sign_in?: string;
+  retry_after?: number;
+}
+
+/**
+ * Shape of the error thrown by the response interceptor and `streamRequest`.
+ * Fields are optional: a network failure has no response body to read them
+ * from, so always check before branching on one.
+ */
+export interface ApiClientError extends Error {
+  status?: number;
+  code?: string;
+  signIn?: string;
+  retryAfter?: number;
+}
 
 /**
  * Streaming request helper that applies interceptor logic
@@ -171,14 +204,22 @@ export async function streamRequest(
 
     // Try to extract error message from response
     let message = 'Request failed';
+    let body: ApiErrorBody = {};
     try {
-      const errorData = await response.json();
-      message = errorData.error || message;
+      body = (await response.json()) as ApiErrorBody;
+      message = body.error || message;
     } catch {
       message = response.statusText || message;
     }
 
-    throw new Error(message);
+    // Same additive fields as the interceptor above, so a caller can branch on
+    // `code` regardless of which helper it used.
+    throw Object.assign(new Error(message), {
+      status: response.status,
+      code: body.code,
+      signIn: body.sign_in,
+      retryAfter: body.retry_after,
+    });
   }
 
   return response;

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -22,6 +22,7 @@
 
 // Export the base client and streaming utility
 export { apiClient, streamRequest } from './client';
+export type { ApiClientError } from './client';
 
 // Export all types (single source of truth)
 export * from './types';

--- a/tests/unit/transliterate-anon-gate.test.ts
+++ b/tests/unit/transliterate-anon-gate.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The anonymous gate on the transliterate routes, and — the part that actually
+ * matters — WHERE it sits relative to the cache return.
+ *
+ * `transliterate` is the only AI page route with real anonymous reader traffic:
+ * `TranslationEditor` auto-fires it from a `useEffect` when the transliteration
+ * panel opens, and the toolbar toggle sits outside every `<AuthCheck>`. So it
+ * gets a meter, not a wall — and the meter runs on the **cache-miss path only**.
+ * A cache hit is a page we have already paid for; walling it would take
+ * signed-out reading away from every non-Latin-script book for nothing.
+ *
+ * Both twins are covered (`/api/pages/...` and `/api/[tenant]/pages/...`) per
+ * CLAUDE.md's "check the twins" rule — #3511 found two pairs that disagreed.
+ *
+ * This exercises the REAL route modules with `anonActionGate` mocked at the
+ * boundary. Negative controls, each run and restored:
+ *   - delete the gate from the unscoped route  → its 3 gate cases go red
+ *   - delete it from the tenant route          → its 3 gate cases go red
+ *   - move the gate ABOVE the cache return     → both cache-hit cases go red
+ * The third is the plausible mistake and the expensive one.
+ */
+
+const { gateState, aiCalls } = vi.hoisted(() => ({
+  gateState: { allowed: true, retryAfter: undefined as number | undefined },
+  aiCalls: [] as string[],
+}));
+
+vi.mock('@/lib/anon-gate', () => ({
+  SIGNIN_URL: 'https://sourcelibrary.org/auth/signin',
+  anonActionGate: vi.fn(async () => ({
+    allowed: gateState.allowed,
+    retryAfter: gateState.retryAfter,
+  })),
+}));
+
+// If this fires on a walled request, the gate did not stop the paid call.
+vi.mock('@/lib/ai', () => ({
+  performTransliteration: vi.fn(async (text: string) => {
+    aiCalls.push(text);
+    return { text: 'ho anthropos', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15, costUsd: 0.0001 } };
+  }),
+}));
+
+vi.mock('@/lib/gemini-logger', () => ({ logGeminiCall: vi.fn(async () => undefined) }));
+vi.mock('@/lib/cron-auth', () => ({ getTriggerSource: vi.fn(() => 'manual') }));
+vi.mock('@/lib/tenant-context', () => ({ resolveTenantId: vi.fn(async () => 'tenant-uuid-1') }));
+
+/**
+ * Same hash the routes use to decide whether a stored transliteration is still
+ * valid for the current OCR. Duplicated here deliberately: the cache-hit cases
+ * are only meaningful if the fixture's `source_ocr_hash` genuinely matches, and
+ * asserting through the real comparison is the point.
+ */
+function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  return hash.toString(16);
+}
+
+const OCR_TEXT = 'ὁ ἄνθρωπος';
+const CACHED_TRANSLITERATION = 'ho anthropos (cached)';
+
+/** Whether the page fixture carries a transliteration valid for OCR_TEXT. */
+let pageHasValidCache = false;
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      findOne: async () => {
+        if (name === 'books') return { id: 'b1', language: 'Greek' };
+        return {
+          id: 'p1',
+          book_id: 'b1',
+          tenantId: 'tenant-uuid-1',
+          ocr: { data: OCR_TEXT, language: 'Greek' },
+          transliteration: pageHasValidCache
+            ? { data: CACHED_TRANSLITERATION, source_ocr_hash: hashString(OCR_TEXT), script: 'Greek' }
+            : undefined,
+        };
+      },
+      updateOne: async () => ({ matchedCount: 1 }),
+      insertOne: async () => ({ insertedId: 'x' }),
+    }),
+  })),
+}));
+
+type Twin = {
+  name: string;
+  load: () => Promise<{ POST: (req: Request, ctx: { params: Promise<Record<string, string>> }) => Promise<Response> }>;
+  params: Record<string, string>;
+};
+
+const TWINS: Twin[] = [
+  {
+    name: 'unscoped /api/pages/[id]/transliterate',
+    load: () => import('@/app/api/pages/[id]/transliterate/route') as Promise<never>,
+    params: { id: 'p1' },
+  },
+  {
+    name: 'tenant /api/[tenant]/pages/[id]/transliterate',
+    load: () => import('@/app/api/[tenant]/pages/[id]/transliterate/route') as Promise<never>,
+    params: { tenant: 'bph', id: 'p1' },
+  },
+];
+
+function post(body: unknown = {}): Request {
+  return new Request('https://sourcelibrary.org/api/pages/p1/transliterate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe.each(TWINS)('anon gate — $name', (twin) => {
+  beforeEach(() => {
+    gateState.allowed = true;
+    gateState.retryAfter = undefined;
+    pageHasValidCache = false;
+    aiCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('walls an anonymous cache-miss with 429 and a machine-readable code', async () => {
+    gateState.allowed = false;
+    gateState.retryAfter = 1800;
+
+    const { POST } = await twin.load();
+    const res = await POST(post(), { params: Promise.resolve(twin.params) });
+    const json = await res.json();
+
+    expect(res.status).toBe(429);
+    // The client keys on `code`, not on the copy — a regex over user-facing
+    // prose stops matching the first time the wording changes.
+    expect(json.code).toBe('SIGNIN_REQUIRED');
+    expect(json.sign_in).toContain('/auth/signin');
+    expect(json.error).toBeTruthy();
+    expect(res.headers.get('Retry-After')).toBe('1800');
+    // The whole point of the gate: no paid call happened.
+    expect(aiCalls).toHaveLength(0);
+  });
+
+  it('omits Retry-After when the gate reports no reset window', async () => {
+    gateState.allowed = false;
+    gateState.retryAfter = undefined;
+
+    const { POST } = await twin.load();
+    const res = await POST(post(), { params: Promise.resolve(twin.params) });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeNull();
+    expect((await res.json()).code).toBe('SIGNIN_REQUIRED');
+  });
+
+  it('lets an allowed cache-miss through to generation', async () => {
+    const { POST } = await twin.load();
+    const res = await POST(post(), { params: Promise.resolve(twin.params) });
+
+    expect(res.status).toBe(200);
+    expect(aiCalls).toHaveLength(1);
+  });
+
+  it('serves a valid cache hit ungated', async () => {
+    pageHasValidCache = true;
+
+    const { POST } = await twin.load();
+    const res = await POST(post(), { params: Promise.resolve(twin.params) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.cached).toBe(true);
+    expect(json.transliteration).toBe(CACHED_TRANSLITERATION);
+
+    const { anonActionGate } = await import('@/lib/anon-gate');
+    // The gate must not even be consulted: this response costs nothing.
+    expect(anonActionGate).not.toHaveBeenCalled();
+  });
+
+  it('still serves a cache hit when the gate is exhausted', async () => {
+    // The regression this file exists for. If the gate moves above the cache
+    // return, a signed-out reader past the cap loses pages we already paid to
+    // transliterate — silently, and for an hour at a time.
+    pageHasValidCache = true;
+    gateState.allowed = false;
+    gateState.retryAfter = 3600;
+
+    const { POST } = await twin.load();
+    const res = await POST(post(), { params: Promise.resolve(twin.params) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.cached).toBe(true);
+  });
+
+  it('gates a forced regenerate even when a valid cache exists', async () => {
+    // `regenerate: true` skips the cache, so it is a paid call and must meter.
+    pageHasValidCache = true;
+    gateState.allowed = false;
+
+    const { POST } = await twin.load();
+    const res = await POST(post({ regenerate: true }), { params: Promise.resolve(twin.params) });
+
+    expect(res.status).toBe(429);
+    expect(aiCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Salvages the client half of #3575. Its server half is superseded by #4205 and #3575 is now closed.

## Why this is a live bug, not a follow-up

`main` already gates both transliterate twins — `anonActionGate({ name: 'transliterate', limit: 15, allowBotBypass: false })`, **429**, on the cache-miss path only. That half is correct and **this PR does not touch it**: same status, same limit, same bypass setting, same `retry_after`, same copy.

What never shipped is the client side. `TranslationEditor` **auto-fires** the route from a `useEffect` when the transliteration panel opens ([TranslationEditor.tsx:913](src/components/pipeline/TranslationEditor.tsx#L913)), and both call sites ended in `toast.error(\`Transliteration failed: ...\`)`. So a signed-out reader who trips the cap on a Greek, Hebrew, Arabic or Tibetan book gets a **red failure toast** for something they did nothing wrong to hit. The 15-cap makes that easier to reach than the 200 #3575 assumed.

## What changed

**Routes** (`/api/pages/[id]/transliterate` + the `[tenant]` twin) — add `code: 'SIGNIN_REQUIRED'` and `sign_in` to the 429 body, the same shape [search/unified](src/app/api/search/unified/route.ts#L107) already sends. Purely additive.

**`src/lib/api-client/client.ts`** — the response interceptor collapsed every error to `new Error(message)`, so a caller could only recognise an anon-gate wall by regex-matching the copy. It now carries `status` / `code` / `signIn` / `retryAfter` through, and exports the `ApiClientError` type. `err.message` is unchanged, so every existing caller keeps working. `streamRequest` gets the same fields so a caller can branch on `code` regardless of which helper it used.

**`src/app/search/page.tsx`** — was detecting its own wall with `/free searches this hour/i.test(msg)`, i.e. a regex over user-facing prose that stops matching the first time anyone rewords the sentence. Now keys on `code === 'SIGNIN_REQUIRED'`.

**`TranslationEditor.tsx`** — both call sites (the auto-fire effect and the explicit button) go through one shared `handleTransliterationError`, which renders an in-panel sign-in CTA on `SIGNIN_REQUIRED` and keeps the existing toast for everything else. **Nothing retries.** Two ordering details that are the actual content of the change:

- The gate branch sits **after** the cached-text branch, so a page whose transliteration we have already paid for still renders while the wall is up.
- The gate clears on page change, so a stale wall can't hide cached text on the next page.

Also removes the last `as any` in `client.ts`. eslint errors on the touched files: **29 → 28**, no new ones (verified by diffing the error sets before/after; every other difference is a line shift).

## Guard

`tests/unit/transliterate-anon-gate.test.ts` — 12 tests, parameterised over **both twins** per CLAUDE.md's "check the twins" rule. Exercises the real route modules with `anonActionGate` mocked at the boundary.

Three negative controls, each run and restored:

| Mutation | Result |
|---|---|
| Delete the gate from the unscoped route | 3 red |
| Delete it from the tenant route | 3 red |
| Move it **above** the cache return | both cache-hit cases red, in **both** twins (4) |

The third is the one that matters: it's the plausible mistake, and it would silently take pages we've already paid for away from signed-out readers for an hour at a time.

`npx tsc --noEmit` clean. **3354/3354** unit tests pass (3342 before, +12).

## Out of scope, deliberately

- **The limit itself.** 15/hour is #4205's number and this PR does not relitigate it. The thing that decides whether it's right is `{ event: 'gate_hit', feature: 'transliterate' }` in `analytics_events` — worth reading a week after this deploys, since until now every gate hit also produced an error toast and readers had no reason to report it as a limit.
- **Tripping the cap end-to-end on the preview.** Doing it for real means 15 uncached transliterations against real pages, i.e. paid Gemini calls to prove a rate limiter that is unchanged here still works. The gate is unit-covered at the boundary and `anonActionGate` is already in production on `embassy/voice`, `search/unified` and the alignment route.
- **Watching the CTA render after a real wall in a browser.** Same reason. Worth one manual pass after deploy: open a non-Latin-script book signed out and confirm the panel degrades to a sign-in prompt rather than an error toast.
- **The other `toast.error` call sites in `TranslationEditor`.** Only the transliteration ones are reachable by an anonymous reader; the rest sit behind `<AuthCheck>`.