### PR TITLE
Scope envelopes: a named book list gets its own spend ceiling (#4540)

### DIFF
--- a/scripts/audit/scope-progress.mjs
+++ b/scripts/audit/scope-progress.mjs
@@ -29,14 +29,14 @@
  *   - --verify counts pages with non-empty ocr.data / translation.data. Blank pages
  *     carry a translation placeholder, so verified translation counts can read a
  *     touch high; the point of --verify is catching ZEROS behind a confident counter.
- *   - The dial is global: a scope here bypasses the PAUSE (selective-unpause) but
- *     NOT the spend ceiling — that gap is #4540. The gates header says which
- *     ceiling is currently binding so the report never implies motion that
- *     cannot happen.
+ *   - Gates: a scope without a budget envelope bypasses the PAUSE only; a scope
+ *     WITH budget_usd (#4540) also opens a confined lane past the closed daily
+ *     dial, on its own measured ceiling. The gates header says which ceiling is
+ *     currently binding so the report never implies motion that cannot happen.
  */
 
 import { withMongo } from '../lib/mongo.mjs';
-import { getTodaySpendUsd, readDailyBudgetUsd } from '../lib/spend-guard.mjs';
+import { getTodaySpendUsd, readDailyBudgetUsd, readScopeEnvelopes, getScopeSpendUsd } from '../lib/spend-guard.mjs';
 
 const args = process.argv.slice(2);
 const flag = (n) => args.includes(`--${n}`);
@@ -149,6 +149,26 @@ await withMongo(async (db) => {
   const budget = readDailyBudgetUsd(control);
   const spend = await getTodaySpendUsd(db);
   const dialOpen = budget !== null && !spend.meterError && spend.usd < budget;
+  // Envelope lanes (#4540): a scope with budget_usd can dispatch past a
+  // closed global dial, on its own measured ceiling.
+  const envelopes = [];
+  for (const env of readScopeEnvelopes(control)) {
+    const envIds = new Set(env.book_ids);
+    if (env.collections.length) {
+      const rows = await db.collection('books').find({ collections: { $in: env.collections } }).project({ id: 1 }).toArray();
+      for (const b of rows) envIds.add(String(b.id));
+    }
+    const s = await getScopeSpendUsd(db, { ids: [...envIds], since: env.created_at });
+    envelopes.push({
+      tag: env.tag,
+      budget_usd: env.budget_usd,
+      spent_usd: Number(s.usd.toFixed(2)),
+      books: envIds.size,
+      open: !s.meterError && s.usd < env.budget_usd,
+      meter_error: s.meterError || null,
+    });
+  }
+
   const gates = {
     paused: !!control.paused,
     paused_phases: control.paused_phases || [],
@@ -157,6 +177,7 @@ await withMongo(async (db) => {
     meter_error: spend.meterError || null,
     dial_open: dialOpen,
     scopes: Object.keys(control.allow_scopes || {}),
+    envelopes,
     legacy_allow_book_ids: (control.allow_book_ids || []).length,
   };
 
@@ -166,8 +187,11 @@ await withMongo(async (db) => {
     console.log(`  paused: ${gates.paused}${gates.paused_phases.length ? ` (phases: ${gates.paused_phases.join(', ')})` : ''}`);
     console.log(`  dial:   $${gates.spent_today_usd} spent / ${budget === null ? 'UNSET (default-closed)' : '$' + budget} today → ${dialOpen ? 'OPEN' : 'CLOSED — no paid dispatch'}${gates.meter_error ? ` [METER ERROR: ${gates.meter_error}]` : ''}`);
     console.log(`  allow_scopes: ${gates.scopes.length ? gates.scopes.join(', ') : '(none)'}  legacy allow_book_ids: ${gates.legacy_allow_book_ids}`);
+    for (const e of envelopes) {
+      console.log(`    envelope ${e.tag}: $${e.spent_usd}/$${e.budget_usd} → ${e.meter_error ? `METER ERROR: ${e.meter_error}` : e.open ? 'OPEN' : 'SPENT'} (${e.books} books)`);
+    }
     console.log('\nPass --scope <tag>, --collection <slug>, or --books id1,id2 for per-book progress.');
-    console.log('NOTE: a scope bypasses the PAUSE only — the spend dial is global (#4540).');
+    console.log('NOTE: a scope without a budget envelope bypasses the PAUSE only; an envelope (#4540) also opens a confined lane past the closed dial. Manage with scripts/maintenance/set-scope.mjs.');
     return;
   }
 
@@ -210,7 +234,10 @@ await withMongo(async (db) => {
   }
 
   console.log(`Scope progress — ${source} (${texts.length} text books${artworks.length ? `, ${artworks.length} artwork records excluded` : ''})${verified ? ' [verified from pages]' : ' [book counters]'}`);
-  console.log(`Gates: paused=${gates.paused}  dial ${dialOpen ? 'OPEN' : 'CLOSED'} ($${gates.spent_today_usd}/${budget === null ? 'unset' : '$' + budget})  — a scope bypasses the pause, NOT the dial (#4540)\n`);
+  const envNote = envelopes.length
+    ? envelopes.map((e) => `${e.tag} $${e.spent_usd}/$${e.budget_usd} ${e.open ? 'OPEN' : 'SPENT'}`).join('; ')
+    : 'none (books wait on the global dial)';
+  console.log(`Gates: paused=${gates.paused}  dial ${dialOpen ? 'OPEN' : 'CLOSED'} ($${gates.spent_today_usd}/${budget === null ? 'unset' : '$' + budget})  envelopes: ${envNote}\n`);
   if (missing.length) console.log(`⚠ ${missing.length} ids not found in books (check id vs _id): ${missing.join(', ')}\n`);
 
   for (const r of reports) {

--- a/scripts/lib/spend-guard.mjs
+++ b/scripts/lib/spend-guard.mjs
@@ -168,3 +168,187 @@ export async function budgetAllowsDispatch(db, label, { bypass = false, control:
   console.log(`  [spend-guard] ${label}: spend $${spend.usd.toFixed(2)} / $${budget.toFixed(2)} today (UTC, both stores), ${spend.rows} calls${blind} → ${allowed ? 'DISPATCH' : 'CEILING REACHED — no new dispatch'}`);
   return allowed;
 }
+
+// ─── Scope envelopes (#4540) ────────────────────────────────────────────────
+//
+// A scope in processing_control.allow_scopes may carry its own budget:
+//   allow_scopes.<tag> = { book_ids, collections, budget_usd, created_at, created_by }
+// A book in such a scope may dispatch while the SCOPE's envelope has room,
+// even when the global daily dial is closed. This is a second, separately
+// accounted ceiling — never an absence of one (#3826 is why the dial is
+// default-closed; an unbounded "allowlisted books ignore the ceiling" flag
+// would recreate that exposure).
+//
+// Envelope spend is MEASURED from the same two usage stores as the daily
+// dial, attributed by book_id membership since the scope's created_at.
+// Nothing trusts a stored spent_usd counter — the guard measures, every
+// time, and fails closed when it cannot read. Rows without a book_id can
+// never be attributed to an envelope (they still count against the global
+// dial), so an envelope's measured spend is a floor; the envelope is a
+// brake, not an accounting system, same as the dial.
+
+/** Scopes that carry a positive budget envelope. */
+export function readScopeEnvelopes(control) {
+  const scopes = control?.allow_scopes;
+  if (!scopes || typeof scopes !== 'object') return [];
+  const out = [];
+  for (const tag of Object.keys(scopes)) {
+    const s = scopes[tag];
+    const b = s?.budget_usd;
+    if (typeof b === 'number' && Number.isFinite(b) && b > 0) {
+      out.push({
+        tag,
+        budget_usd: b,
+        book_ids: Array.isArray(s.book_ids) ? s.book_ids.filter(Boolean).map(String) : [],
+        collections: Array.isArray(s.collections) ? s.collections.filter(Boolean).map(String) : [],
+        created_at: s.created_at ? new Date(s.created_at) : null,
+      });
+    }
+  }
+  return out;
+}
+
+/** Resolve one envelope's full book-id set (book_ids ∪ collection members). */
+async function resolveEnvelopeIds(db, env) {
+  const ids = new Set(env.book_ids);
+  if (env.collections.length) {
+    const rows = await db.collection('books')
+      .find({ collections: { $in: env.collections } }, { projection: { id: 1 } })
+      .toArray();
+    for (const b of rows) ids.add(String(b.id));
+  }
+  return ids;
+}
+
+/** Spend attributed to a set of book ids in the Supabase primary store. */
+async function getSupabaseScopeSpend(ids, since) {
+  if (!SUPABASE_SERVICE_KEY) {
+    return { usd: 0, rows: 0, error: 'SUPABASE_SERVICE_ROLE_KEY missing' };
+  }
+  let usd = 0, rows = 0;
+  const sinceClause = since ? `&timestamp=gte.${since.toISOString()}` : '';
+  try {
+    for (let i = 0; i < ids.length; i += 80) { // chunk the in-list: keep URLs sane
+      const inList = ids.slice(i, i + 80).map(encodeURIComponent).join(',');
+      for (let pageNo = 0; ; pageNo++) {
+        if (pageNo >= SUPABASE_MAX_PAGES) {
+          return { usd, rows, error: `>${SUPABASE_MAX_PAGES * 1000} rows for one chunk — sum truncated` };
+        }
+        const from = pageNo * 1000;
+        const resp = await fetch(
+          `${SUPABASE_URL}/rest/v1/gemini_usage?select=cost_usd&book_id=in.(${inList})${sinceClause}&order=id.asc`,
+          {
+            headers: {
+              apikey: SUPABASE_SERVICE_KEY,
+              Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+              Range: `${from}-${from + 999}`,
+            },
+          },
+        );
+        if (!resp.ok && resp.status !== 206) {
+          return { usd, rows, error: `Supabase read failed (${resp.status})` };
+        }
+        const batch = await resp.json();
+        for (const r of batch) {
+          rows++;
+          if (r.cost_usd != null) usd += r.cost_usd;
+        }
+        if (batch.length < 1000) break;
+      }
+    }
+    return { usd, rows, error: null };
+  } catch (err) {
+    return { usd, rows, error: `Supabase read error: ${err.message}` };
+  }
+}
+
+// Test seam, same shape as the daily reader's.
+let supabaseScopeSpendReader = getSupabaseScopeSpend;
+export function _setSupabaseScopeSpendReaderForTests(fn) {
+  supabaseScopeSpendReader = fn || getSupabaseScopeSpend;
+}
+
+/**
+ * Measured spend attributed to a book-id set across BOTH stores, since a
+ * given time (or all-time when since is null — tighter, never looser).
+ * meterError non-null means the envelope is UNREADABLE; callers fail closed.
+ */
+export async function getScopeSpendUsd(db, { ids, since = null }) {
+  const mongoMatch = { book_id: { $in: ids } };
+  if (since) mongoMatch._id = { $gte: ObjectId.createFromTime(Math.floor(since.getTime() / 1000)) };
+  const [agg] = await db.collection('gemini_usage').aggregate([
+    { $match: mongoMatch },
+    { $group: { _id: null, usd: { $sum: { $ifNull: ['$cost_usd', 0] } }, rows: { $sum: 1 } } },
+  ]).toArray();
+  const supa = await supabaseScopeSpendReader(ids, since);
+  return {
+    usd: (agg?.usd || 0) + supa.usd,
+    rows: (agg?.rows || 0) + supa.rows,
+    meterError: supa.error,
+  };
+}
+
+/**
+ * The scope-aware gate (#4540). Same contract as budgetAllowsDispatch, plus a
+ * second lane: when the global dial is closed (or unset), a scope whose
+ * envelope has room opens dispatch FOR ITS BOOKS ONLY.
+ *
+ * Returns { allowed, envelopeIds }:
+ *   allowed=true,  envelopeIds=null  → global dial open, dispatch normally
+ *   allowed=true,  envelopeIds=Set   → SCOPED dispatch: the caller MUST
+ *                                      confine candidates to these book ids.
+ *                                      A caller that cannot confine must use
+ *                                      budgetAllowsDispatch (boolean) instead.
+ *   allowed=false                    → every ceiling is closed
+ */
+export async function budgetAllowsDispatchScoped(db, label, { bypass = false, control: preloadedControl } = {}) {
+  if (bypass) {
+    console.log(`  [spend-guard] ${label}: BYPASS (explicit --book operator run)`);
+    return { allowed: true, envelopeIds: null };
+  }
+  const control = preloadedControl
+    ?? await db.collection('system_config').findOne({ _id: 'processing_control' });
+  const budget = readDailyBudgetUsd(control);
+
+  if (budget !== null) {
+    const spend = await getTodaySpendUsd(db);
+    if (spend.meterError) {
+      // An unreadable meter closes EVERY lane — envelopes read the same stores.
+      console.log(`  [spend-guard] ${label}: METER UNREADABLE (${spend.meterError}) — refusing dispatch (all lanes). Partial sum was $${spend.usd.toFixed(2)}.`);
+      return { allowed: false, envelopeIds: null };
+    }
+    if (spend.usd < budget) {
+      const blind = spend.costlessRows > 0 ? ` (${spend.costlessRows} rows without cost_usd — spend is undercounted)` : '';
+      console.log(`  [spend-guard] ${label}: spend $${spend.usd.toFixed(2)} / $${budget.toFixed(2)} today (UTC, both stores), ${spend.rows} calls${blind} → DISPATCH`);
+      return { allowed: true, envelopeIds: null };
+    }
+  }
+
+  // Global dial closed (spent, or unset = default-closed). Envelope lane.
+  const envelopes = readScopeEnvelopes(control);
+  if (envelopes.length === 0) {
+    console.log(`  [spend-guard] ${label}: ${budget === null ? 'no daily_budget_usd set (default-closed)' : 'daily ceiling reached'} and no scope envelopes — no new dispatch.`);
+    return { allowed: false, envelopeIds: null };
+  }
+  const open = new Set();
+  const parts = [];
+  for (const env of envelopes) {
+    const ids = await resolveEnvelopeIds(db, env);
+    if (ids.size === 0) { parts.push(`${env.tag}: empty scope`); continue; }
+    const s = await getScopeSpendUsd(db, { ids: [...ids], since: env.created_at });
+    if (s.meterError) { parts.push(`${env.tag}: METER UNREADABLE (${s.meterError}) — closed`); continue; } // fail closed per envelope
+    if (s.usd < env.budget_usd) {
+      for (const id of ids) open.add(id);
+      parts.push(`${env.tag}: $${s.usd.toFixed(2)}/$${env.budget_usd.toFixed(2)} OPEN (${ids.size} books)`);
+    } else {
+      parts.push(`${env.tag}: $${s.usd.toFixed(2)}/$${env.budget_usd.toFixed(2)} ENVELOPE SPENT`);
+    }
+  }
+  const globalNote = budget === null ? 'global dial unset' : 'global daily ceiling reached';
+  if (open.size > 0) {
+    console.log(`  [spend-guard] ${label}: ${globalNote} → SCOPED DISPATCH, confined to ${open.size} book(s). Envelopes: ${parts.join('; ')}`);
+    return { allowed: true, envelopeIds: open };
+  }
+  console.log(`  [spend-guard] ${label}: ${globalNote}; every envelope closed (${parts.join('; ')}) — no new dispatch.`);
+  return { allowed: false, envelopeIds: null };
+}

--- a/scripts/maintenance/set-scope.mjs
+++ b/scripts/maintenance/set-scope.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * set-scope — manage named allow_scopes entries, including budget envelopes (#4540).
+ *
+ * A scope names a set of books (ids and/or collections) that may run while the
+ * line is otherwise stopped: past the global PAUSE (#2610), and — when the
+ * scope carries a budget_usd envelope — past the closed daily spend dial, on
+ * its own separately-measured ceiling. Removing the scope removes the
+ * permission immediately.
+ *
+ * Writes are versioned (system_config_revisions) and touch ONLY this scope's
+ * key — never the allow_scopes map as a whole. That is the multi-session rule:
+ * ~10 concurrent sessions share this config, and whole-map writes have
+ * clobbered other sessions' scopes before (2026-06-20).
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/set-scope.mjs --show
+ *   node --env-file=.env.production.local scripts/maintenance/set-scope.mjs \
+ *     --tag wellcome-2026-09 --collection forum-of-conscience --budget 30 --by "derek: finish the 34"
+ *   node --env-file=.env.production.local scripts/maintenance/set-scope.mjs \
+ *     --tag repair-xyz --books id1,id2 --budget 5 --by "why"
+ *   node --env-file=.env.production.local scripts/maintenance/set-scope.mjs --tag wellcome-2026-09 --budget 40 --by "top up"
+ *   node --env-file=.env.production.local scripts/maintenance/set-scope.mjs --tag wellcome-2026-09 --remove --by "done"
+ *
+ * Monitor with: scripts/audit/scope-progress.mjs --scope <tag>
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+import { updateConfigVersioned } from '../lib/versioned-config.mjs';
+import { readScopeEnvelopes, getScopeSpendUsd } from '../lib/spend-guard.mjs';
+
+const args = process.argv.slice(2);
+const flag = (n) => args.includes(`--${n}`);
+const val = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : null; };
+
+await withMongo(async (db) => {
+  const control = (await db.collection('system_config').findOne({ _id: 'processing_control' })) || {};
+  const scopes = control.allow_scopes || {};
+
+  if (flag('show')) {
+    const tags = Object.keys(scopes);
+    if (!tags.length) { console.log('No allow_scopes configured.'); return; }
+    const envelopes = new Map(readScopeEnvelopes(control).map((e) => [e.tag, e]));
+    for (const tag of tags) {
+      const s = scopes[tag];
+      const env = envelopes.get(tag);
+      let spendNote = 'no envelope (pause-bypass only — does NOT open the spend dial)';
+      if (env) {
+        const ids = new Set((s.book_ids || []).map(String));
+        if (env.collections.length) {
+          const rows = await db.collection('books').find({ collections: { $in: env.collections } }).project({ id: 1 }).toArray();
+          for (const b of rows) ids.add(String(b.id));
+        }
+        const spend = await getScopeSpendUsd(db, { ids: [...ids], since: env.created_at });
+        const state = spend.meterError ? `METER ERROR: ${spend.meterError}` : (spend.usd < env.budget_usd ? 'OPEN' : 'SPENT');
+        spendNote = `envelope $${spend.usd.toFixed(2)} / $${env.budget_usd.toFixed(2)} → ${state} (${ids.size} books, ${spend.rows} usage rows)`;
+      }
+      console.log(`${tag}`);
+      console.log(`  book_ids: ${(s.book_ids || []).length}  collections: ${(s.collections || []).join(', ') || '(none)'}`);
+      console.log(`  created: ${s.created_at ? new Date(s.created_at).toISOString() : '(unknown)'} by ${s.created_by || '(unknown)'}`);
+      console.log(`  ${spendNote}`);
+    }
+    return;
+  }
+
+  const tag = val('tag');
+  const by = val('by');
+  if (!tag) { console.error('--tag <name> is required (or --show)'); process.exit(1); }
+  if (!/^[a-zA-Z0-9_-]+$/.test(tag)) { console.error('--tag must be [a-zA-Z0-9_-]+ (it becomes a Mongo field name)'); process.exit(1); }
+  if (!by) { console.error('--by "who/why" is required for any change (the trail is the point)'); process.exit(1); }
+
+  if (flag('remove')) {
+    if (!scopes[tag]) { console.error(`No scope '${tag}' to remove.`); process.exit(1); }
+    await updateConfigVersioned(db, 'processing_control', { $unset: { [`allow_scopes.${tag}`]: '' } }, by);
+    console.log(`Removed scope '${tag}' — its pause bypass and any envelope are gone immediately.`);
+    return;
+  }
+
+  const existing = scopes[tag] || null;
+  const books = val('books') ? val('books').split(',').map((s) => s.trim()).filter(Boolean) : null;
+  const collection = val('collection');
+  const budgetRaw = val('budget');
+  const budget = budgetRaw != null ? Number(budgetRaw) : null;
+  if (budgetRaw != null && (!Number.isFinite(budget) || budget <= 0)) {
+    console.error('--budget must be a positive number of USD'); process.exit(1);
+  }
+  if (!existing && !books && !collection) {
+    console.error(`Scope '${tag}' does not exist — creating one needs --books and/or --collection.`); process.exit(1);
+  }
+
+  // Build the scope doc: on update, only the passed fields change; the
+  // envelope's created_at is set once and never touched by a budget top-up
+  // (envelope spend is measured from created_at — resetting it would forgive
+  // spend already accounted).
+  const next = {
+    book_ids: books ?? existing?.book_ids ?? [],
+    collections: collection ? [...new Set([...(existing?.collections || []), collection])] : (existing?.collections ?? []),
+    created_at: existing?.created_at ?? new Date(),
+    created_by: existing?.created_by ?? by,
+    updated_at: new Date(),
+    updated_by: by,
+  };
+  if (budget != null) next.budget_usd = budget;
+  else if (existing?.budget_usd != null) next.budget_usd = existing.budget_usd;
+
+  await updateConfigVersioned(db, 'processing_control', { $set: { [`allow_scopes.${tag}`]: next } }, by);
+  console.log(`${existing ? 'Updated' : 'Created'} scope '${tag}': ${next.book_ids.length} book_ids, collections [${next.collections.join(', ')}]${next.budget_usd != null ? `, envelope $${next.budget_usd}` : ' (no envelope — pause bypass only)'}`);
+  if (next.budget_usd != null) {
+    console.log('Envelope spend is measured from created_at over both usage stores; monitor with scripts/audit/scope-progress.mjs --scope ' + tag);
+  }
+  console.log('(prior state snapshotted to system_config_revisions)');
+});

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -41,7 +41,7 @@ import { createBookRevisions } from './lib/book-revisions.mjs';
 import { buildSummaryPrompt, SUMMARY_GEN_CONFIG } from './lib/summary-prompt.mjs';
 import { createClient } from '@supabase/supabase-js';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
-import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
+import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 import { buildPageTexts, attributeEntityPages, entityCounters } from '../lib/entity-page-match.mjs';
 import { composeBookEmbeddingText } from '../lib/book-embedding-text.mjs';
 import { embedBookPages } from '../lib/embed-book-pages.mjs';
@@ -1493,8 +1493,15 @@ async function main() {
 
   // The dial caps money regardless of pause/scope state (#3826): a scope
   // confines WHICH books, the budget caps HOW MUCH. Every Gemini call below
-  // is paid work.
-  if (!DRY_RUN && !await budgetAllowsDispatch(db, 'enrich-worker', { control })) {
+  // is paid work. A scope ENVELOPE (#4540) can open a confined lane when the
+  // global dial is closed — the gate then returns the book ids the lane is
+  // limited to, and the candidate queries below are confined to them.
+  const _gate = DRY_RUN ? { allowed: true, envelopeIds: null } : await budgetAllowsDispatchScoped(db, 'enrich-worker', { control });
+  if (_gate.envelopeIds) {
+    SCOPE_FILTER = { id: { $in: [..._gate.envelopeIds] } };
+    console.log(`[ENRICH] Global dial closed, scope envelope open — confining to ${_gate.envelopeIds.size} envelope book(s).`);
+  }
+  if (!DRY_RUN && !_gate.allowed) {
     await db.collection('cron_runs').insertOne({
       cron: 'hetzner-enrich-worker', timestamp: new Date(),
       duration_ms: Date.now() - startTime, status: 'skipped', failed: false,

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -23,7 +23,7 @@ import { nanoid } from 'nanoid';
 import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
-import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
+import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 
 // Structured-output schema. Forces scan_quality to be present as an object with the
 // required fields populated; extracted_images is left loosely shaped because its
@@ -1052,9 +1052,15 @@ async function main() {
 
   // The dial caps money regardless of pause/scope state (#3826): a scope
   // confines WHICH books, the budget caps HOW MUCH. Vision calls are paid work.
-  if (!await budgetAllowsDispatch(db, 'image-extract-worker', { control: ctrl })) {
+  // A scope envelope (#4540) can open a confined lane when the dial is closed.
+  const _gate = await budgetAllowsDispatchScoped(db, 'image-extract-worker', { control: ctrl });
+  if (!_gate.allowed) {
     await client.close();
     return;
+  }
+  if (_gate.envelopeIds) {
+    SCOPE_FILTER = { id: { $in: [..._gate.envelopeIds] } };
+    console.log(`[IMAGE-EXTRACT] Global dial closed, scope envelope open — confining to ${_gate.envelopeIds.size} envelope book(s).`);
   }
 
   // Find books ready for image extraction

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -26,7 +26,7 @@ import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
-import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
+import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 import { getTranslateModelForBook, SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
@@ -2461,11 +2461,12 @@ async function run() {
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
 
   // ── Selective unpause ──────────────────────────────────────────────
-  // Process specific books even while globally paused. Driven by
-  // system_config.processing_control.allow_book_ids[] / allow_collections[].
-  // When a scope is set, the global pause is bypassed but EVERY phase is
-  // confined to the allowlisted books (via applyBookOverride below). An
-  // empty scope means the pause is a full stop, unchanged. The free
+  // Process specific books even while the line is otherwise stopped. Driven by
+  // system_config.processing_control.allow_book_ids[] / allow_collections[] /
+  // allow_scopes{}. A configured scope CONFINES the run only when the line is
+  // stopped for everyone else — globally paused (#2610), or the daily dial is
+  // closed and a scope envelope is open (#4540). When the line is open, scoped
+  // books flow with everything else and unscoped books are unaffected. The free
   // archiving workers already do this per-book (archive-bulk --book-id,
   // archive-iiif-local --ignore-pause); this brings the paid path in line.
   const { bookIds: _scopeBookIds, collections: _scopeCollections } = getScopeConfig(control);
@@ -2476,10 +2477,7 @@ async function run() {
       .toArray();
     for (const b of scoped) _scopeIds.add(String(b.id));
   }
-  const SCOPED_MODE = _scopeIds.size > 0;
-  // SCOPE_ACTIVE gates the per-phase applyBookOverride calls — true for either
-  // a single --book override (existing behavior) or a config-driven allowlist.
-  const SCOPE_ACTIVE = !!BOOK_OVERRIDE || SCOPED_MODE;
+  const SCOPE_CONFIGURED = _scopeIds.size > 0;
 
   if (RECOVERY_ONLY && !shouldBypassPause(control, { bookOverride: !!BOOK_OVERRIDE })) {
     console.log('[pipeline-orchestrator] PAUSED, but this is a recovery-only run (--phase 8.5): rolling back stuck statuses spends nothing, so it proceeds.');
@@ -2497,8 +2495,25 @@ async function run() {
     await client.close();
     return;
   }
+  // ── Run mode (#4540): measure the dial once, decide the lane ──
+  // ENVELOPE MODE: the global dial is closed but a scope envelope has room —
+  // the run proceeds confined to the envelope-open books only. The decision is
+  // made at run START so confinement and dispatch can never disagree: if the
+  // dial closes mid-run and an envelope opens, this run's phases refuse and
+  // the NEXT run (2 min) enters envelope mode with candidates confined.
+  const _startGate = await budgetAllowsDispatchScoped(db, 'run start (mode decision)', { bypass: !!BOOK_OVERRIDE, control });
+  const ENVELOPE_MODE = !!(_startGate.allowed && _startGate.envelopeIds);
+  if (ENVELOPE_MODE) {
+    for (const id of [..._scopeIds]) if (!_startGate.envelopeIds.has(id)) _scopeIds.delete(id);
+    console.log(`[pipeline-orchestrator] ENVELOPE MODE: global dial closed, scope envelope(s) open — processing ONLY ${_scopeIds.size} envelope book(s).`);
+  }
+  const SCOPED_MODE = SCOPE_CONFIGURED && (!!control?.paused || ENVELOPE_MODE);
+  // SCOPE_ACTIVE gates the per-phase applyBookOverride calls — true for either
+  // a single --book override (existing behavior) or a confining scope.
+  const SCOPE_ACTIVE = !!BOOK_OVERRIDE || SCOPED_MODE;
+
   if (control?.paused && SCOPED_MODE) {
-    console.log(`[pipeline-orchestrator] PAUSED globally, but selective-unpause scope is active — processing ONLY ${_scopeIds.size} allowlisted book(s) (allow_book_ids + allow_collections).`);
+    console.log(`[pipeline-orchestrator] PAUSED globally, but selective-unpause scope is active — processing ONLY ${_scopeIds.size} allowlisted book(s) (allow_book_ids + allow_collections + allow_scopes).`);
   }
 
   // DB health probe — adjusts submission limits based on Atlas load
@@ -2573,6 +2588,24 @@ async function run() {
       return normalBooks.filter(b => _scopeIds.has(String(b.id || b._id)));
     }
     return normalBooks;
+  }
+
+  /**
+   * Per-phase paid-dispatch gate (#4540). Wraps budgetAllowsDispatchScoped so
+   * every paid phase re-measures (the dial can close mid-run as spend lands),
+   * with one safety rule: envelope-lane dispatch is honored ONLY when the run
+   * started in envelope mode — that is the only case where the phase's
+   * candidates are already confined to the envelope books. A lane that opens
+   * mid-run waits for the next run rather than dispatching unconfined.
+   */
+  async function budgetAllowsDispatchForPhase(label) {
+    const g = await budgetAllowsDispatchScoped(db, label, { bypass: !!BOOK_OVERRIDE });
+    if (!g.allowed) return false;
+    if (g.envelopeIds && !ENVELOPE_MODE) {
+      console.log(`  [spend-guard] ${label}: envelope lane opened mid-run, but this run's candidates are not confined — deferring scoped dispatch to the next run.`);
+      return false;
+    }
+    return true;
   }
 
   const log = {
@@ -2921,7 +2954,7 @@ async function run() {
       // the free screen keeps running when the dial is closed — gating the whole
       // phase would stop `split_checked` being written, and Phase 1.5 requires
       // it, so a closed dial would silently stall preview OCR as well.
-      const splitConfirmAllowed = await budgetAllowsDispatch(db, 'Phase 1.25 (split confirm)', { bypass: !!BOOK_OVERRIDE });
+      const splitConfirmAllowed = await budgetAllowsDispatchForPhase('Phase 1.25 (split confirm)');
 
       // Scoped mode raises the window so allowlisted books behind the backlog
       // aren't stranded (work stays confined by applyBookOverride below). The
@@ -3206,7 +3239,7 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
     // Dial-gated. Phase 1.5 spends, so it must ask — it was outside the dial
     // while it was inline realtime, which meant the one phase that runs every
     // two minutes was the one phase the ceiling could not stop.
-    if (shouldRun(1.5) && await budgetAllowsDispatch(db, 'Phase 1.5 (preview OCR)', { bypass: !!BOOK_OVERRIDE })) {
+    if (shouldRun(1.5) && await budgetAllowsDispatchForPhase('Phase 1.5 (preview OCR)')) {
       console.log('\n--- Phase 1.5: Preview OCR (flash-lite batch, first 25 pages) ---');
 
       const previewRetryCutoff = new Date(Date.now() - PREVIEW_BATCH_RETRY_HOURS * 60 * 60 * 1000);
@@ -3314,7 +3347,7 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
     // language, description, display_title, categories, source_work_dates, FT pre-screen.
     // Also does catalog cross-reference (USTC/EFM) for year/place/publisher.
     // Writes ai_metadata and updates book fields at medium+ confidence.
-    if ((shouldRun(1.6) || shouldRun(1.5)) && await budgetAllowsDispatch(db, 'Phase 1.6 (metadata classification)', { bypass: !!BOOK_OVERRIDE })) {
+    if ((shouldRun(1.6) || shouldRun(1.5)) && await budgetAllowsDispatchForPhase('Phase 1.6 (metadata classification)')) {
       console.log('\n--- Phase 1.6: AI metadata classification ---');
 
       const metadataApiKey = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
@@ -3848,7 +3881,7 @@ Rules:
     // Two-pass strategy:
     //   Pass 1 ("preview"): First 25 pages of first-translation books — gives readers content fast
     //   Pass 2 ("full"): Remaining pages for books that already have preview OCR
-    if (shouldRun(2) && await budgetAllowsDispatch(db, 'Phase 2 (OCR submit)', { bypass: !!BOOK_OVERRIDE })) {
+    if (shouldRun(2) && await budgetAllowsDispatchForPhase('Phase 2 (OCR submit)')) {
       console.log('\n--- Phase 2: OCR submission ---');
 
       // Ordering gate: never OCR a book before Phase 1.97 has deduped it, else
@@ -4374,7 +4407,7 @@ Rules:
 
     // ── Phase 3.7: Transliteration for non-Latin books (inline, runs on ocr_complete books) ──
     // Not a pipeline state — just enriches pages before translation. Cheap & fast (text-only, lite model).
-    if ((shouldRun(3.7) || shouldRun(3.5) || shouldRun(3)) && await budgetAllowsDispatch(db, 'Phase 3.7 (transliteration)', { bypass: !!BOOK_OVERRIDE })) {
+    if ((shouldRun(3.7) || shouldRun(3.5) || shouldRun(3)) && await budgetAllowsDispatchForPhase('Phase 3.7 (transliteration)')) {
       console.log('\n--- Phase 3.7: Transliteration (non-Latin books) ---');
 
       // Find ocr_complete books with non-Latin languages
@@ -4457,7 +4490,7 @@ Rules:
     // ── Phase 4: Dispatch translation to Lambda via SQS FIFO ──
     // Hetzner focuses on OCR; Lambdas scale out translation.
     // Creates a job record, enqueues pages to SQS FIFO, Lambdas process sequentially per book.
-    if (shouldRun(4) && await budgetAllowsDispatch(db, 'Phase 4 (translation dispatch)', { bypass: !!BOOK_OVERRIDE })) {
+    if (shouldRun(4) && await budgetAllowsDispatchForPhase('Phase 4 (translation dispatch)')) {
       console.log('\n--- Phase 4: Dispatch translation to Lambda (SQS FIFO) ---');
 
       // Zombie job reaper: cancel ANY job stuck in processing with no update for >1h.
@@ -4907,7 +4940,7 @@ Rules:
     }
 
     // ── Phase 8: Image extraction (chapters_complete -> images_submitted/complete) ──
-    if (shouldRun(8) && await budgetAllowsDispatch(db, 'Phase 8 (image extraction)', { bypass: !!BOOK_OVERRIDE })) {
+    if (shouldRun(8) && await budgetAllowsDispatchForPhase('Phase 8 (image extraction)')) {
       console.log('\n--- Phase 8: Image extraction ---');
 
       const USE_BATCH = process.env.IMAGE_EXTRACTION_USE_BATCH !== 'false'; // Default: true (batch)

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -38,7 +38,7 @@ import {
 import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-revisions.mjs';
 import { syncPageUpdate, syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
-import { budgetAllowsDispatch } from '../lib/spend-guard.mjs';
+import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 
 // Selective-unpause scope confinement, set in main() after the pause check and
 // read by the candidate queries (incl. selfDispatch). In normal operation
@@ -1076,7 +1076,15 @@ async function selfDispatch(db, limit) {
   // work exactly like orchestrator Phase 4 does, and during the 2026-08-08
   // incident it was the only dispatcher actually running — ungated. Every
   // path that turns a book into Gemini calls must ask the budget first.
-  if (!await budgetAllowsDispatch(db, 'translate-self-dispatch')) return [];
+  // Envelope-lane dispatch (#4540) is honored only via the module-level
+  // SCOPE_FILTER set by the main-run gate — if the envelope opened but this
+  // call's confinement isn't in place, refuse rather than dispatch unconfined.
+  const _sdGate = await budgetAllowsDispatchScoped(db, 'translate-self-dispatch');
+  if (!_sdGate.allowed) return [];
+  if (_sdGate.envelopeIds && !SCOPE_IDS) {
+    console.log('[TRANSLATE] self-dispatch: envelope lane open but no scope confinement active — deferring to the next confined run.');
+    return [];
+  }
 
   // Find fresh books (ocr_complete) — sorted by language speed tier
   // so each batch is homogeneous (all fast or all slow books together).
@@ -1252,7 +1260,8 @@ async function main() {
   //
   // A queue is stored spend. Anything that turns a queued job into Gemini
   // calls has to ask, or the dial only limits how fast we ENQUEUE money.
-  if (!await budgetAllowsDispatch(db, 'translate-worker run', { control })) {
+  const _gate = await budgetAllowsDispatchScoped(db, 'translate-worker run', { control });
+  if (!_gate.allowed) {
     await db.collection('cron_runs').insertOne({
       cron: 'hetzner-translate-worker', timestamp: new Date(),
       duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
@@ -1269,6 +1278,16 @@ async function main() {
     SCOPE_SET = new Set(SCOPE_IDS);
     SCOPE_FILTER = { id: { $in: SCOPE_IDS } };
     console.log(`[TRANSLATE] PAUSED globally, scope active — confining to ${SCOPE_IDS.length} allowlisted book(s).`);
+  }
+  // Scope envelope (#4540): global dial closed but an envelope has room — the
+  // run proceeds confined to the envelope books. This governs CONSUMPTION too:
+  // a queue is stored spend, so resuming translate_submitted/orphaned work for
+  // non-envelope books would spend the global budget the dial just refused.
+  if (_gate.envelopeIds) {
+    SCOPE_IDS = [..._gate.envelopeIds];
+    SCOPE_SET = new Set(SCOPE_IDS);
+    SCOPE_FILTER = { id: { $in: SCOPE_IDS } };
+    console.log(`[TRANSLATE] Global dial closed, scope envelope open — confining to ${SCOPE_IDS.length} envelope book(s).`);
   }
 
   // Find books — fresh (0 translated) first, then partials sorted by most remaining pages.

--- a/tests/unit/spend-guard.test.ts
+++ b/tests/unit/spend-guard.test.ts
@@ -15,7 +15,10 @@ import {
   getTodaySpendUsd,
   readDailyBudgetUsd,
   budgetAllowsDispatch,
+  budgetAllowsDispatchScoped,
+  readScopeEnvelopes,
   _setSupabaseSpendReaderForTests,
+  _setSupabaseScopeSpendReaderForTests,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore — plain-JS module, no declarations
 } from '../../scripts/lib/spend-guard.mjs';
@@ -23,6 +26,7 @@ import {
 // Default: Supabase store empty and readable. Individual tests override.
 beforeEach(() => {
   _setSupabaseSpendReaderForTests(async () => ({ usd: 0, rows: 0, costlessRows: 0, error: null }));
+  _setSupabaseScopeSpendReaderForTests(async () => ({ usd: 0, rows: 0, error: null }));
 });
 const supaStub = (usd: number, rows = 0, error: string | null = null) =>
   _setSupabaseSpendReaderForTests(async () => ({ usd, rows, costlessRows: 0, error }));
@@ -130,5 +134,120 @@ describe('budgetAllowsDispatch', () => {
     expect(await budgetAllowsDispatch(db, 'test', { bypass: true })).toBe(true);
     expect(calls.findOnes).toBe(0);
     expect(calls.aggregates.length).toBe(0);
+  });
+});
+
+// ─── Scope envelopes (#4540) ────────────────────────────────────────────────
+
+describe('readScopeEnvelopes — only positive finite budgets are envelopes', () => {
+  it('filters non-budgeted, zero, negative and malformed budgets', () => {
+    const control = {
+      allow_scopes: {
+        good: { book_ids: ['a'], budget_usd: 5 },
+        pauseOnly: { book_ids: ['b'] },
+        zero: { book_ids: ['c'], budget_usd: 0 },
+        negative: { book_ids: ['d'], budget_usd: -3 },
+        stringy: { book_ids: ['e'], budget_usd: '5' },
+      },
+    };
+    const envs = readScopeEnvelopes(control);
+    expect(envs.map((e: { tag: string }) => e.tag)).toEqual(['good']);
+    expect(envs[0].budget_usd).toBe(5);
+  });
+  it('empty/missing allow_scopes → no envelopes', () => {
+    expect(readScopeEnvelopes({})).toEqual([]);
+    expect(readScopeEnvelopes(undefined)).toEqual([]);
+  });
+});
+
+/**
+ * Stub distinguishing the DAILY aggregate (matches by _id time range only)
+ * from a SCOPE aggregate (matches book_id) on the same gemini_usage collection.
+ */
+function makeScopedDbStub({ dailyUsd = 0, scopeUsd = 0, control }: {
+  dailyUsd?: number; scopeUsd?: number; control: Record<string, unknown>;
+}) {
+  return {
+    collection(name: string) {
+      return {
+        aggregate: (pipeline: Array<{ $match?: Record<string, unknown> }>) => {
+          const isScope = !!pipeline[0]?.$match?.book_id;
+          const usd = isScope ? scopeUsd : dailyUsd;
+          return { toArray: async () => (usd === 0 ? [] : [{ _id: null, usd, rows: 1, costlessRows: 0 }]) };
+        },
+        findOne: async () => (name === 'system_config' ? control : null),
+        find: () => ({ project: () => ({ toArray: async () => [] }) }),
+      };
+    },
+  };
+}
+
+describe('budgetAllowsDispatchScoped — a second ceiling, never an absence of one', () => {
+  const envControl = (over: Record<string, unknown> = {}) => ({
+    _id: 'processing_control',
+    daily_budget_usd: 5,
+    allow_scopes: { lane: { book_ids: ['b1', 'b2'], budget_usd: 10, created_at: new Date('2026-09-01T00:00:00Z') } },
+    ...over,
+  });
+
+  it('global dial open → unrestricted dispatch, envelopes not consulted', async () => {
+    const db = makeScopedDbStub({ dailyUsd: 2, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(true);
+    expect(g.envelopeIds).toBeNull();
+  });
+
+  it('dial closed + envelope with room → scoped dispatch confined to the envelope books', async () => {
+    const db = makeScopedDbStub({ dailyUsd: 21, scopeUsd: 3, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(true);
+    expect([...g.envelopeIds!].sort()).toEqual(['b1', 'b2']);
+  });
+
+  it('dial closed + envelope spent → refused (ceilings all the way down)', async () => {
+    const db = makeScopedDbStub({ dailyUsd: 21, scopeUsd: 10, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(false);
+  });
+
+  it('dial closed + no envelopes → refused (a pause-only scope never opens the dial)', async () => {
+    const db = makeScopedDbStub({ dailyUsd: 21, control: envControl({ allow_scopes: { lane: { book_ids: ['b1'] } } }) });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(false);
+  });
+
+  it('dial UNSET (default-closed) + envelope with room → scoped dispatch (an envelope is an explicit bounded grant)', async () => {
+    const db = makeScopedDbStub({ scopeUsd: 3, control: envControl({ daily_budget_usd: null }) });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(true);
+    expect(g.envelopeIds!.size).toBe(2);
+  });
+
+  it('FAILS CLOSED for every lane when the daily meter is unreadable', async () => {
+    supaStub(0, 0, 'Supabase read error: fetch failed');
+    const db = makeScopedDbStub({ dailyUsd: 0, scopeUsd: 0, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(false);
+  });
+
+  it('FAILS CLOSED for an envelope whose own meter is unreadable', async () => {
+    _setSupabaseScopeSpendReaderForTests(async () => ({ usd: 0, rows: 0, error: 'Supabase read failed (500)' }));
+    const db = makeScopedDbStub({ dailyUsd: 21, scopeUsd: 0, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(false);
+  });
+
+  it('envelope spend SUMS both stores — Supabase spend alone can close the envelope', async () => {
+    _setSupabaseScopeSpendReaderForTests(async () => ({ usd: 9.5, rows: 100, error: null }));
+    const db = makeScopedDbStub({ dailyUsd: 21, scopeUsd: 0.6, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test');
+    expect(g.allowed).toBe(false); // 9.5 + 0.6 >= 10
+  });
+
+  it('bypass short-circuits, unrestricted', async () => {
+    const db = makeScopedDbStub({ dailyUsd: 999, control: envControl() });
+    const g = await budgetAllowsDispatchScoped(db, 'test', { bypass: true });
+    expect(g.allowed).toBe(true);
+    expect(g.envelopeIds).toBeNull();
   });
 });


### PR DESCRIPTION
Implements #4540. A scope in `allow_scopes` may now carry `budget_usd` — an envelope. When the global daily dial is closed (or unset), books in a scope whose envelope has room dispatch **confined to exactly those books**, until the envelope itself is spent. Ceilings all the way down; never a bypass — #3826 ($2.3K against a $15 dial) is why the answer is a second accounted ceiling, not an exemption.

## Design

- **`budgetAllowsDispatchScoped()`** (spend-guard) returns `{allowed, envelopeIds}`. Envelope spend is **measured every time** from both usage stores (rows attributed by `book_id` membership since the scope's `created_at`) — nothing trusts a stored counter. Any unreadable meter fails that lane closed, same doctrine as the daily guard. Rows without `book_id` can't be attributed, so envelope spend is a floor: the envelope is a brake, not an accounting system, exactly like the dial.
- **Orchestrator: mode decided once at run start.** If the dial closes mid-run and an envelope opens, that run's phases refuse and the *next* run (2 min) enters envelope mode with candidates confined — confinement and dispatch can never disagree. The 7 phase gates go through `budgetAllowsDispatchForPhase` (name keeps the spend-perimeter audit's structural check matching — it passes).
- **Scope semantics fix:** a configured scope now confines the orchestrator only when the line is otherwise stopped (paused, or envelope mode). Previously any configured scope confined the whole run even while unpaused with the dial open — which would have made creating an envelope throttle every unscoped book, violating the acceptance criterion "a book not in any scope is unaffected." This also aligns the orchestrator with the three workers, which already confined only when paused.
- **enrich / image-extract / translate workers** use the scoped gate; envelope mode sets their existing `SCOPE_FILTER`, which confines candidate selection **and queue consumption** (the 2026-08-30 lesson: a queue is stored spend). translate self-dispatch refuses envelope dispatch if confinement isn't in place.
- **Embed workers deliberately unchanged** (strict boolean gate): embeddings are corpus infrastructure, not part of a book's completion chain, and those sweeps can't be book-confined cheaply. They stay governed by the global dial only.
- **`set-scope.mjs`**: create/update/remove scopes + envelopes; versioned via `system_config_revisions`; writes only its own `allow_scopes.<tag>` key (the multi-session rule). **`scope-progress.mjs`** now shows each envelope's measured spend and OPEN/SPENT state.

## Verified

- 31 unit tests pass (9 new: envelope parsing, open/spent/unset-dial lanes, fail-closed on either meter, both-stores summing).
- Live dry-run on today's actually-closed dial: `run start (mode decision): daily ceiling reached and no scope envelopes — no new dispatch`.
- Positive control with an injected forum-of-conscience envelope: `SCOPED DISPATCH, confined to 34 book(s). test-lane: $0.01/$30.00 OPEN`.
- `spend-perimeter.mjs` audit: PASS. `tsc --noEmit` clean.

## Deployment sequencing — read before creating any envelope

Hetzner auto-pulls main; **do not create an envelope scope until this is merged and the workers have pulled**, because the *old* orchestrator confines the whole pipeline whenever any scope exists.

## Out of scope

- Batch-path gating (`bulk-reocr-local.mjs` submits ungated; see the issue comment) — deliberate operator-only path for now, needs its own decision.
- Tagging usage rows with a scope id at write time (would make attribution exact rather than book\_id-derived) — follow-up.
- The "move the guard after candidate selection" structural variant — this PR is the issue's smaller-step option, landed with the envelope as the issue requires.

Closes #4540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SER4WMgwsMDLXik34yb16k