### PR TITLE
fix(dataset): keyset cursor for the pages export (deep offset 504s)

### DIFF
--- a/src/app/api/dataset/v1/pages/route.ts
+++ b/src/app/api/dataset/v1/pages/route.ts
@@ -9,6 +9,27 @@ import { keyRef } from '@/lib/bot-attribution';
 export const maxDuration = 30;
 
 /**
+ * Keyset cursor over the (book_id, page_number) sort key: "<book_id>:<page>".
+ * Returns a Mongo clause selecting everything strictly after that point, or
+ * null for an absent/malformed cursor (which falls back to `offset` rather
+ * than erroring — a bad cursor should not lose a caller their whole walk).
+ */
+function parseCursor(after: string | null): Record<string, unknown> | null {
+  if (!after) return null;
+  const sep = after.lastIndexOf(':');
+  if (sep <= 0) return null;
+  const bookId = after.slice(0, sep);
+  const pageNumber = parseInt(after.slice(sep + 1), 10);
+  if (!bookId || !Number.isFinite(pageNumber)) return null;
+  return {
+    $or: [
+      { book_id: { $gt: bookId } },
+      { book_id: bookId, page_number: { $gt: pageNumber } },
+    ],
+  };
+}
+
+/**
  * GET /api/dataset/v1/pages
  *
  * Streaming JSONL endpoint for dataset pages.
@@ -20,7 +41,12 @@ export const maxDuration = 30;
  *   from_year - minimum publication year
  *   to_year   - maximum publication year
  *   content   - ocr, translation, or both (default: both)
- *   offset    - pagination offset (default: 0)
+ *   after     - keyset cursor "<book_id>:<page_number>"; USE THIS to walk the
+ *               corpus. Echo the X-Next-Cursor response header back until it
+ *               stops being returned. Constant-time; offset is not.
+ *   offset    - pagination offset (default: 0). Fine for shallow reads; at
+ *               deep offsets it walks every skipped document and will exceed
+ *               maxDuration. Ignored when `after` is supplied.
  *   limit     - max records (default: 1000, max: 10000)
  */
 export async function GET(request: NextRequest) {
@@ -129,12 +155,25 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Query pages
+  // Query pages.
+  // Two pagination modes. `after` is a keyset cursor on the sort key
+  // (book_id, page_number) and is the one to use for walking the corpus:
+  // measured on prod, offset=50000 costs 12.2s and grows linearly (it walks
+  // every skipped doc), while the equivalent cursor read is 155ms and flat,
+  // because {book_id:1, page_number:1} is indexed. At a few hundred thousand
+  // rows in, offset alone exceeds this route's 30s maxDuration. `offset` is
+  // kept for compatibility and for shallow reads.
+  const cursorClause = parseCursor(searchParams.get('after'));
+  const pageQuery = {
+    $and: [
+      { book_id: { $in: bookIds } },
+      pageFilter,
+      ...(cursorClause ? [cursorClause] : []),
+    ],
+  };
+
   const pages = await db.collection('pages')
-    .find({
-      book_id: { $in: bookIds },
-      ...pageFilter,
-    })
+    .find(pageQuery)
     .project({
       book_id: 1,
       page_number: 1,
@@ -142,7 +181,7 @@ export async function GET(request: NextRequest) {
       'translation.data': 1,
     })
     .sort({ book_id: 1, page_number: 1 })
-    .skip(offset)
+    .skip(cursorClause ? 0 : offset)
     .limit(limit)
     .toArray();
 
@@ -196,9 +235,18 @@ export async function GET(request: NextRequest) {
     ip_address: request.headers.get('x-forwarded-for') || 'unknown',
   });
 
+  // Keyset cursor for the next page. Derived from the last PAGE row, not the
+  // last emitted line: a row whose book was filtered out still advances the
+  // scan, and dropping it from the cursor would replay it forever.
+  const lastPage = pages[pages.length - 1];
+  const nextCursor = pages.length === limit && lastPage
+    ? `${String(lastPage.book_id)}:${lastPage.page_number}`
+    : null;
+
   return new Response(lines.join('\n') + (lines.length ? '\n' : ''), {
     status: 200,
     headers: {
+      ...(nextCursor ? { 'X-Next-Cursor': nextCursor } : {}),
       'Content-Type': 'application/x-ndjson',
       'X-Total-Records': String(lines.length),
       'X-Offset': String(offset),

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -223,8 +223,9 @@ const SPEC = {
     '/dataset/v1/pages': {
       get: {
         summary: 'Bulk page text as streaming JSONL (requires API key)',
-        description: 'One JSON record per line. Text carries the invisible provenance colophon including your key reference.',
-        parameters: [q('language', 'Filter by book language'), q('cluster', 'Taxonomy cluster'), q('from_year', 'Year range start', { type: 'integer' }), q('to_year', 'Year range end', { type: 'integer' }), q('content', 'ocr | translation | both'), q('offset', 'Offset', { type: 'integer' }), q('limit', 'Limit ≤10000 (default 1000)', { type: 'integer' })],
+        description:
+          'One JSON record per line. Text carries the invisible provenance colophon including your key reference. To walk the corpus use the `after` keyset cursor: echo the X-Next-Cursor response header back as `after` until it is no longer returned. Deep `offset` values are slow by construction and can exceed the request deadline.',
+        parameters: [q('language', 'Filter by book language'), q('cluster', 'Taxonomy cluster'), q('from_year', 'Year range start', { type: 'integer' }), q('to_year', 'Year range end', { type: 'integer' }), q('content', 'ocr | translation | both'), q('after', 'Keyset cursor "<book_id>:<page_number>" from the X-Next-Cursor header — preferred over offset'), q('offset', 'Offset (shallow reads only; ignored when `after` is given)', { type: 'integer' }), q('limit', 'Limit ≤10000 (default 1000)', { type: 'integer' })],
         responses: { '200': { description: 'JSONL stream', content: { 'application/x-ndjson': {} } } },
         security: [{ apiKey: [] }],
       },


### PR DESCRIPTION
## What

Found by **testing** the export revived in #4500 — an endpoint that had never actually returned data, so its failure modes had never been exercised.

Offset pagination over `pages` walks every skipped document. Measured against production:

| pagination | cost |
|---|---|
| `offset=0` (first page) | 301ms |
| `offset=50000` | **12,251ms**, growing linearly |
| keyset cursor, same position | **155ms**, flat |

With `maxDuration = 30` and a ~3.7s book-id stage on top, a consumer walking the corpus starts 504ing a few hundred thousand rows in. The `{book_id: 1, page_number: 1}` index already existed — the route simply wasn't using it as a cursor.

## Change

- New `after=<book_id>:<page_number>` keyset cursor + `X-Next-Cursor` response header. Echo the header back until it stops being returned.
- `offset` still works for shallow reads; ignored when `after` is supplied. A **malformed cursor falls back to offset rather than erroring** — a typo shouldn't lose a caller their whole walk.
- The next cursor is derived from the **last page row, not the last emitted line**: a row whose book was filtered out still advances the scan, otherwise it would replay forever.
- Documented in the route header and the OpenAPI spec.

## Verification

Equivalence-tested against prod on a real filtered set (Czech, deliberately non-round batch size of 37 to catch boundary off-by-ones): cursor walk and offset walk both yield **1,020 rows, identical order, 0 duplicates**, terminating in the same 28 batches. `npx tsc --noEmit` clean.

Part of #4491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc