### PR TITLE
fix(libraries): readable Digital Sources tiles

### DIFF
--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -120,7 +120,8 @@ function PartnerCard({ partner, heroImage, count, languages, size = 'normal' }: 
   languages: string[];
   size?: 'hero' | 'featured' | 'normal';
 }) {
-  const topLangs = languages.slice(0, 4).join(', ');
+  const isCompact = size === 'normal';
+  const topLangs = languages.slice(0, isCompact ? 3 : 4).join(', ');
   const isHero = size === 'hero';
   const isFeatured = size === 'featured';
 
@@ -156,7 +157,7 @@ function PartnerCard({ partner, heroImage, count, languages, size = 'normal' }: 
       <div className={`absolute inset-0 ${
         isHero || isFeatured
           ? 'bg-gradient-to-r from-[rgba(26,22,18,0.92)] via-[rgba(26,22,18,0.5)] to-transparent'
-          : 'bg-gradient-to-t from-[rgba(26,22,18,0.88)] via-[rgba(26,22,18,0.3)] to-transparent'
+          : 'bg-gradient-to-t from-[rgba(26,22,18,0.95)] via-[rgba(26,22,18,0.55)] via-40% to-transparent'
       }`} />
 
       {/* Content */}
@@ -177,23 +178,28 @@ function PartnerCard({ partner, heroImage, count, languages, size = 'normal' }: 
           {partner.name}
         </h2>
 
-        <p className={`text-white/70 leading-relaxed ${
-          isHero ? 'mt-2 text-base md:text-lg line-clamp-3' :
-          isFeatured ? 'mt-2 text-sm md:text-base line-clamp-2' :
-          'mt-1 text-xs line-clamp-2 hidden sm:block'
-        }`}>
-          {partner.description}
-        </p>
+        {/* Descriptions only on the large cards — on small tiles they overflow the
+            image and land on unreadably light scan backgrounds. The tile links to
+            /libraries/[slug], which carries the full description. */}
+        {!isCompact && (
+          <p className={`text-white/70 leading-relaxed ${
+            isHero ? 'mt-2 text-base md:text-lg line-clamp-3' : 'mt-2 text-sm md:text-base line-clamp-2'
+          }`}>
+            {partner.description}
+          </p>
+        )}
 
-        <div className={`flex flex-wrap items-center gap-x-3 gap-y-1 ${isHero || isFeatured ? 'mt-5' : 'mt-2'}`}>
-          <span className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-white/90 bg-white/15 backdrop-blur-sm rounded-full">
+        <div className={`flex items-center gap-x-3 gap-y-1 min-w-0 ${
+          isCompact ? 'mt-2 flex-nowrap' : 'mt-5 flex-wrap'
+        }`}>
+          <span className="inline-flex shrink-0 items-center gap-1.5 px-3 py-1 text-xs font-medium text-white/90 bg-white/15 backdrop-blur-sm rounded-full">
             <BookOpen className="w-3 h-3" />
             {count.toLocaleString('en-US')} books
           </span>
           {topLangs && (
-            <span className="inline-flex items-center gap-1.5 text-xs text-white/50">
-              <Globe className="w-3 h-3" />
-              {topLangs}
+            <span className={`inline-flex items-center gap-1.5 text-xs text-white/60 min-w-0 ${isCompact ? 'hidden md:inline-flex' : ''}`}>
+              <Globe className="w-3 h-3 shrink-0" />
+              <span className="truncate">{topLangs}</span>
             </span>
           )}
         </div>
@@ -268,7 +274,7 @@ export default async function LibrariesPage() {
             Libraries and platforms whose digitized collections we import, translate, and preserve.
           </p>
 
-          <div className="grid gap-3 sm:gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="grid gap-4 sm:gap-5 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
             {rest.map((partner) => (
               <PartnerCard
                 key={partner.slug}

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -197,7 +197,7 @@ function PartnerCard({ partner, heroImage, count, languages, size = 'normal' }: 
             {count.toLocaleString('en-US')} books
           </span>
           {topLangs && (
-            <span className={`inline-flex items-center gap-1.5 text-xs text-white/60 min-w-0 ${isCompact ? 'hidden md:inline-flex' : ''}`}>
+            <span className={`items-center gap-1.5 text-xs text-white/60 min-w-0 ${isCompact ? 'hidden md:inline-flex' : 'inline-flex'}`}>
               <Globe className="w-3 h-3 shrink-0" />
               <span className="truncate">{topLangs}</span>
             </span>


### PR DESCRIPTION
## Problem
/libraries looked cramped and the tile text was unreadable (Derek's report + screenshot).

Root cause: the small-tile description used `hidden sm:block line-clamp-2`. At `sm+`, `sm:block` overrides the `display: -webkit-box` that `line-clamp` requires, so the clamp silently died. The full description then overflowed the fixed aspect-ratio tile, pushing white text up into the transparent top of the card — straight onto light parchment thumbnails with no gradient behind it.

## Fix
- Small grid tiles now show only title + book count (+ languages, truncated to one line, md+ only). Descriptions still appear on the BPH hero and Internet Archive featured cards, and on each library's own `/libraries/[slug]` page.
- Stronger bottom gradient behind the remaining tile text.
- Slightly wider grid gaps.

## Out of scope
- The hero/featured card design (reads fine today).
- `/libraries/[slug]` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjAU6kQKngdU3X5JJEsSGg