### PR TITLE
feat(api): expose work_id + edition_key, add edition filter (#4509)

### DIFF
--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -44,6 +44,12 @@ export async function GET(request: NextRequest) {
     // canonical person; membership is the same 3-key union as /author/[slug]).
     // Slugs come from /api/catalog/author-search or from `author_id` on rows.
     const authorIdParam = (searchParams.get('author_id') || '').trim();
+    // `edition_key=<key>`: other digitizations of ONE printing. Gated to
+    // full-quality keys on BOTH sides, exactly as the reader-facing "other
+    // scans of this edition" rail is (isTrustedEditionKey) — a `no-year` key
+    // collapses every printing of a title across centuries into one set, which
+    // is fine for a review queue and wrong for a public answer.
+    const editionKeyParam = (searchParams.get('edition_key') || '').trim();
     // Numeric edition-year range. Matches the `year` field only — the free-text
     // `published` is not comparable (see search-filters-and-lanes.md); books
     // without a numeric year (~40% of live books) never match a year filter.
@@ -68,7 +74,7 @@ export async function GET(request: NextRequest) {
 
     // Serve cached response for cacheable requests (no text search, reasonable pagination)
     const isCacheable = !search.trim() && skip < 200;
-    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|he:${hasEdition}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}|a:${authorIdParam}|yf:${yearFrom}|yt:${yearTo}`;
+    const cacheKey = `t:${tenantSlug}|s:${sort}|sk:${skip}|l:${limit}|ft:${firstTranslation}|ht:${hasTranslation}|he:${hasEdition}|lang:${language}|cat:${category}|col:${collection}|lib:${library}|w:${workId}|a:${authorIdParam}|yf:${yearFrom}|yt:${yearTo}|ek:${editionKeyParam}`;
     if (isCacheable) {
       const cached = browseCache.get(cacheKey);
       if (cached && (Date.now() - cached.timestamp) < BROWSE_CACHE_TTL) {
@@ -97,6 +103,9 @@ export async function GET(request: NextRequest) {
         );
       }
     }
+    const editionMatch: Record<string, unknown> | null = editionKeyParam
+      ? { edition_key: editionKeyParam, edition_key_quality: 'full' }
+      : null;
     const yearMatch: Record<string, unknown> | null = (yearFrom !== null || yearTo !== null)
       ? { year: { ...(yearFrom !== null ? { $gte: yearFrom } : {}), ...(yearTo !== null ? { $lte: yearTo } : {}) } }
       : null;
@@ -122,6 +131,7 @@ export async function GET(request: NextRequest) {
         // and reads as active either way (search-filters-and-lanes.md).
         ...(hasEdition ? [{ $match: { [`pages_translated_${hasEdition}`]: { $gt: 0 } } }] : []),
         ...(authorFilter ? [{ $match: authorFilter.match }] : []),
+        ...(editionMatch ? [{ $match: editionMatch }] : []),
         ...(yearMatch ? [{ $match: yearMatch }] : []),
         ...(tenantId ? [{ $match: { tenantId } }] : []),
       ];
@@ -140,6 +150,7 @@ export async function GET(request: NextRequest) {
       if (hasTranslation) matchConditions.push({ pages_translated: { $gt: 0 } });
       if (hasEdition) matchConditions.push({ [`pages_translated_${hasEdition}`]: { $gt: 0 } });
       if (authorFilter) matchConditions.push(authorFilter.match);
+      if (editionMatch) matchConditions.push(editionMatch);
       if (yearMatch) matchConditions.push(yearMatch);
       pipelineStart = [{ $match: { $and: matchConditions } }];
     }
@@ -196,6 +207,15 @@ export async function GET(request: NextRequest) {
       // `published` is free text and `author` is an uncanonicalized string.
       author_id: 1,
       year: 1,
+      // The rest of the identity stack (#4509). `work_id` was filterable via
+      // ?work_id= but never returned, so a consumer could not learn a book's
+      // work without a per-book call — the same defect the author facet had.
+      // `edition_key_quality` ships beside the key because only 'full' is
+      // trustworthy: with the year slot empty a key merges every printing of a
+      // title across centuries (edition-identity.md).
+      work_id: 1,
+      edition_key: 1,
+      edition_key_quality: 1,
       thumbnail: 1, image_display: 1,
       thumbnail_blob: 1, image_thumb: 1,
       language: 1,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -297,6 +297,7 @@ async function listBooks(args: Record<string, unknown>) {
   // Canonical author slug — every row of every listing carries author_id, so a
   // follow-up "all books by this person" call needs no separate lookup.
   if (args.author_id) params.set('author_id', String(args.author_id));
+  if (args.edition_key) params.set('edition_key', String(args.edition_key));
   if (typeof args.year_from === 'number' && Number.isFinite(args.year_from)) params.set('year_from', String(Math.trunc(args.year_from)));
   if (typeof args.year_to === 'number' && Number.isFinite(args.year_to)) params.set('year_to', String(Math.trunc(args.year_to)));
   // `has_edition` filters by a language the book can be READ in; `language`
@@ -314,6 +315,12 @@ async function listBooks(args: Record<string, unknown>) {
     published: b.published, year: b.year ?? null,
     pages_count: b.pages_count, pages_translated: b.pages_translated,
     translation_percent: b.translation_percent,
+    // Identity ids so a follow-up call needs no per-book lookup: work_id feeds
+    // list_editions, edition_key feeds edition_key= (other scans of THIS
+    // printing). The key is only emitted at full quality — a lower-quality key
+    // would merge printings across centuries (edition-identity.md).
+    ...(b.work_id ? { work_id: b.work_id } : {}),
+    ...(b.edition_key && b.edition_key_quality === 'full' ? { edition_key: b.edition_key } : {}),
     // Canonical author slug + resolvable URL (agent-tool-results.md: an
     // omitted URL is one the model invents — hand over the real one, always
     // unprefixed). authorSlug() is the sanctioned fallback for unlinked rows.
@@ -1100,6 +1107,7 @@ const TOOLS: Tool[] = [
       properties: {
         search: { type: 'string', description: 'Free-text filter matching title or author (relevance-ranked, may include title matches). For exactly one person\'s books use author_id instead.' },
         author_id: { type: 'string', description: 'Canonical author slug, e.g. "jan-hus" — filters to exactly that person\'s books via the author thesaurus (variant slugs resolve to the canonical person). Every book row in results carries its author_id; the response echoes the canonicalized author.' },
+        edition_key: { type: 'string', description: 'Other digitizations of ONE printing — pass the edition_key from a result row. Only full-quality keys match on both sides, so this answers "what other scans of this exact edition do you hold?" and never merges different printings of the same title.' },
         year_from: { type: 'number', description: 'Earliest edition year (inclusive). Matches only books with a known numeric year — ~60% of the library.' },
         year_to: { type: 'number', description: 'Latest edition year (inclusive).' },
         language: { type: 'string' }, category: { type: 'string' },

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -71,9 +71,10 @@ const SPEC = {
       get: {
         summary: 'Browse and filter the catalog',
         description:
-          'Every row carries id, slug, title, author, author_id (canonical), language, year (numeric, when known), published (free text), and translation progress. When author_id is passed the response echoes the canonicalized author; an unknown slug returns an empty page with author: null.',
+          'Every row carries id, slug, title, author, author_id (canonical), work_id, edition_key + edition_key_quality, language, year (numeric, when known), published (free text), and translation progress. When author_id is passed the response echoes the canonicalized author; an unknown slug returns an empty page with author: null.',
         parameters: [
           q('author_id', "Canonical author slug — exactly that person's books. Discover via /catalog/author-search", { example: 'jakob-bohme' }),
+          q('edition_key', 'Other digitizations of one printing (full-quality keys only)'),
           q('year_from', 'Edition-year range start (numeric year only)', { type: 'integer' }),
           q('year_to', 'Edition-year range end (inclusive)', { type: 'integer' }),
           q('language', 'Edition language (the language printed on the leaves)'),

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -527,6 +527,11 @@ source-library search "alchemy" --json | jq .results`}
                     <td className="py-2 text-secondary">Free-text over titles and authors (relevance-ranked)</td>
                   </tr>
                   <tr className="border-b border-stone-100">
+                    <td className="py-2 font-mono text-accent-rust">edition_key</td>
+                    <td className="py-2 text-muted">string</td>
+                    <td className="py-2 text-secondary">Other digitizations of one printing. Take the value from a result row; only full-quality keys match, so different printings of a title are never merged.</td>
+                  </tr>
+                  <tr className="border-b border-stone-100">
                     <td className="py-2 font-mono text-accent-rust">work_id / has_translation / first_translation / has_edition</td>
                     <td className="py-2 text-muted">mixed</td>
                     <td className="py-2 text-secondary">Editions of one work; only translated books; only first translations; only books readable in an ISO language (e.g. es)</td>


### PR DESCRIPTION
## What

The author facet turned out to be one instance of a pattern, found by auditing the whole public API against the site's own UI (#4509):

> **Every layer of the identity stack has page-level browsing, but the API stops at "filter by an id you already have" — and often does not even return that id.**

This PR closes the two cheapest instances:

- **`work_id`, `edition_key`, `edition_key_quality` now ship on `/books/library` rows.** `work_id` was *filterable* via `?work_id=` but never projected — so a consumer could not learn a book's work without a per-book call, exactly the author-shaped defect. `edition_key` had no API path at all.
- **New `?edition_key=` filter** — other digitizations of one printing ("other scans of this edition"). **Gated to `full` quality on both sides**, mirroring the reader-facing rail's `isTrustedEditionKey`: a `no-year` key collapses every printing of a title across centuries, which is correct for a review queue and wrong for a public answer (`edition-identity.md`). Applied in the search **and** browse branches; cache key extended.
- **MCP `list_books`**: `edition_key` param, plus `work_id`/`edition_key` on rows (key emitted only at full quality).

## Backing data measured before shipping

Not just correct code — a filter with only singleton result sets would answer nothing:

| field | live coverage |
|---|---|
| `work_id` | 31,483 / 31,716 (99.3%) |
| `edition_key` | 31,596 (99.6%) |
| `edition_key_quality: full` | 18,782 (59%) |
| **full-quality keys shared by >1 live book** | **221** (largest cluster: 7 scans of one printing) |

## Not in scope (tracked in #4509)

`/api/works` and `/api/libraries` index endpoints, the tenant-gated topics/`faceted_tags` vocabulary (public for humans at `/topics`, silently empty for anonymous API callers), artwork artist-filter parity, `place_published`, and the related-books rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc