### PR TITLE
feat(api): enumerate works, libraries, and the topic vocabulary (#4509)

### DIFF
--- a/src/app/api/books/facets/route.ts
+++ b/src/app/api/books/facets/route.ts
@@ -28,15 +28,23 @@ export async function GET(request: NextRequest) {
   const db = await getReadDb();
   const { id: tenantId } = getTenantContextFromRequest(request);
 
-  if (!tenantId) {
-    return NextResponse.json({ books: [], total: 0 });
-  }
-
   const countsOnly = searchParams.get('counts') === 'true';
 
-  // Build MongoDB query from facet filters
+  // Build MongoDB query from facet filters.
+  //
+  // Tenant scoping is ADDITIVE, matching /api/languages and /api/gallery: a
+  // tenant subdomain sees only its own books (lockdown invariant unchanged),
+  // and a request with no tenant sees the GLOBAL set — which is exactly what
+  // `/topics` already renders publicly and anonymously for humans
+  // (src/app/topics/page.tsx aggregates faceted_tags with no tenant filter).
+  //
+  // Until #4509 this route returned `{books:[],total:0}` to every caller
+  // without a tenant header: not a 4xx, just a silent empty, so the whole
+  // 6-facet vocabulary was undiscoverable via API even though the page built
+  // on it is public. A silently empty filtered result is the same failure
+  // class as the gallery collection that claimed 200 images and served none.
   const query: Record<string, unknown> = {
-    tenantId,
+    ...(tenantId ? { tenantId } : {}),
     'faceted_tags': { $exists: true },
     visible: true,
     pages_count: { $gt: 0 },

--- a/src/app/api/libraries/route.ts
+++ b/src/app/api/libraries/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+// getPartnerByProvider, NOT a direct LIBRARY_PARTNERS[provider] lookup: the
+// record is keyed by human slug ('internet-archive', 'bavarian-state-library')
+// while image_source.provider carries the wire value ('internet_archive',
+// 'mdz'). Indexing directly misses essentially every row and degrades silently
+// to raw slugs — which would make this endpoint useless while looking correct.
+import { getPartnerByProvider } from '@/lib/library-partners';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/libraries
+ *
+ * The contributing-library directory: which institutions' scans we hold, how
+ * many books from each, and what those provider slugs actually NAME.
+ *
+ * Why this exists (#4509): `library=` has long been a filter VALUE on
+ * /api/books/library and /api/search, but nothing enumerated the valid values —
+ * while `/languages` has /api/languages and `/browse/subjects` has
+ * /api/categories. A consumer could filter by a provider only by guessing its
+ * slug. /api/books/distributions returns provider COUNTS; this route adds the
+ * half that only existed on the human page: the partner's display name, URL,
+ * and description, so `bsb` can be rendered as "Bavarian State Library (MDZ)".
+ *
+ * Counted in Mongo rather than paging Supabase like /libraries does — the page
+ * walks every catalog row in 1,000-row batches, which this route does not need
+ * and which is the supabase-cap trap besides.
+ *
+ * Query params:
+ *   include_unpartnered - "true" to include providers with no partner record
+ *                         (default true; set false for the curated set only)
+ */
+
+// Infrastructure buckets, not institutions — the /libraries page hides these
+// and so must the API, or a consumer renders "iiif" as a library.
+const EXCLUDE_PROVIDERS = new Set(['user_upload', 'other', 'library', 'iiif']);
+
+const LIBRARIES_TTL_MS = 30 * 60_000;
+const cache = new Map<string, { data: string; builtAt: number }>();
+
+export async function GET(request: NextRequest) {
+  try {
+    const includeUnpartnered = request.nextUrl.searchParams.get('include_unpartnered') !== 'false';
+    const cacheKey = String(includeUnpartnered);
+
+    const hit = cache.get(cacheKey);
+    if (hit && Date.now() - hit.builtAt < LIBRARIES_TTL_MS) {
+      return new NextResponse(hit.data, {
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=1800, stale-while-revalidate=86400' },
+      });
+    }
+
+    const db = await getReadDb();
+    const rows = await db.collection('books').aggregate<{ _id: string; count: number; languages: string[] }>([
+      { $match: { visible: true, pages_count: { $gt: 0 }, 'image_source.provider': { $type: 'string', $ne: '' } } },
+      { $group: { _id: '$image_source.provider', count: { $sum: 1 }, languages: { $addToSet: '$language' } } },
+      { $sort: { count: -1 } },
+    ], { maxTimeMS: 30000 }).toArray();
+
+    const libraries = rows
+      .filter((r) => !EXCLUDE_PROVIDERS.has(r._id))
+      .map((r) => {
+        const partner = getPartnerByProvider(r._id);
+        return {
+          provider: r._id,
+          // The display name is the point of this endpoint. Falling back to the
+          // raw slug is honest — it says "we hold scans from this source and
+          // have not catalogued who they are" rather than inventing a name.
+          name: partner?.name || r._id,
+          url: partner?.url || null,
+          partner_slug: partner?.slug || null,
+          book_count: r.count,
+          languages: r.languages.filter(Boolean).sort(),
+          books_url: `https://sourcelibrary.org/api/books/library?library=${encodeURIComponent(r._id)}`,
+          ...(partner?.slug ? { page_url: `https://sourcelibrary.org/libraries/${partner.slug}` } : {}),
+        };
+      })
+      .filter((l) => includeUnpartnered || l.partner_slug);
+
+    const body = JSON.stringify({ total: libraries.length, libraries });
+    cache.set(cacheKey, { data: body, builtAt: Date.now() });
+
+    return new NextResponse(body, {
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=1800, stale-while-revalidate=86400' },
+    });
+  } catch (error) {
+    console.error('Error in /api/libraries:', error);
+    return NextResponse.json({ error: 'Failed to list libraries' }, { status: 500 });
+  }
+}

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -114,6 +114,47 @@ const SPEC = {
         responses: jsonResponse('{ total, facets: { languages, categories, collections, libraries, decades }, author? } — each facet a [{value, count}] list'),
       },
     },
+    '/works': {
+      get: {
+        summary: 'List works held in several editions across several centuries',
+        description:
+          'The bootstrap for work-level browsing: returns work_id, witness count, year span, languages and libraries. Feed work_id back to /books/library?work_id= for the witness list. Same set as the /works page.',
+        parameters: [
+          q('sort', 'span (default) | witnesses | earliest | title'),
+          q('limit', 'Max works (index is ~400 entries)', { type: 'integer' }),
+          q('offset', 'Pagination offset', { type: 'integer' }),
+        ],
+        responses: jsonResponse('{ total, offset, limit, works: [{ work_id, slug, title, author, witnesses, earliest, latest, span, languages, libraries, pages_total, url, books_url }] }'),
+      },
+    },
+    '/libraries': {
+      get: {
+        summary: 'Contributing-library directory with book counts',
+        description:
+          'Resolves the `library=` filter values used by /search and /books/library into named institutions (display name, URL, per-library book count and languages).',
+        parameters: [q('include_unpartnered', 'false to return only catalogued partner institutions (default true)')],
+        responses: jsonResponse('{ total, libraries: [{ provider, name, url, book_count, languages, books_url, page_url? }] }'),
+      },
+    },
+    '/books/facets': {
+      get: {
+        summary: 'Faceted-tag vocabulary and books by facet (topics)',
+        description:
+          'The 6-facet Llullian vocabulary (tradition, domain, form, sphere, era, mode) behind /topics. `counts=true` returns the vocabulary plus per-value counts; otherwise returns paginated books matching the facet filters. Facets are AND-ed across facets, OR-ed within one. Global for ordinary callers; scoped automatically on a tenant subdomain.',
+        parameters: [
+          q('counts', 'true — return vocabulary + value counts instead of books'),
+          q('tradition', 'Comma-separated tradition tags (any-of), e.g. hermetic,alchemical'),
+          q('domain', 'Comma-separated domain tags'),
+          q('form', 'Comma-separated form tags'),
+          q('sphere', 'Comma-separated sphere tags'),
+          q('era', 'Comma-separated era tags'),
+          q('mode', 'Comma-separated mode tags'),
+          q('page', 'Page number (default 1)', { type: 'integer' }),
+          q('limit', 'Results per page (default 50, max 200)', { type: 'integer' }),
+        ],
+        responses: jsonResponse('{ total, activeFilters, counts?, vocabulary?, books?, page, limit, pages }'),
+      },
+    },
     '/books/{id}': {
       get: {
         summary: 'Book metadata, AI reading summary, chapters, editions, DOI',

--- a/src/app/api/works/route.ts
+++ b/src/app/api/works/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchWorksIndex, type WorkSummary } from '@/lib/works-index';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/works
+ *
+ * The works index: texts we hold in several editions across several centuries
+ * — the same set `/works` shows humans, via the same `fetchWorksIndex()`.
+ *
+ * Why this exists (#4509): `/api/books/library?work_id=` could always filter by
+ * a work, but nothing could LIST works, so an API consumer had no way to obtain
+ * a work_id except by fetching a book first. Same defect the author facet had.
+ *
+ * COST NOTE — read before changing. `fetchWorksIndex()` groups every visible
+ * book by work_id: 1.4–3.0s measured, and its own docstring says it is safe
+ * only because `/works` is ISR and never runs it per request
+ * (request-path-queries.md). This route therefore serves from a module-level
+ * cache with a long TTL, so the aggregation runs at most once per WORKS_TTL_MS
+ * regardless of traffic, plus CDN caching on top. Do not remove the cache to
+ * "simplify"; a per-request version of this query is exactly the shape that
+ * route invariant forbids.
+ *
+ * Query params:
+ *   sort   - span (default) | witnesses | earliest | title
+ *   limit  - max works to return (default all; the index is ~400 entries)
+ *   offset - pagination offset
+ */
+
+const WORKS_TTL_MS = 30 * 60_000;
+let worksCache: { data: WorkSummary[]; builtAt: number } | null = null;
+
+async function getWorks(): Promise<WorkSummary[]> {
+  const now = Date.now();
+  if (worksCache && now - worksCache.builtAt < WORKS_TTL_MS) return worksCache.data;
+  const data = await fetchWorksIndex();
+  worksCache = { data, builtAt: now };
+  return data;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl;
+    const sort = searchParams.get('sort') || 'span';
+    const limitRaw = parseInt(searchParams.get('limit') || '', 10);
+    const offset = Math.max(0, parseInt(searchParams.get('offset') || '0', 10) || 0);
+
+    const all = await getWorks();
+    const sorted = [...all];
+    switch (sort) {
+      case 'witnesses': sorted.sort((a, b) => b.witnesses - a.witnesses); break;
+      case 'earliest': sorted.sort((a, b) => a.earliest - b.earliest); break;
+      case 'title': sorted.sort((a, b) => a.title.localeCompare(b.title)); break;
+      case 'span':
+      default: sorted.sort((a, b) => b.span - a.span); break;
+    }
+
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 500) : sorted.length;
+    const page = sorted.slice(offset, offset + limit);
+
+    return NextResponse.json({
+      total: sorted.length,
+      offset,
+      limit,
+      works: page.map((w) => ({
+        work_id: w.workId,
+        slug: w.slug,
+        title: w.title,
+        author: w.author,
+        // How many editions/manuscripts of this text we hold, and the window
+        // they span — the two numbers the works page leads with.
+        witnesses: w.witnesses,
+        earliest: w.earliest,
+        latest: w.latest,
+        span: w.span,
+        languages: w.languages,
+        libraries: w.libraries,
+        pages_total: w.totalPages,
+        // Feed work_id straight back to /api/books/library?work_id= for the
+        // witness list, or open the human page.
+        url: `https://sourcelibrary.org/work/${w.slug}`,
+        books_url: `https://sourcelibrary.org/api/books/library?work_id=${encodeURIComponent(w.workId)}`,
+      })),
+    }, {
+      headers: { 'Cache-Control': 'public, max-age=1800, stale-while-revalidate=86400' },
+    });
+  } catch (error) {
+    console.error('Error in /api/works:', error);
+    return NextResponse.json({ error: 'Failed to list works' }, { status: 500 });
+  }
+}

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -564,6 +564,21 @@ source-library search "alchemy" --json | jq .results`}
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/works</td>
+                  <td className="py-2.5 text-secondary">Works held in many editions across centuries — witness counts and year spans. Feed work_id back to /books/library.</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/libraries</td>
+                  <td className="py-2.5 text-secondary">Contributing institutions with book counts — resolves the library= filter values into named libraries</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/books/facets</td>
+                  <td className="py-2.5 text-secondary">Topic vocabulary (tradition, domain, form, sphere, era, mode) and books by facet; ?counts=true for the vocabulary with counts</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/books/distributions</td>
                   <td className="py-2.5 text-secondary">Counts by language, category, collection, library, and decade — same filters as /books/library (no free-text search). Built for charts and timelines.</td>
                 </tr>


### PR DESCRIPTION
## What

Three entity types had public pages for humans and no way for an API consumer to enumerate them — the same "filter by an id you already have" pattern as the author gap.

**`GET /api/works`** — the works index (work_id, witnesses, earliest/latest/span, languages, libraries), the bootstrap that `?work_id=` always lacked. Wraps the existing `fetchWorksIndex()` behind a 30-minute module cache: that aggregation is 1.4–3.0s and **its own docstring warns it is safe only because `/works` is ISR and never runs it per request** (`request-path-queries.md`). A naive per-request wrapper is exactly the shape that invariant forbids.

**`GET /api/libraries`** — the contributing-institution directory, so the `library=` values that `/search` and `/books/library` accept resolve to named libraries with counts.

**`/api/books/facets` tenant scoping is now additive** — matching `/api/languages` and `/api/gallery`. It returned `{books:[],total:0}` to every caller without a tenant header: not a 4xx, a **silent empty**, so the 6-facet vocabulary behind `/topics` was undiscoverable via API even though `/topics` aggregates it publicly, anonymously, and globally for humans. Tenant behavior is untouched — only the no-tenant case changes, and it now sees the same global set the page does.

## Two things caught by testing rather than reading

- **The libraries join was silently broken in my first draft.** `LIBRARY_PARTNERS` is keyed by human slug (`internet-archive`, `bavarian-state-library`) while `image_source.provider` carries the wire value (`internet_archive`, `mdz`). A direct `LIBRARY_PARTNERS[provider]` lookup misses essentially every row and degrades to raw slugs — the endpoint would have looked correct and added nothing over `/books/distributions`. Fixed by using the purpose-built `getPartnerByProvider()`. Positive-controlled: **39/55 providers resolve to a named partner, covering 30,950/31,710 books (98%)**; the 16 unnamed are small tails (etcsl 373, slub_dresden 265, …) that honestly fall back to the slug.
- **The facets gate was hiding an order of magnitude**: 10,434 faceted-tagged live books globally vs 1,207 carrying a tenantId.

`npx tsc --noEmit` clean. Documented in the OpenAPI spec and on `/developers`.

Remaining in #4509 after this: artwork artist-filter parity, `place_published` as a filter, and the related-books rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc