### PR TITLE
feat(api): serve only our own images, lift the gallery cap, expose vectors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -161,7 +161,7 @@ const nextConfig: NextConfig = {
       // POST is for /api/mcp (JSON-RPC); the Mcp-* headers are its session
       // protocol, exposed so browser MCP clients can read the session id.
       {
-        source: '/api/:root(search|books|gallery|collections|catalog|verify|mcp|image|locus|ngrams|openapi|dataset)/:path*',
+        source: '/api/:root(search|books|gallery|collections|catalog|verify|mcp|image|locus|ngrams|openapi|dataset|works|libraries|vectors)/:path*',
         headers: [
           { key: 'Access-Control-Allow-Origin', value: '*' },
           { key: 'Access-Control-Allow-Methods', value: 'GET, POST, OPTIONS' },

--- a/scripts/audit/public-api-contract.sh
+++ b/scripts/audit/public-api-contract.sh
@@ -8,8 +8,14 @@
 # collection counts. Each case pins a behaviour we broke or nearly broke once.
 #
 # Usage:
-#   scripts/audit/public-api-contract.sh                     # prod
-#   BASE=https://<preview>.vercel.app scripts/audit/public-api-contract.sh
+#   scripts/audit/public-api-contract.sh                     # prod (intended)
+#   BASE=https://<preview>.vercel.app AUTH=$CRON_SECRET ...  # preview, partial
+#
+# PROD IS THE REAL TARGET, because the contract being tested IS the anonymous
+# experience. A preview gates anonymous book content (403), so content cases
+# come back empty there even with AUTH — several are written as standalone
+# python that does not carry the header. Use a preview run to smoke the
+# NON-content cases (CORS, openapi, off-infra hosts) and prod for the rest.
 #
 # Exits non-zero with the number of failures, so it works as a smoke gate.
 #
@@ -29,6 +35,12 @@
 #     tenant-lockdown leak).
 UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 BASE="${BASE:-https://sourcelibrary.org}"
+# Preview deployments gate anonymous book content (403), so every content case
+# comes back EMPTY there — indistinguishable from throttling. Pass a bearer to
+# smoke a preview:
+#   BASE=https://<preview>.vercel.app AUTH=$CRON_SECRET scripts/audit/public-api-contract.sh
+AUTH_HEADER=()
+[[ -n "$AUTH" ]] && AUTH_HEADER=(-H "Authorization: Bearer $AUTH")
 CB="cb=$(date +%s)"
 pass=0; fail=0
 t() { # t <name> <cmd-that-prints-1-for-ok>
@@ -38,8 +50,8 @@ t() { # t <name> <cmd-that-prints-1-for-ok>
   else echo "FAIL  $name (got: $out)"; fail=$((fail+1)); fi
 }
 
-j() { curl -s --max-time 40 -A "$UA" "$1" | python3 -c "$2" 2>/dev/null; }
-hdr() { curl -s -D - -o /dev/null --max-time 30 -A "$UA" "${@:2}" "$1"; }
+j() { curl -s --max-time 60 -A "$UA" "${AUTH_HEADER[@]}" "$1" | python3 -c "$2" 2>/dev/null; }
+hdr() { curl -s -D - -o /dev/null --max-time 30 -A "$UA" "${AUTH_HEADER[@]}" "${@:2}" "$1"; }
 
 # 1. author filter: canonical slug
 t "library author_id canonical (113 Böhme)" \
@@ -182,6 +194,37 @@ print(1 if d['items'] and a=={'Hendrick Goltzius'} else a)"
 t "artwork placeholder artist rejected" \
   j "$BASE/api/artwork/search?artist=Various&$CB" \
   "import json,sys; d=json.load(sys.stdin); print(1 if d['total']==0 else d['total'])"
+
+# 22-24. No public endpoint may hand back an IMAGE URL on someone else's
+# server. We hold a copy of every page and 99% of artwork images, so a
+# third-party image host in a response is a fan-out onto a partner library —
+# how an external consumer ended up refusing to harvest at all. Landing pages
+# (current_location, attribution.item_url, DOIs) are CREDIT and stay: the test
+# looks only for image-shaped URLs.
+img_hosts_off_infra() {
+  curl -s --max-time 90 -A "$UA" "${AUTH_HEADER[@]}" "$1" | python3 -c "
+import sys,re,collections
+raw=sys.stdin.read()
+imgs =re.findall(r'https?://([a-zA-Z0-9.\-]+)[^\"]*?\.(?:jpg|jpeg|png|tif|jp2)(?:\?|\")', raw, re.I)
+imgs+=re.findall(r'https?://([a-zA-Z0-9.\-]+)[^\"]*?/(?:iiif|full)/', raw, re.I)
+off=sorted({h for h in imgs if 'sourcelibrary.org' not in h})
+print(1 if not off else off[:4])
+"
+}
+t "book pages: no off-infra image hosts" \
+  img_hosts_off_infra "$BASE/api/books/history-of-both-worlds-macrocosm-fludd?$CB"
+t "gallery: no off-infra image hosts" \
+  img_hosts_off_infra "$BASE/api/gallery?limit=25&$CB"
+
+# 25. minQuality must actually move the number — it was silently clamped to the
+# browse floor, so an explicit request returned the default set.
+t "gallery minQuality is honoured" \
+  sh -c "curl -s --max-time 90 -A '$UA' '$BASE/api/gallery?limit=2&minQuality=0.7' | python3 -c \"
+import json,sys; a=json.load(sys.stdin)['total']
+import urllib.request
+r=urllib.request.Request('$BASE/api/gallery?limit=2', headers={'User-Agent':'$UA'})
+b=json.load(urllib.request.urlopen(r,timeout=90))['total']
+print(1 if a > b else (a,b))\""
 
 echo; echo "== $pass passed, $fail failed"
 exit $fail

--- a/src/app/api/artwork/search/route.ts
+++ b/src/app/api/artwork/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { artistAuthorRegex } from '@/lib/artist-match';
+import { isOwnInfraUrl } from '@/lib/public-image-fields';
 import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
 import { semanticArtworkSearch } from '@/lib/semantic-search';
 import { resolveTitle } from '@/lib/title-provenance';
@@ -269,10 +270,17 @@ function shapeArtworkRow(
   const title = resolvedTitle.display;
   const description = semantic?.summary_text
     || (typeof doc.summary === 'string' ? (doc.summary as string) : null);
-  const thumbnail = (doc.image_thumb as string) || (doc.thumbnail_blob as string)
-    || (doc.thumbnail as string) || null;
-  const image = (doc.image_display as string) || (doc.image_full as string)
-    || (doc.thumbnail as string) || thumbnail;
+  // Our own images only. `doc.thumbnail` on an artwork record is frequently
+  // the holding museum's URL (rct.uk, wellcomeimages.org, polona.pl, and in
+  // one case a bare IP), and serving those to every API caller points our
+  // traffic at their servers. Measured over 4,000 artwork records: 99.1% have
+  // our thumbnail and 76.9% our display copy, so this costs almost nothing —
+  // and the 0.9% that would go imageless say so explicitly rather than
+  // borrowing a museum's URL. Same rule as page images
+  // (src/lib/public-image-fields.ts).
+  const pickOurs = (...vals: unknown[]) => (vals.find(isOwnInfraUrl) as string | undefined) ?? null;
+  const thumbnail = pickOurs(doc.image_thumb, doc.thumbnail_blob, doc.thumbnail);
+  const image = pickOurs(doc.image_display, doc.image_full, doc.thumbnail) ?? thumbnail;
 
   return {
     id: doc.id as string,
@@ -288,6 +296,7 @@ function shapeArtworkRow(
     description: description ? description.slice(0, 500) : null,
     image_url: image,
     thumbnail_url: thumbnail,
+    ...(image || thumbnail ? {} : { image_unavailable: true as const }),
     url: `https://sourcelibrary.org/book/${slug}`,
     collections: (doc.collections as string[]) ?? [],
     current_location: (doc.current_location as string) ?? null,

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -14,6 +14,8 @@ import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
 import { deleteBookArchived, purgeBookUnarchived } from '@/lib/delete-book';
+import { toPublicPageImages } from '@/lib/public-image-fields';
+import { getPartnerByProvider } from '@/lib/library-partners';
 
 export const preferredRegion = 'fra1';
 
@@ -147,7 +149,33 @@ export const GET = withApiAuth(async (
       (book as any).index = { ...(book as any).index, ...indexDoc };
     }
 
-    return NextResponse.json({ ...book, pages }, {
+    // Public responses serve OUR images only. The page docs also carry the
+    // originating institution's URLs (74% of `photo` values point off our
+    // infrastructure), and handing those to a paginating consumer turns our
+    // API into a fan-out attack on twenty partner libraries. We hold a
+    // full-resolution copy of every page, so nothing is lost — see
+    // src/lib/public-image-fields.ts for the measurements.
+    // Provenance survives as ATTRIBUTION on the book below, not as a per-page
+    // image endpoint.
+    const publicPages = pages.map(p => toPublicPageImages(p as Record<string, unknown>));
+
+    const sourceProvider = (book as any).image_source?.provider as string | undefined;
+    const attribution = sourceProvider ? {
+      provider: sourceProvider,
+      name: getPartnerByProvider(sourceProvider)?.name || sourceProvider,
+      url: getPartnerByProvider(sourceProvider)?.url || null,
+      /** Where the scanned object lives at the holding institution, when known. */
+      item_url: (book as any).source_url || (book as any).ia_identifier
+        ? (book as any).source_url || `https://archive.org/details/${(book as any).ia_identifier}`
+        : null,
+      note: 'Digitized by this institution. Page images are served from Source Library\'s own CDN; please do not bulk-fetch the source.',
+    } : undefined;
+
+    return NextResponse.json({
+      ...book,
+      ...(attribution ? { attribution } : {}),
+      pages: publicPages,
+    }, {
       headers: { 'Cache-Control': cacheControl }
     });
   } catch (error) {

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -87,7 +87,9 @@ let cachedFilters: { data: { types: string[]; subjects: string[]; yearRange: { m
  *   - figure: filter by figure tag
  *   - symbol: filter by symbol tag
  *   - minQuality: minimum gallery_quality score (0-1), default 0.7
- *   - maxPerBook: max images per book (via book_rank), default 3
+ *   - maxPerBook: max images per book (via book_rank), default 1000 (uncapped).
+ *     The human gallery passes 3 explicitly; this default is for API callers,
+ *     for whom a low cap is an invisible ceiling rather than curation.
  *   - includeArchive: show 0.5+ quality images (overrides minQuality to 0.5)
  *   - semantic: use embedding search
  */
@@ -130,7 +132,13 @@ export async function GET(request: NextRequest) {
     const yearStart = searchParams.get('yearStart') ? parseInt(searchParams.get('yearStart')!) : null;
     const yearEnd = searchParams.get('yearEnd') ? parseInt(searchParams.get('yearEnd')!) : null;
     const includeArchive = searchParams.get('includeArchive') === 'true';
-    const maxPerBook = parseInt(searchParams.get('maxPerBook') || '3');
+    // Uncapped by DEFAULT for API callers (#4509 follow-up). The cap exists so
+    // one heavily-illustrated volume cannot dominate the human gallery — and
+    // that surface sets its own value (src/app/gallery/page.tsx passes 3
+    // explicitly), so it is unaffected. As an API default it was a silent
+    // CEILING: it put ~120,000 of our own images out of reach however far a
+    // consumer paginated. Pass maxPerBook=3 to get the curated spread back.
+    const maxPerBook = parseInt(searchParams.get('maxPerBook') || '1000');
     // Quality thresholds
     let minQuality = 0.7; // default: gallery quality
     if (includeArchive) minQuality = 0.5;

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -165,6 +165,8 @@ export async function GET(request: NextRequest) {
       const merged = await mergedGalleryBrowse(db, {
         tenantId, source: sourceParam as 'all' | 'artwork', limit, offset,
         imageType, minQuality, maxPerBook, yearStart, yearEnd, visitorId: visitorIdForMerge,
+        // Honour an explicitly-requested floor instead of silently clamping it.
+        qualityExplicit: searchParams.get('minQuality') !== null,
       });
       const mergedFilters = await getGalleryFilters(db).catch(() => ({ types: [], subjects: [], yearRange: { minYear: null, maxYear: null } }));
       return NextResponse.json({

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -155,11 +155,25 @@ const SPEC = {
         responses: jsonResponse('{ total, activeFilters, counts?, vocabulary?, books?, page, limit, pages }'),
       },
     },
+    '/vectors/{store}': {
+      get: {
+        summary: 'Embedding vectors — the coordinates behind semantic and visual search',
+        description:
+          'For running your own UMAP / clustering / nearest-neighbour work rather than being limited to our ranked results. Stores: `books` (768d, ~35.8k), `gallery` (768d, ~212k illustration descriptions), `clip` (512d, ~313k CLIP VISUAL vectors — use these for "looks alike"), `artworks` (3072d, ~21.9k). Each row carries label fields so points can be captioned without a join. KEYSET pagination: echo `next_cursor` back as `after` until it stops being returned. Page-level vectors (3.9M rows) are not served here — ask for a bulk dump.',
+        parameters: [
+          { name: 'store', in: 'path', required: true, description: 'books | gallery | clip | artworks', schema: { type: 'string' } },
+          q('after', 'Keyset cursor — the last id from the previous page'),
+          q('limit', 'Rows per page (default 200, max 1000)', { type: 'integer' }),
+          q('format', 'json (default, plain float arrays) or base64 (float32 little-endian, ~2.5x smaller)'),
+        ],
+        responses: jsonResponse('{ store, dims, format, returned, next_cursor, vectors: [{ id, …labels, embedding }] }'),
+      },
+    },
     '/books/{id}': {
       get: {
         summary: 'Book metadata, AI reading summary, chapters, editions, DOI',
         description:
-          'IMAGE URLS — read this before fetching any. Each page carries BOTH our copy and the originating institution\'s URL. Use `display_photo` (or `archived_photo`): those are on images.sourcelibrary.org, we hold a copy of every page, and they are the only ones you should fetch in bulk. `photo`, `photo_original` and `thumbnail` point at the SOURCE institution — archive.org, the Bavarian State Library, the British Library, e-rara, Gallica, Harvard and ~15 others — and are provenance metadata, not a download path. Harvesting those hammers libraries that gave us access and will get you (and us) blocked.',
+          'IMAGE URLS: every page returns `image_full` (our full-resolution master), `image_display` (~2000px viewer variant) and `image_thumb`, all on images.sourcelibrary.org. Use `image_full` for archival-quality work — it equals or exceeds what the originating library serves (measured page-for-page: Göttingen 3651x4652 on both sides, Morgan 8308x10576 for ours against 2000x2546 at the source, and one source URL returned HTTP 504 while ours served). The originating institution\'s own image URLs are deliberately NOT returned: we hold a copy of every page, and passing them on would turn this API into a fan-out onto partner libraries. Where a scan came from travels as `attribution` on the book instead. `image_unavailable: true` marks the rare page we hold no copy of.',
         parameters: [pathId('Book id or slug')],
         responses: jsonResponse('Book record, including pages[] with both our image URLs and source provenance URLs'),
       },

--- a/src/app/api/vectors/[store]/route.ts
+++ b/src/app/api/vectors/[store]/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+/**
+ * GET /api/vectors/[store]
+ *
+ * The embedding vectors themselves — the coordinates behind semantic and
+ * visual search, so a consumer can run their own UMAP, clustering, or
+ * nearest-neighbour work instead of being limited to our ranked results.
+ *
+ * Until now every embedding surface returned RANKED RESULTS and never the
+ * vectors, which is fine for search and useless for a corpus map: you cannot
+ * project a top-k list. (Requested by an external visualization app, #4509.)
+ *
+ * Stores (see .claude/docs/embeddings.md for how each is built; row counts
+ * measured 2026-08-31):
+ *   books    book_embeddings          768    35,801  one per book
+ *   gallery  gallery_text_embeddings  768   212,433  illustration descriptions
+ *   clip     clip_embeddings          512   313,249  CLIP VISUAL vectors — the
+ *                                                    ones for "looks alike"
+ *   artworks artwork_embeddings      3072    21,925  standalone artworks
+ *
+ * Page-level vectors (3.9M rows) are deliberately NOT exposed here: that is a
+ * bulk dataset transfer, not an API read. Ask for a dump.
+ *
+ * Pagination is KEYSET, not offset — offset over a few hundred thousand rows
+ * walks every skipped row and blows the request deadline (the lesson from
+ * /api/dataset/v1/pages, #4508). Echo `next_cursor` back as `after` until it
+ * stops being returned.
+ *
+ * Query params:
+ *   after   - keyset cursor: the last id from the previous page
+ *   limit   - rows per page (default 200, max 1000)
+ *   format  - "json" (default) plain float arrays, or "base64" float32
+ *             little-endian, ~2.5x smaller on the wire
+ */
+
+interface StoreSpec {
+  table: string;
+  idColumn: string;
+  dims: number;
+  /** Extra columns worth returning so a vector is identifiable without a join. */
+  extra: string[];
+}
+
+// Column names verified against the live tables 2026-08-31 — `gallery` and
+// `clip` are keyed on their own `id`, NOT on an image id, and the label fields
+// differ per store. A vector with no label is a dot you cannot annotate, so
+// each store carries just enough to plot and caption without a join.
+const STORES: Record<string, StoreSpec> = {
+  books: {
+    table: 'book_embeddings', idColumn: 'book_id', dims: 768,
+    extra: ['title', 'author', 'year', 'language'],
+  },
+  gallery: {
+    table: 'gallery_text_embeddings', idColumn: 'id', dims: 768,
+    extra: ['book_id', 'page_id', 'detection_index'],
+  },
+  clip: {
+    table: 'clip_embeddings', idColumn: 'id', dims: 512,
+    extra: ['book_id', 'title', 'author', 'source_type', 'thumbnail_url'],
+  },
+  artworks: {
+    table: 'artwork_embeddings', idColumn: 'book_id', dims: 3072,
+    extra: ['title', 'author', 'period', 'culture', 'genre'],
+  },
+};
+
+const MAX_LIMIT = 1000;
+const DEFAULT_LIMIT = 200;
+
+/** Supabase returns pgvector as a JSON-ish string; accept both shapes. */
+function parseVector(raw: unknown): number[] | null {
+  if (Array.isArray(raw)) return raw as number[];
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function toBase64(vec: number[]): string {
+  const buf = Buffer.allocUnsafe(vec.length * 4);
+  for (let i = 0; i < vec.length; i++) buf.writeFloatLE(vec[i], i * 4);
+  return buf.toString('base64');
+}
+
+export const GET = withApiAuth(async (
+  request: NextRequest,
+  { params }: { params: Promise<{ store: string }> },
+  identity: ApiIdentity,
+) => {
+  try {
+    const { store } = await params;
+    const spec = STORES[store];
+    if (!spec) {
+      return NextResponse.json(
+        { error: `Unknown vector store "${store}"`, available: Object.keys(STORES) },
+        { status: 404 },
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const after = searchParams.get('after');
+    const format = searchParams.get('format') === 'base64' ? 'base64' : 'json';
+    const limitRaw = parseInt(searchParams.get('limit') || String(DEFAULT_LIMIT), 10);
+    const limit = Math.min(Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : DEFAULT_LIMIT, MAX_LIMIT);
+
+    const columns = [spec.idColumn, ...spec.extra, 'embedding'].join(', ');
+    let query = supabase
+      .from(spec.table)
+      .select(columns)
+      // Keyset order. Ordering by the id column makes `after` a simple >.
+      .order(spec.idColumn, { ascending: true })
+      // .range() is mandatory: supabase-js silently truncates at 1,000 rows
+      // otherwise — no error, just a short array (CLAUDE.md).
+      .range(0, limit - 1);
+    if (after) query = query.gt(spec.idColumn, after);
+
+    const { data, error } = await query;
+    if (error) {
+      console.error(`/api/vectors/${store}:`, error.message);
+      return NextResponse.json({ error: 'Failed to read vectors' }, { status: 500 });
+    }
+
+    const rows = (data || []) as unknown as Array<Record<string, unknown>>;
+    const vectors = rows.map((r) => {
+      const vec = parseVector(r.embedding);
+      const base: Record<string, unknown> = { id: r[spec.idColumn] };
+      for (const e of spec.extra) base[e] = r[e] ?? null;
+      if (!vec) { base.embedding = null; return base; }
+      base.embedding = format === 'base64' ? toBase64(vec) : vec;
+      return base;
+    });
+
+    const last = rows[rows.length - 1];
+    const nextCursor = rows.length === limit && last ? String(last[spec.idColumn]) : null;
+
+    return NextResponse.json({
+      store,
+      dims: spec.dims,
+      format,
+      // float32 little-endian when base64 — stated so a consumer can decode
+      // without guessing the byte order.
+      ...(format === 'base64' ? { encoding: 'float32-le' } : {}),
+      returned: vectors.length,
+      next_cursor: nextCursor,
+      vectors,
+    }, {
+      headers: {
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        ...(nextCursor ? { 'X-Next-Cursor': nextCursor } : {}),
+      },
+    });
+  } catch (error) {
+    console.error('Error in /api/vectors:', error);
+    return NextResponse.json({ error: 'Failed to read vectors' }, { status: 500 });
+  }
+});

--- a/src/app/api/vectors/[store]/route.ts
+++ b/src/app/api/vectors/[store]/route.ts
@@ -164,4 +164,4 @@ export const GET = withApiAuth(async (
     console.error('Error in /api/vectors:', error);
     return NextResponse.json({ error: 'Failed to read vectors' }, { status: 500 });
   }
-});
+}, { route: 'vectors.get' });

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -564,6 +564,11 @@ source-library search "alchemy" --json | jq .results`}
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/vectors/:store</td>
+                  <td className="py-2.5 text-secondary">Embedding vectors — books, gallery, clip (visual), artworks. For your own UMAP, clustering, or nearest-neighbour work.</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/works</td>
                   <td className="py-2.5 text-secondary">Works held in many editions across centuries — witness counts and year spans. Feed work_id back to /books/library.</td>
                 </tr>
@@ -632,27 +637,38 @@ source-library search "alchemy" --json | jq .results`}
         </p>
 
         <div className="bg-white rounded-xl border border-border-light p-6 max-w-2xl">
-          <h3 className="text-base font-semibold text-primary mb-2">Fetching page images: use our copy, not the library&apos;s</h3>
+          <h3 className="text-base font-semibold text-primary mb-2">Page images: every URL we return is ours</h3>
           <p className="text-secondary text-sm mb-3">
-            Every page object carries two kinds of image URL, and only one of them is yours to fetch.
+            Each page in an API response carries three image URLs, all on{' '}
+            <code>images.sourcelibrary.org</code>:
           </p>
           <ul className="text-secondary text-sm space-y-2 mb-3">
             <li>
-              <code className="text-accent-rust">display_photo</code> / <code className="text-accent-rust">archived_photo</code> —
-              on <code>images.sourcelibrary.org</code>. We hold a copy of <strong>every</strong> page image,
-              so these always resolve. Fetch these.
+              <code className="text-accent-rust">image_full</code> — the full-resolution master.
+              Use this for archival work. It <strong>equals or exceeds</strong> what the originating
+              library serves: measured page-for-page, Göttingen is 3651×4652 on both sides, and our
+              Morgan master is 8308×10576 against 2000×2546 at the source.
             </li>
             <li>
-              <code>photo</code> / <code>photo_original</code> / <code>thumbnail</code> —
-              the <strong>originating institution&apos;s</strong> server (archive.org, the Bavarian State Library,
-              the British Library, e-rara, Gallica, Harvard and around fifteen others). These are
-              provenance — they record where a scan came from. They are not a download path.
+              <code className="text-accent-rust">image_display</code> — a ~2000px variant for viewers.
+            </li>
+            <li>
+              <code className="text-accent-rust">image_thumb</code> — thumbnail.
             </li>
           </ul>
+          <p className="text-secondary text-sm mb-3">
+            We deliberately do <strong>not</strong> hand back the originating institution&apos;s own
+            image URLs. Roughly three quarters of the corpus was digitized by other libraries —
+            archive.org, the Bavarian State Library, the British Library, e-rara, Gallica, Harvard
+            and around fifteen more — and passing their per-page endpoints to every API consumer
+            would turn this API into a fan-out onto institutions that gave us access. You would get
+            blocked there; so would we.
+          </p>
           <p className="text-secondary text-sm">
-            Bulk-fetching the second kind sends thousands of requests to libraries that gave us
-            access, and gets your address blocked there long before you finish. There is no reason
-            to: we mirror all of it.
+            Provenance is not lost: the book carries an <code>attribution</code> object naming the
+            institution and linking to the item on their site. Credit the library, don&apos;t hammer
+            it. The rare page we hold no copy of is marked <code>image_unavailable</code> rather
+            than filled in with someone else&apos;s URL.
           </p>
         </div>
       </section>

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -17,6 +17,11 @@ export interface MergedBrowseOpts {
   offset: number;
   imageType?: string | null;
   minQuality?: number;
+  /**
+   * True when the CALLER set minQuality themselves. Without this the default
+   * browse's 0.82 floor silently overrides an explicit request — see qFloor.
+   */
+  qualityExplicit?: boolean;
   maxPerBook?: number;
   yearStart?: number | null;
   yearEnd?: number | null;
@@ -73,14 +78,22 @@ export async function mergedGalleryBrowse(
   const {
     tenantId, source, limit, offset,
     imageType = null, minQuality = 0.7, maxPerBook = 3,
-    yearStart = null, yearEnd = null, visitorId = null,
+    yearStart = null, yearEnd = null, visitorId = null, qualityExplicit = false,
   } = opts;
   const tenant = tenantId ? { tenantId } : {};
   const pageIndex = Math.floor(offset / Math.max(1, limit));
   // The natural-aspect masonry shows full pages, so raise the quality floor for
   // the merged browse — blank/low-content plates the old square crop hid now
-  // read as empty tiles. (Explicit type/quality filters still honor the request.)
-  const qFloor = imageType ? minQuality : Math.max(minQuality, 0.82);
+  // read as empty tiles.
+  //
+  // "Explicit type/quality filters still honor the request" was the stated
+  // intent, but only the TYPE half was implemented: an explicit minQuality was
+  // silently overridden by the 0.82 floor, so a caller passing minQuality=0.5
+  // got exactly the same set as one passing nothing, and ~88,000 images stayed
+  // unreachable however they asked. `qualityExplicit` implements the half that
+  // was documented and missing. The floor still applies to the DEFAULT browse,
+  // which is what it was for.
+  const qFloor = (imageType || qualityExplicit) ? minQuality : Math.max(minQuality, 0.82);
   // Artworks must actually have an image, else they render as blank tiles.
   const artHasImage = { $or: [
     { image_display: { $nin: [null, ''] } },

--- a/src/lib/public-image-fields.ts
+++ b/src/lib/public-image-fields.ts
@@ -1,0 +1,98 @@
+/**
+ * What the PUBLIC API is allowed to hand out as a fetchable image URL.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Page documents carry two kinds of image URL side by side:
+ *
+ *   ours    archived_photo (full-res master), display_photo (~2000px serving
+ *           variant), image_thumb / thumbnail_blob — all on our own CDN
+ *   theirs  photo, photo_original, thumbnail — the ORIGINATING INSTITUTION's
+ *           server: archive.org, the Bavarian State Library, the British
+ *           Library, e-rara, Gallica, Harvard, the Bodleian and ~15 more
+ *
+ * Measured over a 60k-page sample (2026-08-31): 74% of `photo` values point
+ * off our infrastructure. A consumer who takes the most obviously-named field
+ * and paginates therefore sends thousands of requests to libraries that gave
+ * us access — which is how an external consumer got as far as "I stopped
+ * downloading, I didn't want to get spam-filtered by Leiden."
+ *
+ * We do not need to serve theirs. `archived_photo` is present on 100% of
+ * sampled pages, and it EQUALS OR EXCEEDS the source: measured page-for-page,
+ * Göttingen 3651x4652 both sides, HAB 3912x5000 both sides, Morgan 8308x10576
+ * for our master against 2000x2546 at the source URL, and the Bodleian source
+ * returned HTTP 504 while ours served fine. Handing out their URL is worse for
+ * them AND worse for the consumer.
+ *
+ * PROVENANCE IS NOT LOST. Where a scan came from is a first-class fact and
+ * still travels — as attribution (provider name, the item's landing page),
+ * not as a per-page image endpoint to bulk-fetch. That distinction is the
+ * whole point of this module: credit the library, don't hammer it.
+ *
+ * NOT for internal use. The pipeline legitimately fetches source URLs (that is
+ * how the archive gets made), and `src/lib/page-image-url.ts` legitimately
+ * falls back to them when rendering our own pages. This applies only where a
+ * page object crosses the boundary into a public API response.
+ */
+
+/** Hosts we serve ourselves. */
+const OUR_HOSTS = /(^|\.)sourcelibrary\.org$/i;
+
+/** True when a URL is on our own infrastructure (or is a relative path). */
+export function isOwnInfraUrl(url: unknown): boolean {
+  if (typeof url !== 'string' || !url) return false;
+  if (url.startsWith('/')) return true; // our own route, e.g. /api/image
+  try {
+    return OUR_HOSTS.test(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** Image-bearing fields that may hold a third party's URL. */
+const SOURCE_URL_FIELDS = ['photo', 'photo_original', 'thumbnail'] as const;
+
+export interface PublicPageImages {
+  /** Full-resolution master on our CDN — what a bulk consumer should fetch. */
+  image_full: string | null;
+  /** ~2000px serving variant on our CDN — what a viewer should render. */
+  image_display: string | null;
+  /** Thumbnail on our CDN. */
+  image_thumb: string | null;
+  /**
+   * True when we hold no copy of our own. Explicit rather than silent: a
+   * consumer must be able to tell "we have no image" from "the field is
+   * missing", and it is the honest alternative to substituting someone
+   * else's URL (absence-is-not-failure).
+   */
+  image_unavailable?: true;
+}
+
+/**
+ * Strip third-party image URLs from a page object and surface our own under
+ * stable names. Unknown keys pass through untouched, so this is safe to apply
+ * to any projection.
+ */
+export function toPublicPageImages<T extends Record<string, unknown>>(page: T): Omit<T, typeof SOURCE_URL_FIELDS[number]> & PublicPageImages {
+  const out: Record<string, unknown> = { ...page };
+  for (const f of SOURCE_URL_FIELDS) delete out[f];
+
+  const pick = (...vals: unknown[]) => vals.find(isOwnInfraUrl) as string | undefined;
+
+  const full = pick(page.archived_photo, page.cropped_photo, page.display_photo);
+  const display = pick(page.display_photo, page.image_display, page.cropped_photo, page.archived_photo);
+  const thumb = pick(page.image_thumb, page.thumbnail_blob, page.display_photo);
+
+  out.image_full = full ?? null;
+  out.image_display = display ?? null;
+  out.image_thumb = thumb ?? null;
+  if (!full && !display && !thumb) out.image_unavailable = true;
+
+  // Legacy field names kept ONLY when they are already ours, so existing
+  // consumers keep working without any of them becoming a third-party URL.
+  for (const f of ['archived_photo', 'display_photo', 'cropped_photo', 'image_thumb', 'thumbnail_blob'] as const) {
+    if (f in out && !isOwnInfraUrl(out[f])) delete out[f];
+  }
+
+  return out as Omit<T, typeof SOURCE_URL_FIELDS[number]> & PublicPageImages;
+}


### PR DESCRIPTION
Three asks from consumer feedback, plus a correction to advice I gave earlier in the thread.

## 1. The API stops handing out other people's URLs

Page objects carried the originating institution's image URLs beside ours. Measured over a 60k-page sample: **74% of `pages.photo` values point off our infrastructure** — archive.org 36%, Bavarian State Library 16.5%, British Library EAP 8.2%, e-rara 6.9%, Harvard 2.5%, plus ~15 more. A consumer taking the obvious field and paginating turns this API into a fan-out onto partner libraries.

Public page objects now expose `image_full` / `image_display` / `image_thumb`, all ours, via a new `src/lib/public-image-fields.ts`. Source URLs are stripped; legacy names survive only while they're ours.

**Nothing is lost** — and this corrects what I said earlier in this thread. `display_photo` *is* a downsized ~2000px serving variant (Derek was right to ask), but `archived_photo` is the full-res master and **equals or exceeds the source every time**:

| provider | source | our master |
|---|---|---|
| Göttingen | 3651×4652 | 3651×4652 |
| HAB | 3912×5000 | 3912×5000 |
| Morgan | 2000×2546 | **8308×10576** |
| Bodleian | **HTTP 504** | 3000×4000 |

So `image_full` maps to the master, not the display variant. Provenance survives as an `attribution` object on the book (institution, URL, item link) — credit the library, don't hammer it. The rare page we hold no copy of is marked `image_unavailable: true` rather than filled in with someone else's URL.

## 2. The gallery cap is lifted

`maxPerBook` now defaults to uncapped for API callers instead of 3. The human gallery passes 3 explicitly in its own code (`src/app/gallery/page.tsx`), so curation there is untouched — as an API default it was an invisible ceiling putting **~120,000 of our own images** out of reach however far a consumer paginated.

## 3. `GET /api/vectors/{store}` — the embeddings themselves

Every embedding surface returned ranked results and never the vectors, which is fine for search and useless for a corpus map: you can't project a top-k list.

| store | dims | rows |
|---|---|---|
| `books` | 768 | 35,801 |
| `gallery` | 768 | 212,433 |
| `clip` (visual) | 512 | 313,249 |
| `artworks` | 3072 | 21,925 |

Column names and dimensions verified against the live tables first — `gallery` and `clip` key on their own `id`, not an image id, which my first draft got wrong. Keyset pagination (the #4508 lesson), explicit `.range()` to dodge supabase's silent 1000-row truncation, label fields inline so points can be captioned without a join, and optional `format=base64` float32 to cut the payload ~2.5×. Page-level vectors (3.9M rows) stay a bulk-dump conversation.

## Verification

`npx tsc --noEmit` clean. Checked that stripping source URLs can't break our own rendering: the reader builds page images **server-side from Mongo**, not through this API, and the one client component that paginates it (`BookPagesSection`) touches no image fields. Will confirm on the preview that no public endpoint returns a non-sourcelibrary.org host, and add that as a standing case in the contract suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc