### PR TITLE
fix(slugs): the repair sweep skipped 7 books whose author was sluggable (#4521)

### DIFF
--- a/scripts/maintenance/repair-book-slugs.ts
+++ b/scripts/maintenance/repair-book-slugs.ts
@@ -41,7 +41,7 @@
 import { writeFileSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { MongoClient, type Db } from 'mongodb';
-import { generateBookSlug, appendSlugSuffix, isPlaceholderSlug } from '@/lib/slugify';
+import { generateBookSlug, appendSlugSuffix, isGenericAuthor, isPlaceholderSlug } from '@/lib/slugify';
 
 const APPLY = process.argv.includes('--apply');
 const INCLUDE_HIDDEN = process.argv.includes('--include-hidden');
@@ -50,6 +50,25 @@ const INCLUDE_HIDDEN = process.argv.includes('--include-hidden');
 // those books, so the next incremental catalog sync picks them up.
 const RESYNC = process.argv.includes('--resync-catalog');
 const OUT_DIR = join(process.cwd(), 'scripts', 'output');
+
+/**
+ * Books where the author fallback would publish a WRONG name, so no slug is
+ * better than the one this sweep would mint. Editorial decisions, not a rule
+ * the generator can infer — recorded here so a later run does not re-propose
+ * them and a later reader knows why.
+ *
+ * extractLastName takes the final word of an unpunctuated author, which is the
+ * surname in Western order and the GIVEN name in Chinese order. That is right
+ * for "Katsushika Hokusai" (Hokusai is the art name) and wrong for "Qiu Ying"
+ * (family name Qiu). Fixing name order corpus-wide is its own change; these
+ * books belong to the same tail as the 34 skipped above — they need an English
+ * `display_title` from enrichment, which produces a slug describing the work
+ * rather than half-naming its maker.
+ */
+const SKIP_IDS = new Set<string>([
+  // 漢宮春曉 handscroll, Qiu Ying — would become /book/ying.
+  '69e53627ce6791c1bca7d814',
+]);
 
 interface BookRow {
   _id: unknown;
@@ -160,6 +179,13 @@ async function main() {
 
   for (const book of broken) {
     const title = book.display_title || book.title || '';
+
+    const bookId = book.id || String(book._id);
+    if (SKIP_IDS.has(bookId)) {
+      skipped.push(`${bookId} — held back deliberately, see SKIP_IDS: "${title.slice(0, 40)}"`);
+      continue;
+    }
+
     const base = generateBookSlug(book.title || '', book.author || '', book.display_title);
 
     // generateBookSlug already falls back to the author, then to "untitled".
@@ -176,13 +202,23 @@ async function main() {
     // something the old one didn't. Titles like "216" or "2-13" sanitize to
     // themselves, so /book/216 would become /book/216-anonymous: a changed
     // URL, no new information, and a redirect to maintain forever. Those are
-    // a metadata problem, not a slug problem. A book with NO slug is the
+    // a metadata problem, not a slug problem.
+    //
+    // The title is not the only source, though, and reading it as the only one
+    // is what left 7 visible books stranded at /book/-9, /book/-14, /book/-15,
+    // /book/-16, /book/-22, /book/-23 and /book/306-5741 after the first sweep
+    // (#4521). generateBookSlug falls back to the AUTHOR when the title is
+    // entirely non-Latin, and for a Japanese print or a Russian painting that
+    // author is usually written in Latin script - Yoshitoshi, Hokusai, Utagawa
+    // Yoshiiku, Kawanabe Kyosai, Ivan Akimov, Qiu Ying. Those renames DO add
+    // information, so the skip needs both halves: no Latin title AND no named
+    // author. A book with NO slug is the
     // opposite case — any readable segment beats /book/<objectid>.
     const titleHasLetters = /[a-z]/i.test(
       title.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
     );
-    if (book.slug && !titleHasLetters) {
-      skipped.push(`${book.id} — slug "${book.slug}" already matches its title, no gain`);
+    if (book.slug && !titleHasLetters && isGenericAuthor(book.author)) {
+      skipped.push(`${book.id} — slug "${book.slug}" gains nothing: non-Latin title, no named author`);
       continue;
     }
 

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -27,8 +27,18 @@ export function generateBookSlug(
   const authorLast = extractLastName(author);
   const slugAuthor = slugifyText(authorLast, 20);
 
+  // A title segment has to contain a LETTER to be a title. A non-Latin title
+  // does not always sanitize to the empty string the branch below assumes:
+  // catalogue titles carry measurements, and "​漢宮春曉, 卷, 絹本設色, 纵30.6厘米
+  // 横574.1厘米" left "30-6-574-1" behind — the scroll's dimensions in
+  // centimetres, minted as /book/30-6-574-1-ying (#4521). Digits that survived
+  // a script the slugifier cannot read are debris, not information, and
+  // isPlaceholderSlug already treats a letterless slug as broken, so producing
+  // one here just hands the repair sweep its own work back.
+  const titleIsReadable = /[a-z]/.test(slugTitle);
+
   if (!slugAuthor || slugAuthor === 'unknown') {
-    return slugTitle || 'untitled';
+    return titleIsReadable ? slugTitle : 'untitled';
   }
 
   // slugifyText keeps only [a-z0-9], so a title written entirely in Greek,
@@ -39,7 +49,7 @@ export function generateBookSlug(
   // non-Latin title degrades to a plain readable segment instead of a broken
   // one. Prefer giving these books an English `display_title`: the generator
   // reads it first, and it produces a genuinely descriptive slug.
-  if (!slugTitle) {
+  if (!titleIsReadable) {
     return slugAuthor;
   }
 
@@ -205,6 +215,31 @@ function extractLastName(author: string): string {
   // "First Last" format — take last word
   const parts = author.trim().split(/\s+/);
   return parts[parts.length - 1];
+}
+
+/**
+ * Does this author field name somebody, or is it a stand-in for "we do not
+ * know"?
+ *
+ * Used by the repair sweeps to decide whether re-slugging a book whose title
+ * is entirely non-Latin gains anything. generateBookSlug falls back to the
+ * author for those titles, and the answer differs sharply by author:
+ * "Katsushika Hokusai" turns /book/-15 into a URL that names the artist, while
+ * "Anonymous" would only turn /book/216 into /book/216-anonymous — a changed
+ * public URL carrying no new information, plus a redirect to maintain forever.
+ *
+ * Compared on the SLUGIFIED surname, so the qualified spellings catalogues
+ * actually write — "未詳 (Unknown)", "Unknown artist", "Anonymous Sumerian" —
+ * all fold to the same answer as the bare word. Note this is deliberately
+ * stricter than extractLastName's own policy: that function keeps "anonymous"
+ * in the slug on purpose (an anonymous early-modern imprint is a real
+ * attribution), and this predicate is only about whether the segment is worth
+ * *renaming an existing URL* for.
+ */
+export function isGenericAuthor(author: string | null | undefined): boolean {
+  if (!author) return true;
+  const surname = slugifyText(extractLastName(author), 20);
+  return !surname || surname === 'unknown' || surname === 'anonymous' || surname === 'anon';
 }
 
 /**

--- a/tests/unit/book-slug-quality.test.ts
+++ b/tests/unit/book-slug-quality.test.ts
@@ -11,7 +11,7 @@
  * and Sanskrit titles, so that path is load-bearing, not theoretical.
  */
 import { describe, it, expect } from 'vitest';
-import { generateBookSlug, isNonTitle, isPlaceholderSlug, readerPageUrl } from '@/lib/slugify';
+import { generateBookSlug, isGenericAuthor, isNonTitle, isPlaceholderSlug, readerPageUrl } from '@/lib/slugify';
 
 describe('generateBookSlug', () => {
   it('builds title-author for the ordinary case', () => {
@@ -153,5 +153,62 @@ describe('unknown authors', () => {
     // Deliberate, and pinned by tests/unit/slugify.test.ts — an anonymous
     // early-modern imprint is not the same claim as "we do not know".
     expect(generateBookSlug('Some Text', 'Anonymous')).toBe('some-text-anonymous');
+  });
+});
+
+/**
+ * #4521 — the repair sweep's own skip rule stranded 7 of the books it exists
+ * to fix.
+ *
+ * "A rename only earns a changed URL if it adds information" is the right
+ * rule; "the title is where the information comes from" was the wrong reading
+ * of it. generateBookSlug falls back to the author when the title is entirely
+ * non-Latin, and in this corpus that author is very often Latin-script — a
+ * Japanese print signed Hokusai, a Russian painting by Ivan Akimov. Those
+ * books stayed at /book/-15 and /book/-22 because the sweep asked only about
+ * the title.
+ *
+ * isGenericAuthor is the missing half of the question. What this pins: skip
+ * when the author is a stand-in, rename when it names somebody.
+ */
+describe('isGenericAuthor (#4521)', () => {
+  it('reads the stand-ins as generic, in the spellings catalogues write', () => {
+    for (const author of ['', null, undefined, 'Unknown', 'unknown', 'Unknown artist',
+      '未詳 (Unknown)', 'Anonymous', 'Anonymous Sumerian', 'Anonymous (Egyptian)',
+      'Anonymous Yucatec Maya scribes']) {
+      expect(isGenericAuthor(author), `"${author}" is a stand-in, not a person`).toBe(true);
+    }
+  });
+
+  it('reads a named author as named — the 7 books the sweep skipped', () => {
+    for (const author of ['Katsushika Hokusai', 'Yoshitoshi', 'Utagawa Yoshiiku',
+      'Kawanabe Kyōsai', 'Ivan Akimov', 'Hieronymus Bosch', 'Qiu Ying',
+      'Maier, Michael', 'Mousouros, Markos (ed.)']) {
+      expect(isGenericAuthor(author), `"${author}" names a person`).toBe(false);
+    }
+  });
+
+  it('is exactly the difference between a slug worth minting and one that is not', () => {
+    // What the sweep now writes for /book/-15 and /book/-22.
+    expect(generateBookSlug('葛飾北斎筆 鶏と木材鶏図', 'Katsushika Hokusai')).toBe('hokusai');
+    expect(generateBookSlug('Акимов Иван. Прометей делает статую', 'Ivan Akimov')).toBe('akimov');
+    // And what it still refuses to write for /book/216 and /book/untitled-18:
+    // a stand-in author over a non-Latin title is a metadata problem, not a
+    // slug problem — /book/216-anonymous costs a redirect and says nothing.
+    expect(isGenericAuthor('Anonymous')).toBe(true);
+    expect(generateBookSlug('坐禪用心記', '未詳 (Unknown)')).toBe('untitled');
+  });
+
+  it('does not read the digits a non-Latin title leaves behind as a title', () => {
+    // /book/30-6-574-1-ying: the surviving digits are the scroll's dimensions
+    // in centimetres. A title segment needs a letter to be a title.
+    expect(generateBookSlug('​漢宮春曉, 卷, 絹本設色, 纵30.6厘米 横574.1厘米', 'Qiu Ying')).toBe('ying');
+    expect(generateBookSlug('青鬼 2', 'Khunrath, Heinrich')).toBe('khunrath');
+    // With no author either, a letterless title is "untitled", not the digits —
+    // isPlaceholderSlug already reads a letterless slug as broken, so emitting
+    // one would hand the repair sweep its own work back.
+    expect(generateBookSlug('30.6 × 574.1', 'Unknown')).toBe('untitled');
+    // A real title that merely contains a number is untouched.
+    expect(generateBookSlug('De re metallica 1556', 'Agricola')).toBe('de-re-metallica-1556-agricola');
   });
 });


### PR DESCRIPTION
Closes the actionable half of #4521.

## What was wrong

The #4389 generator fix is in place, so I re-ran the sweep expecting it to just work. Dry run on prod: **46 broken visible slugs, 1 planned rename.** The other 45 were skipped by the sweep's own "no gain" guard:

```ts
if (book.slug && !titleHasLetters) continue;  // "already matches its title, no gain"
```

"A rename only earns a changed URL if it adds information" is the right rule. "The title is where the information comes from" was the wrong reading of it — `generateBookSlug` falls back to the **author** when the title is entirely non-Latin, and in this corpus that author is usually written in Latin script.

Bucketing the 46:

| bucket | count | verdict |
|---|---|---|
| Latin title | 1 | the one rename the old guard allowed |
| Non-Latin title, **named Latin-script author** | 7 | falsely skipped — fixed here |
| Non-Latin title, generic author (`Anonymous` ×3, `未詳 (Unknown)`) | 4 | correctly skipped |
| Neither (CJK Buddhist/classical set, `display_title: null`) | 34 | not a slug bug — see Out of scope |

## Changes

1. **`isGenericAuthor()`** (`src/lib/slugify.ts`) — the missing half of the guard's question. Compared on the slugified surname, so `Unknown artist`, `未詳 (Unknown)` and `Anonymous Sumerian` all fold to the same answer as the bare word. The sweep now skips only when there is neither a Latin title **nor** a named author. `/book/216` → `/book/216-anonymous` is still refused: a changed URL, no new information, a redirect to maintain forever.

2. **`generateBookSlug` requires a letter in the title segment.** A non-Latin title does not always sanitize to the empty string the author fallback assumed: `漢宮春曉, 卷, 絹本設色, 纵30.6厘米 横574.1厘米` left `30-6-574-1` behind (the scroll's dimensions in centimetres) and would have shipped as `/book/30-6-574-1-ying`. `isPlaceholderSlug` already reads a letterless slug as broken, so emitting one handed the sweep its own work back.

3. **`SKIP_IDS`** in the sweep, one entry. `extractLastName` takes the final word — the surname in Western order, the *given* name in Chinese order. Right for "Katsushika Hokusai", wrong for "Qiu Ying". That scroll is held back rather than published at `/book/ying`.

## Dry run after the change

```
Planned renames: 7
  untitled  → the-rose-garden     The Rose Garden
  -23       → bosch               «Δύο ανδρικά κεφάλια», Ιερώνυμος Μπος
  -22       → akimov              Акимов Иван. Прометей делает статую…
  -16       → kyosai              東海道名所之内 秋葉山
  -15       → hokusai             葛飾北斎筆 鶏と木材鶏図
  -14       → yoshiiku            今様擬源氏　三十五　鳥山秋作照忠　一恵斎芳幾画
  -9        → yoshitoshi          和漢百物語 貞信公
```

Old slugs are preserved as `slug_aliases` in the same update (unchanged behaviour), so the indexed `/book/-15` URLs keep resolving and 301 to the canonical.

## Out of scope

The remaining **34 visible books** (`/book/untitled-N`, the CJK Buddhist/classical set) have `display_title: null` and no Latin-script author. No slug logic can help them — they need an English `display_title` from enrichment first, and **#4521 will keep re-firing until they get one.** Filing that separately rather than bundling an enrichment run into a slug fix.

Chinese/Japanese name-order handling in `extractLastName` is also out of scope — corpus-wide blast radius, its own PR.

## Verification

- `tests/unit/book-slug-quality.test.ts` — new `isGenericAuthor (#4521)` block pins the stand-in/named split, the 7 books by name, and the digit-debris case
- `npx vitest run tests/unit` — 3295 passed
- `npx tsc --noEmit` — clean
- Dry run against production, above

Applying `--apply` plus the Cloudflare/ISR purge for the 7 paths after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
