### PR TITLE
feat(api): author facet + year filters on the catalog API (#4491)

### DIFF
--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -4,6 +4,7 @@ import { buildBookSearchStage } from '@/lib/atlas-search';
 import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
 import { translationPercent } from '@/lib/translation-percent';
 import { buildSortStage, type SortOption } from '@/lib/book-sort';
+import { resolveAuthorBookFilter } from '@/lib/author-thesaurus';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 120;
@@ -38,6 +39,18 @@ export async function GET(request: NextRequest) {
     // matches `language=Latin` AND `has_edition=es`.
     const hasEditionParam = (searchParams.get('has_edition') || '').trim().toLowerCase();
     const hasEdition = /^[a-z]{2,3}$/.test(hasEditionParam) && hasEditionParam !== 'en' ? hasEditionParam : '';
+    // `author_id=<slug>`: exactly one person's books, resolved through the
+    // authors thesaurus (variant slugs and merge tombstones follow to the
+    // canonical person; membership is the same 3-key union as /author/[slug]).
+    // Slugs come from /api/catalog/author-search or from `author_id` on rows.
+    const authorIdParam = (searchParams.get('author_id') || '').trim();
+    // Numeric edition-year range. Matches the `year` field only — the free-text
+    // `published` is not comparable (see search-filters-and-lanes.md); books
+    // without a numeric year (~40% of live books) never match a year filter.
+    const yearFromRaw = parseInt(searchParams.get('year_from') || '', 10);
+    const yearToRaw = parseInt(searchParams.get('year_to') || '', 10);
+    const yearFrom = Number.isFinite(yearFromRaw) ? yearFromRaw : null;
+    const yearTo = Number.isFinite(yearToRaw) ? yearToRaw : null;
     const sort = (searchParams.get('sort') || 'recent-translation') as SortOption;
     const { slug: tenantSlugHeader, id: tenantIdHeader } = getTenantContextFromRequest(request);
     const tenantSlugParam = searchParams.get('tenant_slug') || '';
@@ -55,7 +68,7 @@ export async function GET(request: NextRequest) {
 
     // Serve cached response for cacheable requests (no text search, reasonable pagination)
     const isCacheable = !search.trim() && skip < 200;
-    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|he:${hasEdition}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}`;
+    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|he:${hasEdition}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}|a:${authorIdParam}|yf:${yearFrom}|yt:${yearTo}`;
     if (isCacheable) {
       const cached = browseCache.get(cacheKey);
       if (cached && (Date.now() - cached.timestamp) < BROWSE_CACHE_TTL) {
@@ -69,6 +82,24 @@ export async function GET(request: NextRequest) {
     }
 
     const db = await getReadDb();
+
+    // Resolve the author filter FIRST: an unknown slug returns an empty page
+    // (with author: null) rather than silently dropping the filter — an
+    // ignored filter would serve the whole library labeled as one person's
+    // books (search-filters-and-lanes.md).
+    let authorFilter: Awaited<ReturnType<typeof resolveAuthorBookFilter>> = null;
+    if (authorIdParam) {
+      authorFilter = await resolveAuthorBookFilter(db, authorIdParam);
+      if (!authorFilter) {
+        return NextResponse.json(
+          { books: [], total: 0, author: null, skip, limit },
+          { headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' } },
+        );
+      }
+    }
+    const yearMatch: Record<string, unknown> | null = (yearFrom !== null || yearTo !== null)
+      ? { year: { ...(yearFrom !== null ? { $gte: yearFrom } : {}), ...(yearTo !== null ? { $lte: yearTo } : {}) } }
+      : null;
 
     // When a search term is present, use Atlas Search ($search must be first stage).
     // Language, category, firstTranslation are pushed as Atlas Search filters.
@@ -90,6 +121,8 @@ export async function GET(request: NextRequest) {
         // omits `search` is inert exactly where it is most likely to be used,
         // and reads as active either way (search-filters-and-lanes.md).
         ...(hasEdition ? [{ $match: { [`pages_translated_${hasEdition}`]: { $gt: 0 } } }] : []),
+        ...(authorFilter ? [{ $match: authorFilter.match }] : []),
+        ...(yearMatch ? [{ $match: yearMatch }] : []),
         ...(tenantId ? [{ $match: { tenantId } }] : []),
       ];
     } else {
@@ -106,6 +139,8 @@ export async function GET(request: NextRequest) {
       if (firstTranslation) matchConditions.push({ is_first_translation: true });
       if (hasTranslation) matchConditions.push({ pages_translated: { $gt: 0 } });
       if (hasEdition) matchConditions.push({ [`pages_translated_${hasEdition}`]: { $gt: 0 } });
+      if (authorFilter) matchConditions.push(authorFilter.match);
+      if (yearMatch) matchConditions.push(yearMatch);
       pipelineStart = [{ $match: { $and: matchConditions } }];
     }
 
@@ -156,6 +191,11 @@ export async function GET(request: NextRequest) {
       title: 1,
       display_title: 1,
       author: 1,
+      // Canonical author slug + numeric edition year: without these a consumer
+      // can SORT by year and SEARCH authors but never see either value —
+      // `published` is free text and `author` is an uncanonicalized string.
+      author_id: 1,
+      year: 1,
       thumbnail: 1, image_display: 1,
       thumbnail_blob: 1, image_thumb: 1,
       language: 1,
@@ -217,7 +257,13 @@ export async function GET(request: NextRequest) {
       tenant_slug: book.tenantId ? tenantSlugMap.get(book.tenantId) || null : null,
     }));
 
-    const responseData = JSON.stringify({ books: booksWithTenantSlug, total });
+    const responseData = JSON.stringify({
+      books: booksWithTenantSlug,
+      total,
+      // Echo the canonicalized author when filtering, so a caller that passed
+      // a variant slug learns the canonical one.
+      ...(authorFilter ? { author: { id: authorFilter.canonicalSlug, name: authorFilter.canonicalName } } : {}),
+    });
 
     // Cache cacheable views
     if (isCacheable) {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -14,6 +14,7 @@ import { MAX_FEEDBACK_MESSAGE, MIN_FEEDBACK_MESSAGE } from '@/lib/feedback-limit
 import { stripProvenanceMarks } from '@/lib/provenance';
 import { languageApparatusFields, type LanguageApparatusSource } from '@/lib/edition-language';
 import { resolveTitle, titleProvenanceNote } from '@/lib/title-provenance';
+import { authorSlug } from '@/lib/slugify';
 import { GALLERY_VIEWER_HTML, GALLERY_VIEWER_RESOURCE_URI, MCP_APP_MIME_TYPE } from '@/lib/mcp-gallery-app';
 import {
   CallToolRequestSchema,
@@ -293,6 +294,11 @@ async function listBooks(args: Record<string, unknown>) {
   if (args.search) params.set('search', String(args.search));
   if (args.language) params.set('language', String(args.language));
   if (args.category) params.set('category', String(args.category));
+  // Canonical author slug — every row of every listing carries author_id, so a
+  // follow-up "all books by this person" call needs no separate lookup.
+  if (args.author_id) params.set('author_id', String(args.author_id));
+  if (typeof args.year_from === 'number' && Number.isFinite(args.year_from)) params.set('year_from', String(Math.trunc(args.year_from)));
+  if (typeof args.year_to === 'number' && Number.isFinite(args.year_to)) params.set('year_to', String(Math.trunc(args.year_to)));
   // `has_edition` filters by a language the book can be READ in; `language`
   // filters by the language printed on its leaves. A Latin book with a Spanish
   // edition matches both.
@@ -305,8 +311,16 @@ async function listBooks(args: Record<string, unknown>) {
   const result = await apiGet('/books/library', params) as Record<string, unknown>;
   const books = (result.books as Array<Record<string, unknown>>)?.map((b) => ({
     id: b.id, title: b.display_title || b.title, author: b.author, language: b.language,
-    published: b.published, pages_count: b.pages_count, pages_translated: b.pages_translated,
+    published: b.published, year: b.year ?? null,
+    pages_count: b.pages_count, pages_translated: b.pages_translated,
     translation_percent: b.translation_percent,
+    // Canonical author slug + resolvable URL (agent-tool-results.md: an
+    // omitted URL is one the model invents — hand over the real one, always
+    // unprefixed). authorSlug() is the sanctioned fallback for unlinked rows.
+    ...(b.author_id || b.author ? {
+      author_id: b.author_id || authorSlug(String(b.author)),
+      author_url: `https://sourcelibrary.org/author/${b.author_id || authorSlug(String(b.author))}`,
+    } : {}),
     ...(params.get('has_edition') ? {
       [`pages_translated_${params.get('has_edition')}`]: b[`pages_translated_${params.get('has_edition')}`],
       // The reader URL for that edition, which only exists because the filter
@@ -318,6 +332,9 @@ async function listBooks(args: Record<string, unknown>) {
   return {
     total: result.total, showing: books?.length || 0,
     ...(params.get('has_edition') ? { has_edition: params.get('has_edition') } : {}),
+    // Canonicalized author echo when filtering by author_id (null-safe: the
+    // route omits it unless the filter was applied).
+    ...(result.author !== undefined ? { author: result.author } : {}),
     books,
   };
 }
@@ -1076,12 +1093,15 @@ const TOOLS: Tool[] = [
   {
     name: 'list_books',
     title: 'List Books',
-    description: 'BROWSES/FILTERS THE CATALOG by metadata (author/title fragment, language, category, translation recency) — no content/topic matching. PICK THIS to see WHAT EXISTS by an author or in a tradition. Returns books with title, author, language, year, and translation progress. → For a relevance-ranked topic search use search_library; for passages on a theme use search_translations (exact words) or search_concept (by meaning).',
+    description: 'BROWSES/FILTERS THE CATALOG by metadata (canonical author via author_id, author/title fragment via search, language, category, year range, translation recency) — no content/topic matching. PICK THIS to see WHAT EXISTS by an author or in a tradition, or to enumerate a date range. Returns books with title, author (string + canonical author_id + author_url), language, year, and translation progress. → For a relevance-ranked topic search use search_library; for passages on a theme use search_translations (exact words) or search_concept (by meaning).',
     annotations: { title: 'List Books', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
       properties: {
-        search: { type: 'string', description: 'Filter by title or author' },
+        search: { type: 'string', description: 'Free-text filter matching title or author (relevance-ranked, may include title matches). For exactly one person\'s books use author_id instead.' },
+        author_id: { type: 'string', description: 'Canonical author slug, e.g. "jan-hus" — filters to exactly that person\'s books via the author thesaurus (variant slugs resolve to the canonical person). Every book row in results carries its author_id; the response echoes the canonicalized author.' },
+        year_from: { type: 'number', description: 'Earliest edition year (inclusive). Matches only books with a known numeric year — ~60% of the library.' },
+        year_to: { type: 'number', description: 'Latest edition year (inclusive).' },
         language: { type: 'string' }, category: { type: 'string' },
         has_edition: { type: 'string', description: 'ISO code — return only books READABLE in that language, e.g. "es". Different from `language`, which is the language printed on the leaves of the scan: a Latin book with a Spanish edition matches language="Latin" AND has_edition="es". Each result then also carries url_localized.' },
         sort: { type: 'string', enum: ['recent-translation', 'recent', 'title-asc', 'title-desc'] },

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -490,6 +490,55 @@ source-library search "alchemy" --json | jq .results`}
             </div>
           </div>
 
+          <div className="bg-white rounded-xl border border-border-light overflow-hidden">
+            <div className="bg-stone-50 px-4 py-3 border-b border-border-light">
+              <div className="flex items-center gap-2">
+                <span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span>
+                <code className="text-primary">/books/library</code>
+              </div>
+              <p className="text-secondary text-sm mt-1">Browse and filter the catalogue. Every row carries id, slug, title, author, author_id, language, year, and translation progress.</p>
+            </div>
+            <div className="p-4">
+              <table className="w-full text-sm">
+                <tbody>
+                  <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">author_id</td>
+                    <td className="py-2 text-muted">string</td>
+                    <td className="py-2 text-secondary">Canonical author slug — exactly that person&apos;s books. Discover slugs via /catalog/author-search; the response echoes the canonicalized author.</td>
+                  </tr>
+                  <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">year_from / year_to</td>
+                    <td className="py-2 text-muted">number</td>
+                    <td className="py-2 text-secondary">Edition-year range (numeric year only; books without a known year never match)</td>
+                  </tr>
+                  <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">language / category / collection / library</td>
+                    <td className="py-2 text-muted">string</td>
+                    <td className="py-2 text-secondary">Edition language, category, collection slug, contributing library</td>
+                  </tr>
+                  <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">search</td>
+                    <td className="py-2 text-muted">string</td>
+                    <td className="py-2 text-secondary">Free-text over titles and authors (relevance-ranked)</td>
+                  </tr>
+                  <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">work_id / has_translation / first_translation / has_edition</td>
+                    <td className="py-2 text-muted">mixed</td>
+                    <td className="py-2 text-secondary">Editions of one work; only translated books; only first translations; only books readable in an ISO language (e.g. es)</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 font-mono text-accent-rust">sort / limit / skip</td>
+                    <td className="py-2 text-muted">mixed</td>
+                    <td className="py-2 text-secondary">recent-translation (default), recent, title-asc, title-desc, date_asc, date_desc; pagination via limit (≤200) + skip, total in every response</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className="mt-4 bg-stone-900 rounded-lg p-3">
+                <code className="text-stone-300 text-sm">GET /books/library?author_id=jakob-bohme&amp;sort=date_asc</code>
+              </div>
+            </div>
+          </div>
+
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <tbody className="divide-y divide-stone-100">
@@ -500,8 +549,18 @@ source-library search "alchemy" --json | jq .results`}
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
-                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/books/library</td>
-                  <td className="py-2.5 text-secondary">Browse with language/category/collection filters</td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/catalog/author-search?q=</td>
+                  <td className="py-2.5 text-secondary">Find canonical authors by name — returns author_id slugs (for /books/library) plus VIAF/Wikidata anchors</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/gallery/collections</td>
+                  <td className="py-2.5 text-secondary">List curated image collections (visual + thematic) with cover images and counts</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/gallery/collections/:slug</td>
+                  <td className="py-2.5 text-secondary">One image collection with resolved items — imageCount always equals items delivered</td>
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>

--- a/src/lib/author-thesaurus.ts
+++ b/src/lib/author-thesaurus.ts
@@ -98,6 +98,63 @@ const ENTITY_PROJECTION = {
   wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1,
 };
 
+/**
+ * The three-key union that defines "this author's books" (see module header).
+ * Every consumer of author membership must use this same $or — a filter that
+ * checks only `author_id` silently drops the ~26% of live books whose link is
+ * an entity id or a not-yet-backfilled author string.
+ */
+function buildAuthorBookOr(doc: AuthorThesaurusDoc): Record<string, unknown>[] {
+  const canonicalSlug = doc.slug || doc._id;
+  const entityIds = (doc.entity_ids || []).filter(Boolean);
+  const variants = (doc.variants || []).filter(Boolean);
+  const orClauses: Record<string, unknown>[] = [{ author_id: canonicalSlug }];
+  if (entityIds.length) orClauses.push({ author_entity_id: { $in: entityIds } });
+  if (variants.length) orClauses.push({ author: { $in: variants } });
+  // Safety net: a doc with no variants/entities still matches by canonical_name.
+  if (orClauses.length === 1) orClauses.push({ author: doc.canonical_name });
+  return orClauses;
+}
+
+export interface AuthorBookFilter {
+  /** Canonical slug — echo to the caller so they see the canonicalization. */
+  canonicalSlug: string;
+  canonicalName: string;
+  /** Drop-in Mongo condition selecting this author's books ({ $or: [...] }). */
+  match: { $or: Record<string, unknown>[] };
+}
+
+/**
+ * Resolve an author slug (canonical or variant, tombstones followed) to a Mongo
+ * filter over `books`, for API routes that filter a listing by author rather
+ * than render the author page. Unlike resolveCanonicalAuthor this does not
+ * fetch books or entity enrichment, and it skips the legacy `author_slugs`
+ * cache fallback — API callers get slugs from /api/catalog/author-search or
+ * from `author_id` on listing rows, both of which are thesaurus-backed.
+ * Returns null for an unknown slug.
+ */
+export async function resolveAuthorBookFilter(
+  db: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  slug: string,
+): Promise<AuthorBookFilter | null> {
+  const authors = db.collection('authors');
+  let doc: AuthorThesaurusDoc | null = await authors.findOne({
+    $or: [{ _id: slug }, { variant_slugs: slug }, { slug }],
+  });
+  if (doc?.merged_into) {
+    const primary: AuthorThesaurusDoc | null = await authors.findOne({
+      $or: [{ _id: doc.merged_into }, { slug: doc.merged_into }],
+    });
+    if (primary) doc = primary;
+  }
+  if (!doc) return null;
+  return {
+    canonicalSlug: doc.slug || doc._id,
+    canonicalName: doc.canonical_name,
+    match: { $or: buildAuthorBookOr(doc) },
+  };
+}
+
 // Memoized normalized-name → canonical-slug index for the orphan-slug fallback
 // (step 2 below). Built once per server instance and refreshed every 10 min,
 // instead of scanning the whole `authors` collection on every cache-miss render.
@@ -190,12 +247,7 @@ export async function resolveCanonicalAuthor(
   //      c. author ∈ variants      — self-healing fallback for not-yet-backfilled
   //                                   books (and freshly imported ones).
   const entityIds = (doc.entity_ids || []).filter(Boolean);
-  const variants = (doc.variants || []).filter(Boolean);
-  const orClauses: any[] = [{ author_id: canonicalSlug }]; // eslint-disable-line @typescript-eslint/no-explicit-any
-  if (entityIds.length) orClauses.push({ author_entity_id: { $in: entityIds } });
-  if (variants.length) orClauses.push({ author: { $in: variants } });
-  // Safety net: a doc with no variants/entities still matches by canonical_name.
-  if (orClauses.length === 1) orClauses.push({ author: doc.canonical_name });
+  const orClauses = buildAuthorBookOr(doc);
 
   const books = await db.collection('books')
     .find({ visible: true, $or: orClauses }, { projection: bookProjection })


### PR DESCRIPTION
## What

Closes the one-sided author gap from #4491: `/api/catalog/author-search` hands out canonical `author_id` slugs, but no listing API accepted one back. Now:

- **`/api/books/library?author_id=<slug>`** — exactly one person's books. Resolved through the `authors` thesaurus (variant slugs + merge tombstones follow to the canonical person); book membership is the **same 3-key union** `/author/[slug]` uses (`author_id` ∪ `author_entity_id ∈ entity_ids` ∪ `author ∈ variants`), extracted into a shared `buildAuthorBookOr()` in `author-thesaurus.ts` so the page and the API cannot drift. An unknown slug returns an **empty page with `author: null`** — never a silently ignored filter (search-filters-and-lanes.md). The response echoes the canonicalized author.
- **`year_from` / `year_to`** — numeric `year` range, applied in **both** the Atlas-search and browse branches. Free-text `published` is never compared.
- **Response rows gain `author_id` and `year`** — previously a consumer could *sort* by year and *search* authors but never see either value.
- **MCP `list_books`**: same params passed through; rows gain `year`, `author_id`, `author_url` (resolvable link per agent-tool-results.md, `authorSlug()` fallback for unlinked rows).
- **`/developers`**: `/books/library` promoted from a one-line row to a full parameter card; `/catalog/author-search` and the `/api/gallery/collections` endpoints (used by external apps today, previously undocumented) added.

## Data/infra done outside the diff

- `{ year: 1 }` index created on prod `books` (2026-08-31) — backs the range filter and the pre-existing `date_asc`/`date_desc` sorts, which previously sorted unindexed.

## Verification

- `npx tsc --noEmit` clean.
- Filter logic exercised against prod data: `jakob-bohme` resolves to 113 live books, all rows carrying `author_id: "jakob-bohme"`; year-range query explain shows 3 docs examined / 4ms via the new index.
- Cache key extended with the three new params (a shared cache entry across filters would serve one author's page as another's).

## Out of scope

- CORS for browser apps (separate PR, same session).
- Facet *counts* (aggregations) — #4491 punts until a consumer asks beyond author.

Part of #4491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc