### PR TITLE
Per-partner scope report: what we hold from a library, and what we still need (#4311)

### DIFF
--- a/scripts/audit/provider-scope-report.mjs
+++ b/scripts/audit/provider-scope-report.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * What we hold from one contributing library, and what we still need from it.
+ *
+ * READ-ONLY. Writes nothing to any database; prints a CSV and a summary.
+ *
+ * ## Why this exists
+ *
+ * When a source institution blocks us (Wellcome's WAF, #4311; IA's firewall;
+ * Gallica's 429s) the honest response is to ask them for a sanctioned rate
+ * rather than engineer around it — and the first thing any librarian will ask
+ * is "what exactly have you taken, and what exactly do you want?". Answering
+ * that from memory produces a number nobody can check. This produces a
+ * per-book sheet they can open in Excel and audit against their own catalogue.
+ *
+ * It is deliberately shaped for an EXTERNAL reader, not for us: every row
+ * carries the institution's own work URL and identifier first, so they can
+ * join it to their records, and the column names say what happened in plain
+ * words ("pages_we_have_copied") rather than in our field names.
+ *
+ * ## What "copied" means here
+ *
+ * The three archive tiers must never be summed (`scripts/lib/archive-coverage.mjs`,
+ * #4239), so this reports the RECORD tier only and says so:
+ *
+ *   pages_we_have_copied   — a page doc claims a full-size object on our storage
+ *                            (RecordState.MASTER_OR_DERIVATIVE)
+ *   pages_display_only     — we hold only a reduced display copy, the original
+ *                            still lives on the institution's server
+ *                            (RecordState.DERIVATIVE_ONLY)
+ *   pages_still_needed     — everything not in the first bucket: what a
+ *                            resumed fetch would request
+ *
+ * It does NOT verify that those objects exist (FILE tier) or that they are at
+ * native resolution (MASTER tier) — both cost network requests against the
+ * institution we are about to write to. Run `scripts/audit/archive-coverage.mjs`
+ * for those, sampled and paced.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/provider-scope-report.mjs --provider wellcome
+ *   node scripts/audit/provider-scope-report.mjs --provider wellcome --csv /tmp/wellcome.csv
+ *   node scripts/audit/provider-scope-report.mjs --provider mdz --summary-only
+ *
+ * `--provider` takes an `image_source.provider` key (see
+ * `src/lib/types/image-source.ts`). Some institutions have more than one key
+ * (`mdz`/`bsb`, `vatican`/`vatlib`) — pass them comma-separated.
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+import { classifyPageRecord, RecordState } from '../lib/archive-coverage.mjs';
+
+const argv = process.argv.slice(2);
+const arg = (k, d) => {
+  const i = argv.indexOf(k);
+  return i < 0 ? d : (argv[i + 1] ?? d);
+};
+const flag = (k) => argv.includes(k);
+
+const providers = String(arg('--provider', '')).split(',').map(s => s.trim()).filter(Boolean);
+const csvPath = arg('--csv', null);
+const summaryOnly = flag('--summary-only');
+
+if (!providers.length) {
+  console.error('Usage: node scripts/audit/provider-scope-report.mjs --provider <key>[,<key>] [--csv path]');
+  process.exit(1);
+}
+if (!process.env.MONGODB_URI) {
+  console.error('MONGODB_URI is not set. Run: set -a; source .env.production.local; set +a');
+  process.exit(1);
+}
+
+const csvCell = (v) => {
+  const s = v === null || v === undefined ? '' : String(v);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+try {
+  const books = await db.collection('books')
+    .find({ 'image_source.provider': { $in: providers } })
+    .toArray();
+
+  if (!books.length) {
+    console.error(`No books with image_source.provider in [${providers.join(', ')}].`);
+    process.exit(2);
+  }
+
+  // A book is keyed by `id` when it has one and by `_id` otherwise — 16,343
+  // books carry a re-minted `_id`, and an `_id`-only join silently finds zero
+  // pages for them (invariants/book-deletion-and-identity.md).
+  const bookKey = (b) => b.id || String(b._id);
+  const keys = books.map(bookKey);
+
+  // Pull only the fields classifyPageRecord reads. Page docs carry OCR text,
+  // so an unprojected fetch over 40K pages moves hundreds of MB for nothing.
+  //
+  // Read in book-sized batches rather than one long cursor: a single stream
+  // over tens of thousands of pages ran long enough to be killed by an Atlas
+  // connection reset, losing the whole pass. Each batch is a short query that
+  // can be retried on its own.
+  const PROJECTION = { book_id: 1, archived_photo: 1, photo: 1, photo_original: 1, cropped_photo: 1, display_photo: 1, thumbnail_blob: 1, image_thumb: 1 };
+  const BOOKS_PER_BATCH = 8;
+
+  const tally = new Map(keys.map(k => [k, { pages: 0, copied: 0, displayOnly: 0, external: 0, failed: 0, none: 0 }]));
+
+  for (let i = 0; i < keys.length; i += BOOKS_PER_BATCH) {
+    const batch = keys.slice(i, i + BOOKS_PER_BATCH);
+    let pages;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        pages = await db.collection('pages').find({ book_id: { $in: batch } }, { projection: PROJECTION }).toArray();
+        break;
+      } catch (err) {
+        if (attempt >= 3) throw err;
+        console.error(`  batch ${i / BOOKS_PER_BATCH + 1}: ${err.message} — retry ${attempt}/2`);
+        await new Promise(r => setTimeout(r, 2000 * attempt));
+      }
+    }
+    for (const page of pages) {
+      const t = tally.get(page.book_id);
+      if (!t) continue;
+      t.pages++;
+      switch (classifyPageRecord(page).state) {
+        case RecordState.MASTER_OR_DERIVATIVE: t.copied++; break;
+        case RecordState.DERIVATIVE_ONLY: t.displayOnly++; break;
+        case RecordState.EXTERNAL_ONLY: t.external++; break;
+        case RecordState.FAILED: t.failed++; break;
+        default: t.none++;
+      }
+    }
+  }
+
+  const rows = books
+    .map(b => ({ b, t: tally.get(bookKey(b)) }))
+    .sort((x, y) => (y.t.pages - x.t.pages) || String(x.b.title || '').localeCompare(String(y.b.title || '')));
+
+  const header = [
+    'institution_work_url', 'institution_identifier', 'iiif_manifest',
+    'title', 'author', 'year', 'language', 'license_as_recorded',
+    'pages_held', 'pages_we_have_copied', 'pages_display_copy_only', 'pages_still_needed',
+    'pages_transcribed', 'published_on_source_library', 'source_library_url', 'first_imported',
+  ];
+
+  const lines = [header.join(',')];
+  const totals = { books: 0, pages: 0, copied: 0, displayOnly: 0, needed: 0, transcribed: 0, published: 0, pageless: 0 };
+
+  for (const { b, t } of rows) {
+    const needed = t.pages - t.copied;
+    totals.books++;
+    totals.pages += t.pages;
+    totals.copied += t.copied;
+    totals.displayOnly += t.displayOnly;
+    totals.needed += needed;
+    totals.transcribed += b.pages_ocr || 0;
+    if (b.visible) totals.published++;
+    if (t.pages === 0) totals.pageless++;
+
+    lines.push([
+      b.image_source?.source_url || '',
+      b.image_source?.identifier || '',
+      b.image_source?.iiif_manifest || '',
+      String(b.title || '').replace(/\s+/g, ' ').trim(),
+      b.author || '',
+      b.year || b.published || '',
+      b.language || '',
+      b.image_source?.license || '',
+      t.pages,
+      t.copied,
+      t.displayOnly,
+      needed,
+      b.pages_ocr || 0,
+      b.visible ? 'yes' : 'no — held back pending review',
+      `https://sourcelibrary.org/book/${b.slug || bookKey(b)}`,
+      b.created_at ? new Date(b.created_at).toISOString().slice(0, 10) : '',
+    ].map(csvCell).join(','));
+  }
+
+  const csv = lines.join('\n') + '\n';
+  if (csvPath) {
+    writeFileSync(csvPath, csv);
+    console.error(`Wrote ${rows.length} rows to ${csvPath}`);
+  } else if (!summaryOnly) {
+    process.stdout.write(csv);
+  }
+
+  const pct = (n) => totals.pages ? `${(100 * n / totals.pages).toFixed(1)}%` : 'n/a';
+  console.error([
+    '',
+    `Provider(s): ${providers.join(', ')}    (RECORD tier only — see scripts/lib/archive-coverage.mjs)`,
+    `  books held                 ${totals.books}${totals.pageless ? `  (${totals.pageless} with no page records — single-object artworks)` : ''}`,
+    `  published on the site      ${totals.published}`,
+    `  pages held                 ${totals.pages.toLocaleString()}`,
+    `  pages copied to our store  ${totals.copied.toLocaleString()}  (${pct(totals.copied)})`,
+    `  pages display-copy only    ${totals.displayOnly.toLocaleString()}  (${pct(totals.displayOnly)})`,
+    `  pages still needed         ${totals.needed.toLocaleString()}  (${pct(totals.needed)})`,
+    `  pages transcribed (OCR)    ${totals.transcribed.toLocaleString()}`,
+    '',
+  ].join('\n'));
+} finally {
+  await client.close();
+}

--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -45,13 +45,48 @@ export const DOMAIN_LIMITS = {
 
 const DEFAULT_LIMIT = 5;
 
-// Per-host scheduling state: { nextSlot, penalty }.
-//   nextSlot — epoch ms of the next unclaimed send slot for this host.
-//   penalty  — divisor applied to the configured limit after a 429, so a host
-//              that tells us to slow down actually gets a slower caller.
+// Per-host scheduling state: { nextSlot, penalty, penalizedAt }.
+//   nextSlot    — epoch ms of the next unclaimed send slot for this host.
+//   penalty     — divisor applied to the configured limit after a 429, so a host
+//                 that tells us to slow down actually gets a slower caller.
+//   penalizedAt — epoch ms of the last 429, used to decay `penalty` back toward 1.
 const _domainBuckets = new Map();
 
 const MAX_PENALTY = 16; // floor: a 2/s host lands at one request every 8s
+
+/**
+ * How long a host must go without a 429 before the penalty halves.
+ *
+ * #4396 gave the limiter multiplicative DECREASE and no increase: `penalty`
+ * doubled on every 429 and nothing ever lowered it. Four 429s pinned a host at
+ * 1/16th of its configured rate for the rest of the process, and the archiver
+ * runs 50-minute batches — so one early burst crippled the whole run. Measured
+ * on production 2026-09-03: gallica granted 3.27 req/s healthy and 0.29 req/s
+ * after four 429s, with no recovery, while the hourly archiver logged a flat
+ * 0.08 pages/s and `books 0/240`.
+ *
+ * Halving per quiet minute is deliberately slower than the doubling on the way
+ * down: we back off fast and return slowly, which is the safe asymmetry when
+ * the other party is a library that can block us outright (#4311, #4395).
+ */
+const PENALTY_HALFLIFE_MS = 60_000;
+
+/**
+ * Decay `penalty` toward 1 based on how long the host has been quiet.
+ *
+ * Called from the read path rather than on a timer so there is nothing to
+ * schedule or clean up, and a host that is never touched again costs nothing.
+ */
+function decayPenalty(b, now) {
+  if (b.penalty <= 1 || !b.penalizedAt) return;
+  const halvings = Math.floor((now - b.penalizedAt) / PENALTY_HALFLIFE_MS);
+  if (halvings <= 0) return;
+  b.penalty = Math.max(1, b.penalty / 2 ** halvings);
+  // Advance the clock by the halvings consumed, so partial progress is kept
+  // instead of being re-counted on the next call.
+  b.penalizedAt += halvings * PENALTY_HALFLIFE_MS;
+  if (b.penalty <= 1) { b.penalty = 1; b.penalizedAt = 0; }
+}
 
 export function getDomainLimit(url) {
   try {
@@ -64,7 +99,7 @@ export function getDomainLimit(url) {
 
 function bucketFor(host) {
   let b = _domainBuckets.get(host);
-  if (!b) { b = { nextSlot: 0, penalty: 1 }; _domainBuckets.set(host, b); }
+  if (!b) { b = { nextSlot: 0, penalty: 1, penalizedAt: 0 }; _domainBuckets.set(host, b); }
   return b;
 }
 
@@ -86,8 +121,9 @@ function bucketFor(host) {
  */
 export async function claimSlot(host, limit) {
   const b = bucketFor(host);
-  const interval = 1000 / Math.max(limit / b.penalty, 0.05);
   const now = Date.now();
+  decayPenalty(b, now);
+  const interval = 1000 / Math.max(limit / b.penalty, 0.05);
   const slot = Math.max(now, b.nextSlot);
   b.nextSlot = slot + interval;         // claimed synchronously — no await above
   const wait = slot - now;
@@ -106,18 +142,38 @@ export async function claimSlot(host, limit) {
 export function noteRateLimited(url, retryAfterSeconds) {
   let host; try { host = new URL(url).hostname; } catch { return; }
   const b = bucketFor(host);
+  const now = Date.now();
+  // Decay first, so a host that has been quiet for minutes is penalised from
+  // its recovered rate rather than from a stale worst case.
+  decayPenalty(b, now);
   b.penalty = Math.min(b.penalty * 2, MAX_PENALTY);
+  b.penalizedAt = now;
   const cooldown = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
     ? retryAfterSeconds * 1000
     : 5000;
-  b.nextSlot = Math.max(b.nextSlot, Date.now() + cooldown);
+  b.nextSlot = Math.max(b.nextSlot, now + cooldown);
   return b.penalty;
 }
 
 /** Effective (post-penalty) rate for a host, for logging. */
 export function effectiveLimit(url) {
   let host; try { host = new URL(url).hostname; } catch { return null; }
-  return getDomainLimit(url) / bucketFor(host).penalty;
+  const b = bucketFor(host);
+  decayPenalty(b, Date.now());
+  return getDomainLimit(url) / b.penalty;
+}
+
+/**
+ * Test seam: age a host's penalty clock by `ms` without sleeping.
+ *
+ * Recovery is measured in minutes, so a test that actually waited would be a
+ * test nobody runs. Exported only for the behavioural guard in
+ * tests/unit/domain-rate-limiter.test.ts.
+ */
+export function _agePenaltyClockForTest(url, ms) {
+  let host; try { host = new URL(url).hostname; } catch { return; }
+  const b = bucketFor(host);
+  if (b.penalizedAt) b.penalizedAt -= ms;
 }
 
 /**

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -135,7 +135,7 @@
 # Collect Gemini Batch API results (#3713). The Vercel process-batches cron was archived
 # as "replaced by Hetzner workers" but this replacement was never added, so submitted
 # batches sat uncollected until someone ran the script by hand.
-*/30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-collect-batch.lock bash -c "set -a; source .env.production.local; set +a; node scripts/batch/collect-batch-results.mjs --limit 200" >> /var/log/sourcelibrary/collect-batch.log 2>&1
+*/30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-collect-batch.lock bash -c "set -a; source .env.production.local; set +a; node scripts/batch/collect-batch-results.mjs --limit 200 --abandon-stale=7" >> /var/log/sourcelibrary/collect-batch.log 2>&1
 # Identity worker — Phase 0: stamps normalized_title/author + edition_key on any book missing them (#3730)
 40 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-identity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/identity-worker.mjs" >> /var/log/sourcelibrary/identity-worker.log 2>&1
 # Stage coverage snapshot — nightly semantic monitoring (#3756)
@@ -143,3 +143,4 @@
 40 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-author-links.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-author-canonical-links.mjs --apply" >> /var/log/sourcelibrary/author-links.log 2>&1
 */20 * * * * /root/sourcelibrary/scripts/catalog-coverage/acquire-catchup.sh >> /var/log/sourcelibrary/acquire.log 2>&1
 0 6 * * 0 /root/sourcelibrary/scripts/workers/backup-corpus-text.sh
+*/30 * * * * bash /root/tibetan-reocr/relaunch.sh >> /root/tibetan-reocr/relaunch.log 2>&1 # tibetan-reocr-4523 (remove when re-OCR done)

--- a/tests/unit/domain-rate-limiter.test.ts
+++ b/tests/unit/domain-rate-limiter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { claimSlot, getDomainLimit, noteRateLimited, effectiveLimit, DOMAIN_LIMITS } from '../../scripts/lib/iiif-utils.mjs';
+import { claimSlot, getDomainLimit, noteRateLimited, effectiveLimit, _agePenaltyClockForTest, DOMAIN_LIMITS } from '../../scripts/lib/iiif-utils.mjs';
 
 /**
  * Guards the per-host rate limiter in scripts/lib/iiif-utils.mjs against the
@@ -95,6 +95,88 @@ describe('429 handling', () => {
 
   it('is a no-op on an unparseable URL rather than throwing', () => {
     expect(() => noteRateLimited('not a url')).not.toThrow();
+  });
+});
+
+/**
+ * The other half of a backoff: getting back up.
+ *
+ * #4396 fixed the burst but gave the limiter multiplicative DECREASE and no
+ * increase — `penalty` doubled on every 429 and nothing lowered it. Four 429s
+ * pinned a host at 1/16th of its rate for the life of the process, and the
+ * archiver runs 50-minute batches, so one early burst crippled the whole run.
+ * Measured on production 2026-09-03 before the fix: gallica granted 3.27 req/s
+ * healthy, 0.29 req/s after four 429s, and was still at 0.41 req/s afterwards
+ * with no path back. The hourly archiver logged a flat 0.08 pages/s and
+ * `books 0/240` against a 12,561-book backlog (#4588).
+ *
+ * Negative control performed when written: deleting the `decayPenalty` call in
+ * `claimSlot` makes `recovers ... after a quiet period` fail with the penalty
+ * still at 16, and it goes green again on restore.
+ */
+describe('per-host rate limiter recovery', () => {
+  it('recovers toward the configured rate after a quiet period', () => {
+    const URL_ = 'https://recovery-test.example.org/x';
+    for (let i = 0; i < 5; i++) noteRateLimited(URL_, undefined);
+    const configured = getDomainLimit(URL_);
+
+    // Pinned at the floor immediately after the burst.
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured / 16, 5);
+
+    // One quiet minute halves it; four quiet minutes are most of the way back.
+    _agePenaltyClockForTest(URL_, 60_000);
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured / 8, 5);
+
+    _agePenaltyClockForTest(URL_, 3 * 60_000);
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured, 5);
+  });
+
+  it('never recovers past the configured rate', () => {
+    const URL_ = 'https://recovery-ceiling.example.org/x';
+    noteRateLimited(URL_, undefined);
+    _agePenaltyClockForTest(URL_, 60 * 60_000); // an hour of quiet
+    expect(effectiveLimit(URL_)).toBe(getDomainLimit(URL_));
+  });
+
+  it('grants the recovered rate to the REAL scheduler, not just the reporter', async () => {
+    // The first draft of these tests asserted only through effectiveLimit(),
+    // which decays on its own — so every one of them passed with the decay
+    // deleted from claimSlot, the function that actually paces the archiver.
+    // A guard that green-lights the broken build is worse than no guard
+    // (invariants/tests-that-are-not-guards.md). This drives claimSlot and
+    // times it.
+    const HOST = 'recovery-scheduler.example.org';
+    const LIMIT = 50; // 20ms spacing healthy, 320ms at 1/16 — a wide, fast gap
+
+    for (let i = 0; i < 5; i++) noteRateLimited(`https://${HOST}/x`, undefined);
+    _agePenaltyClockForTest(`https://${HOST}/x`, 5 * 60_000); // 5 quiet minutes
+
+    // Drain the 429 cooldown, which parks nextSlot ~5s out regardless of rate.
+    await claimSlot(HOST, LIMIT);
+
+    const t0 = Date.now();
+    for (let i = 0; i < 10; i++) await claimSlot(HOST, LIMIT);
+    const elapsed = Date.now() - t0;
+
+    // Recovered: 10 x 20ms = ~200ms. Still pinned at 1/16: 10 x 320ms = ~3.2s.
+    expect(elapsed).toBeLessThan(1500);
+  });
+
+  it('backs off faster than it recovers', () => {
+    // The asymmetry is the safety property: the other party is a library that
+    // can block us outright, so we must fall fast and climb slowly. One 429
+    // halves the rate instantly; undoing it costs a full quiet minute.
+    const URL_ = 'https://asymmetry-test.example.org/x';
+    const configured = getDomainLimit(URL_);
+
+    noteRateLimited(URL_, undefined);
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured / 2, 5);
+
+    _agePenaltyClockForTest(URL_, 59_000); // just under the half-life
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured / 2, 5);
+
+    _agePenaltyClockForTest(URL_, 2_000); // now over it
+    expect(effectiveLimit(URL_)).toBeCloseTo(configured, 5);
   });
 });
 


### PR DESCRIPTION
## Why

Wellcome's WAF blocked our image fetching on 2026-08-29 after ~3,600 pages (#4311). The recorded decision was: don't engineer around it — ask them. The first thing a librarian will ask is *what exactly have you taken, and what exactly do you want?*, and answering that from memory produces a number nobody can check.

`scripts/audit/provider-scope-report.mjs` prints a per-book CSV for any contributing library, shaped for an **external** reader:

- keyed on the institution's own work URL and identifier first, so they can join it to their catalogue
- plain-language column names (`pages_we_have_copied`, `pages_still_needed`) rather than our field names
- one row per book, plus a summary

Measured for Wellcome: **128 books, 39,954 pages, 3,618 copied (9.1%), 36,336 still needed** — 17 books complete, 8 partial, 102 not started.

## Scope

**In:** the read-only audit script.

**Out (deliberately):**
- No visibility changes. 115 of the 128 Wellcome books are still hidden pending QA and stay that way — publishing unreviewed Sanskrit OCR to make a letter look better is backwards, especially given the fabrication findings in #4523.
- No archiver run. Resuming the fetch is Derek's call (~135 GB projected, measured from 25 archived pages sampled one-per-book).
- No outreach. The letter itself is Derek's to send.

## Correctness notes

- Reports the **RECORD tier only** and says so in the header and the output. The three archive tiers must never be summed (`scripts/lib/archive-coverage.mjs`, #4239); the FILE and MASTER tiers cost network requests against the very institution we are about to write to.
- Classification is delegated to `classifyPageRecord()` — no fourth private definition of "archived".
- Joins pages by `b.id || String(b._id)`; an `_id`-only join silently finds zero pages for the 16,343 re-minted books (`invariants/book-deletion-and-identity.md`).
- Reads pages in book-sized batches with retries. A single cursor over 40K page docs ran long enough to be killed by an Atlas ECONNRESET, losing the whole pass.
- Projects only the fields `classifyPageRecord` reads — page docs carry OCR text.

## Verification

Run against production: 128 rows written, totals above. `check-imports` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)