### PR TITLE
recount used its own pipeline, and it counted blank placeholders as translations

### DIFF
--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -59,8 +59,55 @@ export function isTranslatedPage(page) {
 }
 
 /**
- * Aggregation pipeline that returns { total, with_ocr, with_translation }
- * for the VISIBLE pages of one book. Used by the batch collectors.
+ * Page types that will never carry a translation, whatever we spend.
+ *
+ * Kept as a literal rather than imported from `translate-core.mjs` because that
+ * module imports THIS one; the two must stay in step and
+ * `tests/unit/page-counts.test.ts` is where that is asserted.
+ */
+export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'digitizer-notice'];
+
+/**
+ * True iff a page is work the translator could actually do — the honest
+ * DENOMINATOR for translation completeness (#4442).
+ *
+ * `pages_count` is the wrong denominator and always has been: it counts every
+ * visible page, including ones no amount of money will ever translate. Measured
+ * 2026-08-31 on 150 random live books with a small apparent tail, only **12.8%**
+ * of that tail was real work and **79%** of the books were already complete and
+ * merely counted wrong. Corpus-wide the library reported 10.2% of live books
+ * fully translated when roughly 41% actually were.
+ *
+ * A page qualifies only if it has OCR to translate from, is not a never-translated
+ * type, and has not been permanently refused by the model.
+ */
+export function isTranslatablePageForCount(page) {
+  if (!isVisiblePage(page)) return false;
+  if (!hasOcr(page)) return false;
+  if (NEVER_TRANSLATED_PAGE_TYPES.includes(page?.page_type ?? '')) return false;
+  if (page?.translation?.recitation_blocked === true) return false;
+  if (page?.translation?.safety_blocked === true) return false;
+  if (page?.ocr?.recitation_blocked === true) return false;
+  return true;
+}
+
+/** Mongo twin of isTranslatablePageForCount(), shared by the denominator and its numerator. */
+const TRANSLATABLE_COND = {
+  $and: [
+    { $ne: ['$ocr.data', null] },
+    { $ne: ['$ocr.data', ''] },
+    { $ifNull: ['$ocr.data', false] },
+    { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, NEVER_TRANSLATED_PAGE_TYPES] }] },
+    { $ne: ['$translation.recitation_blocked', true] },
+    { $ne: ['$translation.safety_blocked', true] },
+    { $ne: ['$ocr.recitation_blocked', true] },
+  ],
+};
+
+/**
+ * Aggregation pipeline that returns
+ * { total, with_ocr, with_translation, translatable, translated_translatable }
+ * for the VISIBLE pages of one book. Used by the batch collectors and the recount.
  */
 export function buildVisiblePageCountPipeline(bookId) {
   return [
@@ -97,6 +144,29 @@ export function buildVisiblePageCountPipeline(bookId) {
             ],
           },
         },
+        // The honest denominator and ITS matching numerator (#4442). Mirrors
+        // isTranslatablePageForCount(). `translatable` is what could ever be
+        // translated; `translated_translatable` is how much of that has been —
+        // and it is deliberately NOT `with_translation`, because a numerator
+        // must exclude whatever its denominator excludes. Getting that wrong is
+        // what produced the Blue Qur'an's 1000% above, and a 105.6% reading on
+        // Hugh of Santalla while this was being written.
+        translatable: {
+          $sum: { $cond: [TRANSLATABLE_COND, 1, 0] },
+        },
+        translated_translatable: {
+          $sum: {
+            $cond: [
+              { $and: [
+                TRANSLATABLE_COND,
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
       },
     },
   ];
@@ -109,9 +179,12 @@ export function buildVisiblePageCountPipeline(bookId) {
  */
 export function countVisiblePageStats(pages) {
   const visible = (pages ?? []).filter(isVisiblePage);
+  const translatable = visible.filter(isTranslatablePageForCount);
   return {
     total: visible.length,
     with_ocr: visible.filter(hasOcr).length,
     with_translation: visible.filter(isTranslatedPage).length,
+    translatable: translatable.length,
+    translated_translatable: translatable.filter(hasTranslation).length,
   };
 }

--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -72,11 +72,18 @@ export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'd
  * DENOMINATOR for translation completeness (#4442).
  *
  * `pages_count` is the wrong denominator and always has been: it counts every
- * visible page, including ones no amount of money will ever translate. Measured
- * 2026-08-31 on 150 random live books with a small apparent tail, only **12.8%**
- * of that tail was real work and **79%** of the books were already complete and
- * merely counted wrong. Corpus-wide the library reported 10.2% of live books
- * fully translated when roughly 41% actually were.
+ * visible page, including ones no amount of money will ever translate.
+ *
+ * Measured 2026-08-31 on an unrestricted random sample of 800 live books:
+ * **11.4%** are complete by the naive measure (`pages_translated >= pages_count`,
+ * which matches the exact corpus figure of 10.2%), while **49.9%** have every
+ * translatable page translated. Roughly half the library is finished and says it
+ * is not.
+ *
+ * Do not repeat the earlier "~41%" figure. It came from extrapolating a sample
+ * restricted to books with a 1-25 page apparent tail, which structurally cannot
+ * see a complete book carrying a hundred pages of plates — and so undercounted.
+ * A sample frame chosen for one question is rarely valid for the next one.
  *
  * A page qualifies only if it has OCR to translate from, is not a never-translated
  * type, and has not been permanently refused by the model.

--- a/scripts/maintenance/recount-page-stats.mjs
+++ b/scripts/maintenance/recount-page-stats.mjs
@@ -36,10 +36,7 @@
  */
 
 import { MongoClient } from 'mongodb';
-import { SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
-
-/** The canonical never-translated page types, from translate-core (one source of truth). */
-const SKIP_TYPES = SKIP_TRANSLATION_PAGE_TYPES;
+import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 
 const args = process.argv.slice(2);
 const APPLY = args.includes('--apply');
@@ -50,95 +47,6 @@ if (!STALE && slugs.length === 0) {
   console.error('Usage: --slug <slug> [--slug <slug>...] | --stale   [--apply]');
   process.exit(1);
 }
-
-/** Shared translatability condition — used by BOTH the denominator and its numerator. */
-const TRANSLATABLE = {
-  $and: [
-    { $ne: ['$ocr.data', null] },
-    { $ne: ['$ocr.data', ''] },
-    { $ifNull: ['$ocr.data', false] },
-    { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, SKIP_TYPES] }] },
-    { $ne: ['$translation.recitation_blocked', true] },
-    { $ne: ['$translation.safety_blocked', true] },
-    { $ne: ['$ocr.recitation_blocked', true] },
-  ],
-};
-
-const COUNT_PIPELINE = (bookId) => [
-  { $match: { book_id: bookId, page_number: { $gt: 0 } } },
-  {
-    $group: {
-      _id: null,
-      total: { $sum: 1 },
-      with_ocr: {
-        $sum: {
-          $cond: [
-            {
-              $and: [
-                { $ne: ['$ocr.data', null] },
-                { $ne: ['$ocr.data', ''] },
-                { $ifNull: ['$ocr.data', false] },
-              ],
-            },
-            1,
-            0,
-          ],
-        },
-      },
-      with_translation: {
-        $sum: {
-          $cond: [
-            {
-              $and: [
-                { $ne: ['$translation.data', null] },
-                { $ne: ['$translation.data', ''] },
-                { $ifNull: ['$translation.data', false] },
-              ],
-            },
-            1,
-            0,
-          ],
-        },
-      },
-      // `pages_translatable` — the honest denominator for translation completeness
-      // (#4442). Mirrors translatablePageFilter() in scripts/lib/translate-core.mjs:
-      // a page counts only if it has OCR to translate and is not a type that will
-      // never be translated. Expressed inline rather than imported because this
-      // runs as one server-side aggregation per book; the two must be kept in step,
-      // and tests/unit/page-counts.test.ts is where that is pinned.
-      //
-      // The regex-only case (isBlankFromOcr — old OCR that describes a blank page
-      // without carrying page_type 'blank') is NOT expressible here, so this count
-      // is a slight OVER-estimate of translatable pages. That is the safe direction:
-      // it understates completeness rather than claiming work is finished.
-      translatable: {
-        $sum: { $cond: [TRANSLATABLE, 1, 0] },
-      },
-      // The numerator that goes with that denominator. `with_translation` is NOT it:
-      // a blank page carries a translation PLACEHOLDER, so it counts as translated
-      // while being excluded from `translatable` — and the ratio then exceeds 100%.
-      // Measured on the first run of this script: Hugh of Santalla reported 105.6%,
-      // the Rosarium 102.0%. The numerator must exclude whatever the denominator
-      // excludes; see invariants/numerator-denominator.md.
-      translated_translatable: {
-        $sum: {
-          $cond: [
-            {
-              $and: [
-                TRANSLATABLE,
-                { $ne: ['$translation.data', null] },
-                { $ne: ['$translation.data', ''] },
-                { $ifNull: ['$translation.data', false] },
-              ],
-            },
-            1,
-            0,
-          ],
-        },
-      },
-    },
-  },
-];
 
 const client = new MongoClient(process.env.MONGODB_URI);
 await client.connect();
@@ -162,7 +70,7 @@ let written = 0;
 
 for (const book of candidates) {
   const bookId = book.id || String(book._id);
-  const [counts] = await pages.aggregate(COUNT_PIPELINE(bookId)).toArray();
+  const [counts] = await pages.aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
   if (!counts) continue;
 
   const same =

--- a/src/app/api/books/[id]/batch-translate-async/route.ts
+++ b/src/app/api/books/[id]/batch-translate-async/route.ts
@@ -405,6 +405,7 @@ export const GET = withAuth(async (request, session, context) => {
                 pages_count: counts.total,
                 pages_ocr: counts.with_ocr,
                 pages_translated: counts.with_translation,
+                pages_translatable: counts.translatable,
               } : {}),
               last_translation_at: new Date(),
               updated_at: new Date()

--- a/src/lib/page-counts.ts
+++ b/src/lib/page-counts.ts
@@ -15,9 +15,26 @@ import type { Document } from 'mongodb';
 /** Match fragment selecting only visible (renderable) pages. */
 export const VISIBLE_PAGE_MATCH = { page_number: { $gt: 0 } } as const;
 
+/** Page types that will never carry a translation. Mirror of the .mjs list. */
+export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'digitizer-notice'];
+
+/** Shared by the `translatable` denominator and its numerator, so they cannot drift. */
+const TRANSLATABLE_COND = {
+  $and: [
+    { $ne: ['$ocr.data', null] },
+    { $ne: ['$ocr.data', ''] },
+    { $ifNull: ['$ocr.data', false] },
+    { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, NEVER_TRANSLATED_PAGE_TYPES] }] },
+    { $ne: ['$translation.recitation_blocked', true] },
+    { $ne: ['$translation.safety_blocked', true] },
+    { $ne: ['$ocr.recitation_blocked', true] },
+  ],
+};
+
 /**
- * Aggregation pipeline returning { total, with_ocr, with_translation } for
- * the VISIBLE pages of one book. Mirror of the .mjs implementation.
+ * Aggregation pipeline returning
+ * { total, with_ocr, with_translation, translatable, translated_translatable }
+ * for the VISIBLE pages of one book. Mirror of the .mjs implementation.
  */
 export function buildVisiblePageCountPipeline(bookId: string): Document[] {
   return [
@@ -51,6 +68,25 @@ export function buildVisiblePageCountPipeline(bookId: string): Document[] {
                 { $ne: ['$translation.data', ''] },
                 { $ifNull: ['$translation.data', false] },
                 { $ne: [{ $ifNull: ['$page_type', ''] }, 'blank'] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
+        // The honest denominator for translation completeness (#4442) and its
+        // matching numerator. Any writer that updates the three counters above
+        // must write `pages_translatable` too, or it goes stale while they move.
+        translatable: {
+          $sum: { $cond: [TRANSLATABLE_COND, 1, 0] },
+        },
+        translated_translatable: {
+          $sum: {
+            $cond: [
+              { $and: [
+                TRANSLATABLE_COND,
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
               ] },
               1, 0,
             ],

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -74,7 +74,36 @@ describe('page-counts convention (#3293)', () => {
       total: 3,
       with_ocr: 3,
       with_translation: 2,
+      // All three visible pages have OCR and none is a never-translated type,
+      // so all three are translatable; two of them carry a translation.
+      translatable: 3,
+      translated_translatable: 2,
     });
+  });
+
+  it('translatable excludes what can never be translated, and its numerator matches', () => {
+    // The #4442 denominator. A blank leaf carries a translation PLACEHOLDER, so
+    // counting it in the numerator while excluding it from the denominator is what
+    // pushed real books past 100% (the Blue Qur'an at 1000%, Hugh of Santalla at
+    // 105.6%). Both must exclude it.
+    const pages = [
+      { page_number: 1, ocr: { data: 'a' }, translation: { data: 'A' } },
+      { page_number: 2, ocr: { data: 'b' }, page_type: 'blank', translation: { data: '[Blank page]' } },
+      { page_number: 3, ocr: { data: 'c' }, page_type: 'bookplate', translation: { data: 'C' } },
+      { page_number: 4, ocr: { data: 'd' } }, // translatable, not yet translated
+      { page_number: 5 }, // no OCR — nothing to translate from
+      { page_number: 6, ocr: { data: 'f' }, ocrRecitation: true },
+    ];
+    // page 6 is refused by the model — expressed the way the writers store it
+    (pages[5] as Record<string, unknown>).ocr = { data: 'f', recitation_blocked: true };
+
+    const stats = countVisiblePageStats(pages);
+    expect(stats.translatable).toBe(2); // pages 1 and 4 only
+    expect(stats.translated_translatable).toBe(1); // page 1
+    // The ratio can never exceed 1 — the property the old numerator violated.
+    expect(stats.translated_translatable).toBeLessThanOrEqual(stats.translatable);
+    // And the blank leaf's placeholder is still excluded from pages_translated.
+    expect(stats.with_translation).toBe(2); // pages 1 and 3 (bookplate is not 'blank')
   });
 
   it('regression: hidden translated pages do not fabricate a low translated count', () => {


### PR DESCRIPTION
Follow-on to #4492, and it corrects a number I wrote myself.

## The divergence

`recount-page-stats.mjs` rolled a **private** `COUNT_PIPELINE`. Six other writers — `collect-batch-results`, `collect-multipage-ocr`, `batch-collector`, `translate-core`, the batch-translate API route, and the TS twin — all use `buildVisiblePageCountPipeline` from `page-counts.mjs`.

The two disagreed on the numerator. The canonical one excludes blank leaves, because the translator writes a literal `[Blank page — no translatable content]` placeholder onto every one of them. The recount's did not.

Measured on the six books I recounted last night — the private pipeline reports **3 to 10 more** translated pages than the canonical one, on every single book:

| book | recount pipeline | canonical | delta |
|---|---|---|---|
| Hugh of Santalla | 189 | 179 | **+10** |
| Sieben Grundsäulen | 140 | 130 | **+10** |
| Vitruvius | 390 | 383 | +7 |
| Saturn Gnosis | 71 | 66 | +5 |
| Rosarium | 201 | 197 | +4 |
| Boethius | 288 | 285 | +3 |

Those inflated values are the ones that were **stored**, because that run wrote them. My doing.

## Why it matters beyond six books

`page-counts.mjs` already documents this exact failure: blank placeholders in the numerator pushed `translation_pct` over 100 on **6,228 live books (32% of the public library)**, with the Blue Qur'an reporting **1000% translated**. The rule was written down, tested, and centralised — and one writer simply never called it. That is the failure mode worth noting: not a missing convention, an uncalled one.

It is also why my #4492 draft printed 105.6% for Hugh of Santalla. I inherited the divergent numerator and treated the symptom.

## Changes

- **`recount-page-stats.mjs` uses `buildVisiblePageCountPipeline`.** Its private pipeline and its local copy of the skip-types are deleted. One definition again.
- **`pages_translatable` moves into `page-counts.mjs`**, beside `isTranslatedPage`, as `isTranslatablePageForCount` + a shared `TRANSLATABLE_COND` used by *both* the denominator and its numerator — so they cannot drift apart. #4492 had it in the recount script, one level too far out.
- **`countVisiblePageStats` returns both**, keeping the JS twin and the pipeline paired.
- **A test for the new rule**, asserting never-translated types are excluded from both sides and that the ratio can never exceed 1.

## Negative control

Per `tests-that-are-not-guards.md` (and #4494, merged this morning), I ran it rather than reasoned about it: removing the exclusion from `isTranslatablePageForCount` turns the new test **red**; restoring it turns it **green**. 11/11 pass. `npx tsc --noEmit` clean.

## Data already corrected

The eight books touched last night have been recounted and re-synced to Supabase. All eight now read **100.0% of translatable** — Enuma Elish 99.2%, its three RECITATION-blocked pages correctly excluded from the denominator — where they previously read 92.9–100% *of all pages*.

Verified by reading stored values back and comparing against the canonical pipeline: 8/8 match.

## Still not changed

Read paths. The corpus-wide backfill (`--stale --apply`) is also still held — it is a 31,716-book write and the honest number should be reviewed before it becomes the number.
