### PR TITLE
Put our social accounts where a reader can actually see them

### DIFF
--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -30,6 +30,28 @@ const PARTNERS: Partner[] = [
   { name: 'Frond Studio', src: '/partners/frond-studio-white.png', href: 'https://frond-studio.com', width: 400, height: 213, invert: false },
 ];
 
+// Source Library's own accounts. Kept beside PARTNERS so the two lists that
+// render in the footer's lower zones live together. These are also mirrored in
+// the homepage `sameAs` array (src/components/seo/HomePageSchema.tsx) — update
+// both, or search engines and readers see different sets.
+const SOCIALS: { name: string; href: string; path: string }[] = [
+  {
+    name: 'X',
+    href: 'https://x.com/SourceLibrary_',
+    path: 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z',
+  },
+  {
+    name: 'Instagram',
+    href: 'https://www.instagram.com/source.library',
+    path: 'M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z',
+  },
+  {
+    name: 'GitHub',
+    href: 'https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2',
+    path: 'M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12',
+  },
+];
+
 export default function GlobalFooter() {
   const pathname = usePathname();
   const t = FOOTER_STRINGS[useLocale()];
@@ -50,7 +72,8 @@ export default function GlobalFooter() {
   // Same shared `useEmbedContext` signal the header uses, not a second
   // hostname check (#3367). Resolved after mount, so the static HTML the
   // global site serves is unchanged and only a tenant visitor sees links drop.
-  const navColumns = visibleFooterNavColumns(useIsEmbedded());
+  const isEmbedded = useIsEmbedded();
+  const navColumns = visibleFooterNavColumns(isEmbedded);
 
   useEffect(() => {
     try {
@@ -184,6 +207,30 @@ export default function GlobalFooter() {
             ))}
           </div>
         </div>
+
+        {/* Zone 3b: Our own accounts. Hidden on partner subdomains for the same
+            reason the global-only nav links are (#3364): a tenant reading room
+            is the partner's surface, and Source Library's social accounts are
+            not theirs to carry. */}
+        {!isEmbedded && (
+          <div className="flex justify-center gap-6 pb-6">
+            {SOCIALS.map((s) => (
+              <a
+                key={s.name}
+                href={s.href}
+                target="_blank"
+                rel="noopener noreferrer me"
+                aria-label={s.name}
+                title={s.name}
+                className="text-white/35 hover:text-white/70 transition-colors"
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+                  <path d={s.path} />
+                </svg>
+              </a>
+            ))}
+          </div>
+        )}
 
         {/* Zone 4: License line */}
         <div className="pb-4 -mt-2 text-center">

--- a/src/components/seo/HomePageSchema.tsx
+++ b/src/components/seo/HomePageSchema.tsx
@@ -48,9 +48,13 @@ export default function HomePageSchema({ books, bookCount, translatedCount }: Ho
       '@type': 'Organization',
       name: 'Embassy of the Free Mind',
     },
+    // Mirrors the SOCIALS list rendered in the footer
+    // (src/components/layout/GlobalFooter.tsx) — update both together, or
+    // search engines and readers are told different things.
     sameAs: [
       'https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2',
       'https://x.com/SourceLibrary_',
+      'https://www.instagram.com/source.library',
       'https://en.wikipedia.org/wiki/Embassy_of_the_Free_Mind',
     ],
   };


### PR DESCRIPTION
## Why

Derek noticed our social handles weren't on the site. They weren't — anywhere a person could see.

The only place any handle existed was the homepage JSON-LD `sameAs` array in `HomePageSchema.tsx`, listing X and GitHub. That's structured data: search engines read it, humans never do. `GlobalFooter.tsx` carried navigation, partners, the in-memoriam link and licensing, and no social links at all.

Instagram (`source.library`) appeared nowhere in the repo. The only Instagram references in the codebase are in-app-browser detection — about Instagram's webview breaking OAuth, not about our account.

## What

- `SOCIALS` list beside `PARTNERS` in `GlobalFooter.tsx`, rendered between the partner logos and the licence line: X, Instagram, GitHub.
- Inline SVG paths — no new dependency, no fetch, nothing to install.
- Instagram added to the homepage `sameAs` array.
- A comment on each list pointing at the other. Two lists of the same thing drift, and then readers and crawlers are told different things.

## Tenant behaviour

Gated on `useIsEmbedded()` — the same signal that already filters the footer's global-only nav columns (#3364). A partner reading room like `bph.sourcelibrary.org` is the partner's surface, and our accounts aren't theirs to carry. Resolved after mount, so the static HTML the global site serves is unchanged; only a tenant visitor sees the row drop.

## Out of scope

No Bluesky. I couldn't confirm an account exists, and an HTTP check is useless here: a deliberately fake handle returns 200 from Bluesky exactly as a real one does. If there's an account, it's a one-line addition to both lists.

No Facebook — there isn't one.

## Testing

`npx tsc --noEmit` clean. Visual check of the row and the tenant gate would be worth doing on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5GrwxDWJqLLE9H1jYtMq9