### PR TITLE
Carry pages_translatable into the catalog, and clamp the stored percentages

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -89,6 +89,10 @@ function transformBook(book) {
     // catalog-fed /es card. Move the two together, always.
     pages_translated_es: book.pages_translated_es || 0,
     pages_blank: book.pages_blank || 0,
+    // The honest denominator (#4442). Null rather than 0 when absent, so the read-side
+    // helper can tell "not recounted yet" from "genuinely nothing translatable" — 0
+    // means a book of plates and must not be confused with a missing value.
+    pages_translatable: typeof book.pages_translatable === 'number' ? book.pages_translatable : null,
     is_first_translation: book.is_first_translation === true,
     // LISTING predicate: matches the canonical public-listing filter
     // (visible: true), so Mongo's unset-visible legacy books collapse to
@@ -148,13 +152,21 @@ function transformBook(book) {
     description: book.ai_metadata?.description || book.description || null,
     subject_keywords: Array.isArray(book.subject_keywords) ? book.subject_keywords : null,
     // Computed columns
+    // Mirrors src/lib/translation-completeness.ts — same denominator, same clamp.
+    // These are STORED, so an unclamped value here outlives the request that made it:
+    // the Blue Quran's 1000% and the 6,228 books once over 100 were read from columns
+    // like this one. Prefer pages_translatable; fall back to count - blank.
     translation_pct: (() => {
-      const denom = (book.pages_count || 0) - (book.pages_blank || 0);
-      return denom > 0 ? Math.round(((book.pages_translated || 0) / denom) * 100) : 0;
+      const denom = typeof book.pages_translatable === 'number'
+        ? book.pages_translatable
+        : (book.pages_count || 0) - (book.pages_blank || 0);
+      if (denom <= 0) return 0;
+      return Math.min(100, Math.round(((book.pages_translated || 0) / denom) * 100));
     })(),
     ocr_pct: (() => {
       const denom = (book.pages_count || 0) - (book.pages_blank || 0);
-      return denom > 0 ? Math.round(((book.pages_ocr || 0) / denom) * 100) : 0;
+      if (denom <= 0) return 0;
+      return Math.min(100, Math.round(((book.pages_ocr || 0) / denom) * 100));
     })(),
     pipeline_status: book.pipeline_auto?.status || null,
     needs_splitting: book.needs_splitting === true,
@@ -200,7 +212,7 @@ const projection = {
   id: 1, slug: 1, title: 1, display_title: 1, author: 1,
   thumbnail: 1, thumbnail_blob: 1, photo: 1, language: 1, year: 1, published: 1,
   read_count: 1, pages_blank: 1,
-  pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1,
+  pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_translated_es: 1, pages_translatable: 1,
   is_first_translation: 1, visible: 1, quality_score: 1,
   last_translation_at: 1, updated_at: 1, created_at: 1,
   categories: 1, collections: 1, collection_relevance: 1,


### PR DESCRIPTION
Completes the chain from #4442 — the honest number now actually reaches a reader.

The Mongo backfill gave every live book a `pages_translatable`, but **browse reads `books_catalog`**, which had no such column. The read helper was quietly falling back to `pages_count - pages_blank`, so the work stopped one hop short.

## Done here

- **`ALTER TABLE books_catalog ADD COLUMN pages_translatable integer`** — applied to production. Additive, nullable, reversible with `DROP COLUMN`.
- **`sync-books-catalog.mjs` carries the field** (and its projection asks for it). Written as **null** rather than 0 when absent, so the read side can distinguish "not recounted yet" from "genuinely nothing translatable" — `0` means a book of plates and must not be read as a missing value.
- **Its `translation_pct` was a sixth formula** for the same quantity — blank-adjusted denominator, **no clamp**. A *stored* percentage outlives the request that computed it, which is exactly how the Blue Qur'an's 1000% and the 6,228 books once over 100 were served to people. It now prefers `pages_translatable` and clamps, matching `src/lib/translation-completeness.ts`. `ocr_pct` clamped for the same reason.
- **Full re-sync run:** 47,468 rows.

## Verified against the live catalog

Paginated with `.range()` — a bare select caps at 1,000 and would have made every count below a statement about the cap rather than the corpus.

| | |
|---|---|
| `pages_translatable` populated | **31,716 of 31,716 live books (100%)** |
| `translation_pct` over 100 anywhere | **0** |
| complete, old measure | 3,244 — 10.2% |
| complete, honest measure | **14,984 — 47.2%** |

## What a reader sees

Browse now divides by what can actually be translated. **11,740 books that were finished and displaying as unfinished** stop understating themselves, and nothing can render above 100 — in the request path or from the stored column.

## Note on the DDL

I ran it directly against production Postgres via `secret-lover run` (the credential is `SUPABASE_DB_URL`, which isn't in `.env.production.local`). Positive control first: asserted the connection string was present and long enough before connecting, because secret-lover reports an unreadable secret as a *missing* one and lets the command run anyway. Then confirmed the column by reading `information_schema` back rather than trusting the statement's return.
