### PR TITLE
The translatable denominator must include pages awaiting OCR

### DIFF
--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -89,12 +89,19 @@ export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'd
  * "49.9%" was an unrestricted 800-book sample — sound method, just superseded by the
  * exact count. A sample frame chosen for one question is rarely valid for the next.
  *
- * A page qualifies only if it has OCR to translate from, is not a never-translated
- * type, and has not been permanently refused by the model.
+ * A page qualifies unless it is a never-translated type or the model has permanently
+ * refused it.
+ *
+ * CRUCIALLY, a page with no OCR yet still counts. "Not yet OCR'd" is PENDING work, not
+ * IMPOSSIBLE work, and excluding it is how a book gets badged finished while half of it
+ * is blank. The first version of this did exactly that: Theatrum Chemicum vol. 6 —
+ * 4,198 pages, only 2,003 OCR'd — displayed 100% translated with 2,195 pages carrying
+ * no text at all, and 1,701 books (11.4% of everything badged complete) had more than
+ * a fifth of the book un-OCR'd. Overstating completeness is a worse failure than the
+ * understatement this field exists to fix, because a reader can see it.
  */
 export function isTranslatablePageForCount(page) {
   if (!isVisiblePage(page)) return false;
-  if (!hasOcr(page)) return false;
   if (NEVER_TRANSLATED_PAGE_TYPES.includes(page?.page_type ?? '')) return false;
   if (page?.translation?.recitation_blocked === true) return false;
   if (page?.translation?.safety_blocked === true) return false;
@@ -105,9 +112,8 @@ export function isTranslatablePageForCount(page) {
 /** Mongo twin of isTranslatablePageForCount(), shared by the denominator and its numerator. */
 const TRANSLATABLE_COND = {
   $and: [
-    { $ne: ['$ocr.data', null] },
-    { $ne: ['$ocr.data', ''] },
-    { $ifNull: ['$ocr.data', false] },
+    // No `ocr.data` requirement — see isTranslatablePageForCount. A page awaiting OCR
+    // is pending work and belongs in the denominator.
     { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, NEVER_TRANSLATED_PAGE_TYPES] }] },
     { $ne: ['$translation.recitation_blocked', true] },
     { $ne: ['$translation.safety_blocked', true] },

--- a/src/lib/page-counts.ts
+++ b/src/lib/page-counts.ts
@@ -21,9 +21,9 @@ export const NEVER_TRANSLATED_PAGE_TYPES = ['blank', 'exlibris', 'bookplate', 'd
 /** Shared by the `translatable` denominator and its numerator, so they cannot drift. */
 const TRANSLATABLE_COND = {
   $and: [
-    { $ne: ['$ocr.data', null] },
-    { $ne: ['$ocr.data', ''] },
-    { $ifNull: ['$ocr.data', false] },
+    // No `ocr.data` requirement: a page awaiting OCR is PENDING work, not impossible
+    // work, and excluding it badges half-OCR'd books as 100% translated. Mirror of the
+    // .mjs rule — keep the two in step.
     { $not: [{ $in: [{ $ifNull: ['$page_type', ''] }, NEVER_TRANSLATED_PAGE_TYPES] }] },
     { $ne: ['$translation.recitation_blocked', true] },
     { $ne: ['$translation.safety_blocked', true] },

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -99,7 +99,9 @@ describe('page-counts convention (#3293)', () => {
     (pages[5] as Record<string, unknown>).ocr = { data: 'f', recitation_blocked: true };
 
     const stats = countVisiblePageStats(pages);
-    expect(stats.translatable).toBe(2); // pages 1 and 4 only
+    // Pages 1, 4 and 5. Page 5 has NO OCR and still counts: not-yet-OCR'd is pending
+    // work, not impossible work. Excluding it badged half-OCR'd books as 100%.
+    expect(stats.translatable).toBe(3);
     expect(stats.translated_translatable).toBe(1); // page 1
     // The ratio can never exceed 1 — the property the old numerator violated.
     expect(stats.translated_translatable).toBeLessThanOrEqual(stats.translatable);
@@ -195,5 +197,23 @@ describe('blank pages are excluded from pages_translated', () => {
     // translation_pct divides by (pages_ocr - pages_blank) = 60 - 54 = 6.
     const denominator = stats.with_ocr - 54;
     expect((stats.with_translation / denominator) * 100).toBe(100); // was 1000
+  });
+
+  it('a half-OCR\'d book does not read as complete (Theatrum Chemicum regression)', () => {
+    // Real shape: 4,198 visible pages, only 2,003 with OCR, 1,985 translated. The first
+    // version of the denominator excluded un-OCR'd pages, so this book displayed
+    // **100% translated** with 2,195 pages carrying no text at all. 1,701 books were
+    // in that state. The denominator must count pages that WILL be translatable.
+    const pages = [];
+    for (let n = 1; n <= 1985; n++) pages.push({ page_number: n, ocr: { data: 'o' }, translation: { data: 't' } });
+    for (let n = 1986; n <= 2003; n++) pages.push({ page_number: n, ocr: { data: 'o' }, page_type: 'blank', translation: { data: '[Blank page]' } });
+    for (let n = 2004; n <= 4198; n++) pages.push({ page_number: n }); // awaiting OCR
+
+    const stats = countVisiblePageStats(pages);
+    expect(stats.total).toBe(4198);
+    expect(stats.translatable).toBe(4180); // everything except the 18 blank leaves
+    expect(stats.translated_translatable).toBe(1985);
+    const pct = Math.round((100 * stats.translated_translatable) / stats.translatable);
+    expect(pct).toBe(47); // honest, and nowhere near 100
   });
 });


### PR DESCRIPTION
**I shipped this wrong and a spot check caught it.** Correcting before it sits in production any longer.

## The defect

`isTranslatablePageForCount` required a page to already have OCR. That conflates two different things:

- a page that will **never** be translatable — blank leaf, bookplate, ex-libris
- a page that is simply **not OCR'd yet**

The second is *pending* work and belongs in the denominator. Excluding it means a book that is only half transcribed reads as fully translated.

## What it did to real books

| Theatrum Chemicum vol. 6 | |
|---|---|
| visible pages | 4,198 |
| with OCR | 2,003 |
| translated | 1,985 |
| **displayed** | **100% translated** |
| pages carrying no text at all | **2,195** |

And it wasn't one book: **1,701 books — 11.4% of everything badged complete — had more than a fifth of the book un-OCR'd** and were badged the same way.

Overstating completeness is a **worse** failure than the understatement this field exists to fix, because a reader can *see* it. Someone opening a book badged 100% and paging into blanks is entitled to conclude the number is a lie.

## The fix

Drop the OCR requirement from the JS predicate and its Mongo twin. Blanks, ex-libris, bookplates, digitizer notices and model-refused pages stay excluded — those genuinely never become translatable.

## Corpus effect

Random sample of 300 live books:

| | |
|---|---|
| complete, naive | 11.0% |
| complete, **corrected** honest denominator | **34.7%** (was 47.2% under the flawed rule) |
| of the complete ones, >20% un-OCR'd | **0** (was 11.4%) |

So the honest figure is **~35%, not 47%**.

That is the **fourth** revision of this number — 41% → 49.9% → 47.2% → ~35% — and every revision came from specifying the denominator more carefully rather than from new data. Worth stating plainly: the difficulty here was never measurement, it was deciding what counts.

## Tests

The case asserting `translatable === 2` encoded the rule being changed and now asserts 3. Added a regression test built to the **real** Theatrum Chemicum shape — 1,985 translated, 18 blank, 2,195 awaiting OCR — asserting it reads **47%, not 100%**.

23/23 unit tests pass, `tsc` clean.

## Follow-through in this session

Stored values in Mongo and Supabase are currently wrong in the misleading direction. Re-backfill and re-sync immediately after this merges.
