### PR TITLE
Projection-starvation sweep: 10 more guards reading projected-away fields

### DIFF
--- a/scripts/audit/scope-progress.mjs
+++ b/scripts/audit/scope-progress.mjs
@@ -198,15 +198,21 @@ await withMongo(async (db) => {
   const books = await db.collection('books')
     .find({ id: { $in: ids } })
     .project({
-      id: 1, title: 1, resource_type: 1, visible: 1, hidden: 1, processing_priority: 1,
+      id: 1, title: 1, resource_type: 1, content_type: 1, visible: 1, hidden: 1, processing_priority: 1,
       pages_count: 1, pages_archived: 1, pages_ocr: 1, pages_translated: 1, pages_translatable: 1,
       summary: 1, chapters: 1, detected_images_count: 1, cover_page: 1, pipeline_auto: 1,
     })
     .toArray();
   const foundIds = new Set(books.map((b) => b.id));
   const missing = ids.filter((id) => !foundIds.has(id));
-  const artworks = books.filter((b) => b.resource_type);
-  const texts = books.filter((b) => !b.resource_type);
+  // Mirrors the orchestrator's ARTWORK_MATCH: content_type is AUTHORITATIVE
+  // ('book' is never artwork, even with an object-ish resource_type — textual
+  // papyri); resource_type is only a fallback, and only for the artwork types.
+  const ARTWORK_TYPES = new Set(['painting', 'print', 'drawing', 'fresco', 'object']);
+  const isArtwork = (b) => b.content_type !== 'book'
+    && (b.content_type === 'artwork' || ARTWORK_TYPES.has(b.resource_type));
+  const artworks = books.filter(isArtwork);
+  const texts = books.filter((b) => !isArtwork(b));
 
   const verified = flag('verify') ? await verifyFromPages(db, texts.map((b) => b.id)) : null;
 

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -1547,7 +1547,15 @@ async function main() {
       books = await db.collection('books')
         .find({ 'pipeline_auto.status': 'translate_complete', ...SCOPE_FILTER })
         .sort({ is_first_translation: -1, pages_count: 1, 'pipeline_auto.retry_count': 1 })  // First translations first, then small books
-        .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, chapters: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1, pages_count: 1 })
+        // The embedding path (composeBookEmbeddingText + upsertBookEmbedding)
+        // reads far more than the enrich loop itself: published/categories go
+        // into the embedded text, content_type + commons_* + resource_type +
+        // medium are the whole descriptive signal for artworks, quality_score/
+        // collections land in the stored metadata. Projected away, artworks got
+        // generic embeddings and book_embeddings.year/categories were always
+        // null/[] — the single-book --book lane (unprojected findOne) was
+        // correct while this batch lane silently wasn't.
+        .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, published: 1, categories: 1, quality_score: 1, content_type: 1, resource_type: 1, medium: 1, collections: 1, commons_description: 1, commons_categories: 1, chapters: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1, pages_count: 1 })
         .limit(PHASE_6_LIMIT)
         .toArray();
     }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3374,12 +3374,17 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
           'ai_metadata.enriched_at': { $exists: false },
         })
         .sort({ 'pipeline_auto.likely_first_translation': -1, hidden: 1 })
+        // place_of_publication + publisher must survive the projection:
+        // verifyMetadataInline guards on them ("only fill if absent"), and a
+        // projected-away field made the guard always pass — overwriting real
+        // values and recording previous_value: null in field_provenance.
         .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1,
                    description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1,
+                   place_of_publication: 1, publisher: 1,
                    field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 })
         .limit(METADATA_ENRICH_LIMIT)
         .toArray();
-      if (SCOPE_ACTIVE) readyForMetadata = await applyBookOverride(db, readyForMetadata, { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1, field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 });
+      if (SCOPE_ACTIVE) readyForMetadata = await applyBookOverride(db, readyForMetadata, { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1, place_of_publication: 1, publisher: 1, field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 });
 
       console.log(`  Books ready for AI metadata: ${readyForMetadata.length}`);
       let metadataEnriched = 0;
@@ -3965,7 +3970,7 @@ Rules:
             { $limit: ocrLimit },
           ])
           .toArray();
-        if (SCOPE_ACTIVE) previewCandidates = await applyBookOverride(db, previewCandidates, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, pipeline_auto: 1 });
+        if (SCOPE_ACTIVE) previewCandidates = await applyBookOverride(db, previewCandidates, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, language: 1, image_source: 1, pipeline_auto: 1 });
 
         const dedupedPreview = await filterDuplicateWorks(db, previewCandidates);
 
@@ -4071,7 +4076,7 @@ Rules:
           { $limit: ocrLimit },
         ])
         .toArray() : [];
-      if (SCOPE_ACTIVE) readyForOcr = await applyBookOverride(db, readyForOcr, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, pipeline_auto: 1 });
+      if (SCOPE_ACTIVE) readyForOcr = await applyBookOverride(db, readyForOcr, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, language: 1, image_source: 1, pipeline_auto: 1 });
 
       const dedupedFull = await filterDuplicateWorks(db, readyForOcr);
 
@@ -4172,9 +4177,12 @@ Rules:
 
       let ocrPending = await db.collection('books')
         .find({ 'pipeline_auto.status': 'ocr_submitted' })
-        .project({ id: 1, title: 1, 'pipeline_auto.ocr_job_name': 1, 'pipeline_auto.ocr_job_id': 1, 'pipeline_auto.ocr_loop_count': 1 })
+        // thumbnail_source must survive the projection: the early-cover guard
+        // below reads it, and a missing field made "!== 'manual'" always true —
+        // silently overwriting human-chosen covers on every run.
+        .project({ id: 1, title: 1, thumbnail_source: 1, 'pipeline_auto.ocr_job_name': 1, 'pipeline_auto.ocr_job_id': 1, 'pipeline_auto.ocr_loop_count': 1 })
         .toArray();
-      if (SCOPE_ACTIVE) ocrPending = await applyBookOverride(db, ocrPending, { id: 1, title: 1, pipeline_auto: 1 });
+      if (SCOPE_ACTIVE) ocrPending = await applyBookOverride(db, ocrPending, { id: 1, title: 1, thumbnail_source: 1, pipeline_auto: 1 });
 
       console.log(`  Books waiting for OCR: ${ocrPending.length}`);
 
@@ -4601,10 +4609,13 @@ Rules:
           // then first translations, then speed tier. Descending sort puts books
           // without the field last.
           { $sort: { processing_priority: -1, _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
-          { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+          // pages_ocr must survive the projection: the "OCR incomplete" guard
+          // reads it, and a projected-away field read as 0 — bouncing every
+          // fully-translated >30-page book back to archive_complete forever.
+          { $project: { id: 1, title: 1, pages_count: 1, pages_ocr: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
-        if (SCOPE_ACTIVE) freshBooks = await applyBookOverride(db, freshBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1, image_source: 1 });
+        if (SCOPE_ACTIVE) freshBooks = await applyBookOverride(db, freshBooks, { id: 1, title: 1, pages_count: 1, pages_ocr: 1, language: 1, pipeline_auto: 1, image_source: 1 });
 
         // If no fresh books, re-queue partially-translated books (gap-fill)
         // Includes books at ANY pipeline stage with incomplete translation — not just translate_partial.
@@ -4622,13 +4633,13 @@ Rules:
             { $match: { _denominator: { $gt: 0 }, $expr: { $lt: [{ $divide: [{ $ifNull: ['$pages_translated', 0] }, '$_denominator'] }, 0.9] } } },
             // processing_priority + pages_translated must survive the projection
             // for the sort below to see them (#3756).
-            { $project: { id: 1, title: 1, pages_count: 1, pages_translated: 1, processing_priority: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+            { $project: { id: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, processing_priority: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
             { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
             // Reader requests first (#3750) — see the fresh-books sort above.
             { $sort: { processing_priority: -1, _isBph: 1, pages_translated: -1 } },
             { $limit: effectiveLimit },
           ]).toArray();
-          if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1 });
+          if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, language: 1, image_source: 1, pipeline_auto: 1 });
           if (partialBooks.length > 0) {
             console.log(`  No fresh books — gap-filling ${partialBooks.length} under-translated books`);
           }
@@ -5443,7 +5454,7 @@ Rules:
         .project({ id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1 })
         .limit(FINALIZE_LIMIT)
         .toArray();
-      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1 });
+      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1, content_type: 1 });
 
       console.log(`  Books ready to finalize: ${readyToFinalize.length}`);
 

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -1294,7 +1294,10 @@ async function main() {
   // Grouping similar workloads per batch minimizes convoy tail waste.
   // Books with <10 pages remaining are auto-completed (overhead not worth it).
   const MIN_REMAINING = 1;
-  const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1 };
+  // last_translation_at must survive the projection: the circuit breaker
+  // branches on it, and a projected-away field made both breaker conditions
+  // permanently false — zero-progress books re-billed forever, never parked.
+  const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1, last_translation_at: 1 };
 
   // Auto-complete near-zero books — job setup overhead exceeds the work
   const nearZero = await db.collection('books').aggregate([


### PR DESCRIPTION
Follow-up to #4563, which fixed one instance of this class. A systematic sweep of every worker (helper functions that branch on book fields × every call site's projection) found **ten more**, five live on the unconditional production path:

| Where | Missing field | Silent consequence |
|---|---|---|
| Phase 3 early cover | `thumbnail_source` | `!== 'manual'` always true → **human-chosen covers overwritten** on every OCR-completion tick (Phase 8.9 projects it correctly — same lesson, one phase never got it) |
| Phase 1.6 metadata | `place_of_publication`, `publisher` | only-fill-if-absent guards always passed → **real values overwritten by catalog matches**, and `field_provenance` recorded `previous_value: null` — the provenance lies about what was destroyed |
| Phase 4 dispatch | `pages_ocr` | 'OCR incomplete' guard always fired → **fully-translated >30-page books bounce `ocr_complete`→`archive_complete` forever**, never reaching translate_complete/enrichment — a likely contributor to the stuck-book population |
| translate-worker | `last_translation_at` | **circuit breaker could never fire** — zero-progress/high-error books re-billed indefinitely instead of parking at needs_attention (the field is written by this same file, just never survived the read projection) |
| enrich-worker batch lane | 9 fields (`published, categories, quality_score, content_type, resource_type, medium, collections, commons_*`) | **artwork embeddings stripped of their entire descriptive signal**; `book_embeddings.year` always null, `categories` always `[]`. The `--book` lane (unprojected findOne) was correct — batch lane wasn't |

Plus the `--book` override lane (each `applyBookOverride` call restates its phase's projection by hand, and five had drifted): Phase 2 both passes still routed to flash-preview under `--book` (the very bug #4563 fixed, alive in its twin), Phase 4 partial lost the BPH translate-quality routing, Phase 9 misfiles artworks as failed imports under `--book`. And `scope-progress.mjs`'s artwork split now mirrors the orchestrator's authoritative `ARTWORK_MATCH` (`content_type` first) instead of `resource_type` truthiness.

**Verification:** every production-path finding was verified against the code at the cited lines before fixing (guard reads confirmed against projection field lists). `node --check` passes on all four files. Live smoke test of scope-progress pending a local network recovery (Mongo egress currently blocked on this laptop — syntax + logic verified; the added projection fields are additive and cannot remove data from the docs).

**Deliberately out of scope:** the structural fix — one named projection constant per phase, shared by `.project()` and `applyBookOverride`, so the two copies cannot drift (Phase 1.5's `previewProjection` is the existing good example). That's a refactor PR; this one is the bleeding-stopper. Also out: repairing data already damaged (overwritten covers/publishers are recoverable from `field_provenance` history and `books` revisions where they exist — separate audit).

Found because the #4540 envelope made a 2.75× spend anomaly visible within two hours (#4541 run), which led to #4563, which led to asking "where else does this class live?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SER4WMgwsMDLXik34yb16k