### PR TITLE
fix(audit): the slug detector fired on work nobody could do, muting itself (#4521)

### DIFF
--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -338,10 +338,33 @@ reads all three:
   is not failure — no silent skips" (#3740): here the skip was counted but
   unexplained, which reads as a working instrument reporting a broken world.
 
+- **A finding must be ACTIONABLE, or the dedupe that protects your inbox becomes
+  a mute button.** `book-slug-placeholders` fired on every placeholder book slug,
+  and `corpus-integrity-watch.yml` files **one open issue at a time** — correct on
+  its own, since a deterministic finding filed daily buries the first report under
+  30 copies. But after the #4521 repair, 38 of the 39 remaining bad URLs were
+  waiting on an English `display_title` (#4390), not on slug logic: nothing the
+  repair sweep can touch, ever. So the issue stays open forever, and the *next*
+  importer that bypasses `generateBookSlug` — the regression the detector exists
+  for — files **nothing**. The alarm was masked by its own backlog. Worse, the
+  issue body said "Repair with `repair-book-slugs.ts`", which was now false for
+  every row in it: the next reader runs the sweep, gets 0 renames, and re-derives
+  the whole triage. **Split "broken" from "fixable" and fire only on fixable**
+  (#4530): `classifySlugRepair` in `src/lib/book-slug-repair.ts` returns
+  `repairable` vs a named blocker, the repairable count drives the exit code, and
+  the blocked tail is *reported with its reason and its owning issue* so it reads
+  as a known backlog rather than N mysterious rows. **Put the triage in ONE module
+  the detector and its repair tool both import** — a detector that disagrees with
+  its own sweep reports work that cannot be done, which is the failure itself.
+  **Tell:** a standing detector whose count never reaches zero, or an auto-filed
+  issue whose remedy you have already run.
+
 **Diagnostic tell for the next person:** an auto-filed issue whose fenced block is
 an *error message* rather than a *measurement*. Read the body before believing the
 title — and when a watchdog has filed the same title on a regular cadence with no
-one acting on it, suspect the watchdog before the corpus.
+one acting on it, suspect the watchdog before the corpus. Conversely, a watchdog
+that filed **once** and has been quiet since may be muzzled by its own open issue
+rather than satisfied: check whether its finding is still actionable.
 
 Related: the same self-referential shape as the error reporter that reported its
 own failures (#4045/#4047), and the inverse of "absence is not failure — no silent

--- a/.github/workflows/corpus-integrity-watch.yml
+++ b/.github/workflows/corpus-integrity-watch.yml
@@ -135,6 +135,13 @@ jobs:
       # One open issue at a time. The finding is deterministic and stays true
       # until someone repairs it, so filing daily would bury the first report
       # under 30 copies of itself.
+      #
+      # That dedupe is why exit 1 must mean REPAIRABLE and nothing else (#4521).
+      # The audit used to fire on every placeholder slug, and 38 of them are
+      # waiting on an English title (#4390) rather than on slug logic — so the
+      # issue stayed open forever and this step would never file again. The next
+      # importer to bypass generateBookSlug, which is the regression this whole
+      # job exists to catch, would have been reported to nobody.
       - name: File findings
         if: steps.run.outputs.fired == '1'
         env:
@@ -147,7 +154,7 @@ jobs:
             exit 0
           fi
           BODY=$(printf '%s\n\n```\n%s\n```\n' \
-            "A visible book is published at a URL that says nothing about it (/book/unknown-7, /book/untitled-3, /book/-9). The slug is the public, citable address, so this is a broken page address, not a cosmetic issue. Repair with scripts/maintenance/repair-book-slugs.ts (dry run by default) — it preserves the old slug as an alias. See #4389." \
+            "A visible book is published at a URL that says nothing about it (/book/unknown-7, /book/untitled-3, /book/-9). The slug is the public, citable address, so this is a broken page address, not a cosmetic issue. Everything under REPAIRABLE below can be fixed right now with scripts/maintenance/repair-book-slugs.ts (dry run by default) — it preserves the old slug as an alias. Anything under BLOCKED is waiting on metadata (usually an English display_title, #4390); running the sweep will not move it, so do not read a leftover BLOCKED count as a failed repair. See #4389 and #4521." \
             "$(cat report.txt)")
           gh issue create --title "$TITLE" --body "$BODY" --label data-quality
       # Exit 2 means the detector never reached the database. A silent green run

--- a/scripts/audit/book-slug-placeholders.ts
+++ b/scripts/audit/book-slug-placeholders.ts
@@ -22,9 +22,28 @@
  *   hidden          → reported for context; a hidden book with a bad slug
  *                     becomes a public one the day it is unhidden.
  *
+ * AND SPLIT AGAIN BY WHETHER ANYONE CAN ACT ON IT (#4521)
+ * "Broken" and "fixable" are different questions, and firing on the first one
+ * broke the alarm. After the #4521 repair, 39 visible books still carried
+ * placeholder slugs — 34 of them CJK records with `display_title: null` and an
+ * author in Chinese characters. No slug logic can help those; they need an
+ * English title first (#4390). But the workflow keeps ONE open issue at a time,
+ * so a finding that stays true forever means the next importer to bypass
+ * generateBookSlug — the exact regression this detector exists to catch — files
+ * nothing at all. A detector that always fires is not a detector.
+ *
+ * So `classifySlugRepair` (src/lib/book-slug-repair.ts, shared with the repair
+ * sweep) splits the hits:
+ *
+ *   repairable      → the sweep can write a readable slug from today's data.
+ *                     THIS is the finding, and the only thing that exits 1.
+ *   blocked         → reported with the reason and a count, exits 0. Waiting on
+ *                     metadata, tracked in #4390, not actionable here.
+ *
  * EXIT CONTRACT (.claude/docs/invariants/measurement-instruments.md)
- *   0  ran, clean
- *   1  ran, found placeholder slugs on visible books
+ *   0  ran; no REPAIRABLE placeholder slug on a visible book (blocked ones may
+ *      still be reported — read the output, not just the code)
+ *   1  ran, found a repairable placeholder slug on a visible book
  *   2  could not run — no measurement was taken. Never read as clean.
  *
  * USAGE
@@ -34,6 +53,7 @@
 import 'dotenv/config';
 import { MongoClient } from 'mongodb';
 import { isPlaceholderSlug } from '../../src/lib/slugify';
+import { classifySlugRepair, type SlugRepairBlocker } from '../../src/lib/book-slug-repair';
 
 const argv = process.argv.slice(2);
 const JSON_OUT = argv.includes('--json');
@@ -44,7 +64,26 @@ interface Row {
   slug: string;
   title: string;
   visible: boolean;
+  /** The slug the sweep would write now, or null when it cannot write one. */
+  repairTo: string | null;
+  /** Why the sweep cannot act, or null when it can. */
+  blockedBy: SlugRepairBlocker | null;
+  reason: string;
 }
+
+/**
+ * What a reader should do about each blocker. The detector's job is not just to
+ * count — an unactionable finding with no route out is what turns into a
+ * permanently-red check nobody reads.
+ */
+const BLOCKER_ROUTES: Record<SlugRepairBlocker, string> = {
+  'needs-english-title':
+    'no Latin-script title or author on the record — needs an English display_title first (#4390)',
+  'no-gain':
+    'the slug already says everything the record says — needs real metadata, not a new slug (#4390)',
+  'held-back':
+    'held back on editorial grounds — see SLUG_REPAIR_HOLDBACK in src/lib/book-slug-repair.ts',
+};
 
 async function main(): Promise<number> {
   const uri = process.env.MONGODB_URI || process.env.MONGODB_URL;
@@ -63,7 +102,9 @@ async function main(): Promise<number> {
     // hidden book's slug is one `visible: true` away from being public.
     const cursor = db.collection('books').find(
       {},
-      { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, visible: 1 } },
+      // `author` is projected because it is half the repairability question:
+      // a non-Latin title with a Latin-script author IS repairable (#4521).
+      { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1 } },
     );
 
     let scanned = 0;
@@ -79,33 +120,76 @@ async function main(): Promise<number> {
       if (!slug) continue;
       slugged += 1;
       if (!isPlaceholderSlug(slug)) continue;
+      const verdict = classifySlugRepair(doc as Parameters<typeof classifySlugRepair>[0]);
       const row: Row = {
         id: (doc.id as string) || '',
         slug,
         title: ((doc.display_title as string) || (doc.title as string) || '').slice(0, 70),
         visible: doc.visible === true,
+        repairTo: verdict.slug,
+        blockedBy: verdict.blockedBy,
+        reason: verdict.reason,
       };
       (row.visible ? visibleHits : hiddenHits).push(row);
     }
 
+    // The finding is the REPAIRABLE subset. Everything else is a report.
+    const repairable = visibleHits.filter((r) => r.repairTo !== null);
+    const blocked = visibleHits.filter((r) => r.repairTo === null);
+
     if (JSON_OUT) {
-      console.log(JSON.stringify({ scanned, slugged, visible: visibleHits, hidden: hiddenHits }, null, 2));
+      console.log(JSON.stringify({
+        scanned,
+        slugged,
+        repairable,
+        blocked,
+        hidden: hiddenHits,
+      }, null, 2));
     } else {
       // Print the denominator. "Clean" means nothing until you can see what was
       // actually in scope.
       console.log(`Scanned ${scanned} books, ${slugged} of them with a slug.`);
       console.log(`Placeholder slugs: ${visibleHits.length} visible, ${hiddenHits.length} hidden.`);
-      if (visibleHits.length) {
-        console.log('\nPublic URLs that say nothing about the book:');
-        for (const r of visibleHits.slice(0, LIMIT)) {
-          console.log(`  /book/${r.slug}  ←  "${r.title}"  (${r.id})`);
+      console.log(`  repairable now: ${repairable.length}   blocked on metadata: ${blocked.length}`);
+
+      if (repairable.length) {
+        console.log('\nREPAIRABLE — a readable slug can be built from what the record already holds:');
+        for (const r of repairable.slice(0, LIMIT)) {
+          console.log(`  /book/${r.slug}  →  /book/${r.repairTo}   "${r.title}"  (${r.id})`);
         }
-        if (visibleHits.length > LIMIT) console.log(`  … and ${visibleHits.length - LIMIT} more`);
+        if (repairable.length > LIMIT) console.log(`  … and ${repairable.length - LIMIT} more`);
         console.log('\nRepair: npx tsx scripts/maintenance/repair-book-slugs.ts   (dry run by default)');
+      }
+
+      if (blocked.length) {
+        // Reported, not raised. Grouped so the tail reads as one known backlog
+        // rather than N mysterious rows — and so a NEW blocker shows up as a
+        // new group instead of hiding inside the count.
+        const byBlocker = new Map<SlugRepairBlocker, Row[]>();
+        for (const r of blocked) {
+          const key = r.blockedBy ?? 'needs-english-title';
+          const list = byBlocker.get(key) ?? [];
+          list.push(r);
+          byBlocker.set(key, list);
+        }
+        console.log(`\nBLOCKED (${blocked.length}) — reported, not a finding. Running the sweep will not move these:`);
+        for (const [blocker, rows] of byBlocker) {
+          console.log(`\n  ${rows.length} × ${blocker} — ${BLOCKER_ROUTES[blocker]}`);
+          for (const r of rows.slice(0, 5)) {
+            console.log(`      /book/${r.slug}  ←  "${r.title}"  (${r.id})`);
+          }
+          if (rows.length > 5) console.log(`      … and ${rows.length - 5} more`);
+        }
+      }
+
+      if (!repairable.length && blocked.length) {
+        console.log('\nNothing to repair today. The remaining URLs are waiting on titles, not on slug logic.');
       }
     }
 
-    return visibleHits.length > 0 ? 1 : 0;
+    // Only repairable findings fire. See the header: a detector that stays red
+    // on an unactionable backlog silences the regression it exists to catch.
+    return repairable.length > 0 ? 1 : 0;
   } finally {
     await client.close().catch(() => {});
   }

--- a/scripts/maintenance/repair-book-slugs.ts
+++ b/scripts/maintenance/repair-book-slugs.ts
@@ -14,6 +14,13 @@
  *      generateBookSlug fix in src/lib/slugify.ts, which stops a non-Latin
  *      title from minting new ones.
  *
+ * WHICH OF THOSE THIS SWEEP CAN ACTUALLY FIX is decided by
+ * `classifySlugRepair` in src/lib/book-slug-repair.ts — holdbacks, "nothing
+ * Latin-script to build from", "the slug already says what the record says".
+ * That module is shared with scripts/audit/book-slug-placeholders.ts, the
+ * detector that REPORTS this work, so the two cannot drift into disagreeing
+ * about what is repairable (#4521). Change the rule there, not here.
+ *
  * Renaming a slug changes a public URL, so the old one is pushed onto
  * `slug_aliases` in the SAME update. findBookByIdOrSlug resolves aliases on
  * its miss path and the caller 301s to the canonical slug, so existing links,
@@ -41,7 +48,8 @@
 import { writeFileSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { MongoClient, type Db } from 'mongodb';
-import { generateBookSlug, appendSlugSuffix, isGenericAuthor, isPlaceholderSlug } from '@/lib/slugify';
+import { appendSlugSuffix, isPlaceholderSlug } from '@/lib/slugify';
+import { classifySlugRepair } from '@/lib/book-slug-repair';
 
 const APPLY = process.argv.includes('--apply');
 const INCLUDE_HIDDEN = process.argv.includes('--include-hidden');
@@ -50,25 +58,6 @@ const INCLUDE_HIDDEN = process.argv.includes('--include-hidden');
 // those books, so the next incremental catalog sync picks them up.
 const RESYNC = process.argv.includes('--resync-catalog');
 const OUT_DIR = join(process.cwd(), 'scripts', 'output');
-
-/**
- * Books where the author fallback would publish a WRONG name, so no slug is
- * better than the one this sweep would mint. Editorial decisions, not a rule
- * the generator can infer — recorded here so a later run does not re-propose
- * them and a later reader knows why.
- *
- * extractLastName takes the final word of an unpunctuated author, which is the
- * surname in Western order and the GIVEN name in Chinese order. That is right
- * for "Katsushika Hokusai" (Hokusai is the art name) and wrong for "Qiu Ying"
- * (family name Qiu). Fixing name order corpus-wide is its own change; these
- * books belong to the same tail as the 34 skipped above — they need an English
- * `display_title` from enrichment, which produces a slug describing the work
- * rather than half-naming its maker.
- */
-const SKIP_IDS = new Set<string>([
-  // 漢宮春曉 handscroll, Qiu Ying — would become /book/ying.
-  '69e53627ce6791c1bca7d814',
-]);
 
 interface BookRow {
   _id: unknown;
@@ -179,48 +168,18 @@ async function main() {
 
   for (const book of broken) {
     const title = book.display_title || book.title || '';
-
     const bookId = book.id || String(book._id);
-    if (SKIP_IDS.has(bookId)) {
-      skipped.push(`${bookId} — held back deliberately, see SKIP_IDS: "${title.slice(0, 40)}"`);
+
+    // The whole triage — holdbacks, "nothing to build from", "no gain" — lives
+    // in src/lib/book-slug-repair.ts, shared with the detector that reports
+    // this work. A detector disagreeing with its own repair tool reports work
+    // that cannot be done; see the header there (#4521).
+    const verdict = classifySlugRepair({ ...book, id: bookId });
+    if (!verdict.repairable || !verdict.slug) {
+      skipped.push(`${bookId} — ${verdict.reason}: "${title.slice(0, 40)}"`);
       continue;
     }
-
-    const base = generateBookSlug(book.title || '', book.author || '', book.display_title);
-
-    // generateBookSlug already falls back to the author, then to "untitled".
-    // If we land on a placeholder anyway (no Latin characters anywhere in
-    // title OR author), leave the book alone rather than moving it from one
-    // meaningless URL to another — it needs a display_title first, which is
-    // the enrichment pipeline's job, not this sweep's.
-    if (isPlaceholderSlug(base)) {
-      skipped.push(`${book.id} — nothing to build a slug from: "${title.slice(0, 40)}"`);
-      continue;
-    }
-
-    // A book that ALREADY has a URL only earns a rename if the new slug says
-    // something the old one didn't. Titles like "216" or "2-13" sanitize to
-    // themselves, so /book/216 would become /book/216-anonymous: a changed
-    // URL, no new information, and a redirect to maintain forever. Those are
-    // a metadata problem, not a slug problem.
-    //
-    // The title is not the only source, though, and reading it as the only one
-    // is what left 7 visible books stranded at /book/-9, /book/-14, /book/-15,
-    // /book/-16, /book/-22, /book/-23 and /book/306-5741 after the first sweep
-    // (#4521). generateBookSlug falls back to the AUTHOR when the title is
-    // entirely non-Latin, and for a Japanese print or a Russian painting that
-    // author is usually written in Latin script - Yoshitoshi, Hokusai, Utagawa
-    // Yoshiiku, Kawanabe Kyosai, Ivan Akimov, Qiu Ying. Those renames DO add
-    // information, so the skip needs both halves: no Latin title AND no named
-    // author. A book with NO slug is the
-    // opposite case — any readable segment beats /book/<objectid>.
-    const titleHasLetters = /[a-z]/i.test(
-      title.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
-    );
-    if (book.slug && !titleHasLetters && isGenericAuthor(book.author)) {
-      skipped.push(`${book.id} — slug "${book.slug}" gains nothing: non-Latin title, no named author`);
-      continue;
-    }
+    const base = verdict.slug;
 
     const to = await reserveSlug(db, base, taken);
     plan.push({

--- a/src/lib/book-slug-repair.ts
+++ b/src/lib/book-slug-repair.ts
@@ -1,0 +1,132 @@
+/**
+ * book-slug-repair — can this book's placeholder URL actually be repaired today?
+ *
+ * WHY THIS IS ONE MODULE AND NOT TWO COPIES
+ * `isPlaceholderSlug` answers "is this URL broken?", and the answer for 39
+ * visible books is yes. But "broken" and "fixable" are different questions, and
+ * conflating them made the detector useless: it fired on all 39, the repair
+ * sweep could fix 0 of them, and because the workflow keeps one open issue at a
+ * time (corpus-integrity-watch.yml), a permanently-red finding meant the NEXT
+ * importer to bypass generateBookSlug would file nothing at all. The alarm the
+ * detector exists for was masked by its own backlog (#4521).
+ *
+ * So the triage lives here, imported by both the sweep
+ * (scripts/maintenance/repair-book-slugs.ts) and the detector
+ * (scripts/audit/book-slug-placeholders.ts), rather than being implemented once
+ * in each. Two copies of a rule this fiddly drift, and the drift is invisible:
+ * a detector that disagrees with its own repair tool reports work that cannot
+ * be done, which is exactly the failure being fixed. Same reasoning as
+ * scripts/lib/gutter-clip.mjs being shared by its audit and its sweep.
+ *
+ * WHAT MAKES A PLACEHOLDER REPAIRABLE
+ * Only that generateBookSlug can build a readable segment from what the record
+ * already holds. That is a question about the DATA, not about the slug: a
+ * Japanese print signed "Katsushika Hokusai" is repairable (the author is
+ * Latin-script), while 大乘百法明門論疏 by 義忠 is not — there is nothing on the
+ * record to put in a URL, and no slug logic can invent it. Those need an
+ * English display_title first (#4390), which then yields a slug describing the
+ * work rather than naming its maker.
+ */
+import { generateBookSlug, isGenericAuthor, isPlaceholderSlug } from './slugify';
+
+/**
+ * Books held back on editorial grounds: the author fallback would publish a
+ * WRONG name, so no slug beats the one the sweep would mint.
+ *
+ * extractLastName takes the final word of an unpunctuated author, which is the
+ * surname in Western order and the GIVEN name in Chinese order. Right for
+ * "Katsushika Hokusai" (an art name), wrong for "Qiu Ying" (family name Qiu).
+ * Corpus-wide name-order handling is its own change; until then these belong
+ * with the #4390 tail, which will give them a slug describing the work.
+ *
+ * Recorded here rather than in the sweep so the detector agrees: a book the
+ * sweep refuses to touch must not be reported as repairable work.
+ */
+export const SLUG_REPAIR_HOLDBACK = new Set<string>([
+  // 漢宮春曉 handscroll, Qiu Ying — the author fallback gives /book/ying.
+  '69e53627ce6791c1bca7d814',
+]);
+
+export type SlugRepairBlocker =
+  /** Editorial holdback — see SLUG_REPAIR_HOLDBACK. */
+  | 'held-back'
+  /** Nothing Latin-script in title OR author. Needs an English title (#4390). */
+  | 'needs-english-title'
+  /** The slug already says everything the record says. Needs real metadata. */
+  | 'no-gain';
+
+export interface SlugRepairVerdict {
+  /** `true` when the sweep can write a readable slug from today's data. */
+  repairable: boolean;
+  /** The slug to write, before uniqueness reservation. Null when blocked. */
+  slug: string | null;
+  /** Why not, when blocked. Null when repairable. */
+  blockedBy: SlugRepairBlocker | null;
+  /** One line naming the reason, for a report or a skip log. */
+  reason: string;
+}
+
+export interface SlugRepairInput {
+  id?: string | null;
+  slug?: string | null;
+  title?: string | null;
+  display_title?: string | null;
+  author?: string | null;
+}
+
+/**
+ * Triage one book whose slug `isPlaceholderSlug` has already flagged.
+ *
+ * Callers pass any book; a book with a perfectly good slug comes back
+ * `repairable: false, blockedBy: null` — nothing to do is not a blocker.
+ */
+export function classifySlugRepair(book: SlugRepairInput): SlugRepairVerdict {
+  const title = book.display_title || book.title || '';
+
+  if (!isPlaceholderSlug(book.slug)) {
+    return { repairable: false, slug: null, blockedBy: null, reason: 'slug is already readable' };
+  }
+
+  const id = book.id || '';
+  if (id && SLUG_REPAIR_HOLDBACK.has(id)) {
+    return {
+      repairable: false,
+      slug: null,
+      blockedBy: 'held-back',
+      reason: 'held back deliberately — the author fallback would publish a wrong name',
+    };
+  }
+
+  const base = generateBookSlug(book.title || '', book.author || '', book.display_title);
+
+  // generateBookSlug falls back to the author, then to "untitled". Landing on a
+  // placeholder anyway means there is no Latin-script text ANYWHERE on the
+  // record — moving the book from one meaningless URL to another is not a
+  // repair.
+  if (isPlaceholderSlug(base)) {
+    return {
+      repairable: false,
+      slug: null,
+      blockedBy: 'needs-english-title',
+      reason: 'no Latin-script title or author to build from — needs an English display_title (#4390)',
+    };
+  }
+
+  // A book that ALREADY has a URL only earns a rename if the new slug says
+  // something the old one didn't. Title "216" sanitizes to itself, so
+  // /book/216 would become /book/216-anonymous: a changed public URL, no new
+  // information, and a redirect to maintain forever. The author half of this
+  // test is load-bearing — dropping it is what stranded seven books whose
+  // artist was sitting one field over (#4521).
+  const titleHasLetters = /[a-z]/i.test(title.normalize('NFD').replace(/[̀-ͯ]/g, ''));
+  if (book.slug && !titleHasLetters && isGenericAuthor(book.author)) {
+    return {
+      repairable: false,
+      slug: null,
+      blockedBy: 'no-gain',
+      reason: 'slug already says what the record says — needs real metadata, not a new slug (#4390)',
+    };
+  }
+
+  return { repairable: true, slug: base, blockedBy: null, reason: '' };
+}

--- a/tests/unit/book-slug-repair.test.ts
+++ b/tests/unit/book-slug-repair.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The triage that decides whether a broken book URL is FIXABLE, not just broken.
+ *
+ * Why this is worth pinning: the detector fires on `repairable` alone, and the
+ * workflow keeps one open issue at a time (corpus-integrity-watch.yml). Widen
+ * `repairable` by accident and the detector reports work nobody can do; narrow
+ * it by accident and a genuinely broken URL ships silently. Both failures have
+ * already happened once — #4389 shipped 111 bad URLs because nothing looked,
+ * and #4521 left 7 fixable ones behind because the sweep asked only about the
+ * title.
+ *
+ * The other invariant here is agreement: the repair sweep and the detector call
+ * this same function, so a case that classifies `repairable` MUST be one the
+ * sweep will actually write.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifySlugRepair, SLUG_REPAIR_HOLDBACK } from '@/lib/book-slug-repair';
+
+describe('classifySlugRepair — repairable', () => {
+  it('takes a Latin title', () => {
+    const v = classifySlugRepair({
+      id: 'a1', slug: 'untitled', title: 'گلستان سعدی', display_title: 'The Rose Garden',
+      author: 'Saadi Shirazi',
+    });
+    expect(v.repairable).toBe(true);
+    expect(v.slug).toBe('the-rose-garden-shirazi');
+    expect(v.blockedBy).toBeNull();
+  });
+
+  it('takes a Latin-script AUTHOR under a non-Latin title — the #4521 seven', () => {
+    // Each of these was live at a digit URL with the artist one field over.
+    const cases: Array<[string, string, string]> = [
+      ['-15', '葛飾北斎筆 鶏と木材鶏図', 'Katsushika Hokusai'],
+      ['-9', '和漢百物語 貞信公', 'Yoshitoshi'],
+      ['-14', '今様擬源氏　三十五　鳥山秋作照忠　一恵斎芳幾画', 'Utagawa Yoshiiku'],
+      ['-16', '東海道名所之内 秋葉山', 'Kawanabe Kyōsai'],
+      ['-22', 'Акимов Иван. Прометей делает статую', 'Ivan Akimov'],
+      ['-23', '«Δύο ανδρικά κεφάλια», Ιερώνυμος Μπος', 'Hieronymus Bosch'],
+    ];
+    for (const [slug, title, author] of cases) {
+      const v = classifySlugRepair({ id: `id-${slug}`, slug, title, author });
+      expect(v.repairable, `${slug} (${author}) should be repairable`).toBe(true);
+      expect(v.slug, `${slug} should get a readable segment`).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+
+  it('never returns a slug that is itself a placeholder', () => {
+    // The sweep writes `v.slug` verbatim (after uniqueness reservation). If this
+    // ever hands back a placeholder, the sweep hands the detector its own work.
+    const v = classifySlugRepair({ id: 'a2', slug: '-9', title: '和漢百物語', author: 'Yoshitoshi' });
+    expect(v.slug).toBe('yoshitoshi');
+  });
+});
+
+describe('classifySlugRepair — blocked, and therefore NOT a finding', () => {
+  it('reports a CJK record with a CJK author as needing an English title', () => {
+    const v = classifySlugRepair({
+      id: 'b1', slug: 'untitled-3', title: '大乘百法明門論疏', display_title: null, author: '義忠',
+    });
+    expect(v.repairable).toBe(false);
+    expect(v.slug).toBeNull();
+    expect(v.blockedBy).toBe('needs-english-title');
+    expect(v.reason).toContain('#4390');
+  });
+
+  it('refuses to append a generic author to a slug that already matches its title', () => {
+    // /book/216 → /book/216-anonymous: a changed public URL, no new information.
+    for (const n of ['216', '217', '218']) {
+      const v = classifySlugRepair({ id: `b-${n}`, slug: n, title: n, author: 'Anonymous' });
+      expect(v.repairable, `/book/${n} should not be renamed`).toBe(false);
+      expect(v.blockedBy).toBe('no-gain');
+    }
+  });
+
+  it('honours the editorial holdback', () => {
+    const [held] = [...SLUG_REPAIR_HOLDBACK];
+    const v = classifySlugRepair({
+      id: held, slug: '306-5741', title: '​漢宮春曉, 卷, 絹本設色, 纵30.6厘米 横574.1厘米', author: 'Qiu Ying',
+    });
+    expect(v.repairable).toBe(false);
+    expect(v.blockedBy).toBe('held-back');
+    // Without the holdback the same record WOULD be repairable — which is
+    // exactly why the list has to live beside the classifier rather than in the
+    // sweep, or the detector would report it as actionable work forever.
+    const unheld = classifySlugRepair({
+      id: 'not-held', slug: '306-5741', title: '​漢宮春曉, 卷, 絹本設色, 纵30.6厘米 横574.1厘米', author: 'Qiu Ying',
+    });
+    expect(unheld.repairable).toBe(true);
+  });
+
+  it('a stand-in author under a non-Latin title is not a named author', () => {
+    const v = classifySlugRepair({
+      id: 'b2', slug: 'untitled-18', title: '坐禪用心記', author: '未詳 (Unknown)',
+    });
+    expect(v.repairable).toBe(false);
+    expect(v.blockedBy).toBe('needs-english-title');
+  });
+});
+
+describe('classifySlugRepair — a good slug is not a blocker', () => {
+  it('says nothing to do, with no blocker, for a readable slug', () => {
+    const v = classifySlugRepair({
+      id: 'c1', slug: 'atalanta-fugiens-maier', title: 'Atalanta Fugiens', author: 'Michael Maier',
+    });
+    expect(v.repairable).toBe(false);
+    expect(v.blockedBy).toBeNull();
+  });
+
+  it('treats a missing slug as repairable when there is a title to use', () => {
+    // /book/<objectid> is ugly rather than broken, but any readable segment
+    // beats it, and there is no old URL to preserve.
+    const v = classifySlugRepair({
+      id: 'c2', slug: null, title: 'Atalanta Fugiens', author: 'Michael Maier',
+    });
+    expect(v.repairable).toBe(true);
+    expect(v.slug).toBe('atalanta-fugiens-maier');
+  });
+});


### PR DESCRIPTION
Follow-up to #4530. That PR repaired the 7 fixable placeholder slugs; this one fixes the instrument that reported them, so #4521 can close honestly.

## The detector was muting itself

After #4530, **39 visible books still carry a placeholder slug, and the sweep can fix 0 of them** — 35 are CJK records with `display_title: null` and an author in Chinese characters, 3 are books whose title literally *is* `"216"`/`"217"`/`"218"`, 1 is the editorial holdback. They're waiting on an English title (#4390), not on slug logic. The audit exited `1` on all 39 anyway.

That's not a cosmetic complaint about a red check. `corpus-integrity-watch.yml` files **one open issue at a time**:

```bash
OPEN=$(gh issue list --state open --search "in:title $TITLE" …)
if [ "$OPEN" != "0" ]; then echo "…not filing another."; exit 0; fi
```

Correct on its own — a deterministic finding filed daily buries the first report under 30 copies. But combined with a finding that stays true *forever*, it becomes a mute button: **the next importer to bypass `generateBookSlug` — the regression this detector exists to catch — files nothing at all.** The alarm was masked by its own backlog.

The issue body made it worse by being confidently wrong. "Repair with `repair-book-slugs.ts`" was false for every row in it, which is exactly the hour this session lost: run the sweep, get 0 renames, re-derive the triage from scratch.

## Split "broken" from "fixable", fire only on fixable

**New `src/lib/book-slug-repair.ts`** — `classifySlugRepair()` returns `repairable` plus the slug to write, or a named blocker (`needs-english-title`, `no-gain`, `held-back`). The editorial holdback list moves here from the sweep.

It's **one module imported by both the sweep and the detector**, deliberately. A detector that disagrees with its own repair tool reports work that cannot be done — which is the bug being fixed. Same reasoning as [gutter-clip.mjs](scripts/lib/gutter-clip.mjs) being shared by its audit and its sweep.

- **[book-slug-placeholders.ts](scripts/audit/book-slug-placeholders.ts)** — reports the classes separately. REPAIRABLE lists `old → new` and drives the exit code; BLOCKED is grouped by blocker with counts, five examples each, and the issue that owns the fix. A *new* blocker shows up as a new group instead of hiding inside a total.
- **[repair-book-slugs.ts](scripts/maintenance/repair-book-slugs.ts)** — three inline guards become one `classifySlugRepair()` call. Same verdicts, same skip messages, one source of truth.
- **[corpus-integrity-watch.yml](.github/workflows/corpus-integrity-watch.yml)** — the filed body now explains both classes and says outright that a leftover BLOCKED count is not a failed repair.

## Measured on production

```
Scanned 112974 books, 112969 of them with a slug.
Placeholder slugs: 39 visible, 31 hidden.
  repairable now: 0   blocked on metadata: 39

  1 × held-back — see SLUG_REPAIR_HOLDBACK in src/lib/book-slug-repair.ts
      /book/306-5741  ←  "​漢宮春曉, 卷, 絹本設色, 纵30.6厘米 横574.1厘米"
  3 × no-gain — needs real metadata, not a new slug (#4390)
      /book/216, /book/217, /book/218
  35 × needs-english-title — needs an English display_title first (#4390)
      /book/untitled-2 … /book/untitled-42

Nothing to repair today. The remaining URLs are waiting on titles, not on slug logic.
exit=0
```

The refactored sweep agrees: **0 planned renames**, same 39 skipped, same reasons.

## Exit contract verified by making it fail

Per [measurement-instruments.md](.claude/docs/invariants/measurement-instruments.md) — observed, not inferred:

| case | result |
|---|---|
| `MONGODB_URI` unset | `exit 2`, "no measurement taken" |
| production, nothing repairable | `exit 0` |
| throwaway scratch DB, 1 repairable + 1 blocked row | **`exit 1`**, fired on the repairable one, reported the other |

The scratch DB (`slug_detector_selftest_4521`, seeded with a non-Latin title + Latin-script author) was removed afterwards; `bookstore` was never touched.

## Doc

Added the general shape to `measurement-instruments.md` — it isn't slug-specific: *a finding must be actionable, or the dedupe that protects your inbox silences the detector.* New tell for the next reader: a watchdog that filed **once** and has been quiet since may be muzzled by its own open issue rather than satisfied.

## Tests

`tests/unit/book-slug-repair.test.ts` pins both directions — the #4521 seven classify repairable, the CJK/`216`/holdback cases classify blocked, and the holdback case is shown to be repairable *without* the holdback, which is why that list has to sit beside the classifier rather than in the sweep.

`npx vitest run tests/unit` — 3304 passed. `npx tsc --noEmit` — clean.

## After merge

Close #4521, referencing #4390 for the 38-book tail. Reopening will then mean something: a genuinely repairable slug appeared.

## Out of scope

Writing English titles for the 34 CJK books — that's #4390's enrichment run, it needs real bibliographic judgment on Buddhist canonical titles, and doing it inside a detector fix turns a one-concern PR into two. Chinese/Japanese name-order handling in `extractLastName` likewise stays its own change; the holdback exists so we don't publish `/book/ying` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
