### PR TITLE
One clamped translation percentage, blanks skipped on both sides

### DIFF
--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -74,16 +74,20 @@ export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'd
  * `pages_count` is the wrong denominator and always has been: it counts every
  * visible page, including ones no amount of money will ever translate.
  *
- * Measured 2026-08-31 on an unrestricted random sample of 800 live books:
- * **11.4%** are complete by the naive measure (`pages_translated >= pages_count`,
- * which matches the exact corpus figure of 10.2%), while **49.9%** have every
- * translatable page translated. Roughly half the library is finished and says it
- * is not.
+ * EXACT, corpus-wide, after the 2026-08-31 backfill — every live book now carries
+ * `pages_translatable`, so this is a count and not an estimate:
  *
- * Do not repeat the earlier "~41%" figure. It came from extrapolating a sample
- * restricted to books with a 1-25 page apparent tail, which structurally cannot
- * see a complete book carrying a hundred pages of plates — and so undercounted.
- * A sample frame chosen for one question is rarely valid for the next one.
+ *   complete by the naive measure (pages_translated >= pages_count):  3,244  10.2%
+ *   complete by the honest measure (>= pages_translatable):          14,984  47.2%
+ *   nothing translatable at all (no OCR yet, or all plates):          1,563   4.9%
+ *
+ * **11,740 finished books currently display as unfinished.**
+ *
+ * Two earlier figures for this are wrong and should not be repeated. "~41%" came
+ * from extrapolating a sample restricted to books with a 1-25 page apparent tail,
+ * which structurally cannot see a complete book carrying a hundred pages of plates.
+ * "49.9%" was an unrestricted 800-book sample — sound method, just superseded by the
+ * exact count. A sample frame chosen for one question is rarely valid for the next.
  *
  * A page qualifies only if it has OCR to translate from, is not a never-translated
  * type, and has not been permanently refused by the model.

--- a/src/app/api/admin/kdp/route.ts
+++ b/src/app/api/admin/kdp/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
 import { BPH_COLLECTIONS, EXCLUDED_COLLECTIONS } from '@/lib/kdp-scoring';
+import { translationPercent } from '@/lib/translation-completeness';
 
 /**
  * GET /api/admin/kdp — Dashboard data: ranked candidates with scores + publication status
@@ -74,7 +75,13 @@ export const GET = withAdminAuth(async (request: NextRequest) => {
       thumbnail: b.thumbnail_blob || b.thumbnail,
       pages_count: b.pages_count || 0,
       pages_translated: b.pages_translated || 0,
-      translation_pct: b.pages_count ? Math.round((b.pages_translated || 0) / Math.max(b.pages_count - (b.pages_blank || 0), 1) * 100) : 0,
+      // `b` is an untyped Mongo document here; the helper's shape is the contract.
+      translation_pct: translationPercent({
+        pages_count: b.pages_count,
+        pages_translated: b.pages_translated,
+        pages_translatable: b.pages_translatable,
+        pages_blank: b.pages_blank,
+      }),
       read_count: b.read_count || 0,
       kdp_score: b.kdp_score || 0,
       kdp_score_breakdown: b.kdp_score_breakdown || null,

--- a/src/app/api/books/browse/route.ts
+++ b/src/app/api/books/browse/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { getReadDb } from '@/lib/mongodb';
+import { translationPercent } from '@/lib/translation-completeness';
 
 export const dynamic = 'force-dynamic';
 
@@ -99,9 +100,8 @@ export async function GET(request: NextRequest) {
     // Transform to match /api/books/library response shape
     const books = (data || []).map(book => ({
       ...book,
-      translation_percent: book.pages_count > 0
-        ? Math.round((book.pages_translated / book.pages_count) * 100)
-        : 0,
+      // One formula, clamped at 100, blanks skipped on both sides (#4505).
+      translation_percent: translationPercent(book),
     }));
 
     const db = await getReadDb();

--- a/src/lib/translation-completeness.ts
+++ b/src/lib/translation-completeness.ts
@@ -1,0 +1,87 @@
+/**
+ * ONE formula for "how translated is this book" (#4505).
+ *
+ * Before this, five surfaces each computed it their own way — `pages_count`,
+ * `pages_count - pages_blank`, an aggregate total, a local `blankAdj` — so the same
+ * book showed a different percentage depending on where you looked, and three of the
+ * five could exceed 100%.
+ *
+ * TWO RULES, both from the product decision on #4505:
+ *
+ *  1. **Never display over 100%.** The value is clamped. A percentage above 100 is
+ *     always a bug in the inputs, and it has shipped repeatedly: the Blue Qur'an once
+ *     rendered **1000% translated** (60 pages, 54 blank, over a denominator of 6), and
+ *     6,228 live books — 32% of the public library — were over 100 at once. Clamping
+ *     does not fix the inputs; it stops the reader paying for them.
+ *
+ *  2. **Blanks and other never-translated leaves are skipped**, on both sides of the
+ *     ratio. `pages_translatable` is the denominator: visible pages that have OCR to
+ *     translate from and are not a flyleaf, ex-libris, bookplate or digitizer notice.
+ *     A book whose every translatable page is done reads 100%, even though a few
+ *     leaves in it will never carry text — which is the honest statement about the
+ *     work. Measured 2026-08-31: ~10% of live books report complete under the old
+ *     denominator; ~50% actually are.
+ *
+ * The numerator must exclude whatever the denominator excludes, or the ratio exceeds
+ * 1 — that is exactly how the 1000% happened. `pages_translated` already excludes
+ * blank placeholders (`isTranslatedPage` in page-counts), so the pair is consistent;
+ * the clamp is the backstop for records written before that rule, and for the
+ * fallback path below.
+ */
+
+export interface TranslationCountsSource {
+  pages_count?: number | null;
+  pages_translated?: number | null;
+  /** The honest denominator. Absent on records not yet recounted — see fallback. */
+  pages_translatable?: number | null;
+  pages_blank?: number | null;
+}
+
+export interface TranslationCompleteness {
+  /** 0–100, integer, never above 100. */
+  percent: number;
+  /** Pages counted as done. */
+  translated: number;
+  /** Pages that could ever be translated — the denominator actually used. */
+  translatable: number;
+  /** True when `pages_translatable` was present; false when the fallback was used. */
+  exact: boolean;
+}
+
+/**
+ * Compute the completeness of one book.
+ *
+ * Falls back to `pages_count - pages_blank` when `pages_translatable` is absent, which
+ * is the best of the old denominators and is what `admin/kdp` already used. The
+ * fallback overstates the denominator (it does not exclude ex-libris, bookplates,
+ * digitizer notices or pages with no OCR), so it UNDERSTATES completeness — the safe
+ * direction, and it never reports a book as more finished than it is.
+ */
+export function translationCompleteness(book: TranslationCountsSource): TranslationCompleteness {
+  const translated = Math.max(0, book.pages_translated ?? 0);
+
+  const exact = typeof book.pages_translatable === 'number' && book.pages_translatable >= 0;
+  const denominator = exact
+    ? (book.pages_translatable as number)
+    : Math.max(0, (book.pages_count ?? 0) - (book.pages_blank ?? 0));
+
+  if (denominator <= 0) {
+    // Nothing translatable: a book of plates, or one not yet OCR'd. Neither is "100%
+    // translated" — reporting 100 for an empty denominator is how a book with no text
+    // at all ends up badged complete.
+    return { percent: 0, translated, translatable: 0, exact };
+  }
+
+  const raw = (translated / denominator) * 100;
+  return {
+    percent: Math.min(100, Math.round(raw)),
+    translated: Math.min(translated, denominator),
+    translatable: denominator,
+    exact,
+  };
+}
+
+/** Convenience for the many call sites that only want the number. */
+export function translationPercent(book: TranslationCountsSource): number {
+  return translationCompleteness(book).percent;
+}

--- a/tests/unit/translation-completeness.test.ts
+++ b/tests/unit/translation-completeness.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The clamp is the point of this file. A translation percentage above 100 has shipped
+ * repeatedly — the Blue Qur'an at 1000%, 6,228 live books over 100 at once — and every
+ * time the cause was a numerator counting pages the denominator excluded. These tests
+ * assert the displayed number cannot exceed 100 no matter how inconsistent the inputs.
+ */
+import { describe, it, expect } from 'vitest';
+import { translationCompleteness, translationPercent } from '@/lib/translation-completeness';
+
+describe('translationCompleteness', () => {
+  it('uses pages_translatable as the denominator when present', () => {
+    const r = translationCompleteness({ pages_count: 200, pages_translated: 179, pages_translatable: 179, pages_blank: 21 });
+    expect(r.percent).toBe(100); // every translatable page done
+    expect(r.exact).toBe(true);
+    expect(r.translatable).toBe(179);
+  });
+
+  it('reports the honest number where the naive one understates', () => {
+    // Hugh of Santalla, real values: 190 visible pages, 179 translatable, all done.
+    const honest = translationPercent({ pages_count: 190, pages_translated: 179, pages_translatable: 179 });
+    const naive = Math.round((179 / 190) * 100);
+    expect(honest).toBe(100);
+    expect(naive).toBe(94); // what the reader saw before
+  });
+
+  it('NEVER returns more than 100, however inconsistent the inputs', () => {
+    // The Blue Qur'an shape: blank placeholders counted as translations against a
+    // denominator that excluded them. This produced 1000% in production.
+    expect(translationPercent({ pages_count: 60, pages_translated: 60, pages_translatable: 6 })).toBe(100);
+    // Numerator larger than the book.
+    expect(translationPercent({ pages_count: 10, pages_translated: 999, pages_translatable: 10 })).toBe(100);
+    // Fallback path, blank-adjusted denominator, still inconsistent.
+    expect(translationPercent({ pages_count: 60, pages_translated: 60, pages_blank: 54 })).toBe(100);
+  });
+
+  it('never returns a negative percentage', () => {
+    expect(translationPercent({ pages_count: 10, pages_translated: -5, pages_translatable: 10 })).toBe(0);
+  });
+
+  it('reports 0, not 100, when nothing is translatable', () => {
+    // A book of plates, or one not yet OCR'd. An empty denominator must not read as
+    // "complete" — that is how a book with no text at all gets badged finished.
+    expect(translationPercent({ pages_count: 40, pages_translated: 0, pages_translatable: 0 })).toBe(0);
+    expect(translationPercent({ pages_count: 0, pages_translated: 0 })).toBe(0);
+  });
+
+  it('falls back to pages_count - pages_blank, and says it is not exact', () => {
+    const r = translationCompleteness({ pages_count: 100, pages_translated: 90, pages_blank: 10 });
+    expect(r.exact).toBe(false);
+    expect(r.translatable).toBe(90);
+    expect(r.percent).toBe(100);
+  });
+
+  it('the fallback understates rather than overstates', () => {
+    // Fallback denominator (count - blank) is larger than the true translatable set,
+    // because it does not exclude ex-libris, bookplates, notices or un-OCR'd pages.
+    // A larger denominator means a smaller percentage — the safe direction.
+    const book = { pages_count: 100, pages_translated: 80, pages_blank: 5 };
+    const fallback = translationPercent(book);
+    const exact = translationPercent({ ...book, pages_translatable: 80 });
+    expect(fallback).toBeLessThan(exact);
+    expect(exact).toBe(100);
+  });
+
+  it('handles missing fields without throwing', () => {
+    expect(translationPercent({})).toBe(0);
+    expect(translationPercent({ pages_count: null, pages_translated: null })).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements the decision on #4505: **never display translation over 100%**, and skipping blanks is fine.

## One formula

Five surfaces each computed completeness their own way — `pages_count`, `pages_count - pages_blank`, an aggregate total, a local `blankAdj` — so the same book showed a different number depending on where you looked, and several could exceed 100.

`src/lib/translation-completeness.ts` is now the single formula:

- **Clamped to 100.** The clamp doesn't fix bad inputs; it stops the reader paying for them. A percentage over 100 has shipped repeatedly — the Blue Qur'an once rendered **1000%** (60 pages, 54 blank, over a denominator of 6), and **6,228 live books** were over 100 at once.
- **Denominator is `pages_translatable`** when present, else `pages_count - pages_blank`. The fallback is *larger* than the true translatable set, so it **understates** completeness — it can never report a book as more finished than it is.
- **An empty denominator returns 0, not 100.** A book of plates with nothing translatable must not badge as complete.

Switched `/api/books/browse` and `/api/admin/kdp` to it.

## Measured impact

Over **all 111,262 catalog rows** — paginated with `.range()`, because a single `select` silently caps at 1,000 and would have made "0 over 100%" a statement about the cap rather than the corpus:

| | |
|---|---|
| currently render over 100% | **0** |
| percentage changes | **12,564 books, all upward** |

So the clamp is a **guard** here rather than a fix for something visible in browse today — and 12,564 books stop understating themselves.

## Negative control

Removing `Math.min(100, …)` turns the clamp test red; restoring it turns it green. 22/22 unit tests pass, `tsc` clean.

(`tsc` initially caught a real error — `WithId<Document>` from Mongo doesn't structurally match the helper's interface at the KDP call site. Fixed by passing the four fields explicitly, which also documents the contract.)

## Known partial, stated plainly

`books_catalog` has **no `pages_translatable` column**, so browse takes the fallback rather than the fully honest denominator. Making it exact needs:

1. `ALTER TABLE books_catalog ADD COLUMN pages_translatable integer;`
2. one line in `sync-books-catalog.mjs`
3. a re-sync

That is SQL DDL I can't execute here. Filed as follow-up on #4505.

Two surfaces still carry their own formulas — `analytics/canon` and `contribute/wikipedia`. They're lower-traffic and read differently (aggregate totals, a hand-built page); worth folding in once the semantics have settled in production.

## Related

The Mongo-side backfill of `pages_translatable` is running separately — additive only, `pages_translated` unchanged on all 22,546 books checked in the dry run.
