### PR TITLE
FT demolition step 1–2: retire the badge actuators, harvest citations toward cards (#4536)

### DIFF
--- a/.claude/docs/first-translation-census-methodology.md
+++ b/.claude/docs/first-translation-census-methodology.md
@@ -287,6 +287,8 @@ cost sign-off.
 
 ## 8. Current best estimate (how many of the ~16k are firsts)
 
+> **SUPERSEDED (2026-08-31, round 5 — PR #4524):** the current canonical estimate is **~8,565 books never previously translated into English, 95% CI 7,362–9,768**, over a 16,151-book pool. The ~5,000 below was built on the pre-July `not_applicable` rubric (46% badged-genuine) that Derek's July 2026 policies replaced; it is kept as history. See `scripts/eval/results/ft-pilot-round-5.md` and the runs ledger.
+
 | pool | books | genuine-first rate | genuine firsts |
 |---|---|---|---|
 | Badged eligible | 5,570 | 46–66% | ~2,560–3,680 |

--- a/.claude/docs/first-translation-history.md
+++ b/.claude/docs/first-translation-history.md
@@ -186,7 +186,10 @@ The session that turned the instrument into recorded, per-book truth.
 - **The instrument works and is proven.** Per-book, cross-model, adversarial,
   fully auditable (every query + source + verdict in the provenance log), gated
   on human sign-off before any public flip.
-- **The numbers, honestly:** of ~14,106 FT-eligible books, the best estimate is
+- **The numbers, honestly (SUPERSEDED 2026-08-31 by round 5, PR #4524: the
+  canonical estimate is now **~8,565, 95% CI 7,362–9,768** over a 16,151 pool —
+  the figure below used the pre-July `not_applicable` rubric):** of ~14,106
+  FT-eligible books, the old estimate was
   **~5,000 genuine first English translations (range ~4,000–6,500)** — close to
   the count we badge today, but composed of *substantially different books*
   (~1,900 over-claims roughly cancel ~1,900 missed firsts). Rigorously verified

--- a/.claude/docs/first-translation-system.md
+++ b/.claude/docs/first-translation-system.md
@@ -25,7 +25,7 @@
 > no prior" was written without that measurement and should be re-derived. The
 > verdict model, the badge, and the writer topology below remain accurate.
 
-> **Scaling verification across the whole corpus (tiered census methodology — models, prompts, tools, cost, the ~5,000 estimate): [`first-translation-census-methodology.md`](./first-translation-census-methodology.md).**
+> **Scaling verification across the whole corpus (tiered census methodology — models, prompts, tools, cost, the ~5,000 estimate — SUPERSEDED by round 5's ~8,565, PR #4524): [`first-translation-census-methodology.md`](./first-translation-census-methodology.md).**
 
 **Related issues:** [#2567](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2567) (cluster map / tracking) · [#1974](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1974) (no automated setter — central gap) · [#2352](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2352) (work-keyed translation index) · [#2564](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2564) (measurement + effort-routing + single-writer) · [#2264](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2264) (work resolver) · [#2453](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2453) (works catalog) · [#2244](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2244) (backfill) · [#2332](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2332) (subsystem cleanup).
 

--- a/.claude/docs/ft-eval-runs-ledger.md
+++ b/.claude/docs/ft-eval-runs-ledger.md
@@ -42,7 +42,7 @@
 
 - **Canonical vs scratch.** Where several files share a stem, the canonical one is tagged above (`-final` usually wins; `-merged`/`-rerun`/`-partial`/`-raw` are stages). Don't cite a non-final copy.
 - **Two different kinds of eval.** *Grade-the-pile* (#2876) scores **stored** verdicts at zero token cost. *Run-the-method* (the Tier-2 censuses, the 7-book test, the planned #2880) **runs searches live** and costs tokens. They answer different questions — don't conflate "58.9% disposition precision" (the old pile) with the accuracy of the live search.
-- **The over-claim rate (462-study, ~46% genuine) and the unbadged recall (~25%) are the two load-bearing numbers** behind "≈5,000 genuine firsts, composed of substantially different books" (history doc).
+- **The over-claim rate (462-study, ~46% genuine) and the unbadged recall (~25%) are the two load-bearing numbers** behind the SUPERSEDED "≈5,000 genuine firsts" (history doc) — the canonical corpus estimate is now the round-5 row above (~8,565, CI 7,362–9,768).
 - **What's missing and why #2880 exists:** no run has done the **Gemini-vs-Claude live head-to-head on a properly stratified, oracle-labeled whole-corpus sample**. The 2026-06-19 sonnet-vs-gemini set (106) is the closest precursor but was small and Gemini erred on 1/3. Recall of the live search remains unmeasured (the `catalog.completeness` blocker).
 
 ## Provenance

--- a/.claude/docs/translation-card-method.md
+++ b/.claude/docs/translation-card-method.md
@@ -87,8 +87,15 @@ edition path).
 - Seeded: 919 verified-layer works, 1,730 cited entries, 62 sibling-disagreement
   sets exposed (PRs #3890, #3891). Canary: Q1232238 caught wrong at seed —
   `under_review`.
-- Readers of the collection: **none yet.** The label rule (rule 2) ships as its
-  own reviewed PR — that is the moment the registry becomes actuating.
-- The book-grain machinery (verdicts, derive, valve) remains in place and
-  untouched until the card replaces it; then it is deleted, not migrated
-  (#3881 passes 3–6).
+- Readers of the collection: **LIVE since #3910/#3916** — `/book/[id]` renders
+  the card (hero + bibliographic panel) wherever `cardLabel()` is non-null.
+  Every `--apply` against a rendering status is reader-visible actuation.
+- The book-grain machinery's nightly actuators were **retired 2026-09-01**
+  (#4536): the 05:30 derive+reconcile cron and the 09:30 census cron are off
+  (`#RETIRED-3881` in `scripts/workers/crontab.production`). The badge boolean
+  `books.is_first_translation` is frozen except through reviewed card work.
+  Deletion of the machinery itself (verdicts, derive, valve) is #3881 passes
+  3–6 — deleted, not migrated.
+- Citation harvest: `scripts/audit/harvest-priors-to-card-proposals.mjs`
+  (#4536) moves ledger `priors[]` citations toward cards — new cards land as
+  silent `under_review`, existing cards get proposals only.

--- a/scripts/audit/harvest-priors-to-card-proposals.mjs
+++ b/scripts/audit/harvest-priors-to-card-proposals.mjs
@@ -1,0 +1,247 @@
+/**
+ * Harvest citable priors[] evidence from the attempts ledger into Translation
+ * Card PROPOSALS (#3881 / #4536 — the citation harvest of the FT demolition).
+ *
+ * The one durable organ of the retired book-grain machinery is its citations:
+ * `first_translation_attempts.priors[]` (11,323 books at harvest time). This
+ * script moves that evidence toward the card layer WITHOUT bypassing review:
+ *
+ *   - Works that already have a card are NEVER touched. Harvested entries not
+ *     already on the card are emitted to the proposals file for human review
+ *     (the reseed-clobber lesson, #3928: the ledger is append-only, cards are
+ *     corrected — regeneration restores removed fabrications).
+ *   - Works with NO card get a new card with status `under_review`, which
+ *     cardLabel() renders as NOTHING (src/lib/first-translation/card.ts).
+ *     Inserting one changes no reader-visible surface; a human review that
+ *     flips the status is the actuation moment. This is card method rule 3
+ *     enforced structurally, not procedurally.
+ *   - Verdicts are NOT migrated. Only citations. `gemini_verifier` rows carry
+ *     a measured ~20% false-found rate (#4525) — every entry records its
+ *     source methods so a reviewer can weigh that.
+ *
+ * Entry hygiene = the seeder's rules (ft-work-registry-pilot.mjs, #3901,
+ * card-rounds 1–4): no citation → no entry; placeholder screens on title,
+ * translator and year; dedupe by translation event.
+ *
+ * Dry-run by default: writes the proposals JSONL + summary, no DB writes.
+ * --apply additionally inserts the new under_review cards (insert-only) and
+ * records one sweep_log row per insert.
+ *
+ * Usage (Hetzner, per import-cost invariant):
+ *   node scripts/audit/harvest-priors-to-card-proposals.mjs
+ *   node scripts/audit/harvest-priors-to-card-proposals.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const NOW = new Date().toISOString();
+const SWEEP = 'card-harvest-3881';
+const OUT_DIR = 'scripts/output';
+const OUT_JSONL = `${OUT_DIR}/card-harvest-3881.jsonl`;
+
+const VERIFIED_METHODS = new Set(['tier2_agent', 'human', 'claude_subagent_verify']);
+
+// Round-1 + round-2 hygiene: placeholder prose is extraction noise, not
+// knowledge — on any of the three locating fields. Genuine 'anonymous'
+// translators are preserved (round 2).
+const TITLE_PLACEHOLDER = /^\s*(none\b|no |n\/a|unknown\b|partial translations? of|various\b)/i;
+const NAME_PLACEHOLDER = /^\s*(various\b|not specified|n\/a$|unknown\b|none\b|unnamed\b|multiple\b)/i;
+
+function cleanEntry(p, attempt) {
+  const locatable = p.source_url || (p.translator && p.pub_year);
+  if (!locatable) return null;
+  if (TITLE_PLACEHOLDER.test(p.english_title ?? '')) return null;
+  if (p.translator && NAME_PLACEHOLDER.test(p.translator)) return null;
+  if (p.pub_year && !/\d/.test(String(p.pub_year))) return null;
+  return {
+    kind: 'english_translation',
+    year: p.pub_year ?? null,
+    translator: p.translator ?? null,
+    title: p.english_title ?? null,
+    publisher: p.publisher ?? null,
+    completeness: p.completeness ?? 'unknown',
+    relationship: p.relationship ?? null,
+    citation_url: p.source_url ?? null,
+    source_attempt_ids: [attempt.attempt_id],
+    source_methods: [attempt.method ?? 'unknown'],
+    evidence_grade: attempt.evidence_strength ?? null,
+    verified: VERIFIED_METHODS.has(attempt.method),
+  };
+}
+
+function eventKey(e) {
+  return `${(e.translator ?? '').toLowerCase()}|${e.year ?? ''}|${(e.title ?? '').toLowerCase().slice(0, 40)}`;
+}
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const db = c.db('bookstore');
+const books = db.collection('books');
+const attempts = db.collection('first_translation_attempts');
+const registry = db.collection('work_translation_history');
+
+console.log(`=== ${SWEEP} (${APPLY ? 'APPLY' : 'DRY-RUN'}) ${NOW} ===`);
+
+// 1. Every attempt row carrying priors evidence.
+const rows = await attempts
+  .find(
+    { result: 'found', 'priors.0': { $exists: true } },
+    { projection: { attempt_id: 1, book_id: 1, method: 1, date: 1, priors: 1, evidence_strength: 1 } },
+  )
+  .toArray();
+console.log(`priors[] attempt rows: ${rows.length}`);
+
+// 2. Resolve books → works.
+const bookIds = [...new Set(rows.map((r) => r.book_id))];
+const bookDocs = await books
+  .find(
+    { id: { $in: bookIds } },
+    { projection: { id: 1, work_id: 1, title: 1, author: 1, visible: 1 } },
+  )
+  .toArray();
+const bookById = new Map(bookDocs.map((b) => [b.id, b]));
+
+const stats = {
+  rows: rows.length,
+  books_with_priors: bookIds.length,
+  books_not_found: 0,
+  books_without_work_id: 0,
+  raw_entries: 0,
+  entries_rejected_hygiene: 0,
+  works_total: 0,
+  works_with_existing_card: 0,
+  works_proposed_new_card: 0,
+  new_cards_with_verified_entry: 0,
+  proposals_for_existing_cards: 0,
+  inserted: 0,
+};
+
+// 3. Group cleaned entries by work.
+const byWork = new Map();
+const orphanBooks = [];
+for (const row of rows) {
+  const book = bookById.get(row.book_id);
+  if (!book) { stats.books_not_found++; continue; }
+  if (!book.work_id) { orphanBooks.push(row.book_id); continue; }
+  let w = byWork.get(book.work_id);
+  if (!w) {
+    w = { work_id: book.work_id, title: book.title, author: book.author ?? null, book_ids: new Set(), entries: new Map() };
+    byWork.set(book.work_id, w);
+  }
+  w.book_ids.add(book.id);
+  for (const p of row.priors ?? []) {
+    stats.raw_entries++;
+    const e = cleanEntry(p, row);
+    if (!e) { stats.entries_rejected_hygiene++; continue; }
+    const key = eventKey(e);
+    const prev = w.entries.get(key);
+    if (prev) {
+      // Same translation event seen by another attempt — merge provenance.
+      if (!prev.source_attempt_ids.includes(e.source_attempt_ids[0])) prev.source_attempt_ids.push(e.source_attempt_ids[0]);
+      if (!prev.source_methods.includes(e.source_methods[0])) prev.source_methods.push(e.source_methods[0]);
+      prev.verified = prev.verified || e.verified;
+      prev.citation_url = prev.citation_url ?? e.citation_url;
+    } else {
+      w.entries.set(key, e);
+    }
+  }
+}
+stats.books_without_work_id = new Set(orphanBooks).size;
+stats.works_total = byWork.size;
+
+// 4. Partition: existing card vs new card.
+const workIds = [...byWork.keys()];
+const existing = new Set(
+  (await registry.find({ _id: { $in: workIds } }, { projection: { _id: 1 } }).toArray()).map((d) => d._id),
+);
+
+mkdirSync(OUT_DIR, { recursive: true });
+const out = createWriteStream(OUT_JSONL);
+const newCards = [];
+
+for (const w of byWork.values()) {
+  const entries = [...w.entries.values()];
+  if (!entries.length) continue;
+  if (existing.has(w.work_id)) {
+    stats.works_with_existing_card++;
+    stats.proposals_for_existing_cards += entries.length;
+    out.write(`${JSON.stringify({ type: 'proposal_for_existing_card', work_id: w.work_id, title: w.title, entries })}\n`);
+    continue;
+  }
+  // Reader-facing search record across ALL attempts on this work's books.
+  const allAttempts = await attempts
+    .find({ book_id: { $in: [...w.book_ids] } }, { projection: { sources_checked: 1, date: 1 } })
+    .toArray();
+  const sourceSet = new Set();
+  let lastSearched = null;
+  for (const a of allAttempts) {
+    for (const s of a.sources_checked ?? []) if (s) sourceSet.add(String(s));
+    if (a.date && (!lastSearched || String(a.date) > String(lastSearched))) lastSearched = a.date;
+  }
+  const card = {
+    _id: w.work_id,
+    work_id: w.work_id,
+    work_title: w.title,
+    author: w.author,
+    // NEVER a rendering status: under_review is silent in cardLabel().
+    // A reviewer flips it — that flip is the actuation moment.
+    status: 'under_review',
+    entries,
+    search: {
+      summary: 'Citations harvested from the attempts ledger (#4536); status pending human review.',
+      sources: [...sourceSet].sort(),
+      attempt_count: allAttempts.length,
+      last_searched: lastSearched,
+    },
+    review_note: `${SWEEP} (unreviewed) ${NOW.slice(0, 10)}`,
+    seeded_from: SWEEP,
+    seeded_at: NOW,
+  };
+  newCards.push(card);
+  stats.works_proposed_new_card++;
+  if (entries.some((e) => e.verified)) stats.new_cards_with_verified_entry++;
+  out.write(`${JSON.stringify({ type: 'new_card', ...card })}\n`);
+}
+await new Promise((res) => out.end(res));
+
+// 5. Apply: insert-only. Existing _ids are untouched by construction, and
+// insertMany(ordered:false) tolerates a card created between scan and write.
+if (APPLY && newCards.length) {
+  for (let i = 0; i < newCards.length; i += 500) {
+    const chunk = newCards.slice(i, i + 500);
+    try {
+      const r = await registry.insertMany(chunk, { ordered: false });
+      stats.inserted += r.insertedCount;
+    } catch (err) {
+      stats.inserted += err.result?.insertedCount ?? 0;
+      const dupes = (err.writeErrors ?? []).filter((e) => e.code === 11000).length;
+      if (dupes !== (err.writeErrors ?? []).length) throw err;
+      console.log(`  chunk ${i / 500}: ${dupes} duplicate _id(s) skipped (card created concurrently)`);
+    }
+  }
+  for (const card of newCards) {
+    const primaryBook = card.entries[0]?.source_attempt_ids?.[0] ?? null;
+    await recordSweepAction(db, {
+      sweep: SWEEP,
+      book_id: [...byWork.get(card.work_id).book_ids][0],
+      action: 'card-proposed-under-review',
+      detail: { work_id: card.work_id, entries: card.entries.length, basis_attempt: primaryBook },
+    });
+  }
+}
+
+console.log(JSON.stringify(stats, null, 2));
+console.log(`proposals written: ${OUT_JSONL}`);
+if (APPLY) {
+  console.log(`inserted ${stats.inserted} under_review card(s) — reader-invisible until reviewed.`);
+  // Post-write verification (round-4 rule): what does the collection actually hold?
+  const check = await registry.countDocuments({ seeded_from: SWEEP });
+  console.log(`post-write check: ${check} card(s) in work_translation_history with seeded_from=${SWEEP}`);
+  if (check !== stats.inserted) console.log('WARNING: post-write count differs from insert count — investigate before trusting.');
+} else {
+  console.log('DRY-RUN — no DB writes. Re-run with --apply to insert the under_review cards.');
+}
+await c.close();

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -19,7 +19,6 @@
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
 */2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
 30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
-# embed-gemini self-gates on pause + daily budget since #3826 — the cron line can stay enabled; a paused/over-budget night is a logged no-op.
 30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1
 30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/snapshot-stats.mjs" >> /var/log/sourcelibrary/snapshot.log 2>&1
 30 5 * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; curl -s -X POST https://sourcelibrary.org/api/admin/cache-probe -H "Authorization: Bearer $CRON_SECRET"" >> /var/log/sourcelibrary/cache-probe.log 2>&1
@@ -95,7 +94,7 @@
 #RETIRED-2933 0 8 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-ground.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/ft-ground-remediation.mjs --set unverified --limit 250" >> /var/log/sourcelibrary/ft-ground.log 2>&1
 
 # FT single-writer loop (#2933-C): derive graded verdicts (free) then materialize ONLY agent/human-verified demotions
-30 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-derive.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --apply && npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply --only-demotions --verdict=not_first,not_applicable --resolver=tier2_agent,human" >> /var/log/sourcelibrary/ft-derive.log 2>&1
+#RETIRED-3881 (card is the only writer; see issue 4536) 30 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-derive.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --apply && npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply --only-demotions --verdict=not_first,not_applicable --resolver=tier2_agent,human" >> /var/log/sourcelibrary/ft-derive.log 2>&1
 
 # Crontab drift detector — logs if live crontab diverges from committed snapshot (#2332)
 0 4 * * * /root/sourcelibrary/scripts/workers/sync-crontab.sh >> /var/log/sourcelibrary/crontab-sync.log 2>&1
@@ -105,10 +104,6 @@
 50 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-classify-text-role.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/classify-text-role.mjs --only-missing" >> /var/log/sourcelibrary/classify-text-role.log 2>&1
 30 6 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-lang-audit.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/audit-language-mismatch.mjs --flag" >> /var/log/sourcelibrary/lang-audit.log 2>&1
 0 4 * * * /root/sourcelibrary/scripts/workers/backup-bph-catalog.sh
-# Catalogue integrity: fingerprint every record and flag changes that no revision
-# and no known automation explains. Runs after the 04:00 backup and before restic
-# at 05:00, so a flagged night is preserved in that night's snapshot.
-30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-bph-integrity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/bph-integrity-check.mjs" >> /var/log/sourcelibrary/bph-integrity.log 2>&1
 30 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-work-id-mint.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/mint-local-work-ids.mjs --apply --include-anon --include-parts --include-hidden && node scripts/analysis/assign-work-slugs.mjs --apply" >> /var/log/sourcelibrary/work-id-mint.log 2>&1
 # Refresh book locations[] (publication/author/tradition) before the map-cache rebuild at 05:45
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-geocode.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/geocode-publication-places.mjs && node scripts/enrichment/backfill-author-locations.mjs --write-books && node scripts/enrichment/geocode-origin-by-tradition.mjs" >> /var/log/sourcelibrary/geocode-locations.log 2>&1
@@ -122,28 +117,29 @@
 # On-mission acquisition: hourly bounded concurrent batch
 30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-acquire.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/acquire-gap-batch.mjs --batch 400 --concurrency 10" >> /var/log/sourcelibrary/acquire.log 2>&1
 # Archive newly-acquired gap books to R2 (companion to acquisition)
-45 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-arch-acq.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/catalog-coverage/archive-acquired.ts --batch 240 --concurrency 10" >> /var/log/sourcelibrary/archive-acquired.log 2>&1
-
-# Collect Gemini Batch API results (#3713). Submitting a batch and getting text are
-# different events: the Vercel process-batches cron was archived as "replaced by Hetzner
-# workers", but this replacement was never added, so results sat on Gemini's side until
-# somebody ran the script by hand. --abandon-stale=7 stops the collector retrying jobs
-# whose output Gemini has already discarded, which otherwise keeps this log permanently red.
-*/30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-collect-batch.lock bash -c "set -a; source .env.production.local; set +a; node scripts/batch/collect-batch-results.mjs --limit 200 --abandon-stale=7" >> /var/log/sourcelibrary/collect-batch.log 2>&1
-*/20 * * * * tmux has-session -t catchup 2>/dev/null || ( cd /root/sourcelibrary && P=$(bash -c "set -a; source .env.production.local; set +a; node -e \"const {MongoClient}=require(process.cwd()+\x27/node_modules/mongodb\x27);(async()=>{const c=new MongoClient(process.env.MONGODB_URI);await c.connect();console.log(await c.db(\x27bookstore\x27).collection(\x27acquisition_queue\x27).countDocuments({status:\x27pending\x27}));await c.close();})()\"" 2>/dev/null); [ "$P" -gt 500 ] 2>/dev/null && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
+45 * * * * /root/sourcelibrary/scripts/catalog-coverage/archive-acquired-cron.sh >> /var/log/sourcelibrary/archive-acquired.log 2>&1
 30 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1
 # catchup-watchdog: restart the acquisition catch-up if it died (loop self-exits when queue drains)
-*/15 * * * * ( [ -f /tmp/acquire_catchup.sh ] && tmux has-session -t catchup 2>/dev/null ) || ( [ -f /tmp/acquire_catchup.sh ] && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
 #TEMP-FT-CENSUS (#2933) — remove when ft-census-daily reports exhausted
-30 9 * * * flock -n /tmp/sl-ft-census.lock bash /root/sourcelibrary/scripts/eval/ft-census-daily.sh >> /var/log/sourcelibrary/ft-census.log 2>&1
+#RETIRED-3881 (worklist exhausted 2026-09-01) 30 9 * * * flock -n /tmp/sl-ft-census.lock bash /root/sourcelibrary/scripts/eval/ft-census-daily.sh >> /var/log/sourcelibrary/ft-census.log 2>&1
 # canonical_entities read-model rebuild (#2979) — after 02:15 Vercel enrich-entities cron + 03:30 entity sync
 45 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-canonical-entities.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/build-canonical-entities.mjs --apply" >> /var/log/sourcelibrary/canonical-entities.log 2>&1
 0 5 * * * /root/restic-backup.sh
 # Traffic anomaly detector — pushes to ntfy on state change (#3446)
 17 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-traffic-anomaly.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/traffic-anomaly-alert.mjs" >> /var/log/sourcelibrary/traffic-anomaly.log 2>&1
+# Catalogue integrity: flag changes no revision or known automation explains (#3492)
+30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-bph-integrity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/bph-integrity-check.mjs" >> /var/log/sourcelibrary/bph-integrity.log 2>&1
+# Rebuild the volunteer review-candidate pool weekly (#3568). Off :00 — nine
+# schedules converge there and the pile of cold Atlas dials drops handshakes.
+42 6 * * 1 cd /root/sourcelibrary && flock -n /tmp/sl-review-candidates.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/build-review-candidates.mjs --target=3000 --per-book=2" >> /var/log/sourcelibrary/review-candidates.log 2>&1
+# Collect Gemini Batch API results (#3713). The Vercel process-batches cron was archived
+# as "replaced by Hetzner workers" but this replacement was never added, so submitted
+# batches sat uncollected until someone ran the script by hand.
+*/30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-collect-batch.lock bash -c "set -a; source .env.production.local; set +a; node scripts/batch/collect-batch-results.mjs --limit 200" >> /var/log/sourcelibrary/collect-batch.log 2>&1
 # Identity worker — Phase 0: stamps normalized_title/author + edition_key on any book missing them (#3730)
 40 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-identity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/identity-worker.mjs" >> /var/log/sourcelibrary/identity-worker.log 2>&1
-# Stage coverage snapshot — nightly semantic monitoring, coverage from data not job counters (#3756). Supervised runs 2026-08-08; page-level counts need the long socket timeout.
+# Stage coverage snapshot — nightly semantic monitoring (#3756)
 15 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-stage-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/stage-coverage-snapshot.mjs" >> /var/log/sourcelibrary/stage-coverage.log 2>&1
-# Author canonical-link convergence (#3769/#3756) — link books.author -> authors._id where unambiguous; live-only default (backlog inclusion is the #3780 decision)
 40 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-author-links.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-author-canonical-links.mjs --apply" >> /var/log/sourcelibrary/author-links.log 2>&1
+*/20 * * * * /root/sourcelibrary/scripts/catalog-coverage/acquire-catchup.sh >> /var/log/sourcelibrary/acquire.log 2>&1
+0 6 * * 0 /root/sourcelibrary/scripts/workers/backup-corpus-text.sh


### PR DESCRIPTION
Part of #4536 (executing #3881 passes 3–6). Derek-directed 2026-09-01.

## In scope

**1. The off-switch (already flipped on the box).** The 05:30 derive+reconcile cron — the only scheduled writer that flips `books.is_first_translation` by verdict — and the 09:30 `#TEMP-FT-CENSUS` cron (its own log reported `worklist exhausted — remove the cron line`) are retired live on Hetzner with `#RETIRED-3881` prefixes; backup at `/root/crontab.bak.2026-09-01-3881`. This PR re-snapshots `scripts/workers/crontab.production` per the sync-crontab policy (live is source of truth). The snapshot also captures unrelated drift accumulated since the last re-snapshot (archive-acquired wrapper, review-candidates cron, corpus-text backup, collect-batch flags) — none of it is this PR's doing, it is the state of the box.

Effect: the public badge is frozen except through reviewed card work. The Translation Card (`work_translation_history`, live on `/book/[id]` since #3910/#3916) is now the only sanctioned actuation path.

**2. The citation harvest** (`scripts/audit/harvest-priors-to-card-proposals.mjs`). Moves the durable organ of the old machinery — `priors[]` citations on `first_translation_attempts` — toward the card layer without bypassing review:
- Works with an existing card are never touched (the #3928 reseed-clobber lesson); their harvested entries go to a proposals file.
- Works with no card get one with status `under_review`, which `cardLabel()` renders as **nothing** — inserting one changes no reader-visible surface. The human review that flips the status is the actuation moment (card method rule 3, enforced structurally).
- Verdicts are not migrated. Entries carry `source_methods` so reviewers can weigh the measured ~20% false-found rate of `gemini_verifier` rows (#4525).

Dry-run measured on Hetzner 2026-09-01: 23,130 priors[] rows → 35,761 raw entries → 14,497 rejected by hygiene (40.5%, consistent with the historical 41.5% noise rate) → 5,174 proposed new cards (151 containing a verified-method entry), 1,237 entry proposals for 297 existing cards, 262 books skipped for missing `work_id`, 640 dangling `book_id`s. Full proposals: `scripts/output/card-harvest-3881.jsonl` on the box.

**3. Method-doc correction** — `translation-card-method.md` still claimed the card collection had no readers; it has been live since #3910.

## Out of scope
Deletion of the machinery itself (derive/reconcile/valve code + retired-cron scripts) — separate deletion-class PR, next on #4536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7KeuLsey2dMw22HYMxGd9