### PR TITLE
fix(libraries): merge duplicate partners, book-page-style header, curated tile images

### DIFF
--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
 import { notFound } from 'next/navigation';
-import { getPartnerBySlug } from '@/lib/library-partners';
+import { getPartnerBySlug, getProviderKeys } from '@/lib/library-partners';
 import SharedLibraryView, { type SharedLibraryViewProps } from '@/components/libraries/SharedLibraryView';
 import LibrarySchema from '@/components/seo/LibrarySchema';
 
@@ -99,12 +99,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 // ---------- Data fetching ----------
 
 async function fetchLibraryData(
-  providerKey: string,
+  // All provider keys for the partner — canonical + aliases (ndl/ndl_japan,
+  // mdz/bsb). Single-element for most partners.
+  providerKeys: string[],
   sort: string,
   language: string,
   offset: number,
   q?: string
 ): Promise<Pick<SharedLibraryViewProps, 'books' | 'total' | 'topBooks' | 'languages' | 'galleryImages' | 'contributingLibraries'>> {
+  const providerKey = providerKeys.length === 1 ? providerKeys[0] : providerKeys;
   // Every query is independently guarded: one slow/failing catalog call must
   // degrade its own slice, never 500 the whole page.
   const safe = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {
@@ -189,7 +192,7 @@ async function fetchLibraryData(
       .from('books_catalog')
       .select('contributing_library')
       .eq('visible', true)
-      .eq('image_source_provider', providerKey)
+      .in('image_source_provider', providerKeys)
       .gt('pages_count', 0)
       .gt('pages_translated', 0)
       .not('contributing_library', 'is', null);
@@ -266,7 +269,7 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
 
   // Fetch data — catalog data only for BPH
   const [libraryData, digitizedUbns, catalogTotal] = await Promise.all([
-    fetchLibraryData(partner.providerKey, sort, language, offset, q || undefined),
+    fetchLibraryData(getProviderKeys(partner), sort, language, offset, q || undefined),
     isBph ? fetchBphDigitizedMap() : Promise.resolve({}),
     isBph ? fetchBphCatalogTotal() : Promise.resolve(0),
   ]);

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
-import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
+import { browseBooks, countBooks, getLanguageCounts } from '@/lib/books-catalog';
 import { notFound } from 'next/navigation';
 import { getPartnerBySlug, getProviderKeys } from '@/lib/library-partners';
 import SharedLibraryView, { type SharedLibraryViewProps } from '@/components/libraries/SharedLibraryView';
@@ -121,8 +121,9 @@ async function fetchLibraryData(
   // pages_count>0 first (fast + safe, even over huge providers); only if that
   // yields NOTHING (e.g. an art-only provider like the Met, whose single-object
   // items have pages_count:0) fall back to including page-less artworks. Never
-  // exactCount (it times out over big providers and empties the page).
-  const fetchGrid = async (): Promise<BrowseResult> => {
+  // exactCount on the GRID query (it times out over big providers and empties
+  // the page) — the exact total comes from a separate head-only countBooks below.
+  const fetchGrid = async (): Promise<BrowseResult & { usedArtworkFallback: boolean }> => {
     const paged = await safe(() => browseBooks({
       provider: providerKey,
       language: language || undefined,
@@ -131,8 +132,8 @@ async function fetchLibraryData(
       offset,
       limit: PER_PAGE_LOCAL,
     }), emptyResult);
-    if (paged.books.length > 0) return paged;
-    return safe(() => browseBooks({
+    if (paged.books.length > 0) return { ...paged, usedArtworkFallback: false };
+    const fallback = await safe(() => browseBooks({
       provider: providerKey,
       language: language || undefined,
       search: q && q.length >= 2 ? q : undefined,
@@ -141,6 +142,7 @@ async function fetchLibraryData(
       limit: PER_PAGE_LOCAL,
       hasPages: false,
     }), paged);
+    return { ...fallback, usedArtworkFallback: true };
   };
   const fetchSample = async (): Promise<BrowseResult> => {
     const paged = await safe(() => browseBooks({ provider: providerKey, sort: 'popular', limit: 50 }), emptyResult);
@@ -152,10 +154,24 @@ async function fetchLibraryData(
   // heavy enough that running them concurrently starved/timed-out the grid query
   // and emptied the page. Books first, then the supporting data.
   const booksResult = await fetchGrid();
-  const [languages, sampleResult] = await Promise.all([
+  // browseBooks defaults to Postgres's 'planned'/'estimated' count to dodge
+  // statement timeouts, but the estimate is off by 2-3x on provider filters
+  // (MDZ showed "5,596 books" against a true 2,104). A head-only exact count
+  // on the same filters measures 1.5-3.5s — fine under 24h ISR — so overwrite
+  // the estimate with the truth; on failure keep the estimate rather than 0.
+  const [languages, sampleResult, exactTotal] = await Promise.all([
     safe(() => getLanguageCounts({ provider: providerKey }), [] as Array<{ lang: string; count: number }>),
     fetchSample(),
+    safe(() => countBooks({
+      provider: providerKey,
+      language: language || undefined,
+      search: q && q.length >= 2 ? q : undefined,
+      // Count the same set the grid rendered: pages_count>0 normally, or the
+      // page-less-artworks fallback set when fetchGrid took that branch.
+      hasPages: booksResult.usedArtworkFallback ? false : undefined,
+    }), null as number | null),
   ]);
+  if (exactTotal !== null) booksResult.total = exactTotal;
 
   const sampleBookIds = sampleResult.books.map(b => b.id);
 

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Library, ExternalLink, BookOpen, Globe } from 'lucide-react';
 import ContentPageLayout from '@/components/layout/ContentPageLayout';
 import SiteHeader from '@/components/layout/SiteHeader';
+import HeroScrim from '@/components/HeroScrim';
 import { LIBRARY_PARTNERS, getPartnerByProvider } from '@/lib/library-partners';
 import type { Metadata } from 'next';
 
@@ -219,13 +220,23 @@ export default async function LibrariesPage() {
     fetchContributingLibraries().catch((err) => { console.error('Libraries contributing fetch failed:', err); return [] as ContributingLibrary[]; }),
   ]);
 
-  const partners = stats
-    .map(s => {
-      const partner = getPartnerByProvider(s.provider);
-      if (!partner) return null;
-      return { ...partner, count: s.count, languages: s.languages, heroImage: partner.heroImageOverride || s.heroImage };
-    })
-    .filter(Boolean) as (typeof LIBRARY_PARTNERS[string] & { count: number; languages: string[]; heroImage?: string })[];
+  // Group provider stats by PARTNER, not by provider key: some institutions
+  // imported books under two keys over time (ndl + ndl_japan, mdz + bsb) and
+  // must render as one tile with summed counts, not duplicates.
+  const byPartnerSlug = new Map<string, typeof LIBRARY_PARTNERS[string] & { count: number; languageSet: Set<string>; heroImage?: string }>();
+  for (const s of stats) {
+    const partner = getPartnerByProvider(s.provider);
+    if (!partner) continue;
+    const entry = byPartnerSlug.get(partner.slug)
+      || { ...partner, count: 0, languageSet: new Set<string>(), heroImage: partner.heroImageOverride };
+    entry.count += s.count;
+    for (const lang of s.languages) entry.languageSet.add(lang);
+    if (!entry.heroImage) entry.heroImage = s.heroImage;
+    byPartnerSlug.set(partner.slug, entry);
+  }
+  const partners = [...byPartnerSlug.values()]
+    .map(({ languageSet, ...p }) => ({ ...p, languages: [...languageSet].sort() }))
+    .sort((a, b) => b.count - a.count) as (typeof LIBRARY_PARTNERS[string] & { count: number; languages: string[]; heroImage?: string })[];
 
   const totalBooks = partners.reduce((s, p) => s + p.count, 0);
   const totalInstitutions = contributingLibraries.length;
@@ -239,10 +250,24 @@ export default async function LibrariesPage() {
     <div className="min-h-screen bg-stone-50">
       <SiteHeader variant="light" />
 
-      {/* Hero: dark gradient header */}
-      <div className="relative overflow-hidden text-white py-16 md:py-20">
-        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
-        <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+      {/* Hero: a tiled mosaic of the partners' own scans under the shared
+          HeroScrim — the same treatment as the book-page hero, so the two
+          surfaces read as one design. Falls back to the dark base color if
+          images are missing. */}
+      <div className="relative overflow-hidden text-white" style={{ background: '#14100c' }}>
+        <div className="absolute inset-0 grid grid-cols-3 grid-rows-4 md:grid-cols-6 md:grid-rows-2">
+          {partners
+            .map(p => p.heroImage)
+            .filter((src): src is string => !!src)
+            .slice(0, 12)
+            .map((src, i) => (
+              <div key={src} className="relative">
+                <Image src={src} alt="" fill sizes="(max-width: 768px) 34vw, 17vw" className="object-cover" priority={i < 6} />
+              </div>
+            ))}
+        </div>
+        <HeroScrim />
+        <div className="relative max-w-[var(--container-wide)] mx-auto px-6 py-20 md:py-28" style={{ textShadow: '0 1px 16px rgba(0,0,0,0.72)' }}>
           <h1 className="font-serif text-4xl md:text-5xl tracking-tight mb-4">Libraries</h1>
           <p className="text-lg md:text-xl text-stone-300 max-w-2xl font-body leading-relaxed">
             {totalBooks.toLocaleString('en-US')} books sourced from {partners.length} libraries and archives

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -279,11 +279,14 @@ async function attachCardVariants(rows: CatalogBook[]): Promise<CatalogBook[]> {
  */
 export async function countBooks(filter: {
   language?: string;
-  provider?: string;
+  provider?: string | string[];
   collection?: string;
   firstTranslation?: boolean;
   hasPages?: boolean;
   hasTranslation?: boolean;
+  /** Same fuzzy title/author match browseBooks applies for its `search` opt —
+   *  pass the identical value so a count matches its grid. */
+  search?: string;
 }): Promise<number> {
   let query = supabase
     .from('books_catalog')
@@ -293,9 +296,14 @@ export async function countBooks(filter: {
   if (filter.hasPages !== false) query = query.gt('pages_count', 0);
   if (filter.hasTranslation) query = query.gt('pages_translated', 0);
   if (filter.language) query = query.eq('language', filter.language);
-  if (filter.provider) query = query.eq('image_source_provider', filter.provider);
+  if (filter.provider) {
+    query = Array.isArray(filter.provider)
+      ? query.in('image_source_provider', filter.provider)
+      : query.eq('image_source_provider', filter.provider);
+  }
   if (filter.collection) query = query.contains('collections', [filter.collection]);
   if (filter.firstTranslation) query = query.eq('is_first_translation', true);
+  if (filter.search) { const s = sanitizeFilterValue(filter.search); query = query.or(`title.ilike.%${s}%,display_title.ilike.%${s}%,author.ilike.%${s}%`); }
 
   const { count } = await query;
   return count || 0;

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -141,7 +141,9 @@ export async function browseBooks(opts: {
   language?: string;
   collection?: string;
   category?: string;
-  provider?: string;
+  /** One provider key, or several that belong to the same partner
+   *  (see getProviderKeys in library-partners.ts). */
+  provider?: string | string[];
   library?: string;
   firstTranslation?: boolean;
   hasTranslation?: boolean;
@@ -181,7 +183,11 @@ export async function browseBooks(opts: {
   if (opts.language) query = query.eq('language', opts.language);
   if (opts.collection) query = query.contains('collections', [opts.collection]);
   if (opts.category) query = query.contains('categories', [canonicalizeCategory(opts.category)]);
-  if (opts.provider) query = query.eq('image_source_provider', opts.provider);
+  if (opts.provider) {
+    query = Array.isArray(opts.provider)
+      ? query.in('image_source_provider', opts.provider)
+      : query.eq('image_source_provider', opts.provider);
+  }
   if (opts.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
   if (opts.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts.yearMin != null) query = query.gte('year', opts.yearMin);
@@ -337,12 +343,16 @@ export async function fetchAllVisibleCatalogRows<T = Record<string, unknown>>(
 }
 
 export async function getLanguageCounts(filter: {
-  provider?: string;
+  provider?: string | string[];
   collection?: string;
 }): Promise<{ lang: string; count: number }[]> {
   const rows = await fetchAllVisibleCatalogRows<{ language: string | null }>('language', (q) => {
     let query = q;
-    if (filter.provider) query = query.eq('image_source_provider', filter.provider);
+    if (filter.provider) {
+      query = Array.isArray(filter.provider)
+        ? query.in('image_source_provider', filter.provider)
+        : query.eq('image_source_provider', filter.provider);
+    }
     if (filter.collection) query = query.contains('collections', [filter.collection]);
     return query;
   });

--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -6,6 +6,12 @@ export interface LibraryPartner {
   name: string;
   shortName: string;
   providerKey: ImageSourceProvider;
+  /** Additional provider keys that belong to the SAME institution. Books were
+   *  imported under both keys over time (e.g. 'ndl' + 'ndl_japan'); listing the
+   *  extras here folds them into this partner everywhere instead of rendering
+   *  a duplicate tile. Query with getProviderKeys(partner), never providerKey
+   *  alone, on any surface that filters books by provider. */
+  aliasProviderKeys?: ImageSourceProvider[];
   url: string;
   description: string;
   color: 'rust' | 'sage' | 'violet' | 'gold';
@@ -36,7 +42,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://archive.org',
     description: 'The Internet Archive is a non-profit digital library offering free access to millions of books, movies, and web pages. Their Open Library and book scanning initiatives have digitized millions of volumes from partner libraries worldwide.',
     color: 'rust',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69d0065c73df40dce83db54c/0006.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/6953cc0c77f38f6761be0ed8/6953cc0d77f38f6761be0f72-0.jpg?v=1773153012299',
     logo: 'https://upload.wikimedia.org/wikipedia/commons/8/84/Internet_Archive_logo_and_wordmark.svg',
   },
   'gallica': {
@@ -47,16 +53,19 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://gallica.bnf.fr',
     description: 'Gallica is the digital library of the Bibliothèque nationale de France, providing free access to over 10 million documents including manuscripts, books, maps, and prints from one of the largest libraries in the world.',
     color: 'violet',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69a5ef41bfd8cafd91e44049/0022.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/6a6be1c4b7e35edd8ad0421f/6a6be1c4b7e35edd8ad04226-0.jpg?v=1785555098090',
     logo: 'https://upload.wikimedia.org/wikipedia/commons/c/c2/Gallica_logo.svg',
   },
   'bavarian-state-library': {
     slug: 'bavarian-state-library',
-    name: 'Bavarian State Library (MDZ)',
-    shortName: 'MDZ',
+    name: 'Bavarian State Library',
+    shortName: 'BSB',
     providerKey: 'mdz',
+    // Books arrived under two keys over time: 'mdz' (the digitization center's
+    // IIIF) and 'bsb' (direct). Same Munich institution — one tile, one page.
+    aliasProviderKeys: ['bsb'],
     url: 'https://www.digitale-sammlungen.de',
-    description: 'The Münchener DigitalisierungsZentrum (MDZ) is the digitization center of the Bayerische Staatsbibliothek, one of the most important research libraries in Europe. Their digital collections include over 3 million digitized pages of rare books and manuscripts.',
+    description: 'The Bayerische Staatsbibliothek in Munich is one of Europe\'s most important research libraries, holding extensive medieval codices, incunabula, and East Asian manuscripts. Its digitization center (MDZ) has digitized millions of pages of rare books and manuscripts.',
     color: 'sage',
     heroImageOverride: 'https://images.sourcelibrary.org/pages/69b51ec447b06ecd58196723/0002.jpg',
   },
@@ -100,7 +109,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://www.e-rara.ch',
     description: 'e-rara.ch is the platform for digitized rare books from Swiss libraries. It provides free access to printed works from the 15th to the 20th century held by Swiss research libraries, with a focus on early printed books.',
     color: 'sage',
-    heroImageOverride: 'https://images.sourcelibrary.org/archived/69b69ff8080b19f98fd128a3/2.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69b67cff24677234712502ea/69b67cff24677234712504b8-0.jpg?v=1781697060038',
   },
   'wellcome-collection': {
     slug: 'wellcome-collection',
@@ -142,7 +151,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://books.google.com',
     description: 'Google Books has digitized millions of volumes in partnership with major research libraries worldwide. Source Library imports Google Books content via Internet Archive mirrors, which host the digitized page images.',
     color: 'sage',
-    heroImageOverride: 'https://images.sourcelibrary.org/archived/6991ebe2e93551dd846a79cd/4.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69a5edc996d6dd816a56b5ec/69a5edc996d6dd816a56b5f0-0.jpg',
   },
   'hathi-trust': {
     slug: 'hathi-trust',
@@ -183,7 +192,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://allardpierson.nl',
     description: 'Allard Pierson at the University of Amsterdam houses the Bibliotheca Rosenthaliana and important collections of early printed books, manuscripts, and maps from the Dutch Golden Age and beyond.',
     color: 'gold',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69b525ce6be6046083032a57/0007.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69b4cd1ad5b6c3815e1a3f81/69b4cd1ad5b6c3815e1a3fc6-0.jpg?v=1781731220938',
   },
   'laurenziana': {
     slug: 'laurenziana',
@@ -213,7 +222,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://digitalcollections.universiteitleiden.nl',
     description: 'Leiden University Library, founded in 1575, holds the Scaliger collection of Oriental manuscripts, the Vossius collection of classical texts, and important Dutch Golden Age scientific works.',
     color: 'sage',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/6991c57d3074a1745a4118d2/0004.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69b3f74ba107e55a0ee1ca1a/69b3f74ba107e55a0ee1cad9-0.jpg',
   },
   'e-codices': {
     slug: 'e-codices',
@@ -240,6 +249,8 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     name: 'National Diet Library of Japan',
     shortName: 'NDL',
     providerKey: 'ndl_japan',
+    // 'ndl' was a second import key for the same library — folded in here.
+    aliasProviderKeys: ['ndl'],
     url: 'https://dl.ndl.go.jp',
     description: 'The National Diet Library of Japan is the national library of Japan, providing digital access to rare Japanese books, manuscripts, maps, and prints spanning over a millennium of Japanese literary and scientific tradition.',
     color: 'rust',
@@ -318,7 +329,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://library.harvard.edu/libraries/houghton',
     description: 'The Houghton Library at Harvard University is the primary repository for rare books and manuscripts, housing the Islamic Heritage Project collection, medieval codices, incunabula, and extensive printing history materials.',
     color: 'rust',
-    heroImageOverride: 'https://images.sourcelibrary.org/hero/harvard-houghton.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69f338e1876dd827cbc54599/69f338e1876dd827cbc545a5-0.jpg?v=1780586019308',
   },
   'penn-schoenberg': {
     slug: 'penn-schoenberg',
@@ -397,28 +408,12 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     description: 'The Metropolitan Museum of Art in New York provides open access to its encyclopedic collection spanning 5,000 years, including Egyptian papyri, Islamic manuscripts, medieval art, and Asian calligraphy.',
     color: 'rust',
     logo: 'https://upload.wikimedia.org/wikipedia/commons/7/73/The_Metropolitan_Museum_of_Art_Logo.svg',
-    heroImageOverride: 'https://images.sourcelibrary.org/hero/met-book-of-dead.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69e11aec918f5a3cda71f7b7/69e11aed918f5a3cda71f7bc-0.jpg?v=1780586279093',
   },
-  'ndl': {
-    slug: 'ndl',
-    name: 'National Diet Library of Japan',
-    shortName: 'NDL',
-    providerKey: 'ndl',
-    url: 'https://dl.ndl.go.jp',
-    description: 'The National Diet Library is Japan\'s national library, providing digital access to rare Japanese books, Buddhist manuscripts, woodblock prints, and historical texts spanning over a millennium.',
-    color: 'rust',
-    heroImageOverride: 'https://images.sourcelibrary.org/hero/ndl-genji-monogatari.jpg',
-  },
-  'bsb': {
-    slug: 'bsb',
-    name: 'Bayerische Staatsbibliothek',
-    shortName: 'BSB',
-    providerKey: 'bsb',
-    url: 'https://www.bsb-muenchen.de',
-    description: 'The Bavarian State Library in Munich holds one of Europe\'s most important manuscript collections, with extensive holdings of medieval codices, incunabula, and East Asian manuscripts including the Turfan collection.',
-    color: 'sage',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69b51e0dcf111105c42961ed/0003.jpg',
-  },
+  // 'ndl' and 'bsb' entries removed 2026-09-01: they duplicated 'ndl-japan'
+  // and 'bavarian-state-library' (same institutions, second import keys) and
+  // rendered duplicate tiles on /libraries. Their provider keys live on as
+  // aliasProviderKeys of the canonical entries; their slugs as PARTNER_SLUG_ALIASES.
   'v-and-a': {
     slug: 'v-and-a',
     name: 'Victoria & Albert Museum',
@@ -497,6 +492,8 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
  */
 const PARTNER_SLUG_ALIASES: Record<string, string> = {
   'bph': 'bibliotheca-philosophica-hermetica',
+  'ndl': 'ndl-japan',
+  'bsb': 'bavarian-state-library',
 };
 
 /** Look up a partner by its URL slug (e.g. "internet-archive" or "bph") */
@@ -506,9 +503,18 @@ export function getPartnerBySlug(slug: string): LibraryPartner | undefined {
   return aliasTarget ? LIBRARY_PARTNERS[aliasTarget] : undefined;
 }
 
-/** Look up a partner by its `image_source.provider` value (e.g. "internet_archive") */
+/** Look up a partner by its `image_source.provider` value (e.g. "internet_archive").
+ *  Alias keys resolve to the canonical partner (e.g. 'bsb' → Bavarian State Library). */
 export function getPartnerByProvider(provider: string): LibraryPartner | undefined {
-  return Object.values(LIBRARY_PARTNERS).find(p => p.providerKey === provider);
+  return Object.values(LIBRARY_PARTNERS).find(
+    p => p.providerKey === provider || p.aliasProviderKeys?.includes(provider as ImageSourceProvider)
+  );
+}
+
+/** Every provider key whose books belong to this partner. Use this — not
+ *  `partner.providerKey` alone — wherever books are filtered by provider. */
+export function getProviderKeys(partner: LibraryPartner): string[] {
+  return [partner.providerKey, ...(partner.aliasProviderKeys || [])];
 }
 
 /** Get all partner slugs for generateStaticParams */


### PR DESCRIPTION
Follow-up to #4539, from Derek's review of the live page.

## In scope
1. **Duplicate tiles.** National Diet Library of Japan rendered twice ('ndl' 37 + 'ndl_japan' 41 books) and Munich twice ('mdz' 2,104 + 'bsb' 909). New `aliasProviderKeys` field on the partner registry folds a partner's extra import keys into one tile and one library page — counts sum, `browseBooks`/`getLanguageCounts` accept `string | string[]`, and the retired slugs (`/libraries/ndl`, `/libraries/bsb`) keep resolving via `PARTNER_SLUG_ALIASES`. `/api/libraries` still enumerates per provider key (that endpoint's stated purpose) but now names alias keys correctly.
2. **Header.** /libraries now opens with a tiled mosaic of the partners' own scans under the shared `HeroScrim` — the same treatment as the book-page hero — instead of a flat brown gradient.
3. **Tile backgrounds.** Replaced the weakest `heroImageOverride`s (washed-out text pages, the IA Krishna photo) with high-`gallery_quality` plates selected from `gallery_images` for IA, Gallica, BSB, e-rara, Google Books, Allard Pierson, Leiden, Harvard, and the Met.

## Out of scope
- Import routes keep writing 'bsb' as a provider key (they may — the alias resolves it).
- No data migration: both provider keys stay in Mongo/Supabase untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjAU6kQKngdU3X5JJEsSGg