### PR TITLE
realtime-ocr: no silent skips, and stop re-paying for refused pages

### DIFF
--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -212,10 +212,18 @@ async function callGemini(imageBase64, mimeType, promptText, apiKey) {
   }
 
   const result = await response.json();
-  const text = result.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  const candidate = result.candidates?.[0];
+  // Concatenate ALL text parts. Reading only parts[0] loses the tail whenever the
+  // model splits its answer, and returns '' when parts[0] is a non-text part.
+  const text = (candidate?.content?.parts || []).map(p => p.text || '').join('');
   const usage = result.usageMetadata || {};
   return {
     text,
+    // `finishReason` is the difference between "this page is blank" and "the model
+    // refused to transcribe it". Both used to arrive here as text === '' and both
+    // were then discarded as 'empty', which is how a legible page could vanish with
+    // no record (#4458). RECITATION in particular returns zero content parts.
+    finishReason: candidate?.finishReason || null,
     usage: { inputTokens: usage.promptTokenCount || 0, outputTokens: usage.candidatesTokenCount || 0 },
   };
 }
@@ -239,10 +247,59 @@ function isDigitizerPage(pageType, ocrText) {
 // no OCR prompt here has ever asked for, so it returned [] on every page and the
 // `length > 0` guard below turned that into silence.
 
+/**
+ * Record a page the run declined to write, so it is not invisible (#4458).
+ *
+ * A skip used to leave NOTHING behind — no `gemini_usage` row (the success path's
+ * insert sits after the early returns and the catch only covers thrown errors), and
+ * no field on the page. The count in the run summary was the only trace, and
+ * `--no-ocr` re-selects the page on every later run, so the same Gemini call was paid
+ * for and discarded forever. Six of nine such pages turned out to be transient
+ * failures that succeeded on an identical re-run; three were RECITATION refusals on
+ * a legible 1902 contents page.
+ *
+ * The rule this restores: a completeness predicate is satisfied by output OR by an
+ * explicit recorded skip. Never by silence.
+ */
+async function recordSkip(db, page, { reason, finishReason, chars, durationMs, model }) {
+  db.collection('gemini_usage').insertOne({
+    type: 'ocr', mode: 'realtime', model,
+    book_id: page.book_id, page_ids: [page.id],
+    status: 'skipped', skip_reason: reason,
+    finish_reason: finishReason ?? null,
+    chars: chars ?? null,
+    duration_ms: durationMs ?? null,
+    prompt_version: TARGET_PROMPT,
+    endpoint: 'scripts/realtime-ocr.mjs', timestamp: new Date(),
+  }).catch(() => {});
+
+  // A durable marker on the page itself, so the NEXT run can see what happened here
+  // rather than rediscovering it at full price.
+  const set = {
+    'ocr.last_skip': { reason, finish_reason: finishReason ?? null, at: new Date(), model },
+  };
+  // RECITATION is not transient: the model refuses this image, and repeating the
+  // identical call cannot change that. Count it, and let the orchestrator's existing
+  // `ocr.recitation_blocked` gate (pipeline-orchestrator.mjs) exclude the page once
+  // it has refused N=3 times — the same threshold batch-collector.mjs uses.
+  if (finishReason === 'RECITATION') {
+    const count = (page.ocr?.recitation_count ?? 0) + 1;
+    set['ocr.recitation_count'] = count;
+    if (count >= 3) {
+      set['ocr.recitation_blocked'] = true;
+      set['ocr.recitation_blocked_at'] = new Date();
+    }
+  }
+  await db.collection('pages').updateOne({ id: page.id }, { $set: set }).catch(() => {});
+}
+
 // --- Process one page ---
 async function processPage(page, promptText, db) {
   const imageUrl = getPageImageUrl(page);
-  if (!imageUrl) return { pageId: page.id, status: 'skip', reason: 'no image' };
+  if (!imageUrl) {
+    await recordSkip(db, page, { reason: 'no-image', model: TARGET_MODEL });
+    return { pageId: page.id, status: 'skip', reason: 'no image' };
+  }
 
   const startTime = Date.now();
   const keyInfo = getNextKey();
@@ -253,11 +310,20 @@ async function processPage(page, promptText, db) {
     const durationMs = Date.now() - startTime;
 
     if (!result.text || result.text.length < 5) {
-      return { pageId: page.id, status: 'empty', durationMs };
+      // Three different states used to collapse into 'empty': a genuinely blank leaf,
+      // a refusal (RECITATION / SAFETY), and a truncation that produced no text.
+      const reason =
+        result.finishReason === 'RECITATION' ? 'recitation'
+          : result.finishReason === 'SAFETY' ? 'safety'
+            : result.finishReason === 'MAX_TOKENS' ? 'max-tokens-no-text'
+              : 'empty';
+      await recordSkip(db, page, { reason, finishReason: result.finishReason, chars: result.text?.length ?? 0, durationMs, model: TARGET_MODEL });
+      return { pageId: page.id, status: 'skip', reason, finishReason: result.finishReason, durationMs };
     }
 
     // Hallucination guard
     if (result.text.length > 25000) {
+      await recordSkip(db, page, { reason: 'hallucination', finishReason: result.finishReason, chars: result.text.length, durationMs, model: TARGET_MODEL });
       return { pageId: page.id, status: 'skip', reason: 'hallucination (>25k chars)', durationMs };
     }
 
@@ -333,6 +399,7 @@ async function processPage(page, promptText, db) {
 // --- Concurrent processor ---
 async function processBatch(pages, promptText, db, runId) {
   let completed = 0, failed = 0, skipped = 0;
+  const skipReasons = {};
   let totalTokens = 0;
   let consecutiveErrors = 0;
   const startTime = Date.now();
@@ -386,6 +453,11 @@ async function processBatch(pages, promptText, db, runId) {
         }
       } else {
         skipped++;
+        // "Skipped: 9" with no breakdown is the same silence one level up — it was
+        // what hid #4458 for a full run. Tally the reasons so the summary can say
+        // which pages were declined and why.
+        const key = result.reason || 'unknown';
+        skipReasons[key] = (skipReasons[key] || 0) + 1;
       }
     }
 
@@ -437,7 +509,7 @@ async function processBatch(pages, promptText, db, runId) {
     console.log(`  Advanced ${booksCompleted} books to ocr_complete`);
   }
 
-  return { completed, failed, skipped, totalTokens, elapsed: Date.now() - startTime, booksUpdated: Object.keys(bookPages).length, booksCompleted };
+  return { completed, failed, skipped, skipReasons, totalTokens, elapsed: Date.now() - startTime, booksUpdated: Object.keys(bookPages).length, booksCompleted };
 }
 
 // --- Main ---
@@ -526,8 +598,23 @@ async function main() {
       ]}
     ];
 
+    // Skip pages the model has permanently refused. pipeline-orchestrator.mjs has
+    // honoured this flag in two places all along; this script set neither and read
+    // neither, so a RECITATION-blocked page was re-selected and re-paid-for on every
+    // run, silently, forever (#4458). `--all` is an explicit human override and is
+    // left alone.
+    if (targetMode !== 'all') {
+      pageFilter['ocr.recitation_blocked'] = { $ne: true };
+    }
+
     const totalEligible = await db.collection('pages').countDocuments(pageFilter);
     console.log(`Eligible pages: ${totalEligible.toLocaleString()}`);
+    if (targetMode !== 'all') {
+      const blocked = await db.collection('pages').countDocuments({
+        ...pageFilter, 'ocr.recitation_blocked': true,
+      });
+      if (blocked > 0) console.log(`  (excluding ${blocked} page(s) the model has permanently refused)`);
+    }
 
     if (totalEligible === 0) {
       console.log('Nothing to process.');
@@ -628,6 +715,13 @@ async function main() {
     console.log(`Completed: ${result.completed}`);
     console.log(`Failed: ${result.failed}`);
     console.log(`Skipped: ${result.skipped}`);
+    // Never print a bare skip count — say what was declined and why (#4458).
+    for (const [reason, n] of Object.entries(result.skipReasons || {}).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${reason}: ${n}`);
+    }
+    if (result.skipReasons?.recitation) {
+      console.log(`  ↳ recitation refusals are counted on the page; 3 strikes sets ocr.recitation_blocked`);
+    }
     console.log(`Tokens: ${result.totalTokens.toLocaleString()}`);
     console.log(`Books updated: ${result.booksUpdated}`);
     console.log(`Books advanced to ocr_complete: ${result.booksCompleted}`);


### PR DESCRIPTION
Closes #4458.

A page this script declined to write left **no trace anywhere** — no `gemini_usage` row, no field on the page, nothing in the summary but a number. The Gemini call was paid for and thrown away, and `--no-ocr` re-selected the same page on the next run, forever.

## Three defects, one shape

**1. Nothing was recorded.** The `empty` and `hallucination` returns sit *before* the success path's `gemini_usage` insert and *outside* the `catch` that logs errors. Every non-success outcome now writes a usage row with its reason plus an `ocr.last_skip` marker on the page.

**2. Three states collapsed into one word.** A blank leaf, a RECITATION refusal, a SAFETY block and a MAX_TOKENS truncation all arrived as `text === ''` and were all called `empty`. `callGemini` now returns `finishReason` and the caller branches on it. It also concatenates **all** text parts rather than reading `parts[0]`, which returned `''` whenever the first part wasn't text — which is exactly what RECITATION produces (`parts: []`).

**3. Refused pages were re-selected forever.** `pipeline-orchestrator.mjs` has honoured `ocr.recitation_blocked` in two places all along. This script set neither and read neither. RECITATION now increments `ocr.recitation_count`, sets the block at N=3 (matching `batch-collector.mjs`), and the selection query excludes blocked pages **and says how many it excluded**.

## Evidence

From the run that surfaced this: 24 pages needed OCR, 15 succeeded, **9 were reported only as `Skipped`**. Probing Gemini directly with the same prompt and model:

- **Six were transient** — an identical re-run OCR'd them fine, including a dense, fully legible 13th-century folio with rubrication. They would never have been retried.
- **Three were `finishReason: RECITATION` with `parts: []`** on a public-domain 1902 table of contents.

Neither state was distinguishable from the other, or from a genuinely blank page, in anything the script wrote down.

## Positive control

Against the three known-blocked pages:

```
Eligible pages: 0
  (excluding 3 page(s) the model has permanently refused)
Nothing to process.
```

Before this PR those three were re-fetched and re-billed on every run.

## Deliberately not fixed here

The model is still hardcoded to `gemini-3-flash-preview` for every book, where the translation side takes routing from `getTranslateModelForBook` (#3725) and BPH-vs-everything-else matters for cost. Real, but a different concern — own PR.

Also not here: escalating a RECITATION page to the flash-lite fallback. It *does* bypass the filter, and then loops degenerately to 32k characters of dot-leaders on a contents page (#4334). Escalation has to re-apply the output guard, which is more design than this fix needs.

`node --check` clean; scripts-only.