### PR TITLE
Page-split writers: use the canonical counters (#4499, 34 → 32)

### DIFF
--- a/src/lib/page-split/dedup-overlapping-pages.ts
+++ b/src/lib/page-split/dedup-overlapping-pages.ts
@@ -17,6 +17,7 @@
  */
 
 import type { Db } from 'mongodb';
+import { buildVisiblePageCountPipeline } from '@/lib/page-counts';
 
 export interface DedupResult {
   bookId: string;
@@ -122,23 +123,23 @@ export async function deduplicateOverlappingPages(
   }
 
   // Update book-level caches
-  const newCount = remainingPages.length;
-  const ocrCount = await pagesCol.countDocuments({
-    book_id: bookId,
-    'ocr.data': { $exists: true, $ne: '' },
-  });
-  const transCount = await pagesCol.countDocuments({
-    book_id: bookId,
-    'translation.data': { $exists: true, $ne: '' },
-  });
+
+  // Counters come from the canonical pipeline (#4442/#4499). The private counts that
+  // used to live here matched ALL pages — so the soft-hidden pages this very function
+  // had just created were counted back in — and their translated count included
+  // blank-page placeholders. Both inflate; together they are how a book ends up
+  // reporting more translated pages than it has.
+  const [counts] = await pagesCol.aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
 
   await db.collection('books').updateOne(
     { id: bookId },
     {
       $set: {
-        pages_count: newCount,
-        pages_ocr: ocrCount,
-        pages_translated: transCount,
+        pages_count: counts?.total ?? 0,
+        pages_ocr: counts?.with_ocr ?? 0,
+        pages_translated: counts?.with_translation ?? 0,
+        pages_translatable: counts?.translatable ?? 0,
+        pages_blank: counts?.blank ?? 0,
         updated_at: new Date(),
       },
     },
@@ -149,6 +150,6 @@ export async function deduplicateOverlappingPages(
     duplicatesFound: pageIdsToArchive.length,
     pagesRemoved: pageIdsToArchive.length,
     pagesRenumbered: bulkOps.length,
-    newPageCount: newCount,
+    newPageCount: counts?.total ?? 0,
   };
 }

--- a/src/lib/page-split/detect-ghost-pages.ts
+++ b/src/lib/page-split/detect-ghost-pages.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Db } from 'mongodb';
+import { buildVisiblePageCountPipeline } from '@/lib/page-counts';
 
 export interface GhostDetectionResult {
   bookId: string;
@@ -172,23 +173,23 @@ export async function detectAndRemoveGhostPages(
   }
 
   // Update book-level caches
-  const newCount = remainingPages.length;
-  const ocrCount = await pagesCol.countDocuments({
-    book_id: bookId,
-    'ocr.data': { $exists: true, $ne: '' },
-  });
-  const transCount = await pagesCol.countDocuments({
-    book_id: bookId,
-    'translation.data': { $exists: true, $ne: '' },
-  });
+
+  // Counters come from the canonical pipeline (#4442/#4499). The private counts that
+  // used to live here matched ALL pages — so the soft-hidden pages this very function
+  // had just created were counted back in — and their translated count included
+  // blank-page placeholders. Both inflate; together they are how a book ends up
+  // reporting more translated pages than it has.
+  const [counts] = await pagesCol.aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
 
   await db.collection('books').updateOne(
     { id: bookId },
     {
       $set: {
-        pages_count: newCount,
-        pages_ocr: ocrCount,
-        pages_translated: transCount,
+        pages_count: counts?.total ?? 0,
+        pages_ocr: counts?.with_ocr ?? 0,
+        pages_translated: counts?.with_translation ?? 0,
+        pages_translatable: counts?.translatable ?? 0,
+        pages_blank: counts?.blank ?? 0,
         updated_at: new Date(),
       },
     },
@@ -198,6 +199,6 @@ export async function detectAndRemoveGhostPages(
     bookId,
     ghostPagesFound: ghostPageIds.length,
     pagesRemoved: ghostDocs.length,
-    newPageCount: newCount,
+    newPageCount: counts?.total ?? 0,
   };
 }

--- a/tests/fixtures/page-counter-writers-baseline.json
+++ b/tests/fixtures/page-counter-writers-baseline.json
@@ -10,7 +10,7 @@
     "never by regenerating this file to make a new offender disappear. Burn-down: #4499."
   ],
   "generated_at": "2026-08-31",
-  "count": 34,
+  "count": 32,
   "files": [
     "scripts/dedup-apply-approved.mjs",
     "scripts/dedup-autoapply.mjs",
@@ -43,8 +43,6 @@
     "src/app/api/pages/[id]/route.ts",
     "src/app/api/pages/[id]/split/route.ts",
     "src/app/api/pages/batch-split/route.ts",
-    "src/app/api/process/route.ts",
-    "src/lib/page-split/dedup-overlapping-pages.ts",
-    "src/lib/page-split/detect-ghost-pages.ts"
+    "src/app/api/process/route.ts"
   ]
 }

--- a/tests/unit/page-counter-writers.test.ts
+++ b/tests/unit/page-counter-writers.test.ts
@@ -22,7 +22,7 @@
  * ADDING A WRITER: import `page-counts` and use `buildVisiblePageCountPipeline` (or
  * `countVisiblePageStats` if you already hold the pages).
  *
- * The 34 pre-existing divergent writers are captured in
+ * The pre-existing divergent writers are captured in
  * `tests/fixtures/page-counter-writers-baseline.json` — a ratchet that may shrink and
  * must not grow (#4499). If a file genuinely writes a counter without deriving it —
  * zeroing on clear, say — it still belongs in the baseline with that noted, because
@@ -129,7 +129,7 @@ describe('book page-counter writers', () => {
     const stillDivergent = counterWriters().filter(r => !r.usesLib).map(r => r.file);
     const notInBaseline = stillDivergent.filter(f => !BASELINE.includes(f));
     expect(notInBaseline).toEqual([]);
-    expect(BASELINE.length).toBeLessThanOrEqual(34);
+    expect(BASELINE.length).toBeLessThanOrEqual(32);
   });
 
   it('finds writers at all (guards against the matcher silently matching nothing)', () => {


### PR DESCRIPTION
First burn-down of #4499. Baseline **34 → 32**.

`detect-ghost-pages.ts` and `dedup-overlapping-pages.ts` each recomputed the book counters themselves, and each diverged the same two ways: `countDocuments` over **all** pages with no `page_number > 0` filter, and a translated count that included blank-page placeholders.

## Why the first one is especially wrong here

Both functions exist to **soft-hide pages** — that is their entire job — and then counted the pages they had just hidden straight back in. The counter was computed from a state the function itself had made obsolete, one line earlier.

## Measured

40 random live books: the old count differs from canonical on **25%** of them.

| | |
|---|---|
| worst case | *Epistolarum obscurorum virorum ad Dom. M. Or…* |
| old count | 616 |
| canonical | 406 |
| over-count | **+210 pages** |

## Changes

Both take all five counters from `buildVisiblePageCountPipeline`, so they now also write `pages_translatable` and `pages_blank` rather than leaving them stale while their siblings move — the failure mode that made `batch-translate-async` need fixing in #4502.

The ratchet shrinks 34 → 32 and its ceiling drops with it, so these two can't quietly return.

`npx tsc --noEmit` clean; 22/22 unit tests pass.
