### PR TITLE
feat(api): artist filter for artwork search (#4509)

### DIFF
--- a/src/app/api/artwork/search/route.ts
+++ b/src/app/api/artwork/search/route.ts
@@ -183,8 +183,18 @@ export async function GET(request: NextRequest) {
     if (hasMore) docs.splice(limit);
 
     const items = docs.map(d => shapeArtworkRow(d));
+    // A REAL count on the browse lane, not the limit+1 probe this used to
+    // report. That probe answered "how many works by Goltzius?" with `3` when
+    // the answer is 685 — tolerable while the only browse was an infinite
+    // scroll, misleading now that `artist=` makes cardinality the natural
+    // question a caller asks (agent-tool-results.md: a top-k list cannot
+    // answer "how many"). The q-lane above stays an estimate by construction —
+    // it ranks, so its total is "matches we retrieved", not "matches that
+    // exist".
+    const total = await db.collection('books').countDocuments(filter, { maxTimeMS: 10000 });
+
     return NextResponse.json({
-      total: hasMore ? offset + items.length + 1 : offset + items.length,
+      total,
       showing: items.length,
       items,
     }, {

--- a/src/app/api/artwork/search/route.ts
+++ b/src/app/api/artwork/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { artistAuthorRegex } from '@/lib/artist-match';
 import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
 import { semanticArtworkSearch } from '@/lib/semantic-search';
 import { resolveTitle } from '@/lib/title-provenance';
@@ -26,6 +27,9 @@ const VISUAL_RESOURCE_TYPES = ['painting', 'drawing', 'print', 'fresco', 'engrav
  *   genre      — genre filter (e.g. "religious", "mythological") — passed to semanticArtworkSearch
  *   year_from  — published year >= (string-compared, since published is stored as string)
  *   year_to    — published year <=
+ *   artist     — artist slug ("albrecht-durer"), the API twin of
+ *                /artwork/artist/[slug]; resolved via the shared
+ *                artistAuthorRegex so both surfaces return the same set
  *   book_id    — return a specific artwork
  *   limit      — max results (default 20, max 50)
  *   offset     — pagination offset (default 0)
@@ -50,11 +54,23 @@ export async function GET(request: NextRequest) {
     const yearStart = searchParams.get('year_from') || searchParams.get('yearStart');
     const yearEnd = searchParams.get('year_to') || searchParams.get('yearEnd');
     const bookId = searchParams.get('book_id') || searchParams.get('bookId');
+    const artistSlug = (searchParams.get('artist') || '').trim();
     const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50);
     const offset = parseInt(searchParams.get('offset') || '0');
 
     const db = await getReadDb();
     const tenantScope = tenantId ? { tenantId } : {};
+
+    // `artist=<slug>` resolved ONCE, and applied in BOTH lanes below. A filter
+    // honoured only when the caller omits `q` is inert exactly where it is most
+    // likely to be used, while still reading as active
+    // (search-filters-and-lanes.md). A placeholder slug ("various",
+    // "anonymous") resolves to null: return empty rather than match everything.
+    const artistRegex = artistSlug ? artistAuthorRegex(artistSlug) : null;
+    if (artistSlug && !artistRegex) {
+      return NextResponse.json({ total: 0, showing: 0, items: [], artist: null });
+    }
+    const artistTest = artistRegex ? new RegExp(artistRegex.$regex, artistRegex.$options) : null;
 
     // ── Path A: book_id direct lookup ─────────────────────────────────
     if (bookId) {
@@ -106,6 +122,7 @@ export async function GET(request: NextRequest) {
       if (symbolFilter) merged = merged.filter(r => (r.symbols ?? []).some(s => matchesIgnoreCase(s, symbolFilter)));
       if (yearStart) merged = merged.filter(r => !r.published || r.published >= yearStart);
       if (yearEnd) merged = merged.filter(r => !r.published || r.published <= yearEnd);
+      if (artistTest) merged = merged.filter(r => artistTest.test(r.author ?? ''));
 
       // Fallback: if semantic returned nothing usable, do a regex fallback
       if (merged.length === 0) {
@@ -116,6 +133,7 @@ export async function GET(request: NextRequest) {
           resource_type: typeFilter
             ? typeFilter
             : { $in: VISUAL_RESOURCE_TYPES },
+          ...(artistRegex ? { author: artistRegex } : {}),
           $or: [
             { title: { $regex: pattern, $options: 'i' } },
             { display_title: { $regex: pattern, $options: 'i' } },
@@ -146,6 +164,7 @@ export async function GET(request: NextRequest) {
         ? typeFilter
         : { $in: VISUAL_RESOURCE_TYPES },
     };
+    if (artistRegex) filter.author = artistRegex;
     if (yearStart || yearEnd) {
       const yf: Record<string, string> = {};
       if (yearStart) yf.$gte = yearStart;

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
+import { artistAuthorRegex, artistTokens } from '@/lib/artist-match';
 
 // Must be a finite number — `false` would cache a bad-render fallback forever
 // (e.g. the noindex metadata below) until the next deploy.
@@ -15,12 +16,8 @@ interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
-// Names that should not generate artist pages
-const NON_ARTIST_NAMES = ['Various', 'Unknown', 'Anonymous', 'Splendor Solis'];
-
-function isNonArtist(name: string): boolean {
-  return NON_ARTIST_NAMES.some(n => name.toLowerCase().startsWith(n.toLowerCase()));
-}
+// isNonArtist + the author regex live in src/lib/artist-match.ts so the
+// `artist=` filter on /api/artwork/search resolves exactly this set (#4509).
 
 async function getArtist(slug: string) {
   const db = await getReadDb();
@@ -28,18 +25,10 @@ async function getArtist(slug: string) {
   // Slug can be "Leonardo-da-Vinci" (dashes) or "Leonardo%20da%20Vinci" (encoded)
   const artistName = decodeURIComponent(slug).replace(/-/g, ' ');
 
-  // Don't generate pages for non-artist names
-  if (isNonArtist(artistName)) return null;
-
-  // Link builders write author.replace(/\s+/g, '-'), which makes a slug dash
-  // ambiguous: it may stand for a space OR a real hyphen in the name
-  // ("Abbas Al-Musavi" → "Abbas-Al-Musavi"). Matching with every dash turned
-  // into a literal space could never resolve hyphenated names (404 log,
-  // 2026-08). Match each dash-or-space position as either character instead.
-  const tokens = decodeURIComponent(slug).split(/[-\s]+/).filter(Boolean)
-    .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  if (tokens.length === 0) return null;
-  const authorRegex = { $regex: `^${tokens.join('[-\\s]+')}$`, $options: 'i' };
+  // Placeholder-name rejection and the dash-or-space regex both live in
+  // artist-match.ts — see there for why a dash cannot be treated as a space.
+  const authorRegex = artistAuthorRegex(slug);
+  if (!authorRegex) return null;
 
   // Fetch artworks and books by this author in parallel
   const [artworks, books] = await Promise.all([
@@ -69,7 +58,7 @@ async function getArtist(slug: string) {
   // Also check reversed name format for books (e.g. "Dürer, Albrecht")
   let allBooks = books;
   if (books.length === 0 && !artistName.includes(',')) {
-    const parts = tokens;
+    const parts = artistTokens(slug);
     if (parts.length >= 2) {
       // Same dash-or-space matching as above, with the surname moved in front.
       const reversedPattern = `^${parts[parts.length - 1]},[-\\s]+${parts.slice(0, -1).join('[-\\s]+')}$`;

--- a/src/lib/artist-match.ts
+++ b/src/lib/artist-match.ts
@@ -1,0 +1,48 @@
+/**
+ * Artist-slug matching — shared by `/artwork/artist/[slug]` and the
+ * `artist=` filter on `/api/artwork/search` (#4509).
+ *
+ * Extracted so the page and the API cannot drift: an API filter that resolved
+ * a different set than the page it mirrors would be worse than no filter,
+ * because both look authoritative.
+ */
+
+/** Names that are cataloguing placeholders, not people. */
+const NON_ARTIST_NAMES = ['Various', 'Unknown', 'Anonymous', 'Splendor Solis'];
+
+export function isNonArtist(name: string): boolean {
+  return NON_ARTIST_NAMES.some(n => name.toLowerCase().startsWith(n.toLowerCase()));
+}
+
+/**
+ * Build the `books.author` match for an artist slug.
+ *
+ * Link builders write `author.replace(/\s+/g, '-')`, which makes a slug dash
+ * AMBIGUOUS: it may stand for a space or for a real hyphen in the name
+ * ("Abbas Al-Musavi" → "Abbas-Al-Musavi"). Turning every dash into a literal
+ * space could never resolve hyphenated names — a real 404 class, logged
+ * 2026-08. So each dash-or-space position matches either character.
+ *
+ * Returns null for a slug that resolves to nothing worth a page (empty, or a
+ * placeholder like "Various").
+ */
+export function artistAuthorRegex(slug: string): { $regex: string; $options: string } | null {
+  const decoded = decodeURIComponent(slug);
+  if (isNonArtist(decoded.replace(/-/g, ' '))) return null;
+  const tokens = artistTokens(slug);
+  if (tokens.length === 0) return null;
+  return { $regex: `^${tokens.join('[-\\s]+')}$`, $options: 'i' };
+}
+
+/**
+ * The regex-escaped name tokens behind `artistAuthorRegex`. Exported because
+ * `/artwork/artist/[slug]` also builds a REVERSED-name pattern from them
+ * ("Albrecht Dürer" → "Dürer, Albrecht") when the forward form finds no books;
+ * both callers must split identically or the two lookups disagree.
+ */
+export function artistTokens(slug: string): string[] {
+  return decodeURIComponent(slug)
+    .split(/[-\s]+/)
+    .filter(Boolean)
+    .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+}


### PR DESCRIPTION
## What

Books got `author_id` in #4496; artwork never got the equivalent. `/artwork/artist/[slug]` answers "everything by this artist" for humans, but the API had only a free-text regex buried inside `q` — so the question was unanswerable for a consumer.

Adds **`?artist=<slug>`** to `/api/artwork/search`, resolved through a new `src/lib/artist-match.ts` **extracted from the page**, so the API and the page cannot return different sets. An API filter that resolved a *different* set than the page it mirrors would be worse than no filter — both look authoritative.

The extraction preserves the page's hard-won subtlety, now stated once instead of inline: a slug dash is **ambiguous** — it may stand for a space or for a real hyphen (`Abbas Al-Musavi` → `Abbas-Al-Musavi`) — so each dash-or-space position matches either character. Treating dashes as spaces was a logged 404 class. `artistTokens()` is exported alongside because the page also builds a reversed-name pattern (`Dürer, Albrecht`) from the same split.

Applied in **both lanes** — the semantic `q` path and the browse path. A filter honoured only when the caller omits `q` is inert exactly where it's most likely to be used (`search-filters-and-lanes.md`). Placeholder slugs (`various`, `unknown`, `anonymous`) resolve to null and return an empty page rather than matching everything.

## Verification

Slugs round-trip exactly against production — the regex count equals the grouped count for every top artist:

| artist | artworks | via slug |
|---|---|---|
| Raphael | 1,013 | 1,013 |
| Hendrick Goltzius | 685 | 685 |
| William Blake | 587 | 587 |
| Aegidius Sadeler | 356 | 356 |
| Max Klinger | 248 | 248 |
| `Rops, Félicien (1833-1898). Graveur` | 238 | 238 |

`Various` (495) and `Unknown artist` (317) correctly rejected as placeholders; a genuinely hyphenated name still matches. `npx tsc --noEmit` clean — and it earned its keep here, catching that the extraction had orphaned the `tokens` binding the reversed-name fallback depends on.

Closes the last code-level item in #4509 (remaining there: `place_published` as a filter, and the related-books rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc