### PR TITLE
Reader: 'unverified transcription' notice on Tibetan pages (#4523)

### DIFF
--- a/src/components/reader/PageMetadataPanel.tsx
+++ b/src/components/reader/PageMetadataPanel.tsx
@@ -228,6 +228,19 @@ export default function PageMetadataPanel({
             </div>
           )}
 
+          {/* Standing honesty notice for Tibetan transcriptions (#4523): repeat
+              OCR runs on the same folio disagree on most of the text, so the
+              transcription is not a verified reading. The image is authoritative. */}
+          {/tibetan/i.test(ocrMeta.language || page.ocr?.language || editionBook?.language || '') && (
+            <div className="mx-4 mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
+              <strong>Unverified transcription:</strong> automated reading of
+              Tibetan — especially handwritten manuscripts — has tested
+              unreliable in this collection. Treat the page image as the
+              authoritative source; the transcription and its translation may
+              not correspond to it.
+            </div>
+          )}
+
           {/* Summary if present */}
           {translationMeta.summary && (
             <div className="mx-4 mt-4 p-3 bg-accent-gold/8 border border-accent-gold/20 rounded-lg text-sm text-accent-gold-dark">


### PR DESCRIPTION
Closes the honesty gap from the 2026-09-01 Tibetan retraction (#4523, handoff item 1): we retracted the 795 first-translation claims but still serve the fabrication-prone transcriptions with a warning box that describes the *manuscript*, not our *reading* of it.

Adds a standing amber notice in the page metadata panel when the page/edition language contains "Tibetan": the transcription is not a verified reading (repeat OCR runs agree on only 31–35% of the text vs 87–93% for printed Latin); the page image is authoritative.

Public-facing copy — wants Derek's eyes on the wording before merge.

Out of scope: the re-OCR vs withdraw decision for the text itself (June `pro` proposal, costed in the ops repo), and the inline reader (`NotesRenderer`) — this covers the metadata panel where the existing warning slot lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7KeuLsey2dMw22HYMxGd9