### PR TITLE
Abort on consecutive 429s, and measure Gallica's rate instead of guessing

### DIFF
--- a/scripts/import/gallica-islamic-direct.mjs
+++ b/scripts/import/gallica-islamic-direct.mjs
@@ -91,6 +91,13 @@ async function main() {
   const db = client.db('bookstore');
 
   let ok = 0, skipped = 0, failed = 0, totalPages = 0;
+  // Consecutive-throttle guard. The first run of this script failed 169 times in
+  // a row on 429 and kept going — an hour of hammering a partner institution
+  // with nothing to show, and the shape that earns a longer block (Wellcome,
+  // #4341). The enumerator already had this guard; not carrying it here was the
+  // whole defect. Abort loudly, name the host, exit non-zero.
+  let consecutive429 = 0;
+  const MAX_CONSECUTIVE_429 = 5;
   for (const [i, r] of batch.entries()) {
     const isGreek = GREEK_WORK.test(r.title || '');
     const title = String(r.title || '').replace(/\s+/g, ' ').trim().slice(0, 300) || `Arabic manuscript ${r.ark}`;
@@ -100,8 +107,21 @@ async function main() {
     catch (e) { failed++; console.error(`  FAIL ${r.ark}: ${e.name}`); await new Promise(s => setTimeout(s, DELAY_MS)); continue; }
     if (res.error || !res.pages?.length) {
       failed++; console.error(`  FAIL ${r.ark}: ${res.error || 'no pages in manifest'}`);
+      if (/\b429\b/.test(String(res.error))) {
+        consecutive429++;
+        if (consecutive429 >= MAX_CONSECUTIVE_429) {
+          console.error(`\nABORT: ${consecutive429} consecutive 429s from gallica.bnf.fr.`);
+          console.error(`This IP is throttled. Continuing would batter the source for nothing and`);
+          console.error(`risks a longer block. Let it cool, then re-run — the dedup gate makes a`);
+          console.error(`re-run free, and ${ok} books are already in.`);
+          break;
+        }
+      } else {
+        consecutive429 = 0;   // a non-throttle failure is not evidence of a block
+      }
       await new Promise(s => setTimeout(s, DELAY_MS)); continue;
     }
+    consecutive429 = 0;
 
     if (!COMMIT) {
       console.log(`  [dry] ${r.ark} ${String(res.pages.length).padStart(4)}pp ${isGreek ? '[GREEK]' : '       '} ${title.slice(0, 62)}`);
@@ -171,6 +191,9 @@ async function main() {
   console.log(`\nimported ${ok}, skipped ${skipped}, failed ${failed}, ${totalPages} pages`);
   console.log('Vercel function invocations used: 0');
   await client.close();
+  // Non-zero exit when we stopped because the source blocked us, so a wrapper
+  // or cron can tell "finished" from "gave up".
+  if (consecutive429 >= MAX_CONSECUTIVE_429) process.exitCode = 3;
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/import/gallica-rate-probe.mjs
+++ b/scripts/import/gallica-rate-probe.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Measure what rate Gallica's IIIF manifest endpoint actually sustains.
+ *
+ * WHY. The import wave used a 20s delay picked by guesswork and failed 169 times
+ * in a row on 429. "Slow down a bit" is not a measurement, and a wrong guess
+ * costs a partner institution an hour of refused requests.
+ *
+ * Two phases:
+ *  1. RECOVERY — poll one manifest until it answers 200, to learn how long a
+ *     throttled IP stays throttled.
+ *  2. SUSTAIN — fetch N manifests at a candidate interval and report the success
+ *     rate, so the import delay is set from evidence.
+ *
+ * Read-only: fetches manifests, writes nothing.
+ *
+ * Usage:
+ *   node scripts/import/gallica-rate-probe.mjs --interval 45 --samples 8
+ */
+
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const INTERVAL = parseInt(arg('--interval', '45'), 10) * 1000;
+const SAMPLES = parseInt(arg('--samples', '8'), 10);
+const MAX_WAIT_MIN = parseInt(arg('--max-wait', '20'), 10);
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36';
+
+// Distinct arks — hitting the same one repeatedly could be answered from cache
+// and would measure the cache, not the rate limit.
+const ARKS = [
+  'btv1b10545065q', 'btv1b10721363h', 'btv1b52509699g', 'btv1b11001770s',
+  'btv1b52504032v', 'btv1b110025567', 'btv1b10884453n', 'btv1b10884637c',
+  'btv1b84229648', 'btv1b10037531k', 'btv1b10037511r', 'btv1b100374998',
+];
+
+async function probe(ark) {
+  const t0 = Date.now();
+  try {
+    const r = await fetch(`https://gallica.bnf.fr/iiif/ark:/12148/${ark}/manifest.json`,
+      { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(40000) });
+    return { status: r.status, ms: Date.now() - t0 };
+  } catch (e) { return { status: e.name, ms: Date.now() - t0 }; }
+}
+
+// ── phase 1: how long does a throttled IP stay throttled? ───────────────────
+console.log('PHASE 1 — recovery. Polling one manifest every 60s until it answers 200.');
+const start = Date.now();
+let recovered = false;
+for (let i = 0; i < MAX_WAIT_MIN; i++) {
+  const r = await probe(ARKS[0]);
+  const mins = ((Date.now() - start) / 60000).toFixed(1);
+  console.log(`  t+${String(mins).padStart(5)}min  ${r.status}  (${r.ms}ms)`);
+  if (r.status === 200) { recovered = true; console.log(`  RECOVERED after ~${mins} minutes`); break; }
+  await new Promise(s => setTimeout(s, 60000));
+}
+if (!recovered) {
+  console.log(`\nStill throttled after ${MAX_WAIT_MIN} minutes. Do not start an import.`);
+  process.exit(3);
+}
+
+// ── phase 2: what interval does it sustain? ─────────────────────────────────
+console.log(`\nPHASE 2 — sustain. ${SAMPLES} distinct manifests at ${INTERVAL / 1000}s spacing.`);
+let ok = 0, throttled = 0;
+for (let i = 0; i < SAMPLES; i++) {
+  const r = await probe(ARKS[(i + 1) % ARKS.length]);
+  if (r.status === 200) ok++; else if (r.status === 429) throttled++;
+  console.log(`  ${String(i + 1).padStart(2)}/${SAMPLES}  ${r.status}  (${r.ms}ms)`);
+  if (i < SAMPLES - 1) await new Promise(s => setTimeout(s, INTERVAL));
+}
+const rate = (100 * ok / SAMPLES).toFixed(0);
+console.log(`\nAt ${INTERVAL / 1000}s spacing: ${ok}/${SAMPLES} succeeded (${rate}%), ${throttled} throttled.`);
+console.log(ok === SAMPLES
+  ? `SUSTAINED. Use --delay ${INTERVAL} for the import.`
+  : `NOT sustained. Try a longer interval before importing; do not just retry.`);


### PR DESCRIPTION
## What went wrong

The first overnight run failed **169 times in a row** on HTTP 429 and kept going — an hour of hammering a partner institution with nothing to show, and precisely the shape that earns a longer block (Wellcome, 2026-08-29). Final tally: **6 imported, 169 failed.**

Two defects, both mine.

## 1. No abort guard

I wrote exactly this guard into the *enumerator* earlier the same day, for exactly this failure mode — **#4341: a swallowed failure reads as slow progress rather than as blocked** — and then did not carry it into the importer.

Now: 5 consecutive 429s aborts, names the host, and sets **exit code 3** so a wrapper can distinguish "finished" from "gave up". A non-throttle failure resets the counter, since one bad manifest is not evidence of a block.

## 2. The delay was a guess

20s was picked by feel. "Slow down a bit" is not a measurement, and a wrong guess costs a partner institution an hour of refused requests.

`gallica-rate-probe.mjs` measures it instead:
- **Phase 1 — recovery:** poll until a throttled IP answers 200, learning how long a block lasts
- **Phase 2 — sustain:** fetch N **distinct** manifests at a candidate interval and report the success rate

Distinct arks matter: repeating one ark could be served from cache and would measure the cache, not the limit.

### Measured result

| | |
|---|---|
| Recovery from throttle | **immediate** (~10 min after the run stopped) — a cooldown, not a ban |
| 45s spacing | **8/8 succeeded, 100%, 0 throttled** |

So the import now runs at `--delay 45000`, set from evidence. Relaunched and clean: **0 failures**, correctly skipping the already-held books via the dedup gate.

Read-only probe; writes nothing.

Related: #4311, #4341