### PR TITLE
fix(pipeline): revalidateBook sends CRON_SECRET (#4470 regression)

### DIFF
--- a/src/lib/revalidate.ts
+++ b/src/lib/revalidate.ts
@@ -9,8 +9,12 @@ export async function revalidateBook(bookId: string): Promise<boolean> {
 
   try {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (process.env.REVALIDATE_SECRET) {
-      headers['x-revalidate-secret'] = process.env.REVALIDATE_SECRET;
+    // The route fails CLOSED since #4470 — a missing secret is a guaranteed 401,
+    // not a pass. CRON_SECRET is always set server-side; REVALIDATE_SECRET wins
+    // if someone configures it.
+    const secret = process.env.REVALIDATE_SECRET || process.env.CRON_SECRET;
+    if (secret) {
+      headers['x-revalidate-secret'] = secret;
     }
 
     const res = await fetch(`${baseUrl}/api/admin/revalidate-book/${bookId}`, {


### PR DESCRIPTION
#4470 made the revalidate routes fail closed — correct — but the in-app pipeline caller `src/lib/revalidate.ts` (job-completion → refresh book pages after OCR/translation/enrichment) only attached a secret when `REVALIDATE_SECRET` was set, which it never was in any environment. Since the #4470 deploy (~08:00 UTC today) those calls 401 silently and freshly-processed books stop refreshing until their 24h ISR window. Found by reading the 2026-08-09 ops security note, which predicted this exact deploy-ordering trap.

One-line fix: fall back to `CRON_SECRET`, which the server env always carries and which the route accepts since #4470.

In scope: the one caller. Out of scope: nothing else in src/ calls these routes (grepped; the rest are comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDovjARwRT8q8nFbMLeGWd