### PR TITLE
feat(api): CORS for the public read API (#4491)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -150,6 +150,26 @@ const nextConfig: NextConfig = {
           { key: 'TDM-Policy', value: 'https://sourcelibrary.org/licensing' },
         ],
       },
+      // CORS for the PUBLIC READ API (#4491). /developers advertises "direct
+      // HTTP access, no authentication", but without these headers a browser
+      // app on another domain cannot call any of it — only server-side callers
+      // could. Scoped to the public read surface, NOT blanket /api: auth,
+      // admin, and write routes keep the browser same-origin default.
+      // `Access-Control-Allow-Origin: *` never enables credentialed requests
+      // (browsers refuse to send cookies to a `*` origin), so cookie-gated
+      // routes gain nothing even if a path were added here by mistake.
+      // POST is for /api/mcp (JSON-RPC); the Mcp-* headers are its session
+      // protocol, exposed so browser MCP clients can read the session id.
+      {
+        source: '/api/:root(search|books|gallery|collections|catalog|verify|mcp|image|locus|ngrams)/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET, POST, OPTIONS' },
+          { key: 'Access-Control-Allow-Headers', value: 'Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version' },
+          { key: 'Access-Control-Expose-Headers', value: 'Mcp-Session-Id' },
+          { key: 'Access-Control-Max-Age', value: '86400' },
+        ],
+      },
       // Prevent Cloudflare from caching RSC (React Server Component) responses.
       // CF Free ignores Vary: RSC, so an RSC payload can poison the cache and
       // get served to browsers as raw flight data instead of HTML.


### PR DESCRIPTION
## What

The public API sends no `Access-Control-Allow-Origin` today (verified live: only the DTS, embed, and oauth well-known routes carry it), so a browser app on another domain cannot call `/api/search`, `/api/books/*`, `/api/gallery/*`, or `/api/mcp` at all — despite `/developers` advertising "direct HTTP access, no authentication." External consumers (e.g. the visualization app that surfaced #4486/#4491) are forced to proxy everything server-side.

One `headers()` rule in `next.config.ts`, scoped to the public read surface: `search | books | gallery | collections | catalog | verify | mcp | image | locus | ngrams`. Deliberately **not** blanket `/api` — auth, admin, and write routes keep the browser same-origin default.

## Security reasoning

- `Access-Control-Allow-Origin: *` cannot enable credentialed requests: browsers refuse to attach cookies to a `*`-origin response, so a cross-origin call is exactly as anonymous as curl already is. No cookie-gated surface changes behavior.
- POST is allowed for `/api/mcp` (JSON-RPC); `Mcp-Session-Id`/`Mcp-Protocol-Version` are allowed+exposed so browser MCP clients can hold a session.
- `Access-Control-Max-Age: 86400` caches preflights.

## Verification

- Will verify on the branch preview: `curl -H "Origin: https://example.com" -D -` against `/api/gallery/collections` and an OPTIONS preflight against `/api/books/library` must both show the headers (the `:root(...)/:path*` pattern must match zero-segment paths like `/api/search` too — checking both shapes).

Part of #4491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc