### PR TITLE
fix(gallery): honest imageCount + seed musical-scores by type (#4486)

### DIFF
--- a/src/app/api/admin/seed-collections/route.ts
+++ b/src/app/api/admin/seed-collections/route.ts
@@ -207,11 +207,11 @@ const SEED_COLLECTIONS: CollectionSeed[] = [
     description:
       'Historical musical notation from liturgical chants to Renaissance polyphony and baroque compositions.',
     slug: 'musical-scores',
-    subjects: ['music'],
-    searchTerms: ['musical', 'score', 'notation', 'polyphon'],
-    anchorBooks: [
-      '69557560f63a7571091747c1', // Guqin works (280 imgs, avgQ 0.74)
-    ],
+    // The old subjects/searchTerms regexes were too loose — 'notation' also
+    // matches "annotations", which pulled Leonardo anatomy pages into this
+    // collection (#4486). The classifier now emits a musical_score type;
+    // seed from that. (Old anchor book 69557560f63a7571091747c1 was deleted.)
+    types: ['musical_score'],
     minQuality: 0.7,
     maxPerBook: 10,
     limit: 200,

--- a/src/app/api/gallery/collections/[slug]/route.ts
+++ b/src/app/api/gallery/collections/[slug]/route.ts
@@ -34,7 +34,10 @@ export async function GET(
       featured: collection.featured,
       type: collection.type || 'visual',
       book_collection_slug: collection.book_collection_slug || undefined,
-      imageCount: imageIds.length,
+      // Count what we actually deliver — image_ids can dangle after
+      // gallery_images deletions, and claiming 200 while items is [] misleads
+      // API consumers (issue #4486: musical-scores did exactly that).
+      imageCount: items.length,
       items,
     }, {
       headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },


### PR DESCRIPTION
## What

Two small fixes from #4486 (musical-scores gallery collection claimed `imageCount: 200` while returning `items: []` to an external API consumer):

- `/api/gallery/collections/[slug]` now reports `imageCount` as the number of items actually delivered, not `image_ids.length`. Dangling ids (gallery_images rows deleted since seeding) were silently dropped from `items` but still counted — an API consumer could see 200/0.
- The `musical-scores` seed definition now selects `types: ['musical_score']` (7,534 rows exist today) instead of subject/description regexes — `notation` also matched "annotations", pulling Leonardo anatomy pages into a music collection. Its anchor book was deleted long ago.

## Out of scope

- The list route (`/api/gallery/collections`) still reports `image_ids.length` — resolving ~38K ids per list request is too expensive; the honest fix there is a pruning sweep + stored live count (#4486 items 2/4).
- The production data fix for musical-scores itself was already applied directly (169 resolvable items, verified live) — this PR prevents regression on the next force reseed.

## Verification

- `npx tsc --noEmit` clean.
- Data-side verified: `curl https://sourcelibrary.org/api/gallery/collections/musical-scores` returns 169/169.

Closes nothing on its own — #4486 stays open for the sweep and list-route count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc