### PR TITLE
Privacy: make /privacy true, and make the code keep its promises

### DIFF
--- a/scripts/maintenance/anonymize-stored-ips-2026-09.mjs
+++ b/scripts/maintenance/anonymize-stored-ips-2026-09.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * One-time scrub of full IP addresses persisted before 2026-09 (privacy PR).
+ *
+ * Writers were fixed in the same PR to never store a full IP again:
+ *   - /api/feedback           → stores ip_hash (sha256/16) instead of ip
+ *   - volunteers upsert       → same
+ *   - dataset logAccess()     → anonymizes ip_address at the write boundary
+ *
+ * This script brings EXISTING rows in line with /privacy's "we do not store
+ * full IP addresses" claim:
+ *   - feedback:            ip → ip_hash (same sha256/16 as the writer), $unset ip
+ *   - volunteers:          ip → ip_hash, $unset ip
+ *   - dataset_access_log:  ip_address → anonymized (last octet / last groups zeroed)
+ *
+ * Hashing (not deleting) preserves same-submitter correlation for abuse triage.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/anonymize-stored-ips-2026-09.mjs           # dry run
+ *   node --env-file=.env.production.local scripts/maintenance/anonymize-stored-ips-2026-09.mjs --apply   # write
+ */
+import { MongoClient } from 'mongodb';
+import { createHash } from 'crypto';
+
+const APPLY = process.argv.includes('--apply');
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+function hashIp(ip) {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+// Mirror of src/lib/anonymize-ip.ts
+function anonymizeIp(ip) {
+  if (!ip || ip === 'unknown') return 'unknown';
+  if (ip.includes('.') && !ip.includes(':')) {
+    const parts = ip.split('.');
+    if (parts.length === 4) { parts[3] = '0'; return parts.join('.'); }
+  }
+  if (ip.includes(':')) {
+    const parts = ip.split(':');
+    if (parts.length >= 4) return parts.slice(0, 3).join(':') + '::0';
+  }
+  return 'unknown';
+}
+
+function isAlreadyAnonymized(ip) {
+  return ip === 'unknown' || ip.endsWith('.0') || ip.endsWith('::0');
+}
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+
+// --- feedback + volunteers: ip → ip_hash ---
+for (const collName of ['feedback', 'volunteers']) {
+  const coll = db.collection(collName);
+  const cursor = coll.find(
+    { ip: { $exists: true, $type: 'string' } },
+    { projection: { ip: 1 } }
+  );
+  let seen = 0, changed = 0;
+  for await (const doc of cursor) {
+    seen++;
+    if (APPLY) {
+      await coll.updateOne(
+        { _id: doc._id },
+        { $set: { ip_hash: hashIp(doc.ip) }, $unset: { ip: '' } }
+      );
+      changed++;
+    }
+  }
+  console.log(`${collName}: ${seen} rows with a stored ip${APPLY ? `, ${changed} rewritten to ip_hash` : ' (dry run — would rewrite to ip_hash)'}`);
+}
+
+// --- dataset_access_log: anonymize ip_address in place ---
+{
+  const coll = db.collection('dataset_access_log');
+  const cursor = coll.find(
+    { ip_address: { $exists: true, $type: 'string' } },
+    { projection: { ip_address: 1 } }
+  );
+  let seen = 0, changed = 0, skipped = 0;
+  for await (const doc of cursor) {
+    seen++;
+    if (isAlreadyAnonymized(doc.ip_address)) { skipped++; continue; }
+    if (APPLY) {
+      await coll.updateOne(
+        { _id: doc._id },
+        { $set: { ip_address: anonymizeIp(doc.ip_address) } }
+      );
+      changed++;
+    }
+  }
+  console.log(`dataset_access_log: ${seen} rows, ${skipped} already anonymized${APPLY ? `, ${changed} anonymized now` : ` (dry run — would anonymize ${seen - skipped})`}`);
+}
+
+await client.close();
+console.log(APPLY ? 'Done.' : 'Dry run complete. Re-run with --apply to write.');

--- a/src/app/api/dataset/v1/pages/route.ts
+++ b/src/app/api/dataset/v1/pages/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { validateApiKey, checkKeyRequestRate } from '@/lib/dataset/api-keys';
 import { logAccess, getDailyPageCount } from '@/lib/dataset/access-logger';
+import { getClientIp } from '@/lib/rate-limit';
 import { DatasetPageRecord } from '@/lib/dataset/types';
 import { markForExport } from '@/lib/provenance';
 import { keyRef } from '@/lib/bot-attribution';
@@ -232,7 +233,9 @@ export async function GET(request: NextRequest) {
     records_returned: lines.length,
     book_ids: Array.from(bookIdsAccessed),
     format: 'jsonl',
-    ip_address: request.headers.get('x-forwarded-for') || 'unknown',
+    // cf-connecting-ip first — behind the CDN, x-forwarded-for is a Cloudflare
+    // edge node (#3491). logAccess anonymizes before storing.
+    ip_address: getClientIp(request),
   });
 
   // Keyset cursor for the next page. Derived from the last PAGE row, not the

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
 import { guardPublicSubmission } from '@/lib/public-submission-guard';
@@ -44,7 +45,10 @@ export async function POST(request: NextRequest) {
     // cf-connecting-ip first: behind the CDN, x-forwarded-for is a Cloudflare
     // edge node, so reading it first filed every submission under ~15 shared
     // addresses (#3491). Same helper the limiter above keys on.
-    const ip = getClientIp(request);
+    // Stored as a truncated hash, not the raw address (same scheme as
+    // api-usage/mcp-usage): same submitter → same hash, so abuse triage still
+    // correlates, but no full IP is retained. /privacy promises this.
+    const ipHash = createHash('sha256').update(getClientIp(request)).digest('hex').slice(0, 16);
     const trimmedEmail = email?.trim()?.toLowerCase() || null;
     const wantsHelp = wantsToHelp === true;
 
@@ -62,7 +66,7 @@ export async function POST(request: NextRequest) {
       page: page || null,
       name: name?.trim() || null,
       email: trimmedEmail,
-      ip,
+      ip_hash: ipHash,
       user_agent: userAgent,
       channel,
       created_at: new Date(),
@@ -84,7 +88,7 @@ export async function POST(request: NextRequest) {
             languages: [],
             interests: [],
             source: 'feedback_widget',
-            ip,
+            ip_hash: ipHash,
             created_at: new Date(),
             contacted: false,
           },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -16,18 +16,22 @@ export default function PrivacyPage() {
           Privacy Policy
         </h1>
         <div className="prose-content space-y-6 text-sm leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
-          <p><strong>Effective date:</strong> March 15, 2026</p>
+          <p><strong>Effective date:</strong> September 1, 2026 (replaces the March 15, 2026 version)</p>
 
           <p>
             Source Library is operated by the Embassy of the Free Mind, Amsterdam.
-            We are committed to protecting your privacy.
+            We are committed to protecting your privacy, and to describing what we
+            actually do — this page is checked against our codebase, not aspirations.
           </p>
 
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>Cookies and consent</h2>
           <p>
-            We ask for your consent before setting any analytics cookies. If you decline,
-            no third-party tracking scripts are loaded and no cookies are set. The site
-            works identically either way.
+            Our analytics tools load for every visitor, but run in a <strong>cookieless
+            mode</strong> until you accept: no identifier is stored in your browser, no
+            analytics cookies are set, and no session recording takes place. If you
+            click &ldquo;Accept,&rdquo; analytics cookies are enabled and a sample of visits may be
+            session-recorded to help us improve the reading experience. If you decline,
+            everything stays cookieless and recording stays off.
           </p>
           <p>
             Your choice is stored in your browser&rsquo;s local storage (not a cookie) and
@@ -37,43 +41,64 @@ export default function PrivacyPage() {
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>What we collect</h2>
           <ul className="list-disc pl-5 space-y-2">
             <li><strong>Account information:</strong> Email address (required for registration). Name and profile image if you sign in with Google.</li>
-            <li><strong>First-party analytics</strong> (always active): Pages visited, country (from IP), referrer domain, user agent. IP addresses are anonymized (last octet removed) before storage. Data is automatically deleted after 90 days.</li>
-            <li><strong>Reading activity:</strong> Which books and pages you view, reading history. Used to personalize your experience.</li>
-            <li><strong>Local storage:</strong> A visitor ID (<code>sl_visitor_id</code>) for image likes deduplication. This never leaves your browser.</li>
+            <li><strong>First-party analytics</strong> (always active): Pages visited, country (from IP), referrer domain, user agent. IP addresses are anonymized (last octet removed) before storage.</li>
+            <li><strong>Reading activity:</strong> Which books and pages you view. Used to personalize your experience; you can clear your reading history from your account.</li>
+            <li><strong>Search queries:</strong> What you search for, with a truncated one-way hash of your IP and, if you are signed in, your account ID. Used to improve search.</li>
+            <li><strong>Feedback and volunteering:</strong> If you use the feedback form, we store your message, the page it was sent from, your user agent, a truncated hash of your IP, and — only if you provide them — your name and email.</li>
+            <li><strong>AI chat and &ldquo;ask&rdquo; features:</strong> The messages you type are processed to generate a response (see AI processing below); conversation threads in the Embassy chat are stored.</li>
+            <li><strong>Anonymous visitor ID:</strong> A random ID stored in your browser identifies your likes and favorites while you are not signed in. It is sent with those actions, and if you later sign in it is used once to attach your existing favorites to your account.</li>
+            <li><strong>Developer / dataset API:</strong> Requests made with an API key are logged (key, endpoint, records returned, anonymized IP) for rate limiting and EU AI Act compliance.</li>
           </ul>
 
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>What we don&rsquo;t do</h2>
           <ul className="list-disc pl-5 space-y-2">
             <li>We do not sell your data to third parties.</li>
             <li>We do not use your data for advertising.</li>
-            <li>We do not share personal data with AI model providers.</li>
-            <li>We do not store full IP addresses.</li>
+            <li>We do not store full IP addresses. Analytics store an anonymized form (last octet removed); feedback and usage logs store a truncated one-way hash.</li>
+            <li>We do not send your identity (name, email, account) to AI model providers.</li>
           </ul>
+
+          <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>AI processing</h2>
+          <p>
+            Text you type into AI features — search expansion, book chat, page
+            &ldquo;ask,&rdquo; and the Embassy chat — is sent to Google&rsquo;s Gemini API together
+            with the relevant book text to generate the response. Under Google&rsquo;s
+            paid API terms this data is not used to train their models. Avoid
+            putting personal information in these boxes; the text you type is the
+            only thing about you these requests carry.
+          </p>
 
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>How we use your data</h2>
           <ul className="list-disc pl-5 space-y-2">
             <li>To provide and improve the Service.</li>
             <li>To send important updates about your account or the Service (rare — we don&rsquo;t spam).</li>
             <li>To generate aggregate statistics about library usage.</li>
+            <li>To prevent abuse of our public forms and APIs.</li>
           </ul>
 
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>Third-party services</h2>
-          <p>The following services are only loaded if you accept analytics cookies:</p>
+          <p>Enabled only if you accept analytics cookies:</p>
           <ul className="list-disc pl-5 space-y-2">
-            <li><strong>Google Analytics:</strong> Usage statistics with IP anonymization enabled. Sets cookies to distinguish visitors. <a href="https://policies.google.com/privacy" className="underline" target="_blank" rel="noopener noreferrer">Google&rsquo;s privacy policy</a>.</li>
-            <li><strong>Ahrefs Analytics:</strong> Aggregate traffic statistics. <a href="https://ahrefs.com/privacy" className="underline" target="_blank" rel="noopener noreferrer">Ahrefs&rsquo; privacy policy</a>.</li>
+            <li><strong>Google Analytics:</strong> Loads for all visitors in Google&rsquo;s Consent Mode with all storage denied; sets cookies only after you accept. IP anonymization is enabled. <a href="https://policies.google.com/privacy" className="underline" target="_blank" rel="noopener noreferrer">Google&rsquo;s privacy policy</a>.</li>
+            <li><strong>PostHog</strong> (EU cloud, Frankfurt): Product analytics and session replay. Runs cookieless with recording off until you accept; after acceptance, a sample of visits may be recorded. <a href="https://posthog.com/privacy" className="underline" target="_blank" rel="noopener noreferrer">PostHog&rsquo;s privacy policy</a>.</li>
+            <li><strong>Ahrefs Analytics:</strong> Aggregate traffic statistics; loads only after you accept. <a href="https://ahrefs.com/privacy" className="underline" target="_blank" rel="noopener noreferrer">Ahrefs&rsquo; privacy policy</a>.</li>
           </ul>
-          <p className="mt-3">The following services are always active (no cookies):</p>
+          <p className="mt-3">Always active (part of serving the site):</p>
           <ul className="list-disc pl-5 space-y-2">
-            <li><strong>Google OAuth:</strong> If you sign in with Google, we receive your name, email, and profile image. We do not access any other Google data.</li>
+            <li><strong>Cloudflare:</strong> Content delivery and security in front of the whole site. Cloudflare processes your IP address to serve requests and block abuse; we do not store it. <a href="https://www.cloudflare.com/privacypolicy/" className="underline" target="_blank" rel="noopener noreferrer">Cloudflare&rsquo;s privacy policy</a>.</li>
             <li><strong>Vercel:</strong> Hosting provider. <a href="https://vercel.com/legal/privacy-policy" className="underline" target="_blank" rel="noopener noreferrer">Vercel&rsquo;s privacy policy</a>.</li>
-            <li><strong>MongoDB Atlas:</strong> Database hosting. Data stored in EU (Frankfurt).</li>
+            <li><strong>Google OAuth:</strong> If you sign in with Google, we receive your name, email, and profile image. We do not access any other Google data.</li>
+            <li><strong>Google Gemini:</strong> AI processing of text you submit to AI features (see above).</li>
+            <li><strong>Resend:</strong> Delivers our emails; processes recipient addresses on our behalf. <a href="https://resend.com/legal/privacy-policy" className="underline" target="_blank" rel="noopener noreferrer">Resend&rsquo;s privacy policy</a>.</li>
+            <li><strong>MongoDB Atlas:</strong> Database hosting. Data stored in the EU (Frankfurt).</li>
+            <li><strong>Supabase and Cloudflare R2:</strong> Store library content — texts, translations, search indexes, page images — not personal data.</li>
           </ul>
 
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>Data retention</h2>
           <ul className="list-disc pl-5 space-y-2">
-            <li>Analytics data (pageviews, events): automatically deleted after 90 days.</li>
+            <li>Analytics and usage logs (already anonymized or hashed as described above): retained until periodically reviewed and pruned by a person. We deliberately do not run automated deletion jobs against our archives.</li>
             <li>Performance metrics: automatically deleted after 30 days.</li>
+            <li>Feedback: retained until addressed, then periodically pruned.</li>
             <li>Account data: retained as long as your account is active.</li>
           </ul>
           <p>

--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -26,9 +26,15 @@ const POSTHOG_HOST = 'https://eu.i.posthog.com';
  * Accept — often after client-side navigation — so the landing attribution was
  * already gone and GA recorded the source as "(not set)".
  *
- * Ahrefs and PostHog stay strictly accept-gated (load only after "Accept") —
- * unchanged from before. Tenant subdomains and /embed/ routes are closed
- * partner reading rooms, so we load NO Source Library analytics there at all.
+ * PostHog boots the same way: **cookieless until Accept**. Pre-consent it runs
+ * with memory-only persistence (no identifier stored in the browser — the
+ * ePrivacy line) and session replay OFF; on Accept it upgrades to persistent
+ * storage in-session and rolls replay sampling. Full-audience visit counts are
+ * kept either way. Ahrefs stays strictly accept-gated (loads only after
+ * "Accept"). Tenant subdomains and /embed/ routes are closed partner reading
+ * rooms, so we load NO Source Library analytics there at all.
+ *
+ * /privacy describes exactly this posture — keep the two in step.
  */
 export default function AnalyticsScripts() {
   const isEmbedded = useIsEmbedded();
@@ -58,16 +64,37 @@ export default function AnalyticsScripts() {
     });
   }, [consent, isEmbedded]);
 
-  // PostHog loads on entry for everyone (see below) and captures by default.
-  // Honor an explicit "Decline": opt the user out of all capture + recording.
-  // Undecided (null) and "accepted" both stay opted in — that's the point of
-  // pre-consent loading. opt_in/opt_out are queued safely by the init stub.
+  // PostHog boots cookieless (memory persistence, replay off — see the init
+  // script). On Decline, stop capture entirely. On the first Accept of this
+  // pageload, upgrade to persistent storage and roll the same ~30% replay
+  // sampling a returning accepted visitor gets at boot. Returning accepted
+  // visitors already booted persistent (the init script reads localStorage
+  // synchronously), so the upgrade branch is skipped via _slPhCookieless.
   useEffect(() => {
     if (isEmbedded || consent === null) return;
-    const ph = (window as unknown as { posthog?: { opt_in_capturing?: () => void; opt_out_capturing?: () => void } }).posthog;
+    const w = window as unknown as {
+      posthog?: {
+        opt_in_capturing?: () => void;
+        opt_out_capturing?: () => void;
+        set_config?: (config: Record<string, unknown>) => void;
+        startSessionRecording?: () => void;
+      };
+      _slPhCookieless?: boolean;
+    };
+    const ph = w.posthog;
     if (!ph || typeof ph.opt_out_capturing !== 'function') return;
-    if (consent === 'declined') ph.opt_out_capturing();
-    else ph.opt_in_capturing?.();
+    if (consent === 'declined') {
+      ph.opt_out_capturing();
+      return;
+    }
+    ph.opt_in_capturing?.();
+    if (w._slPhCookieless) {
+      w._slPhCookieless = false;
+      ph.set_config?.({ persistence: 'localStorage+cookie' });
+      // Same sampling rate as the persistent boot path (PostHog free tier —
+      // see the init script). Replay only ever records consented visitors.
+      if (Math.random() < 0.3) ph.startSessionRecording?.();
+    }
   }, [consent, isEmbedded]);
 
   // Closed partner reading rooms get no Source Library analytics (and no
@@ -113,22 +140,29 @@ export default function AnalyticsScripts() {
           strategy="lazyOnload"
         />
       )}
-      {/* PostHog loads on entry for ALL visitors (not accept-gated), so product
-          analytics + session replay capture the full audience, not just the
-          self-selected slice who click Accept. It captures by default; an
-          explicit "Decline" is honored via opt_out_capturing in the effect
-          above. Closed partner reading rooms are already excluded (isEmbedded
-          early-return). */}
+      {/* PostHog loads on entry for ALL visitors so product analytics sees the
+          full audience, not just the self-selected slice who click Accept —
+          but pre-consent it boots COOKIELESS: memory-only persistence (nothing
+          stored in the browser) and session replay disabled. Accept upgrades
+          it in-session (effect above); Decline opts out entirely. Closed
+          partner reading rooms are already excluded (isEmbedded early-return). */}
       <Script id="posthog-init" strategy="afterInteractive">
         {`
           !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageviewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+          // Consent state, read synchronously like the ga-init script above.
+          // Only an already-accepted visitor boots with persistent storage and
+          // is eligible for session replay; everyone else boots cookieless.
+          var _slConsented = false;
+          try { _slConsented = localStorage.getItem('sl_analytics_consent') === 'accepted'; } catch (e) {}
+          window._slPhCookieless = !_slConsented;
           // Session-replay sampling: record ~30% of loads to stay under the
           // PostHog free tier (5K web replays/cycle; full capture overshot at
           // ~8K). The roll runs in the BROWSER, not at render time — rendering
           // it server-side would bake one value into the 24h edge-cached HTML
           // and hand every cached visitor the same decision. Analytics events
-          // are unaffected; only the replay recording is gated.
-          var _slRecordSession = Math.random() < 0.3;
+          // are unaffected; only the replay recording is gated. Consented
+          // visitors only — replay never records a pre-consent session.
+          var _slRecordSession = _slConsented && Math.random() < 0.3;
           // Automated-browser gate (#3400). A headless fleet executing our
           // reader was producing ~35K "users"/day of one-hit sessions — enough
           // to make PostHog report traffic TRIPLING over a month in which real
@@ -155,10 +189,13 @@ export default function AnalyticsScripts() {
           if (!_slAutomated) posthog.init('${POSTHOG_KEY}', {
             api_host: '${POSTHOG_HOST}',
             person_profiles: 'identified_only',
+            // Cookieless until Accept: memory persistence stores no identifier
+            // in the browser (the ePrivacy consent line). The consent effect
+            // upgrades this in-session when the visitor accepts.
+            persistence: _slConsented ? 'localStorage+cookie' : 'memory',
             capture_pageview: true,
             capture_pageleave: true,
-            // Session replay for the sampled ~30% (loaded pre-consent; explicit
-            // Decline is honored via opt_out in the effect above).
+            // Session replay for the sampled ~30% of CONSENTED visitors.
             // Capture everything: unmask all text + inputs so we see exactly what
             // readers see (search queries, navigation, scroll). Passwords are
             // always masked by PostHog regardless of this config.

--- a/src/lib/dataset/access-logger.ts
+++ b/src/lib/dataset/access-logger.ts
@@ -1,4 +1,5 @@
 import { getDb } from '@/lib/mongodb';
+import { anonymizeIp } from '@/lib/anonymize-ip';
 import { DatasetAccessLog } from './types';
 
 const COLLECTION = 'dataset_access_log';
@@ -12,6 +13,11 @@ export async function logAccess(
   opts?: { countPages?: boolean },
 ): Promise<void> {
   const db = await getDb();
+
+  // Anonymize at the write boundary so no call site can forget. The caller is
+  // already identified by api_key_id; a full IP adds nothing the compliance
+  // log needs, and /privacy promises we don't store full IPs.
+  entry.ip_address = anonymizeIp(entry.ip_address);
 
   // Fire-and-forget — don't block the API response
   Promise.all([

--- a/src/lib/dataset/types.ts
+++ b/src/lib/dataset/types.ts
@@ -102,6 +102,7 @@ export interface DatasetAccessLog {
   records_returned: number;
   book_ids: string[];
   format: 'jsonl' | 'json';
+  /** Anonymized (last octet zeroed) by logAccess before storage — never a full IP. */
   ip_address: string;
 }
 


### PR DESCRIPTION
## Why

Derek asked whether signup needs a privacy-policy checkbox (no — the existing link-by-the-button pattern is correct), which led to auditing `/privacy` against the codebase. Four of its claims were false, and several processors/collections were undisclosed. Under GDPR the notice's *accuracy* is the actual obligation, so this PR fixes both directions: code now keeps the promises worth keeping, and the policy now describes what actually happens.

## What was false, and which side got fixed

| Policy claim | Reality | Fix |
|---|---|---|
| "Analytics auto-deleted after 90 days" | TTLs deliberately removed 2026-07-05 (#2976, manual pruning only) | **Policy** — now says manual review/pruning; keeps the still-true 30d performance-metrics TTL line |
| "We do not store full IP addresses" | `feedback` + `volunteers` stored full IP; dataset access log stored full `ip_address` | **Code** — feedback/volunteers store a truncated sha256 hash (same scheme as api-usage/mcp-usage); `logAccess()` anonymizes at the write boundary so no future call site can forget |
| "We do not share personal data with AI model providers" | Book chat / page ask / Embassy chat / search expansion send typed text to Gemini; Embassy threads stored | **Policy** — new "AI processing" section; keeps the true narrower claim (identity is never sent) |
| "If you decline, no third-party tracking scripts are loaded" / visitor ID "never leaves your browser" | GA + PostHog load for everyone; PostHog captured pre-consent incl. ~30% session replay with unmasked inputs; visitor ID is sent with likes and at account-migrate | **Both** — PostHog now boots cookieless (memory persistence, replay OFF) until Accept, upgrading in-session; policy describes the cookieless-until-accept posture and the visitor ID honestly |

Also newly disclosed: feedback/search-query/chat-thread collection, Cloudflare, PostHog, Resend, Gemini, Supabase/R2.

## Out of scope

- `/terms` untouched — this audit was the privacy notice only.
- Bot-tracker (`analytics/bots`) and abuse logs already anonymize; no change needed.
- **After merge**: run `scripts/maintenance/anonymize-stored-ips-2026-09.mjs` (dry-run first) to scrub full IPs from existing `feedback` / `volunteers` / `dataset_access_log` rows — until then the "no full IPs" claim is prospective only. Script is dry-run by default; Derek should approve the `--apply`.

## Verification

- `npx tsc --noEmit` clean.
- Grep-verified no reader of `feedback.ip` / `volunteers.ip` / full `ip_address` exists (admin UI never displayed them; usage monitors don't touch `ip_address`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfaS4sYKmRvL4UwkX9yzgg
