### PR TITLE
test(api): off-infra guard flags image files, not IIIF manifests

### DIFF
--- a/scripts/audit/public-api-contract.sh
+++ b/scripts/audit/public-api-contract.sh
@@ -205,8 +205,13 @@ img_hosts_off_infra() {
   curl -s --max-time 90 -A "$UA" "${AUTH_HEADER[@]}" "$1" | python3 -c "
 import sys,re,collections
 raw=sys.stdin.read()
+# IMAGE-SHAPED ONLY. A bare /iiif/ match is too broad: it flags a
+# manifest.json, which is an interop DOCUMENT describing the object, not a file
+# to fetch - the same category as a DOI or a catalogue landing page, and worth
+# keeping for scholars. What must never appear is an image FILE or a IIIF Image
+# API request, which always carries a /full/ region segment.
 imgs =re.findall(r'https?://([a-zA-Z0-9.\-]+)[^\"]*?\.(?:jpg|jpeg|png|tif|jp2)(?:\?|\")', raw, re.I)
-imgs+=re.findall(r'https?://([a-zA-Z0-9.\-]+)[^\"]*?/(?:iiif|full)/', raw, re.I)
+imgs+=re.findall(r'https?://([a-zA-Z0-9.\-]+)[^\"]*?/full/[^\"]*?/', raw, re.I)
 off=sorted({h for h in imgs if 'sourcelibrary.org' not in h})
 print(1 if not off else off[:4])
 "


### PR DESCRIPTION
Follow-up to #4522 (replaces #4525, whose branch predated that squash merge and couldn't rebase cleanly — this is the same one-file change off current main).

The new "no off-infra image hosts" case flagged `iiif.archive.org` on a book response. Investigated: the URL is a **manifest.json** — an interop document describing the object, the same category as a DOI or a catalogue landing page, and genuinely useful to scholars. The other archive.org references on that response are Dublin Core `dc_source`, the item landing page, a scanner hostname, a dedup fingerprint, and the `attribution` links added in #4522. All provenance; none an image endpoint.

So the test was over-broad, not the API. A real IIIF **Image API** request always carries a `/full/` region segment; a manifest never does. The guard now matches image file extensions plus `/full/`, so it still fails on any actual image served from someone else's host.

Tightened rather than relaxed — what it exists to catch is unchanged.

**27/27 against production.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve8GjsAYmoR791UjeYCXtc