### PR TITLE
Classify and block Lightpanda headless browser (32K reads/day as 'human', #4476)

### DIFF
--- a/src/lib/traffic-classification.ts
+++ b/src/lib/traffic-classification.ts
@@ -33,7 +33,7 @@ const AI_TRAINER = /gptbot|ccbot|claudebot|anthropic-ai|google-extended|bytespid
 const SEARCH_CRAWLER = /googlebot|googleother|bingbot|bingpreview|slurp|duckduckbot|baiduspider|yandexbot|applebot|seznambot|sogou|exabot/i;
 
 // Everything else automated: SEO tools, scrapers, monitors, generic libraries.
-const OTHER_BOT = /ahrefs|semrush|mj12bot|dotbot|petalbot|dataforseo|screaming frog|bot\b|crawler|spider|headlesschrome|python-requests|curl|wget|axios|go-http-client|java\/|okhttp|scrapy|httpclient/i;
+const OTHER_BOT = /ahrefs|semrush|mj12bot|dotbot|petalbot|dataforseo|screaming frog|bot\b|crawler|spider|headlesschrome|lightpanda|python-requests|curl|wget|axios|go-http-client|java\/|okhttp|scrapy|httpclient/i;
 
 export function classifyTraffic(
   userAgent: string | null | undefined,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -55,6 +55,10 @@ const BLOCKED_BOT_PATTERNS = [
   'PetalBot', 'SemrushBot', 'AhrefsBot', 'MJ12bot', 'DotBot',
   'BLEXBot', 'DataForSeoBot', 'serpstatbot', 'Seekport',
   'MegaIndex', 'Linguee', 'YandexBot', 'Amazonbot',
+  // Headless scraping browsers that self-identify. Lightpanda drove 32K
+  // reads/24h from 26.8K residential proxy IPs on 2026-09-01 (#4476); the
+  // Cloudflare rule covers only the zone — this covers every hostname.
+  'Lightpanda',
 ];
 
 const BLOCKED_BOT_RE = new RegExp(BLOCKED_BOT_PATTERNS.join('|'), 'i');

--- a/tests/unit/traffic-classification.test.ts
+++ b/tests/unit/traffic-classification.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { classifyTraffic } from '@/lib/traffic-classification';
+
+// Pins the write-time traffic classifier. It exists because a gap here is not
+// cosmetic: on 2026-09-01 the headless browser Lightpanda — which declares
+// itself plainly in its UA — matched none of the bot patterns (no "bot",
+// "crawler", or "spider" substring) and 32,069 reads/24h from 26,822
+// residential proxy IPs were stored as `traffic_class: human` (#4476).
+// Every audience metric downstream of traffic_class inherited that.
+
+describe('classifyTraffic', () => {
+  it('classifies self-identifying headless browsers as other_bot', () => {
+    expect(classifyTraffic('Lightpanda/1.0')).toBe('other_bot');
+    expect(
+      classifyTraffic('Mozilla/5.0 (X11; Linux x86_64) Lightpanda/1.0 AppleWebKit/537.36')
+    ).toBe('other_bot');
+    expect(classifyTraffic('Mozilla/5.0 HeadlessChrome/120.0.0.0')).toBe('other_bot');
+  });
+
+  it('still classifies a real browser UA as human', () => {
+    expect(
+      classifyTraffic(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36'
+      )
+    ).toBe('human');
+  });
+
+  it('keeps the AI/search precedence ordering', () => {
+    expect(classifyTraffic('Mozilla/5.0 (compatible; ClaudeBot/1.0)')).toBe('ai_trainer');
+    expect(classifyTraffic('Mozilla/5.0 (compatible; Claude-User/1.0)')).toBe('ai_agent');
+    expect(classifyTraffic('Mozilla/5.0 (compatible; Googlebot/2.1)')).toBe('search_crawler');
+  });
+});


### PR DESCRIPTION
## What

`Lightpanda/1.0` — an open-source headless browser built for AI scraping — drove **32,069 page reads in 24h from 26,822 distinct residential proxy IPs** (2026-09-01), all stored as `traffic_class: human`. The UA declares itself honestly, but contains no `bot`/`crawler`/`spider` substring, so `classifyTraffic()` had nothing to key on. It was 57% of all page reads on the site.

- **`src/lib/traffic-classification.ts`**: `lightpanda` added to `OTHER_BOT` — analytics stops counting it as a reader.
- **`src/proxy.ts`** `BLOCKED_BOT_PATTERNS`: hard-403 with the pitch page, same treatment as CCBot/Bytespider. Per `crawler-access-gate.md`, the app layer is the durable control covering every alias hostname.
- **New test** `tests/unit/traffic-classification.test.ts` pins the classification and the AI/search precedence order.

## Already live at the edge (out of band)

Cloudflare block rule `11cee688225c4cb79fcba7678d596396`, appended **last** in the custom ruleset (position 13, after all skips — order is part of the rule per the AS132203 lesson). Curl-verified four directions: Lightpanda → 403 on content, → 200 on /robots.txt and /licensing (funnel intact), normal Chrome UA → 200. Volume verification pending the fleet's next wave — it works in bursts and went quiet ~09:00Z, before the rule existed. Rollback: delete that one rule.

## Out of scope

- The rotating forged-Chrome residential pool (the `distributed_proxy_pool` alarm) — that lever is a Cloudflare challenge decision, tracked in #4476.
- The `sourcelibrary-v2-staging.vercel.app` host leak (12 reads/day) flagged by `reader_traffic_on_unexpected_host` — separate concern, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpyJU11WWiFZhwAT312dWd