### PR TITLE
recount: compute pages_translatable, the honest translation denominator

### DIFF
--- a/scripts/lib/books-known-fields.json
+++ b/scripts/lib/books-known-fields.json
@@ -1,7 +1,7 @@
 {
   "_comment": [
     "Authoritative list of top-level `books` fields, from a FULL-SCAN enumeration",
-    "of production (never sampled \u2014 sampling misses ~95 rare fields).",
+    "of production (never sampled — sampling misses ~95 rare fields).",
     "",
     "This is the single source of truth shared by:",
     "  - scripts/audit/new-field-writes.mjs  (fails a PR that $sets an unknown field)",
@@ -15,7 +15,7 @@
   ],
   "generated_from": "full-scan enumeration of bookstore.books",
   "generated_at": "2026-08-18",
-  "count": 426,
+  "count": 427,
   "retired": [
     "acquisition_priority",
     "acquisition_wave",
@@ -368,6 +368,7 @@
     "pages_count_reconcile_reason",
     "pages_count_reconciled_at",
     "pages_ocr",
+    "pages_translatable",
     "pages_translated",
     "pages_translated_es",
     "papyrus_images",

--- a/scripts/maintenance/recount-page-stats.mjs
+++ b/scripts/maintenance/recount-page-stats.mjs
@@ -36,6 +36,10 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
+
+/** The canonical never-translated page types, from translate-core (one source of truth). */
+const SKIP_TYPES = SKIP_TRANSLATION_PAGE_TYPES;
 
 const args = process.argv.slice(2);
 const APPLY = args.includes('--apply');
@@ -46,6 +50,19 @@ if (!STALE && slugs.length === 0) {
   console.error('Usage: --slug <slug> [--slug <slug>...] | --stale   [--apply]');
   process.exit(1);
 }
+
+/** Shared translatability condition — used by BOTH the denominator and its numerator. */
+const TRANSLATABLE = {
+  $and: [
+    { $ne: ['$ocr.data', null] },
+    { $ne: ['$ocr.data', ''] },
+    { $ifNull: ['$ocr.data', false] },
+    { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, SKIP_TYPES] }] },
+    { $ne: ['$translation.recitation_blocked', true] },
+    { $ne: ['$translation.safety_blocked', true] },
+    { $ne: ['$ocr.recitation_blocked', true] },
+  ],
+};
 
 const COUNT_PIPELINE = (bookId) => [
   { $match: { book_id: bookId, page_number: { $gt: 0 } } },
@@ -83,6 +100,42 @@ const COUNT_PIPELINE = (bookId) => [
           ],
         },
       },
+      // `pages_translatable` — the honest denominator for translation completeness
+      // (#4442). Mirrors translatablePageFilter() in scripts/lib/translate-core.mjs:
+      // a page counts only if it has OCR to translate and is not a type that will
+      // never be translated. Expressed inline rather than imported because this
+      // runs as one server-side aggregation per book; the two must be kept in step,
+      // and tests/unit/page-counts.test.ts is where that is pinned.
+      //
+      // The regex-only case (isBlankFromOcr — old OCR that describes a blank page
+      // without carrying page_type 'blank') is NOT expressible here, so this count
+      // is a slight OVER-estimate of translatable pages. That is the safe direction:
+      // it understates completeness rather than claiming work is finished.
+      translatable: {
+        $sum: { $cond: [TRANSLATABLE, 1, 0] },
+      },
+      // The numerator that goes with that denominator. `with_translation` is NOT it:
+      // a blank page carries a translation PLACEHOLDER, so it counts as translated
+      // while being excluded from `translatable` — and the ratio then exceeds 100%.
+      // Measured on the first run of this script: Hugh of Santalla reported 105.6%,
+      // the Rosarium 102.0%. The numerator must exclude whatever the denominator
+      // excludes; see invariants/numerator-denominator.md.
+      translated_translatable: {
+        $sum: {
+          $cond: [
+            {
+              $and: [
+                TRANSLATABLE,
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
+              ],
+            },
+            1,
+            0,
+          ],
+        },
+      },
     },
   },
 ];
@@ -99,7 +152,7 @@ const query = STALE
 
 const candidates = await books
   .find(query)
-  .project({ _id: 1, id: 1, slug: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1 })
+  .project({ _id: 1, id: 1, slug: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translatable: 1 })
   .toArray();
 
 console.log(`Scanning ${candidates.length} book(s)…`);
@@ -115,14 +168,20 @@ for (const book of candidates) {
   const same =
     (book.pages_count ?? 0) === counts.total &&
     (book.pages_ocr ?? 0) === counts.with_ocr &&
-    (book.pages_translated ?? 0) === counts.with_translation;
+    (book.pages_translated ?? 0) === counts.with_translation &&
+    (book.pages_translatable ?? null) === counts.translatable;
   if (same) continue;
 
   drifted++;
   console.log(
     `${book.slug}\n  pages       ${book.pages_count ?? 0} → ${counts.total}` +
       `\n  ocr         ${book.pages_ocr ?? 0} → ${counts.with_ocr}` +
-      `\n  translated  ${book.pages_translated ?? 0} → ${counts.with_translation}`,
+      `\n  translated  ${book.pages_translated ?? 0} → ${counts.with_translation}` +
+      `\n  translatable ${book.pages_translatable ?? '—'} → ${counts.translatable}` +
+      (counts.translatable > 0
+        ? `   (${((100 * counts.translated_translatable) / counts.translatable).toFixed(1)}% of translatable` +
+          `, vs ${((100 * counts.with_translation) / Math.max(counts.total, 1)).toFixed(1)}% of all pages)`
+        : ''),
   );
 
   if (APPLY) {
@@ -133,6 +192,7 @@ for (const book of candidates) {
           pages_count: counts.total,
           pages_ocr: counts.with_ocr,
           pages_translated: counts.with_translation,
+          pages_translatable: counts.translatable,
           updated_at: new Date(),
         },
       },


### PR DESCRIPTION
Addresses the denominator half of #4442.

## The problem

`pages_count` counts every visible page. `pages_translated` counts only translated ones. Their ratio therefore divides by pages that can **never** be translated — blanks, plates, ex-libris, bookplates, digitizer notices, pages with no OCR, and pages the model permanently refuses.

Measured on a random sample of 150 live books with a 1–25 page counter tail:

| | |
|---|---|
| apparent (counter) tail | 1,475 pages |
| actually translatable and untranslated | **189 pages — 12.8%** |
| books whose real tail is zero — complete, counted wrong | **119 of 150 (79%)** |

Corpus-wide: **3,244 live books (10.2%) report as fully translated. Roughly 13,011 (41%) actually are.**

That is the kind of number that ends up in a funder deck.

## What this adds

`pages_translatable` on the recount path, computed from the same rule the translator uses — `SKIP_TRANSLATION_PAGE_TYPES` is imported from `translate-core.mjs`, not restated, so the counter and the translator cannot drift apart.

Verified against `isTranslatablePage()` on 40 random books: **39 exact, 1 off by +1**, which is the `isBlankFromOcr` regex case that cannot be expressed server-side. Over-estimating translatable pages *understates* completeness — the safe direction to be wrong, and documented as such.

## Two things worth reviewing

**A `pages_blank` field already exists**, on all 31,716 live books, and `api/[tenant]/analytics/canon` already divides by `(pages_ocr - pages_blank)`. That is a better denominator than `pages_count` and still not right: it yields 16,372 books complete against a page-level truth of ~13,011, because it doesn't exclude ex-libris, bookplates or digitizer notices. So there are now **three denominators giving three answers** (3,244 / 16,372 / ~13,011) and this PR adds the one that matches what the translator will actually do. Consolidating the other two is follow-up.

**The first version of this shipped 105.6%.** `with_translation` counts blank pages — which carry a translation *placeholder* — while the denominator excludes them, so the ratio exceeded 100% (Hugh of Santalla 105.6%, the Rosarium 102.0%). Fixed by computing `translated_translatable` from the same shared `TRANSLATABLE` condition. It's a clean instance of the invariant added yesterday in #3804: the numerator must exclude whatever the denominator excludes. Worth a look at the diff for that specifically.

## Deliberately out of scope

**No read path changes.** Switching the surfaces that divide by `pages_count` would move public numbers — homepage stats, book cards, the sibling-edition notice, anything funder-facing. That's a decision, not a refactor, and it needs your sign-off rather than mine. This PR only makes the honest number available and prints both ratios side by side.

Backfilling is `--stale --apply`, which is a large write and also held.

Scripts-only; `node --check` clean.
