### PR TITLE
feat(provenance): key-attributed refs on keyed text egress + revive the dead dataset export

### DIFF
--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -9,7 +9,7 @@ import { isBookReadable } from '@/lib/book-access';
 import { CONTENT_LICENSE } from '@/lib/license-info';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { markForExport } from '@/lib/provenance';
-import { attributionBlock, attributionMeta, clientKeyFor, extractionRef } from '@/lib/bot-attribution';
+import { attributionBlock, attributionMeta, clientKeyFor, extractionRef, keyRef } from '@/lib/bot-attribution';
 import { getTranslation } from '@/lib/page-translations';
 import { isMeteredAnonRequest } from '@/lib/metered-gate';
 
@@ -137,9 +137,17 @@ export const GET = withApiAuth(async (
     //     callers. Verified search crawlers, user-initiated assistant fetches,
     //     signed-in readers and key holders never see it, so indexing and
     //     ordinary reading are untouched.
-    // The ref ties a recovered passage to an extraction campaign; it is
-    // pseudonymous and recomputable from api_usage (see bot-attribution.ts).
-    const ref = isBotRequest ? extractionRef(clientKeyFor(request), new Date()) : undefined;
+    // The ref ties a recovered passage to its puller. Two flavors:
+    //   - bots get a pseudonymous monthly campaign ref (recomputable from
+    //     api_usage, see bot-attribution.ts);
+    //   - API-keyed callers get a STABLE key-derived ref (#4491): a key is
+    //     attribution by design, so keyed egress carries it in the invisible
+    //     colophon — identity upgrades the marking, it never adds visible
+    //     marks. Any response carrying a ref is served private/no-store
+    //     below, so one caller's ref can never be shared-cached to another.
+    const ref = isBotRequest ? extractionRef(clientKeyFor(request), new Date())
+      : identity.kind === 'apikey' && identity.apiKeyId ? keyRef(identity.apiKeyId)
+      : undefined;
     const mark = (text: string) => (text ? markForExport(text, resolvedBookId, { ref }) : text);
     const bookSubject = {
       title: book.display_title || book.title,
@@ -507,7 +515,11 @@ export const GET = withApiAuth(async (
 
     return NextResponse.json(result, {
       headers: {
-        'Cache-Control': 'public, max-age=3600',
+        // Ref-carrying bodies are per-caller — a shared cache would serve one
+        // caller's ref to everyone. The other branches already guard this; the
+        // JSON branch was the one unconditional `public` left (latent since
+        // bot refs shipped).
+        'Cache-Control': ref ? 'private, no-store' : 'public, max-age=3600',
         'X-Pages-Served': String(pagesWithContent.length),
       },
     });

--- a/src/app/api/dataset/v1/books/route.ts
+++ b/src/app/api/dataset/v1/books/route.ts
@@ -80,7 +80,7 @@ export async function GET(request: NextRequest) {
     db.collection('books')
       .find(filter)
       .project({
-        _id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1,
+        _id: 1, id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1,
         pages_count: 1, pages_ocr: 1, pages_translated: 1,
         'taxonomy.cluster': 1, 'taxonomy.subcluster': 1,
         categories: 1, ia_identifier: 1,
@@ -111,7 +111,9 @@ export async function GET(request: NextRequest) {
     offset,
     limit,
     books: books.map(b => ({
-      id: String(b._id),
+      // The PUBLIC id — 16K+ re-created books re-minted their _id, and the id
+      // returned here is what consumers feed to /pages and /api/books/:id.
+      id: b.id || String(b._id),
       title: b.title,
       author: b.author,
       year: b.year,

--- a/src/app/api/dataset/v1/pages/route.ts
+++ b/src/app/api/dataset/v1/pages/route.ts
@@ -3,6 +3,8 @@ import { getReadDb } from '@/lib/mongodb';
 import { validateApiKey, checkKeyRequestRate } from '@/lib/dataset/api-keys';
 import { logAccess, getDailyPageCount } from '@/lib/dataset/access-logger';
 import { DatasetPageRecord } from '@/lib/dataset/types';
+import { markForExport } from '@/lib/provenance';
+import { keyRef } from '@/lib/bot-attribution';
 
 export const maxDuration = 30;
 
@@ -102,14 +104,20 @@ export async function GET(request: NextRequest) {
     ];
   }
 
-  // Get matching book IDs with metadata
+  // Get matching book IDs with metadata.
+  // pages.book_id holds the PUBLIC string id (books.id), never the ObjectId —
+  // joining on _id matches nothing and this endpoint served 0 records for
+  // every query until 2026-08-31 (books.id ≠ _id, see
+  // book-deletion-and-identity.md). Positive control before shipping a change
+  // here: one known-good language filter must return rows.
   const books = await db.collection('books')
     .find(bookFilter)
-    .project({ _id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1, 'taxonomy.cluster': 1, 'taxonomy.subcluster': 1 })
+    .project({ _id: 1, id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1, 'taxonomy.cluster': 1, 'taxonomy.subcluster': 1 })
     .toArray();
 
-  const bookMap = new Map(books.map(b => [String(b._id), b]));
-  const bookIds = books.map(b => b._id);
+  const publicId = (b: { id?: string; _id?: unknown }) => b.id || String(b._id);
+  const bookMap = new Map(books.map(b => [publicId(b), b]));
+  const bookIds = books.map(publicId);
 
   if (bookIds.length === 0) {
     return new Response('', {
@@ -138,7 +146,16 @@ export async function GET(request: NextRequest) {
     .limit(limit)
     .toArray();
 
-  // Build JSONL
+  // Build JSONL. Every text field carries the invisible provenance imprimatur
+  // with a key-derived ref (#4491): this is the KEYED bulk egress, and a key
+  // is attribution by design — the mark names the consumer that pulled the
+  // passage. Invisible, deliberately strippable (attribution, not DRM); a
+  // negotiated bit-clean corpus is delivered offline, never through this
+  // endpoint.
+  const ref = keyRef(String(apiKey._id));
+  const markText = (text: string | undefined, bookId: string) =>
+    text ? markForExport(text, bookId, { ref }) : null;
+
   const bookIdsAccessed = new Set<string>();
   const lines: string[] = [];
 
@@ -153,8 +170,8 @@ export async function GET(request: NextRequest) {
       book_id: bookId,
       page_number: page.page_number,
       language: book.language || 'Unknown',
-      original_text: page.ocr?.data || null,
-      english_translation: page.translation?.data || null,
+      original_text: markText(page.ocr?.data, bookId),
+      english_translation: markText(page.translation?.data, bookId),
       book_title: book.title || '',
       author: book.author || '',
       year: book.year || null,

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -204,6 +204,9 @@ export default function DevelopersPage() {
             Your own meter: <code>GET /api/dataset/v1/usage</code> with your key. Verified search crawlers
             and user-directed assistant fetches are never limited. Full-tier keys can request images without
             the visible provenance marks (<code>&amp;clean=1</code> on <code>/api/image</code>).
+            Text served to a key carries an invisible provenance colophon that includes your key&apos;s
+            reference — attribution, not tracking: it names the edition and the puller, decodes to a
+            readable note, and strips with any Unicode normalization pass.
           </p>
         </div>
       </section>

--- a/src/lib/bot-attribution.ts
+++ b/src/lib/bot-attribution.ts
@@ -58,6 +58,21 @@ export function extractionRef(clientKey: string, now: Date): string {
 }
 
 /**
+ * Attribution ref for an API-KEYED caller (#4491 follow-up). Unlike the bot
+ * extractionRef this is deliberately STABLE (no month rotation) and directly
+ * resolvable: the payload is a prefix of the api_keys._id, so a passage that
+ * surfaces in the wild names the consumer that pulled it without any HMAC
+ * round-trip. That asymmetry is the point — an anonymous scraper gets a
+ * pseudonymous campaign ref; a key holder opted into identity, and the ref IS
+ * the attribution their key exists to provide (api-keys-are-attribution
+ * doctrine). The key id is the Mongo doc id, not the secret token — knowing
+ * it grants nothing.
+ */
+export function keyRef(apiKeyId: string): string {
+  return `SLK-${String(apiKeyId).slice(0, 10)}`;
+}
+
+/**
  * Client identity for the ref. Uses the same forwarded-IP resolution as the
  * API logging layer so a ref can be matched back against `api_usage` rows.
  */


### PR DESCRIPTION
## What — Derek's "free keys can have more marking" direction, implemented as attribution

The right reading of "more marking for keys" is **more *attributed* marking, never more *visible* marking** — identity must stay an upgrade, or consumers rationally stay anonymous. Concretely:

- **API-keyed callers now get a stable key-derived ref** (`SLK-<10 hex of api_keys._id>`, `keyRef()` in `bot-attribution.ts`) woven into the invisible Trithemian imprimatur on `/books/:id/text` and `/api/dataset/v1/pages`. Bots keep their pseudonymous monthly campaign refs; anonymous humans keep the plain edition colophon. Nothing visible changes on any tier.
- The asymmetry is deliberate: an anonymous scraper's ref is HMAC'd and coarse; a key holder opted into identity, so their ref is directly resolvable to the key. A passage surfacing in the wild names the consumer that pulled it — the attribution their key exists to provide.
- **Disclosed on `/developers`** ("attribution, not tracking: … strips with any Unicode normalization pass") — consistent with the friendly-colophon ethos.

## Bugs found in the blast radius, fixed here

1. **`/api/dataset/v1/pages` has returned zero records for every query since it was written.** It joined `pages.book_id` — the public *string* id — against `books._id` ObjectIds. Positive control: `language=Czech` matches 1,025 pages with the fixed join vs 0 with the old one. This is the keyed bulk endpoint that `/developers` and every budget-exceeded error message point people to. (It also served text completely unmarked — the exact inversion of the marking policy — which the ref work above corrects.)
2. **`/books/:id/text` JSON branch** served ref-carrying bodies with unconditional `public, max-age=3600`; the other three branches were already `ref ? 'private, no-store' : 'public'`. A shared cache could cross-serve one caller's ref to everyone. Now conditional like its siblings.
3. **`/api/dataset/v1/books`** returned Mongo `_id` as `id` — the wrong key for the 16K+ re-created books whose `_id` was re-minted (`book-deletion-and-identity.md`). Now the public id.

## Verification

- `npx tsc --noEmit` clean.
- Mark roundtrip: `markForExport(text, bookId, { ref: keyRef(id) })` → `verifyProvenance` returns `authentic: true` with `Ref SLK-…` in the decoded colophon.
- Join fix positive-controlled against prod data (0 → 1,025 pages on the same filter).

## Notes / out of scope

- The pages export has never had a real consumer (it returned nothing), so its scaling behavior is untested — the unfiltered case `$in`s every visible book id. If real bulk use arrives, paginate by book. Flagged, not redesigned.
- Tiered *visible* image marks (anon full / free-key discreet / paid clean) is a separate design question with real R2 cost (a third baked variant corpus-wide) — filing as an issue, not building.

Part of #4491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc