### PR TITLE
fix(covers): five covers pointing at another book's image (#4376)

### DIFF
--- a/scripts/audit/r2-key-book-scope.mjs
+++ b/scripts/audit/r2-key-book-scope.mjs
@@ -4,8 +4,16 @@
  *
  * THE INVARIANT
  *   pages.archived_photo / display_photo / thumbnail_blob, when they point at our
- *   own R2 under an `archived/` or `pages/` prefix, must contain that page's
- *   `book_id`. A URL that doesn't is shared between books.
+ *   own R2 under an `archived/`, `pages/`, `cropped/` or `uploads/` prefix, must
+ *   contain that page's `book_id`. A URL that doesn't is shared between books.
+ *
+ *   The same is true of a BOOK's four cover fields, and that lane was missing
+ *   until #4376. Every page of a book could be perfectly scoped while the book
+ *   document's own `image_display` pointed at `archived/undefined/1.jpg` or at
+ *   another book's `pages/<id>/0007-full.jpg` — this audit looked only at pages
+ *   and reported PASS. Five books were in that state when the lane was added,
+ *   three of them visible; one was serving a different book's title page as its
+ *   cover. Covers are checked by default now (`--no-covers` to skip).
  *
  * WHY IT MATTERS
  *   In Mar–Apr 2026 a missing `book_id` in an archiver's projection sent every
@@ -19,8 +27,10 @@
  *
  * USAGE
  *   set -a; source .env.production.local; set +a
- *   node scripts/audit/r2-key-book-scope.mjs              # sampled sweep (fast)
- *   node scripts/audit/r2-key-book-scope.mjs --full       # every page (slow)
+ *   node scripts/audit/r2-key-book-scope.mjs              # covers (all books) + sampled pages
+ *   node scripts/audit/r2-key-book-scope.mjs --full       # covers + every page (slow)
+ *   node scripts/audit/r2-key-book-scope.mjs --covers     # cover fields only (~1 min, all books)
+ *   node scripts/audit/r2-key-book-scope.mjs --no-covers  # pages only (the pre-#4376 behaviour)
  *   node scripts/audit/r2-key-book-scope.mjs --book <id>  # one book
  *   node scripts/audit/r2-key-book-scope.mjs --json out.json
  *
@@ -33,11 +43,17 @@ import { isBookScopedUrl } from '../lib/r2-key.mjs';
 
 const args = process.argv.slice(2);
 const FULL = args.includes('--full');
+const COVERS_ONLY = args.includes('--covers');
+const COVERS = COVERS_ONLY || !args.includes('--no-covers');
+const PAGES = !COVERS_ONLY;
 const BOOK = args[args.indexOf('--book') + 1] && args.includes('--book') ? args[args.indexOf('--book') + 1] : null;
 const JSON_OUT = args.includes('--json') ? args[args.indexOf('--json') + 1] : null;
 const SAMPLE_BOOKS = 1500;
 
 const FIELDS = ['archived_photo', 'display_photo', 'thumbnail_blob', 'cropped_photo', 'enhanced_photo'];
+
+/** The four canonical cover fields plus the two legacy ones they mirror. */
+const COVER_FIELDS = ['image_display', 'image_thumb', 'image_card', 'image_full', 'thumbnail', 'thumbnail_blob'];
 
 const uri = process.env.MONGODB_URI;
 if (!uri) { console.error('MONGODB_URI not set'); process.exit(2); }
@@ -46,6 +62,38 @@ const client = new MongoClient(uri);
 await client.connect();
 const db = client.db('bookstore');
 const pages = db.collection('pages');
+
+const violations = [];
+
+// ---------------------------------------------------------------- cover lane
+// Cheap enough to run over EVERY book (~113k docs, well under a minute), and it
+// has to be: a cover is the one image a reader sees before they open anything,
+// and it is written from the book document, not from the page series the loop
+// below walks. The scoping id is `id`, not `_id` — 16,424 books carry a
+// re-minted `_id` and every R2 key convention here embeds `id`.
+if (COVERS) {
+  const q = BOOK ? { $or: [{ id: BOOK }, { _id: BOOK }] } : {};
+  const cur = db.collection('books').find(q, {
+    projection: { id: 1, title: 1, visible: 1, ...Object.fromEntries(COVER_FIELDS.map(f => [f, 1])) },
+  });
+  let n = 0;
+  for await (const b of cur) {
+    n++;
+    const bid = b.id || String(b._id);
+    for (const f of COVER_FIELDS) {
+      const url = b[f];
+      if (!url) continue;
+      if (!isBookScopedUrl(url, bid)) {
+        violations.push({ book_id: bid, lane: 'cover', field: f, url, title: b.title, visible: b.visible });
+      }
+    }
+  }
+  console.log(`Checked cover fields on ${n} book(s) — ${violations.length} violation(s).`);
+}
+
+// `reportAndExit` never returns — it exits the process — but it must still be
+// awaited, or the page lane below would start running underneath it.
+if (!PAGES) await reportAndExit();
 
 let bookIds;
 if (BOOK) {
@@ -60,7 +108,6 @@ if (BOOK) {
 }
 console.log(`Auditing ${bookIds.length} book(s)${FULL ? ' (full sweep)' : ' (sample — use --full for all)'}`);
 
-const violations = [];
 let checkedPages = 0, checkedBooks = 0;
 
 for (const bid of bookIds) {
@@ -73,7 +120,7 @@ for (const bid of bookIds) {
       const url = p[f];
       if (!url) continue;
       if (!isBookScopedUrl(url, p.book_id)) {
-        violations.push({ book_id: p.book_id, page_id: p.id, page_number: p.page_number, field: f, url });
+        violations.push({ book_id: p.book_id, lane: 'page', page_id: p.id, page_number: p.page_number, field: f, url });
       }
     }
   }
@@ -82,34 +129,55 @@ for (const bid of bookIds) {
 
 console.log(`\nChecked ${checkedPages} pages across ${checkedBooks} books.`);
 
-if (!violations.length) {
-  console.log('PASS — every stored page-image URL is scoped to its own book.');
+await reportAndExit();
+
+/**
+ * Print the grouped report and exit — 0 when clean, 1 when anything was found,
+ * so this can gate CI or a cron. Shared by both lanes; a `--covers` run reaches
+ * it before the page sweep ever starts.
+ */
+async function reportAndExit() {
+  if (!violations.length) {
+    console.log(`PASS — every stored ${[COVERS && 'cover', PAGES && 'page-image'].filter(Boolean).join(' and ')} URL is scoped to its own book.`);
+    await client.close();
+    process.exit(0);
+  }
+
+  // Group for a readable report: the failure mode is always many fields of one shape.
+  const byBook = new Map();
+  for (const v of violations) {
+    if (!byBook.has(v.book_id)) byBook.set(v.book_id, []);
+    byBook.get(v.book_id).push(v);
+  }
+  console.log(`\nFAIL — ${violations.length} violation(s) across ${byBook.size} book(s):\n`);
+  for (const [bid, vs] of [...byBook.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 40)) {
+    const book = await db.collection('books').findOne({ id: bid }, { projection: { title: 1, visible: 1 } });
+    const covers = vs.filter(v => v.lane === 'cover');
+    const pageVs = vs.filter(v => v.lane !== 'cover');
+    console.log(`  ${bid} "${(book?.title || '?').slice(0, 50)}" ${book?.visible ? '[VISIBLE]' : '[hidden]'} — ${vs.length} field(s)`);
+    // Covers first and never truncated: there are only ever six of them, and a
+    // wrong cover is the one image a reader meets before opening anything.
+    for (const v of covers) console.log(`      COVER ${v.field}: ${v.url}`);
+    for (const v of pageVs.slice(0, 3)) console.log(`      p${v.page_number} ${v.field}: ${v.url}`);
+    if (pageVs.length > 3) console.log(`      ... and ${pageVs.length - 3} more page-field(s)`);
+  }
+  if (byBook.size > 40) console.log(`  ... and ${byBook.size - 40} more books`);
+
+  if (JSON_OUT) {
+    fs.writeFileSync(JSON_OUT, JSON.stringify(violations, null, 2));
+    console.log(`\nFull violation list written to ${JSON_OUT}`);
+  }
+
+  if (violations.some(v => v.lane === 'cover')) {
+    console.log('\nA COVER line means the book document itself names another book\'s image (or a');
+    console.log('shared `undefined` key). Repair it through buildCoverUpdate() so all four cover');
+    console.log('fields move together — see scripts/maintenance/fix-cross-book-covers-4376.mjs.');
+  }
+  if (violations.some(v => v.lane !== 'cover')) {
+    console.log('\nAny page listed above may have been OCR\'d against another book\'s image.');
+    console.log('Verify the OCR text against the current image before trusting it (see #3362).');
+  }
+
   await client.close();
-  process.exit(0);
+  process.exit(1);
 }
-
-// Group for a readable report: the failure mode is always many pages of one shape.
-const byBook = new Map();
-for (const v of violations) {
-  if (!byBook.has(v.book_id)) byBook.set(v.book_id, []);
-  byBook.get(v.book_id).push(v);
-}
-console.log(`\nFAIL — ${violations.length} violation(s) across ${byBook.size} book(s):\n`);
-for (const [bid, vs] of [...byBook.entries()].sort((a, b) => b[1].length - a[1].length).slice(0, 40)) {
-  const book = await db.collection('books').findOne({ id: bid }, { projection: { title: 1, visible: 1 } });
-  console.log(`  ${bid} "${(book?.title || '?').slice(0, 50)}" ${book?.visible ? '[VISIBLE]' : '[hidden]'} — ${vs.length} page-field(s)`);
-  for (const v of vs.slice(0, 3)) console.log(`      p${v.page_number} ${v.field}: ${v.url}`);
-  if (vs.length > 3) console.log(`      ... and ${vs.length - 3} more`);
-}
-if (byBook.size > 40) console.log(`  ... and ${byBook.size - 40} more books`);
-
-if (JSON_OUT) {
-  fs.writeFileSync(JSON_OUT, JSON.stringify(violations, null, 2));
-  console.log(`\nFull violation list written to ${JSON_OUT}`);
-}
-
-console.log('\nAny page listed above may have been OCR\'d against another book\'s image.');
-console.log('Verify the OCR text against the current image before trusting it (see #3362).');
-
-await client.close();
-process.exit(1);

--- a/scripts/lib/r2-key.mjs
+++ b/scripts/lib/r2-key.mjs
@@ -94,8 +94,16 @@ export function isBookScopedUrl(url, bookId) {
   if (typeof url !== 'string' || !url.startsWith('http')) return true; // not our concern
   // A shared-key segment is always wrong, under any prefix.
   if (/\/(undefined|null|NaN)\//.test(url)) return false;
-  // Only judge our own page-image prefixes; other assets are not book-scoped.
-  if (!/\/(archived|pages|thumbnails)\//.test(url)) return true;
+  // Only judge our own page-image prefixes; other assets (gallery/, artwork/,
+  // manuscripts/) are not book-scoped and must not be flagged.
+  //
+  // `cropped/` and `uploads/` were added for #4376. Leaving them out is what let
+  // a mis-keyed cover — `cropped/<another book's id>/<page>.jpg` — sit in front
+  // of a visible book while this helper called it fine. Both were measured over
+  // the whole corpus first (2026-09-02): `uploads/` had zero mismatches, and
+  // `cropped/` had exactly one book (69a02781bd4078a454714f6d, 372 pages, the
+  // subject of #4376), so judging them costs no false positives.
+  if (!/\/(archived|pages|thumbnails|cropped|uploads)\//.test(url)) return true;
   if (!bookId) return false;
   // The corpus carries several key conventions across eras (see src/lib/storage.ts):
   // `archived/<bookId>/<N>.jpg` and `archived/<bookId>-<NNNN>.jpg` are both real and

--- a/scripts/maintenance/fix-cross-book-covers-4376.mjs
+++ b/scripts/maintenance/fix-cross-book-covers-4376.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Covers that point at another book's image — issue #4376 (#3362 survivors).
+ *
+ * WHAT WAS WRONG
+ * --------------
+ * Each book below carries a cover URL whose R2 key does not contain its own
+ * book id, which is the #3362 shape: a key that is not book-scoped is shared by
+ * construction, and nothing downstream can notice, because R2 serves a real,
+ * complete, 200-OK JPEG for it. Two were surfaced by `assertBookScopedKey`
+ * during the cover-card backfill (#4344), which refused to derive a card
+ * variant from either key; the other three by the cover lane this same PR adds
+ * to `scripts/audit/r2-key-book-scope.mjs`, which had only ever looked at pages.
+ * All five images below were opened and read on 2026-09-02.
+ *
+ *   69bfbeb294e521147a83f245  "Complete Works VI — Against Plethon…"   [VISIBLE]
+ *       archived/undefined/1.jpg — an `undefined`-keyed artifact of #3362.
+ *       Renders Google's "This is a digital copy of a book…" boilerplate leaf:
+ *       some other book's front matter on a Greek Gennadios Scholarios volume.
+ *
+ *   69a02781bd4078a454714f6d  "Theologia germanica"                     [VISIBLE]
+ *       cropped/69a02781bd4078a454714f6f/… — one character off its own id, and
+ *       book …f6f is real. Renders the title page of *The Third Booke of the
+ *       Authour… Threefold Life of Man* (Behmen, London 1650) — which is …f6f's
+ *       own title. Wrong twice over: another book's key, another work's page.
+ *
+ *   6974b644457dd8909910b9ef  "Archaeologiae philosophicae…"            [VISIBLE]
+ *       pages/6974b644457dd8909910b9ed/0007-full.jpg — and …9ed is a real,
+ *       visible book ("Arcanum hermeticae philosophiae opus") that owns that
+ *       key. This is a live collision: the catalogue currently shows Arcanum's
+ *       title page on Archaeologiae's card.
+ *
+ *   697c8e0f4733b2a5648ad8bf  "Das Geheimnis aller Geheimnisse…"        [VISIBLE]
+ *       pages/697c8e0f4733b2a5648ad8bd/0002-full.jpg — …8bd is a real, visible
+ *       book ("Gott"). The object happens to hold the right picture today, so
+ *       nothing looks wrong; that is the whole hazard. "Gott" writing its own
+ *       page 2 would silently replace this book's cover.
+ *
+ *   69aeab1767e6731bc1365f75  "Geschichte und Klassenbewußtsein"        [hidden]
+ *       pages/undefined/0007-thumb.jpg on image_thumb + thumbnail_blob. A
+ *       second `undefined` survivor — #4376 called …f245 the only one, which
+ *       was true of the `archived/undefined/` prefix it searched.
+ *
+ * WHY A NAMED TABLE AND NOT A RULE
+ * --------------------------------
+ * `reconcile-cover-fields.mjs` (#4346) deliberately refuses to guess for this
+ * shape. For four of the five there is nothing to guess: the book's own
+ * recorded `cover_page` already carries a correctly book-scoped image, and the
+ * mis-keyed URL was copied onto the book from a *different* field of the same
+ * page. Only …f6d needs a judgement — its cover_page 14 has no book-scoped
+ * variant at all — and that one was made by reading the page (see its `why`).
+ * Five audited decisions, written down; not a heuristic loosed on the corpus.
+ *
+ * SAFETY
+ * ------
+ * Dry-run by default. Per book, before writing, this asserts:
+ *   - the book's current cover really is the mis-scoped URL on record (so a
+ *     later fix, by hand or by another sweep, is never silently overwritten);
+ *   - the replacement page exists, and is the page_type recorded in the table;
+ *   - the replacement URL is book-scoped (`assertBookScopedKey`) — the fix is
+ *     not allowed to reintroduce the bug it is repairing;
+ *   - the replacement URL actually loads (HTTP 200).
+ * It writes through `buildCoverUpdate()` so all four cover fields move
+ * together, and records a `sweep_log` row per book (field-sprawl invariant).
+ *
+ * USAGE
+ *   node --env-file=.env.production.local scripts/maintenance/fix-cross-book-covers-4376.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/fix-cross-book-covers-4376.mjs --apply
+ *
+ * After --apply: `node scripts/maintenance/backfill-cover-cards.mjs` to build the
+ * 500px card variants (buildCoverUpdate clears `image_card` by contract), then
+ * POST the two slugs to /api/admin/revalidate.
+ */
+import { MongoClient } from 'mongodb';
+import { buildCoverUpdate, resolvePageCoverUrl, isRenderableCoverUrl } from '../lib/cover-write.mjs';
+import { assertBookScopedKey, isBookScopedUrl } from '../lib/r2-key.mjs';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const SWEEP = 'cross-book-covers-4376';
+
+/**
+ * The two audited decisions. `expect_cover` pins what we believe is on record;
+ * a mismatch aborts that book rather than writing over someone else's fix.
+ */
+const FIXES = [
+  {
+    book_id: '69bfbeb294e521147a83f245',
+    expect_cover: 'https://images.sourcelibrary.org/archived/undefined/1.jpg',
+    page_number: 1,
+    expect_page_type: 'title-page',
+    why: 'the book\'s own single page — its publisher cover plate, "Gennadius Scholarius '
+       + 'Complete Works / VOLUME 6" — under a correctly book-scoped archived/ key',
+  },
+  {
+    book_id: '69a02781bd4078a454714f6d',
+    expect_cover: 'https://images.sourcelibrary.org/cropped/69a02781bd4078a454714f6f/69a02a0c75873c3b8b8a8e6e.jpg',
+    // NOT the recorded cover_page (14). p14's only image is the mis-keyed crop
+    // itself, so it cannot be repaired in place. p13 is the same right-hand half
+    // of the same spread under a correct key and would preserve the current
+    // picture exactly — but the current picture is another work's title page.
+    // p9 is this volume's own.
+    page_number: 9,
+    expect_page_type: 'title-page',
+    why: 'p9 is this book\'s actual title page — "THEOLOGIA Germanica. LIBELLVS AVREVS… '
+       + 'BASILEAE, PER IOANnem Oporinum" — and its crop is already keyed under this '
+       + 'book\'s own id, unlike the p14 crop it replaces',
+  },
+  {
+    book_id: '6974b644457dd8909910b9ef',
+    expect_cover: 'https://images.sourcelibrary.org/pages/6974b644457dd8909910b9ed/0007-full.jpg',
+    page_number: 7,
+    expect_page_type: 'title-page',
+    why: 'the recorded cover_page, unchanged — p7\'s own `photo` is already book-scoped '
+       + '("ARCHÆOLOGIÆ Philosophicæ… LONDINI… M.DC.XCII"); only the book document had '
+       + 'picked up p7\'s mis-keyed `cropped_photo` instead',
+  },
+  {
+    book_id: '697c8e0f4733b2a5648ad8bf',
+    expect_cover: 'https://images.sourcelibrary.org/pages/697c8e0f4733b2a5648ad8bd/0002-full.jpg',
+    page_number: 2,
+    expect_page_type: 'title-page',
+    why: 'the recorded cover_page, unchanged — p2\'s own `photo` is already book-scoped '
+       + 'and holds the same title page ("Das Geheimnis aller Geheimniße… Leipzig, 1788")',
+  },
+  {
+    book_id: '69aeab1767e6731bc1365f75',
+    expect_cover: 'https://images.sourcelibrary.org/pages/undefined/0007-thumb.jpg',
+    page_number: 1,
+    // A split-spread page from an era that did not set page_type.
+    expect_page_type: null,
+    why: 'the recorded cover_page, unchanged — p1 carries book-scoped `photo` and '
+       + '`thumbnail_blob`, so re-deriving the cover from it clears the shared '
+       + '`pages/undefined/` thumb without changing which page is shown',
+  },
+];
+
+async function loads(url) {
+  try {
+    const r = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(30000) });
+    return r.ok;
+  } catch { return false; }
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const Books = db.collection('books');
+const Pages = db.collection('pages');
+
+console.log(`${APPLY ? 'APPLYING' : 'DRY RUN — nothing will be written'}\n`);
+
+let applied = 0, skipped = 0;
+
+for (const fix of FIXES) {
+  // Look up by `id` OR `_id`: 16,343 books carry a re-minted `_id`, and both of
+  // these do — an `_id`-only lookup finds neither. Pages join on `book_id`,
+  // which is the `id`.
+  const book = await Books.findOne(
+    { $or: [{ id: fix.book_id }, { _id: fix.book_id }] },
+    { projection: { id: 1, title: 1, visible: 1, cover_page: 1, thumbnail_source: 1,
+                    image_display: 1, image_thumb: 1, image_card: 1, image_full: 1,
+                    thumbnail: 1, thumbnail_blob: 1 } },
+  );
+  const label = `${fix.book_id} "${String(book?.title || '?').slice(0, 45)}"`;
+  const bail = (reason) => { console.log(`  SKIP ${label}\n       ${reason}\n`); skipped++; };
+
+  if (!book) { bail('book not found'); continue; }
+
+  // Already fixed, or moved on. Either way this script has nothing to say.
+  const current = [book.image_display, book.thumbnail, book.image_thumb, book.thumbnail_blob]
+    .filter(u => typeof u === 'string');
+  if (!current.includes(fix.expect_cover)) {
+    bail(`cover no longer matches the audited value — expected\n         ${fix.expect_cover}\n       `
+       + `but found\n         image_display=${book.image_display}\n         thumbnail=${book.thumbnail}\n       `
+       + 'left alone: someone else may have fixed this already');
+    continue;
+  }
+  if (book.thumbnail_source === 'manual') {
+    bail('cover was picked by a human (thumbnail_source: manual) — not overruling it');
+    continue;
+  }
+
+  const page = await Pages.findOne(
+    { book_id: book.id, page_number: fix.page_number },
+    { projection: { page_number: 1, page_type: 1, photo: 1, photo_original: 1, crop: 1,
+                    split_from_spread: 1, cropped_photo: 1, enhanced_photo: 1,
+                    archived_photo: 1, image_thumb: 1, thumbnail_blob: 1 } },
+  );
+  if (!page) { bail(`page ${fix.page_number} not found`); continue; }
+  if ((page.page_type ?? null) !== (fix.expect_page_type ?? null)) {
+    bail(`page ${fix.page_number} is page_type "${page.page_type}", expected "${fix.expect_page_type}" — `
+       + 'the page series has changed since this fix was audited');
+    continue;
+  }
+
+  const url = resolvePageCoverUrl(page);
+  if (!url) { bail(`page ${fix.page_number} has no usable image URL`); continue; }
+  if (!isRenderableCoverUrl(url)) { bail(`replacement is not on a renderable host: ${url}`); continue; }
+  try {
+    // The whole point of the repair: refuse to write a key that is not this
+    // book's. `assertBookScopedKey` takes the key, not the URL.
+    assertBookScopedKey(new URL(url).pathname.replace(/^\//, ''), book.id, SWEEP);
+  } catch (e) { bail(`replacement is not book-scoped — ${e.message}`); continue; }
+  if (!await loads(url)) { bail(`replacement URL does not load: ${url}`); continue; }
+
+  // Keep an existing thumb variant when it is genuinely this book's and still
+  // live. `buildCoverUpdate` reads `page.image_thumb` first, so seeding it here
+  // preserves the small derived thumb instead of pointing `image_thumb` at a
+  // full-size scan. Only ever from a book-scoped, loading URL — a mis-keyed
+  // thumb is exactly what we are here to remove.
+  let preserved = null;
+  if (!page.image_thumb && !page.thumbnail_blob) {
+    const candidate = [book.image_thumb, book.thumbnail_blob]
+      .find(u => typeof u === 'string' && u !== fix.expect_cover
+        && isRenderableCoverUrl(u) && isBookScopedUrl(u, book.id));
+    if (candidate && await loads(candidate)) preserved = candidate;
+  }
+
+  const update = buildCoverUpdate(preserved ? { ...page, image_thumb: preserved } : page, {
+    source: SWEEP,
+    method: 'cross-book-cover-repair',
+    actor: 'script',
+    detail: fix.why,
+  });
+  if (!update) { bail('buildCoverUpdate returned null'); continue; }
+
+  console.log(`  ${APPLY ? 'FIX ' : 'WOULD FIX '} ${label}`);
+  console.log(`       drop  ${fix.expect_cover}`);
+  console.log(`       keep  ${url}   (p${page.page_number}, ${page.page_type})`);
+  if (preserved) console.log(`       thumb ${preserved}   (preserved — already book-scoped)`);
+  console.log(`       why   ${fix.why}`);
+
+  if (!APPLY) { console.log(); continue; }
+
+  // No $unset alongside: `buildCoverUpdate` already carries `image_card: null`,
+  // and setting + unsetting the same path makes Mongo reject the whole write.
+  await Books.updateOne({ _id: book._id }, { $set: { ...update, updated_at: new Date() } });
+  await recordSweepAction(db, {
+    sweep: SWEEP,
+    book_id: book.id,
+    action: 'cover-rekeyed-to-own-book',
+    detail: { from: fix.expect_cover, to: url, page_number: page.page_number, why: fix.why },
+  });
+  applied++;
+  console.log(`       written\n`);
+}
+
+console.log(`\n${APPLY ? 'fixed' : 'would fix'}: ${APPLY ? applied : FIXES.length - skipped}   skipped: ${skipped}`);
+if (APPLY && applied) {
+  console.log('\nNext:');
+  console.log('  node scripts/maintenance/backfill-cover-cards.mjs   # rebuild the 500px card variants');
+  console.log('  node scripts/audit/r2-key-book-scope.mjs --covers   # confirm the class is clear');
+}
+
+await client.close();

--- a/src/lib/r2-key.ts
+++ b/src/lib/r2-key.ts
@@ -53,8 +53,14 @@ export function isBookScopedUrl(url: string | null | undefined, bookId: string):
   if (typeof url !== 'string' || !url.startsWith('http')) return true;
   // A shared-key segment is always wrong, under any prefix.
   if (/\/(undefined|null|NaN)\//.test(url)) return false;
-  // Only judge our own page-image prefixes; other assets are not book-scoped.
-  if (!/\/(archived|pages|thumbnails)\//.test(url)) return true;
+  // Only judge our own page-image prefixes; other assets (gallery/, artwork/,
+  // manuscripts/) are not book-scoped and must not be flagged.
+  //
+  // `cropped/` and `uploads/` were added for #4376 — leaving them out let a
+  // `cropped/<another book's id>/<page>.jpg` cover pass as fine. Both measured
+  // corpus-wide first (2026-09-02): `uploads/` zero mismatches, `cropped/` one
+  // book. Keep in lockstep with the .mjs twin.
+  if (!/\/(archived|pages|thumbnails|cropped|uploads)\//.test(url)) return true;
   if (!bookId) return false;
   // Both `archived/<bookId>/<N>.jpg` and `archived/<bookId>-<NNNN>.jpg` are real,
   // book-scoped conventions here. Require the id to sit between delimiters rather

--- a/tests/unit/r2-key.test.ts
+++ b/tests/unit/r2-key.test.ts
@@ -126,6 +126,29 @@ describe('isBookScopedUrl (read-side audit helper)', () => {
     expect(isBookScopedUrl(`${base}/archived/69b220f356715b0e32473bd0/31.jpg`, BOOK)).toBe(false);
   });
 
+  // #4376: `cropped/` and `uploads/` are book-scoped conventions too, and until
+  // this helper judged them, a cover reading `cropped/<another book's id>/…`
+  // passed the standing audit while a visible book showed the wrong title page.
+  it('judges the cropped/ and uploads/ prefixes', () => {
+    const other = '69a02781bd4078a454714f6f';
+    expect(isBookScopedUrl(`${base}/cropped/${BOOK}/69a02a0c75873c3b8b8a8e6e.jpg`, BOOK)).toBe(true);
+    expect(isBookScopedUrl(`${base}/uploads/${BOOK}/0179-original.jpg`, BOOK)).toBe(true);
+    expect(isBookScopedUrl(`${base}/cropped/${other}/69a02a0c75873c3b8b8a8e6e.jpg`, BOOK)).toBe(false);
+    expect(isBookScopedUrl(`${base}/uploads/${other}/0179-original.jpg`, BOOK)).toBe(false);
+    expect(isBookScopedUrl(`${base}/cropped/undefined/31.jpg`, BOOK)).toBe(false);
+    // The exact pair from #4376 — the shipped cover and its repair.
+    const f6d = '69a02781bd4078a454714f6d';
+    expect(isBookScopedUrl(`${base}/cropped/${other}/69a02a0c75873c3b8b8a8e6e.jpg`, f6d)).toBe(false);
+    expect(isBookScopedUrl(`${base}/cropped/${f6d}/6975a093efc24c700962bbc7.jpg`, f6d)).toBe(true);
+  });
+
+  it('still has no opinion on prefixes that are not book-scoped by design', () => {
+    // Galleries, artwork and manuscripts are keyed by their own ids, not a book's.
+    expect(isBookScopedUrl(`${base}/gallery/some-collection/img-1.jpg`, BOOK)).toBe(true);
+    expect(isBookScopedUrl(`${base}/artwork/6970abc.../plate-3.jpg`, BOOK)).toBe(true);
+    expect(isBookScopedUrl(`${base}/manuscripts/xyz/1.jpg`, BOOK)).toBe(true);
+  });
+
   it('ignores URLs it has no opinion about', () => {
     // External sources (IA, IIIF) are not book-scoped and must not be flagged.
     expect(isBookScopedUrl('https://archive.org/download/foo/page/n30/full/pct:50/0/default.jpg', BOOK)).toBe(true);
@@ -142,6 +165,10 @@ describe('.ts / .mjs twin parity', () => {
     'archived//31.jpg',
     'archived/undefinedbook123/31.jpg',
     `pages/${BOOK}/0031-thumb.jpg`,
+    `cropped/${BOOK}/69a02a0c75873c3b8b8a8e6e.jpg`,
+    'cropped/69a02781bd4078a454714f6f/69a02a0c75873c3b8b8a8e6e.jpg',
+    `uploads/${BOOK}/0179-original.jpg`,
+    'gallery/some-collection/img-1.jpg',
   ];
 
   it('validateR2Key agrees on every case', () => {


### PR DESCRIPTION
Fixes #4376.

## What was wrong

#4376 reported **two** books whose cover URL carries an R2 key that does not contain their own book id — the #3362 shape, where a key is shared between books *by construction* and nothing downstream can notice, because R2 serves a real, complete, 200-OK JPEG for it.

Closing the detection gap turned up **three more**, two of them visible:

| book | mis-keyed cover | what it actually was |
|---|---|---|
| `69bfbeb294e521147a83f245` *Complete Works VI — Against Plethon…* | `archived/undefined/1.jpg` | Google's "This is a digital copy of a book…" boilerplate leaf — another book's front matter on a Greek Gennadios Scholarios volume |
| `69a02781bd4078a454714f6d` *Theologia germanica* | `cropped/…f6f/…` | the title page of *The Third Booke of the Authour… Threefold Life of Man* (Behmen, London 1650) — which is also book …f6f's own title. Wrong twice over |
| `6974b644457dd8909910b9ef` *Archaeologiae philosophicae…* | `pages/…9ed/0007-full.jpg` | **a live collision** — …9ed is a real, visible book (*Arcanum hermeticae philosophiae opus*) that owns that key, so the catalogue was serving Arcanum's title page on Archaeologiae's card |
| `697c8e0f4733b2a5648ad8bf` *Das Geheimnis aller Geheimnisse…* | `pages/…8bd/0002-full.jpg` | …8bd is *Gott*. The object happens to hold the right picture today, which is the hazard: *Gott* writing its own page 2 would replace this cover silently |
| `69aeab1767e6731bc1365f75` *Geschichte und Klassenbewußtsein* (hidden) | `pages/undefined/0007-thumb.jpg` | a **second** `undefined` survivor — #4376 called …f245 the only one, which was true of the `archived/undefined/` prefix it searched |

## Why the standing detector missed all five

Two gaps, both closed here.

**1. `r2-key-book-scope.mjs` only ever looked at PAGES.** Every page of a book could be perfectly scoped while the book document's own `image_display` named another book's file — and the audit reported PASS. A cover is the one image a reader meets before opening anything, and it is written from the book document, not from the page series the audit walked. Covers are now checked **by default** over every book (~113k docs, under a minute); `--covers` runs that lane alone, `--no-covers` restores the old behaviour.

**2. `isBookScopedUrl` judged only `archived/`, `pages/`, `thumbnails/`.** So a cover reading `cropped/<another book's id>/…` passed as fine. `cropped/` and `uploads/` are book-scoped conventions too, and both were **measured corpus-wide before being judged** (2026-09-02): `uploads/` had zero mismatches, `cropped/` exactly one book — the #4376 subject — so judging them costs no false positives. Kept in lockstep across the `.ts`/`.mjs` twins, with the #4376 pair pinned in `tests/unit/r2-key.test.ts`.

## The repair

`scripts/maintenance/fix-cross-book-covers-4376.mjs` — a named table of five audited decisions, not a heuristic (`reconcile-cover-fields.mjs` deliberately refuses to guess for this shape, and rightly).

For **four** of the five there was nothing to guess: the book's own recorded `cover_page` already carried a correctly book-scoped image, and the mis-keyed URL had been copied onto the book from a *different field of that same page*. Only …f6d needed a judgement — its `cover_page` 14 has no book-scoped variant at all, and the crop it names is a different work's title page — so it moves to p9, this volume's own *"THEOLOGIA Germanica. LIBELLVS AVREVS… BASILEAE, PER IOANnem Oporinum"*. **Every one of the five images was opened and read before choosing.**

Dry-run by default. Per book it refuses to write unless:

- the cover on record still matches the audited value — so a later hand-fix is never clobbered (and a second run skips all five);
- the replacement page is the `page_type` recorded in the table;
- the replacement key passes `assertBookScopedKey` — the fix may not reintroduce the bug it repairs;
- the URL returns 200.

Writes through `buildCoverUpdate()` so all four cover fields move together, and records a `sweep_log` row carrying the old URL (per the field-sprawl invariant — a row, not a column).

## Applied 2026-09-02

```
fixed: 5   skipped: 0
```

- card variants rebuilt via `backfill-cover-cards.mjs --book-id=…` (×5)
- the four visible book pages revalidated
- cover lane re-run: **0 violations across 112,975 books**, all 30 cover-field values book-scoped and 200
- `books_catalog` mirror picks the covers up on its next incremental sync (the sweep bumps `updated_at`)

## Out of scope

**The page lane is a separate, larger population.** The *pre-existing* page audit already detects it — 58 page-field violations on …9ef, 372 on …f6d — but repairing it means re-keying R2 objects, not just repointing a document, so it is a different job with a different risk profile. Being measured for its own issue rather than bundled here.

**No CLAUDE.md change.** The #3362 invariant is already in the body and already names this detector; the file is at 5,627 words against a ~5,500 cap, so adding a clause would mean demoting something unrelated. The durable layer here is the check, not a sentence — the cover lane and the unit tests.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all five changed files — clean
- `npx vitest run tests/unit/r2-key.test.ts tests/unit/cover-fields.test.ts` — 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
