### PR TITLE
Phase 2 OCR: language must survive the candidate projection (2.75× cost bug)

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3961,7 +3961,10 @@ Rules:
             // processing_priority (#3756): explicit queue weight, higher first
             // (absent sorts last under -1). Existing ordering kept as tiebreak.
             { $sort: { processing_priority: -1, _priority: 1, hidden: 1 } },
-            { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.split_checked': 1 } },
+            // language + image_source.provider must survive the projection:
+            // getOcrModelForBook reads both, and a missing language reads as
+            // "unknown script" and routes EVERY book to flash-preview (~2.75x).
+            { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, language: 1, 'image_source.provider': 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.split_checked': 1 } },
             { $limit: ocrLimit },
           ])
           .toArray();
@@ -4067,7 +4070,8 @@ Rules:
           }},
           // processing_priority (#3756): explicit queue weight, higher first.
           { $sort: { processing_priority: -1, _priority: 1, hidden: 1 } },
-          { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.recitation_retry_lite': 1, 'pipeline_auto.split_checked': 1 } },
+          // language + image_source.provider must survive the projection (see Pass 1).
+          { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, language: 1, 'image_source.provider': 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.recitation_retry_lite': 1, 'pipeline_auto.split_checked': 1 } },
           { $limit: ocrLimit },
         ])
         .toArray() : [];


### PR DESCRIPTION
Both of Phase 2's OCR candidate queries projected away `language` and `image_source.provider` — the two fields `getOcrModelForBook` routes on. Empty language reads as "unknown script" and takes the deliberate fail-safe branch, so **every full-pass OCR submission has been routing to `gemini-3-flash-preview` (~$0.0022/page) instead of `flash-lite` (~$0.0008/page), library-wide** — the safety default for non-Latin scripts silently became the default for everything.

**How it was caught:** the first #4540 envelope run (#4541). The per-scope meter made the anomaly visible within two hours: $20.81 of a $30 envelope on flash-preview OCR rows for books plainly tagged Latin/Spanish (26 usage rows, 9,543 pages). Small dial, small envelope, spend attributed per book — exactly the observability the envelope was built for.

**The tell it was a projection bug and not routing logic:** Phase 4 (translation) carries both fields with the comment "must survive the projection" — same lesson, learned on the translate path, never applied to the OCR path one phase earlier. Same family as the archive-bulk `book_id` projection incident (#3362): a projection quietly starves a callee of the field it branches on, and nothing fails loudly.

Two $project lines + comments. Verified with node --check; the fail-safe branch itself is untouched (genuinely unknown/non-Latin languages still route to flash).

Rough cost impact while live: full-pass OCR has run at ~2.75× intended price since the model-routing landed. The batch-rate figure everyone quotes ($0.00079/page) is the lite price — measurements matched it only because the measured window predated the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SER4WMgwsMDLXik34yb16k