### PR TITLE
docs(curator): hyperlink every book named in a collection description (#1867)

### DIFF
--- a/.claude/docs/collection-description-linking.md
+++ b/.claude/docs/collection-description-linking.md
@@ -1,0 +1,93 @@
+# Linking books from a collection description
+
+**Read this when** you write or edit a collection's `description` or
+`expanded_description` — in `/curator`, `/library-curator`, `/curate-collection`, or by
+hand. This is the single source of truth for how those strings become links; the skills
+route here rather than restating it.
+
+**The rule: every work you name in a collection description must be clickable.** These
+pages are public-facing copy on a site whose whole point is navigation between primary
+sources. Prose that names ten books and links none of them is a dead end — the reader
+has to go back to the grid and hunt. Naming a book you hold and not linking it is the
+one failure mode worth checking for every single time.
+
+## What the renderer actually does
+
+`src/app/collections/[id]/page.tsx` splits the description on `\n\n` into `<p>`s and
+runs each paragraph through `linkBookTitles()`. That function handles exactly three
+things, in priority order:
+
+1. **Inline markdown links** — `[anchor text](/book/some-slug)`. Honored since #3040.
+   **Internal hrefs only**: the href must start with `/`. An absolute
+   `https://sourcelibrary.org/book/...` is **not** matched and renders as literal
+   `[brackets](and-parens)` on the page. So does a `javascript:` or off-site href —
+   that restriction is deliberate, this is admin-authored prose rendered unescaped.
+2. **Explicit `mentioned_books`** — `{ text, book_id }` pairs on the collection doc,
+   matched case-**in**sensitively, longest `text` first so a long-form claim ranges
+   before a short-form fallback.
+3. **Auto-detection** — a book's `title` or `display_title` (≥8 chars) found as an exact
+   substring of the description, plus author names resolved against the collection's
+   author list.
+
+Everything else is plain text. **Markdown emphasis is not parsed**: `**bold**` and
+`*italic*` render with the asterisks visible. Don't write them.
+
+### Why auto-detection is not enough
+
+Auto-detection searches for the *full book title* inside your prose. Real titles here
+are long early-modern Latin ones (`Micrographia, or Some Physiological Descriptions of
+Minute Bodies…`), and good prose names the short form (`Micrographia`). The long string
+is not a substring of the short one, so the match fails. **Assume a named work does not
+auto-link unless you have checked it.** That is exactly how the microscopy collection
+shipped with a description naming eleven works and linking none (#1867).
+
+## What to write
+
+Prefer **inline markdown links** — the anchor is explicit, it survives a later rewrite
+of the prose, and there is no second field to keep in sync:
+
+```
+This collection opens with Cesi and Stelluti's [Apiarium](/book/apiarium-1625), the
+single broadside that produced the first printed image made through a microscope, and
+tracks the field through Hooke's [Micrographia](/book/micrographia-1665).
+```
+
+Use `mentioned_books` instead when the same short name recurs across several paragraphs
+and you want every occurrence linked without repeating the markdown, or when you are
+patching link coverage onto prose you do not want to rewrite.
+
+- **Path form:** `/book/<slug>`, using the book's real `slug` from Mongo. `/book/<id>`
+  works too (the proxy 301s it), but it publishes an unreadable URL and costs a hop —
+  use the slug. Never guess a slug; read it back from the books you tagged.
+- **Deep links are fine:** `/book/<slug>/page/<pageId>` for a specific plate or passage.
+- **No absolute URLs.** See above — they render as literal brackets.
+- **Placeholder for an unresolved link:** if you are sketching prose before the import
+  lands, write `[Title](TODO)` so the gap is obvious. `TODO` does not start with `/`, so
+  it renders as visible literal text rather than a silent dead reference — that is the
+  point. **Never ship a description containing `TODO`.**
+
+## Verify before you ship
+
+Reading back the book ids you just tagged is the whole check:
+
+```bash
+# Slugs for every book in a collection (manifest mode — no pagination)
+curl -s "https://sourcelibrary.org/api/collections/SLUG?mode=manifest" \
+  | jq -r '.books[] | "\(.slug // .id)\t\(.display_title // .title)"'
+```
+
+Then, on the live page: every work named in the intro is rust-coloured and clickable,
+no stray `[`, `]`, `*`, or `TODO` is visible, and each link lands on the right book.
+
+## Scope
+
+- Applies to `description` and `expanded_description` on `collections` documents.
+- The collection page body parses the links; the JSON-LD `description` and the
+  `generateMetadata` meta/og description flatten them to anchor text via
+  `stripMarkdownLinks()`. Any *new* plain-text consumer of these fields must do the same.
+- **Don't retro-rewrite existing descriptions as a side effect** of other work. Adding
+  links to a collection you are already curating is fine and welcome; a bulk sweep over
+  hundreds of hand-tuned intros is its own reviewed change.
+
+Prose style for the intro itself (the three-part structure, the banned framings) is a
+separate doc: `.claude/docs/collection-intro-writing-rules.md`.

--- a/.claude/docs/collection-intro-writing-rules.md
+++ b/.claude/docs/collection-intro-writing-rules.md
@@ -62,6 +62,8 @@ Every collection page opens with a **three-part intro**. Same structure everywhe
    - **No date spans or years.** Not "from 1533 to 1678," not "a fourteenth-century treatise to a 1927 bibliography." Describe range by **era** ("from Renaissance occult philosophy to the great Baroque folios," "from medieval manuscripts to the foundations of modern scholarship").
    - Named *works* may anchor the span ("from the Canon to Leclerc's history") as long as no year is attached.
 
+11c. **Every work you name is clickable.** Parts 2 and 3 name real works (rule 7); each of those names must link to its book page. Write inline `[Short Title](/book/<slug>)` using slugs read back from the collection's own books, or cover the mention in `mentioned_books`. **Internal hrefs only** — an absolute `https://sourcelibrary.org/...` is not parsed and renders as literal brackets, and so do `**bold**` and `*italic*` (emphasis is not parsed — the Part 1 hook is marked bold in this guide's examples to show structure, never by typing asterisks into the field). Don't assume auto-linking covers it: the renderer looks for a book's *full* title inside the prose, and these intros name short forms. Mechanism and verification: `.claude/docs/collection-description-linking.md`.
+
 12. **No em-dashes.** Use commas, colons, or full stops. (Site style.)
 
 13. **Vary paragraph openings.** Parts 2 and 3 should not begin the same way ("This collection…") every time, across the page or across collections.

--- a/.claude/skills/curate-collection/skill.md
+++ b/.claude/skills/curate-collection/skill.md
@@ -236,11 +236,13 @@ Structure each verified quote as:
 
 > **Authoritative editorial rules: `.claude/docs/collection-intro-writing-rules.md`.** For the page-opening intro, that doc is the source of truth and supersedes the brief notes below where they differ (it forbids restating counts/years — the header owns those — bans foil/oppressor framing and proper nouns in the hook, and defines the required three-part structure). Read it before writing any collection prose.
 
+> **Every work you name must be clickable — see `.claude/docs/collection-description-linking.md`.** Write inline `[Short Title](/book/<slug>)` links (internal hrefs only; an absolute `https://sourcelibrary.org/...` renders as literal brackets), or cover the mention in `mentioned_books` at Step 6. Don't assume auto-linking catches it: the renderer looks for the book's *full* title inside your prose, and long Latin titles never appear verbatim in good copy.
+
 Write 2-3 paragraphs of editorial context. Structure:
 
-**Paragraph 1:** What this collection is and why it matters. Situate it in intellectual history. Mention 2-3 key texts by title (these will auto-link via `mentioned_books`).
+**Paragraph 1:** What this collection is and why it matters. Situate it in intellectual history. Mention 2-3 key texts by title, each linked.
 
-**Paragraph 2:** What makes Source Library's collection distinctive — edition quality, language coverage, rare texts. Include 1-2 short quotes from actual translated passages, with the book title mentioned so it links.
+**Paragraph 2:** What makes Source Library's collection distinctive — edition quality, language coverage, rare texts. Include 1-2 short quotes from actual translated passages, with the book title mentioned and linked.
 
 **Paragraph 3 (optional):** Reading path or thematic threads. What someone new to this field should start with.
 
@@ -276,13 +278,15 @@ Interesting, rare, or unusual texts. Notes should be 1 sentence.
 
 ### Step 6: Build mentioned_books Mappings
 
-For every book title referenced in the `expanded_description`, create a `mentioned_books` entry:
+For every book title referenced in the `expanded_description` that you did **not** already wrap in an inline `[Title](/book/<slug>)` link at Step 4, create a `mentioned_books` entry:
 
 ```json
 { "text": "Turba Philosophorum", "book_id": "actual-book-id-here" }
 ```
 
-The `text` must be the **exact string** as it appears in the description. `linkBookTitles()` does regex matching — longest match first, case-sensitive.
+The `text` must appear verbatim in the description. `linkBookTitles()` regex-matches it **case-insensitively** (`gi`), longest `text` first, so list long-form phrases before short-form fallbacks — an earlier match claims its span and later ones only fill unclaimed text.
+
+**Then check the coverage is total:** list every work named in the description and confirm each one is either inline-linked or covered here. Any name left over ships as a dead reference (#1867).
 
 ### Step 7: Audit & Curate Artworks (Visual Art Section)
 
@@ -545,3 +549,4 @@ Match this level of richness for every collection.
 6. **Don't forget to verify book IDs are real.** Always fetch book data before referencing IDs.
 7. **Don't ignore the Visual Art section.** Artwork imports from Rijksmuseum/Wikimedia often bring in text-heavy pages, duplicates, and off-topic prints. Always run the artwork audit (Step 7) when curating collections that have artworks.
 8. **Don't remove artworks from the database — only from collections.** Use `$pull: { collections: slug }` to untag, never `deleteOne`.
+9. **Don't leave a named work unlinked.** Every book the description names must be inline-linked or in `mentioned_books`. And don't write absolute `https://sourcelibrary.org/book/...` hrefs or Markdown emphasis into a description — neither is parsed, both render as literal punctuation. See `.claude/docs/collection-description-linking.md`.

--- a/.claude/skills/curator/SKILL.md
+++ b/.claude/skills/curator/SKILL.md
@@ -158,7 +158,7 @@ const resp = await fetch(`${BASE}/api/collections`, {
 - Use clear, descriptive names (not jargon)
 - Slug format: `kebab-case` (e.g., `persian-literary-tradition`)
 - Colors: `rust` (warm/ancient), `sage` (natural/philosophical), `violet` (mystical/esoteric), `gold` (royal/classical)
-- Write a substantive description — it appears on the public collection page
+- Write a substantive description — it appears on the public collection page. **Hyperlink every book you name in it**: read back the slugs of the `bookIds` you just tagged and write `[Short Title](/book/<slug>)`. See "Collection Page Rendering & `mentioned_books`" below and `.claude/docs/collection-description-linking.md`.
 
 ### Step 6: Run
 ```bash
@@ -245,18 +245,24 @@ const r2 = new S3Client({
 
 ## Collection Page Rendering & `mentioned_books`
 
-**Critical:** The collection page (`/collections/{slug}`) renders `description` and `expanded_description` as **plain text** — Markdown is **NOT parsed**. Links written as `[text](url)` show literal brackets and parentheses; `*italic*` and `**bold**` show literal asterisks.
+> **Full rules: `.claude/docs/collection-description-linking.md`** — read it before writing or editing any collection description. The essentials are below.
 
-Three things the renderer **does** handle:
+**Every work you name in a collection description must be clickable** (#1867). These pages are public copy on a site built for navigating between primary sources; naming ten books and linking none is a dead end.
+
+The collection page (`/collections/{slug}`) renders `description` and `expanded_description` through `linkBookTitles()`, which handles exactly four things:
 1. **Paragraph breaks** on `\n\n` (split into `<p>` tags).
-2. **Auto-linking of book titles** ≥8 chars that appear as exact substrings in the description text. Matches the book's `title` or `display_title` against the collection's books. Renders as `text-accent-rust hover:underline italic`.
-3. **Explicit `mentioned_books` overrides** that take priority over auto-detection.
+2. **Inline markdown links** — `[anchor](/book/some-slug)`, honored since #3040. **Internal hrefs only**: the href must start with `/`. An absolute `https://sourcelibrary.org/book/...` is not matched and renders as literal brackets.
+3. **Explicit `mentioned_books` overrides**, matched case-insensitively, longest text first.
+4. **Auto-linking of book titles** ≥8 chars that appear as exact substrings in the description text. Matches the book's `title` or `display_title` against the collection's books.
+
+Everything else is plain text. **Markdown emphasis is NOT parsed** — `*italic*` and `**bold**` show literal asterisks.
 
 ### When writing a new collection description
 
-- **Plain prose only.** No Markdown syntax.
-- **Use exact title substrings** ≥8 chars from books in the collection — they'll auto-link.
-- **For shorter references** (e.g. "Liezi" = 5 chars, "Hesiod" = 6) or paraphrased titles that don't match book records — populate `mentioned_books`.
+- **Link every named work.** Prefer inline `[Micrographia](/book/<slug>)` — explicit, and no second field to keep in sync. Use the real `slug` read back from the books you tagged; never guess one.
+- **Don't rely on auto-linking.** It searches for the *full* book title inside your prose, and real titles here are long Latin ones while good prose names the short form — so the match usually fails. Assume a named work does not auto-link unless you've checked it.
+- **`mentioned_books` instead** when the same short name recurs across paragraphs, or when patching links onto prose you don't want to rewrite. Needed for references too short or too paraphrased to auto-match ("Liezi", "Hesiod").
+- **No absolute URLs, no Markdown emphasis, and never ship a `[Title](TODO)` placeholder.**
 
 ### `mentioned_books` schema
 

--- a/.claude/skills/library-curator/SKILL.md
+++ b/.claude/skills/library-curator/SKILL.md
@@ -263,8 +263,32 @@ Without retry, a 20-book batch will lose 2-3 books to transient errors and you'l
 5. **Check for Related Editions** - Search by author to see if this is another edition of an existing work. If a matching book has a `work_id`, pass the same `work_id` in the import request (e.g., `"work_id": "agrippa-de-occulta-philosophia"`). All import routes accept `work_id` as an optional field.
 6. **Import Batch** - Import 5-20 books with thematic coherence. Use retry-with-backoff for Atlas transients.
 7. **Verify Imports Landed** - Audit-query your own batch (see section above). Don't trust the script's "OK" output alone — confirm the books are in Mongo with the right page counts.
-8. **Generate Report** - Document batch with rationale and notes
-9. **Update Logs** - Add to successes log in agentcurator.md
+8. **Write/Update the Collection Description** - If the batch creates or reshapes a collection, read back the slugs of the books you just tagged and **hyperlink every work the description names** (see "Collection Descriptions" below). A description is not done until its named works are clickable.
+9. **Generate Report** - Document batch with rationale and notes
+10. **Update Logs** - Add to successes log in agentcurator.md
+
+## Collection Descriptions
+
+> **Full rules: `.claude/docs/collection-description-linking.md`. Prose style: `.claude/docs/collection-intro-writing-rules.md`.** Read both before writing collection copy.
+
+**Hyperlink every book you mention.** A collection description is public-facing copy on a site whose whole point is navigation between primary sources — prose that names ten works and links none of them is a dead end, and defeats the purpose of having a collection page at all. This is the #1 defect in curator-generated descriptions (#1867: the microscopy intro named eleven works and linked zero).
+
+The procedure, every time:
+
+1. **Read back the `bookIds` you just tagged** and get their real slugs — never guess a slug:
+   ```bash
+   curl -s "https://sourcelibrary.org/api/collections/SLUG?mode=manifest" \
+     | jq -r '.books[] | "\(.slug // .id)\t\(.display_title // .title)"'
+   ```
+2. **Replace each bare title with an inline markdown link** to `/book/<slug>`:
+   `Hooke's [Micrographia](/book/micrographia-1665)`.
+3. **Fallback when the slug isn't known yet** (first sketch, before import): leave `[Title](TODO)` so the pending link-resolution is visible. Never ship a description containing `TODO`.
+
+Renderer constraints — get these wrong and the page shows raw punctuation:
+- **Internal hrefs only.** The href must start with `/`. An absolute `https://sourcelibrary.org/book/...` is **not** parsed and renders as literal `[brackets](and-parens)`.
+- **Markdown emphasis is not parsed.** `**bold**` and `*italic*` show their asterisks. Don't write them.
+- **Don't rely on auto-linking.** The renderer auto-links a book's *full* title (≥8 chars) found verbatim in the prose. Real titles here are long early-modern Latin ones and good prose names the short form, so the match usually fails.
+- **Don't retro-rewrite existing descriptions.** Adding links to a collection you're already curating is welcome; a bulk sweep over hand-tuned intros is its own reviewed change.
 
 ## Catalog Sources
 
@@ -318,6 +342,8 @@ Without retry, a 20-book batch will lose 2-3 books to transient errors and you'l
 | **Sancai Tuhui** (Illustrated Encyclopedia) | 1609 | Thousands of woodcuts | Already in collection |
 
 ## Report Format
+
+**Hyperlink every book you mention** — in the batch report as well as in any collection description the batch produces. Titles in the report link to `https://sourcelibrary.org/book/<slug>` (a report is read outside the site, so absolute URLs are right there); titles in a **collection description** must use the site-relative `/book/<slug>` form, because the collection page only parses internal hrefs. See "Collection Descriptions" above.
 
 ### Per-Book Report
 ```

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -60,8 +60,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       return { title: 'Collection Not Found - Source Library' };
     }
 
+    // Flatten inline markdown links the same way the JSON-LD description does —
+    // the page body renders them as <Link>s, but a meta/og description is plain
+    // text and would otherwise publish raw `[anchor](/book/slug)` syntax into
+    // search results and social cards.
     const description = collection.description
-      ? String(collection.description).slice(0, 200)
+      ? stripMarkdownLinks(String(collection.description)).slice(0, 200)
       : `Browse the ${collection.name} collection on Source Library.`;
 
     // Social-card image: the curated hero plate, falling back to the site


### PR DESCRIPTION
Fixes #1867.

## What was actually wrong

The issue asks the curator skills to emit hyperlinks in collection descriptions. Two things had drifted since it was filed (2026-05-18):

1. **The renderer already supports inline links** — `#3040` (2026-07-06) taught `linkBookTitles()` to parse `[anchor](/path)`. But **only internal hrefs**: the regex requires the href to start with `/`. The absolute `https://sourcelibrary.org/book/{slug}` form the issue proposes is *not* matched and renders as literal `[brackets](and-parens)` on the page. So the issue's proposal, implemented literally, would have shipped visible punctuation.
2. **No skill knew any of this.** `library-curator/SKILL.md` never mentioned collection descriptions at all; `curator/SKILL.md` still asserted "Markdown is **NOT** parsed"; `curate-collection` and `collection-intro-writing-rules.md` said nothing about linking.

Also worth stating plainly, because it is why this keeps happening: **auto-linking does not save you.** It searches for a book's *full* `title`/`display_title` (>=8 chars) inside the prose. Real titles here are long early-modern Latin ones and good copy names the short form, so the match usually fails. The hand-fixed microscopy intro linked its works through `mentioned_books`, not auto-detection.

## Changes

**New `.claude/docs/collection-description-linking.md`** — single source of truth: the three link mechanisms in priority order, why auto-detection misses, the internal-href constraint, that emphasis is not parsed either, the `[Title](TODO)` placeholder, and a read-back verification command. The skills route here rather than each restating it (CLAUDE.md: doctrine in one place).

**Skills** (the issue's acceptance criteria):
- `library-curator` — new **Collection Descriptions** section, a new **Workflow** step 8, and a **Report Format** rule. Covers read-back of tagged `bookIds` -> real slugs -> inline links, with the `TODO` fallback.
- `curator` — replaced the stale "Markdown is NOT parsed" section with the corrected four-behaviour list; routed Step 5's "write a substantive description" line to the rule.
- `curate-collection` — linking requirement at Step 4, total-coverage check at Step 6, new pitfall #9. Also corrected Step 6's claim that `mentioned_books` matching is case-sensitive (the regex uses `gi`).
- `collection-intro-writing-rules.md` — rule 11c under Mechanics.

**One code change:** `generateMetadata` now runs `stripMarkdownLinks()` over the meta/og description, as the JSON-LD `description` at line 1069 already did. Without it, telling the skills to adopt inline links publishes raw `[anchor](/book/slug)` into search results and social cards. `npx tsc --noEmit` clean.

## Out of scope

- **No existing description is rewritten** — the issue explicitly asks for this, and the docs say so too. Adding links while curating a collection is welcome; a bulk sweep over hand-tuned intros is its own reviewed change.
- **No routing line added to `CLAUDE.md`.** It is at 5,627 words against a ~5,500 budget, so per its own rule I did not add without demoting something. The existing "Writing a collection intro" line routes to `collection-intro-writing-rules.md`, which now routes to the new doc — one extra hop.
- **No lint/CI check** asserting descriptions are fully linked. That would be the durable enforcement (a doc is the weakest layer), but it needs a decision about what counts as "a named work" and whether to fail on the ~344 existing collections. Left for a follow-up.
