### PR TITLE
Make the mobile sheet closable, and give its header room to breathe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -446,7 +446,11 @@ body:has([data-reader-v2]) {
   from { transform: translateY(14px); opacity: 0; }
   to   { transform: none; opacity: 1; }
 }
-.rv2-slide-up { animation: rv2-slide-up 0.22s ease-out both; }
+/* `backwards`, not `both`, for the same reason as the turn animations below:
+   a filled-forwards animation keeps applying transform:none afterwards, and an
+   animated property beats an inline style — the pull-to-dismiss would track
+   the finger in JS while the sheet sat perfectly still. */
+.rv2-slide-up { animation: rv2-slide-up 0.22s ease-out backwards; }
 /* The page strip slides in by its own height, so the travel reads the same on
    a 92px desktop strip and a 96px phone one. Short on purpose. */
 @keyframes rv2-strip-in {
@@ -485,6 +489,18 @@ body:has([data-reader-v2]) {
    transform would be silently ignored for the rest of the session — the swipe
    would stop moving anything under the finger after the first page turn. The
    end state here is the natural state, so there is nothing to hold. */
+/* Ground behind the mobile sheet. Dark enough to lift the sheet off the page
+   and to say "tap anywhere to get out of this", light enough that the reading
+   underneath is still legibly there. */
+@keyframes rv2-scrim-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.rv2-scrim {
+  background: rgba(30, 20, 8, 0.28);
+  animation: rv2-scrim-in 180ms ease-out both;
+}
+
 .rv2-turn-next { animation: rv2-turn-next 190ms ease-out backwards; }
 .rv2-turn-prev { animation: rv2-turn-prev 190ms ease-out backwards; }
 
@@ -520,7 +536,7 @@ body:has([data-reader-v2]) {
 @media (prefers-reduced-motion: reduce) {
   .rv2-slide-in-left, .rv2-pop, .rv2-slide-up, .rv2-strip-in,
   .rv2-page-in, .rv2-panel-body-in, .rv2-tile-in,
-  .rv2-turn-next, .rv2-turn-prev,
+  .rv2-turn-next, .rv2-turn-prev, .rv2-scrim,
   .rv2-menu-ground, .rv2-menu-item { animation: none; }
 }
 

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -67,6 +67,8 @@ const STRIP_KEY = 'sl-reader-v2c-strip';
 const MOBILE_TOOLBAR_H = 52;
 /** Breathing room kept above a mobile sheet, so it never meets the top edge. */
 const SHEET_TOP_GAP = 24;
+/** How far the sheet has to be pulled down before letting go puts it away. */
+const SHEET_DISMISS_PULL = 90;
 /** Drawer header tint — a shade deeper than the panel, so content passes under it. */
 const PANEL_HEADER_BG = 'color-mix(in srgb, var(--bg-warm) 92%, var(--bg-dark) 5%)';
 /** Mobile sheets that always take the full height — lists and conversations. */
@@ -2656,7 +2658,49 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
    * with no height of its own snaps between sizes, so measure what the content
    * wants — the header plus its scroller's full content — and animate to it.
    */
+  const sheetOpen = !!leftPanel && !isDesktop;
   const sheetRef = useRef<HTMLDivElement>(null);
+  /**
+   * Pull the sheet down to put it away. It opened with one way out: a 16px
+   * glyph tucked under the site header, at the far end of a panel you had just
+   * scrolled to the bottom of. A sheet you can push away with the thumb that
+   * opened it is the whole point of a sheet.
+   */
+  const sheetDrag = useRef<{ y: number; dy: number } | null>(null);
+  const onSheetDragStart = (e: React.TouchEvent) => {
+    if (e.touches.length !== 1) { sheetDrag.current = null; return; }
+    sheetDrag.current = { y: e.touches[0].clientY, dy: 0 };
+    const el = sheetRef.current;
+    if (el) el.style.transition = 'none';
+  };
+  const onSheetDragMove = (e: React.TouchEvent) => {
+    const s = sheetDrag.current;
+    const el = sheetRef.current;
+    if (!s || !el || e.touches.length !== 1) return;
+    // Downward only: dragging up would tear the sheet off its own bottom edge.
+    s.dy = Math.max(0, e.touches[0].clientY - s.y);
+    el.style.transform = `translateY(${s.dy}px)`;
+  };
+  const onSheetDragEnd = () => {
+    const s = sheetDrag.current;
+    const el = sheetRef.current;
+    sheetDrag.current = null;
+    if (!s || !el) return;
+    el.style.transition = 'transform 200ms ease-out';
+    if (s.dy > SHEET_DISMISS_PULL) {
+      el.style.transform = `translateY(${el.offsetHeight}px)`;
+      window.setTimeout(() => setLeftPanel(null), 170);
+    } else {
+      el.style.transform = '';
+    }
+  };
+  // A sheet that closed mid-pull would open again already pushed down.
+  useEffect(() => {
+    const el = sheetRef.current;
+    if (!el) return;
+    el.style.transition = '';
+    el.style.transform = '';
+  }, [leftPanel]);
   const [sheetHeight, setSheetHeight] = useState<number | null>(null);
   useLayoutEffect(() => {
     if (!leftPanel || isDesktop) { setSheetHeight(null); return; }
@@ -3603,11 +3647,17 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
             height: BAR_H,
             background: INK,
             color: '#fdfcf9',
-            transform: barHidden ? 'translateY(-100%)' : 'none',
+            // Also away while a sheet is open. The sheet is a modal with its
+            // own title and its own way out, and it is tall enough to reach
+            // the top of the screen — where it slid UNDER this bar, taking the
+            // grab handle with it and clipping the close button into a flat
+            // white square. Nothing to collide with, and the sheet gets the
+            // height back.
+            transform: barHidden || sheetOpen ? 'translateY(-100%)' : 'none',
             // Same reason as the filmstrips: a bar off the top of the screen
             // still held a focusable back-link and menu button, and aria-hidden
             // over them made that worse rather than better.
-            visibility: barHidden ? 'hidden' : 'visible',
+            visibility: barHidden || sheetOpen ? 'hidden' : 'visible',
             // visibility is in the transition on purpose. It is a discrete
             // property, so transitioning it holds the old value for the whole
             // duration instead of applying at once — without that the contents
@@ -3883,6 +3933,18 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
             the keyboard is up it sits directly on the keyboard instead (the
             toolbar and strip are behind it), so the field being typed in and
             its results stay on screen. */}
+        {/* Something to tap that is not a 16px glyph. The sheet had no ground
+            behind it, so the only way out was the corner button — with a panel
+            of content between your thumb and it. */}
+        {leftPanel && !isDesktop && (
+          <button
+            type="button"
+            aria-label={t.panels.closeAria(leftPanelTitle)}
+            onClick={() => setLeftPanel(null)}
+            className="fixed left-0 right-0 top-0 z-40 rv2-scrim"
+            style={{ bottom: keyboardInset > 0 ? keyboardInset : MOBILE_TOOLBAR_H }}
+          />
+        )}
         {leftPanel && !isDesktop && (
           <div
             ref={sheetRef}
@@ -3903,29 +3965,60 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
             role="dialog"
             aria-labelledby="rv2-sheet-title"
           >
-            <div className="shrink-0 px-4 pt-3 pb-2.5 border-b" style={{ borderColor: 'var(--border-light)', background: PANEL_HEADER_BG }}>
+            {/* The header is also the grip: the handle says the sheet can be
+                pushed away, and the whole band answers the drag, so the pull
+                works wherever the thumb lands rather than on a 4px bar. */}
+            <div
+              className="shrink-0 px-4 pb-2.5 border-b select-none"
+              style={{ borderColor: 'var(--border-light)', background: PANEL_HEADER_BG, touchAction: 'none' }}
+              onTouchStart={onSheetDragStart}
+              onTouchMove={onSheetDragMove}
+              onTouchEnd={onSheetDragEnd}
+              onTouchCancel={onSheetDragEnd}
+            >
+              {/* Square, like everything else here: globals.css flattens every
+                  rounded-* utility site-wide with !important, so a pill grip or
+                  a round close button silently becomes a block. */}
+              <div className="flex justify-center pt-2.5 pb-2">
+                <span
+                  aria-hidden="true"
+                  className="block"
+                  style={{ width: 40, height: 4, background: 'color-mix(in srgb, var(--bg-dark) 22%, transparent)' }}
+                />
+              </div>
               {/* One fixed row: back (when there is somewhere to go back to),
                   title, close. Close holds the top-right corner whatever else
                   is in the row — it used to shift down whenever a back button
                   appeared above it. */}
-              <div className="flex items-center gap-1.5 min-h-[28px]">
+              <div className="flex items-center gap-2 min-h-[44px]">
                 {MORE_TOOLS.some(k => k === leftPanel) && (
                   <button
                     type="button"
                     aria-label={t.panels.backToMore}
                     onClick={() => setLeftPanel('more')}
-                    className="w-11 h-11 -ml-3 shrink-0 flex items-center justify-center transition-colors active:bg-[var(--bg-white)]"
-                    style={{ color: 'var(--text-muted)' }}
+                    className="w-11 h-11 shrink-0 -ml-1.5 flex items-center justify-center transition-colors active:bg-[var(--bg-white)]"
+                    style={{ color: 'var(--text-secondary)' }}
                   >
-                    <ChevronLeft size={17} />
+                    <ChevronLeft size={20} />
                   </button>
                 )}
-                <CapsLabel as="h2" id="rv2-sheet-title" className="flex-1 min-w-0 truncate" style={{ color: 'var(--text-muted)' }}>{leftPanelTitle}</CapsLabel>
-                <button type="button" aria-label={t.panels.closeAria(leftPanelTitle)} onClick={() => setLeftPanel(null)}
-                  className="w-11 h-11 -mr-3 shrink-0 flex items-center justify-center text-[var(--text-muted)]"><X size={16} /></button>
+                <CapsLabel as="h2" id="rv2-sheet-title" className="flex-1 min-w-0 truncate !text-[12px] tracking-[0.13em]" style={{ color: 'var(--text-primary)' }}>{leftPanelTitle}</CapsLabel>
+                {/* 20px in a 44px target, on the header's own ground. A 16px
+                    cross on a bare band read as decoration rather than the way
+                    out — and it is no longer the only way out: the ground
+                    behind the sheet and a pull on this bar both close it. */}
+                <button
+                  type="button"
+                  aria-label={t.panels.closeAria(leftPanelTitle)}
+                  onClick={() => setLeftPanel(null)}
+                  className="w-11 h-11 shrink-0 -mr-1.5 flex items-center justify-center transition-colors active:bg-[var(--bg-white)]"
+                  style={{ color: 'var(--text-secondary)' }}
+                >
+                  <X size={20} />
+                </button>
               </div>
               {leftPanelBlurb && (
-                <p className="mt-1 font-sans text-[11.5px] leading-snug" style={{ color: 'var(--text-faint)' }}>
+                <p className="mt-0.5 pr-10 pb-1 font-sans text-[12.5px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
                   {leftPanelBlurb}
                 </p>
               )}

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -2659,6 +2659,14 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
    * wants — the header plus its scroller's full content — and animate to it.
    */
   const sheetOpen = !!leftPanel && !isDesktop;
+  /**
+   * Whether the sheet's list runs on past its bottom edge. On a 568px phone
+   * ten grouped items do not fit, and the list happened to cut cleanly at a
+   * hairline divider — which reads as the end of the menu rather than as more
+   * to come, so Reading settings and Send feedback looked like they did not
+   * exist. A fade over the last few pixels says the list continues.
+   */
+  const [sheetHasMore, setSheetHasMore] = useState(false);
   const sheetRef = useRef<HTMLDivElement>(null);
   /**
    * Pull the sheet down to put it away. It opened with one way out: a 16px
@@ -2701,6 +2709,23 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     el.style.transition = '';
     el.style.transform = '';
   }, [leftPanel]);
+
+  // The scroller belongs to whichever panel is mounted, so find it rather than
+  // holding a ref to it, and watch the content too: panels fetch.
+  useEffect(() => {
+    const sheet = sheetRef.current;
+    if (!sheet || !leftPanel) { setSheetHasMore(false); return; }
+    const body = sheet.querySelector<HTMLElement>('[class*="overflow-y-auto"]');
+    if (!body) { setSheetHasMore(false); return; }
+    const measure = () => setSheetHasMore(body.scrollHeight - body.scrollTop - body.clientHeight > 8);
+    measure();
+    body.addEventListener('scroll', measure, { passive: true });
+    const ro = new ResizeObserver(measure);
+    ro.observe(body);
+    for (const child of Array.from(body.children)) ro.observe(child);
+    return () => { body.removeEventListener('scroll', measure); ro.disconnect(); };
+    // The observer covers the sheet being resized, so its height is not a dep.
+  }, [leftPanel]);
   const [sheetHeight, setSheetHeight] = useState<number | null>(null);
   useLayoutEffect(() => {
     if (!leftPanel || isDesktop) { setSheetHeight(null); return; }
@@ -2720,8 +2745,12 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
     if (!sheet) return;
     const measure = () => {
       const header = sheet.firstElementChild as HTMLElement | null;
-      const body = sheet.lastElementChild as HTMLElement | null;
-      if (!header || !body) return;
+      // Skip the fade overlay: it is a later sibling of the panel and 36px
+      // tall, and measured as the body it sized the whole sheet to 113px.
+      const body = Array.from(sheet.children)
+        .filter((c): c is HTMLElement => c instanceof HTMLElement && c.dataset.sheetFade === undefined)
+        .pop() ?? null;
+      if (!header || !body || body === header) return;
       setSheetHeight(Math.min(cap, Math.ceil(header.offsetHeight + body.scrollHeight)));
     };
     measure();
@@ -4024,6 +4053,19 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
               )}
             </div>
             <PanelContent panel={leftPanel} {...panelProps} />
+            {/* Over the foot of the sheet, not inside the scroller: a mask on
+                the scroller itself would fade the last row at the end of the
+                list too, which is exactly when there is nothing left to say. */}
+            <div
+              aria-hidden="true"
+              data-sheet-fade=""
+              className="pointer-events-none absolute left-0 right-0 bottom-0 transition-opacity duration-200"
+              style={{
+                height: 36,
+                opacity: sheetHasMore ? 1 : 0,
+                background: `linear-gradient(to top, ${SURFACE.panel}, transparent)`,
+              }}
+            />
           </div>
         )}
 


### PR DESCRIPTION
Reported from a phone: the More panel's header and cross look ugly and badly spaced, and the Edition & page info panel is cramped and hard to get out of.

## What was wrong

The sheet opened tall enough to slide **under** the reader's floating title bar, which cut the top off its own header. That is why the close button read as a white block wedged in the corner — it was a circle with its top clipped. It also meant the header had no room, so the title and the cross sat at the extreme edges with dead space between them.

And there was exactly one way out: a 16px cross in the top-right, at the far end of a panel you had just scrolled to the bottom of.

## What it does now

Three ways out: a ground behind the sheet that closes it wherever you tap, a pull down on the header (which is also the grip), and the cross — now 20px in a 44px target, on the header's own ground rather than a white patch.

The title bar steps aside while a sheet is open. Nothing to collide with, and the sheet gets that height back.

The grip and buttons are square on purpose. `globals.css` flattens every `rounded-*` utility site-wide with `!important` ("Square corners site-wide"), so a pill handle or a round button silently becomes a block — which is what produced the shape being complained about. This works with that rule rather than against it.

## One bug this depended on

`rv2-slide-up` was declared `animation-fill-mode: both`. A filled-forwards animation keeps applying its end value afterwards, and an animated property beats an inline style — so the pull-to-dismiss tracked the finger in JS while the sheet sat perfectly still. `backwards` instead, the same fix the turn animations needed in #4437. Worth watching for: every `rv2-*` animation in this file that a gesture also has to move.

## Measured at 393x750 (iPhone-sized)

- header 77px, close button 44x44, 12px in from the screen edge
- all 10 More rows in view
- tapping the ground closes it
- a 144px pull moves the sheet 144px and lets go into a dismiss
- the title bar no longer overlaps the sheet at any height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eHbLV1PYU8qo9f5T4RZKA