### PR TITLE
fix(prompts): one is_default per type, numeric versions, standing audit (#3614)

### DIFF
--- a/.claude/docs/data-provenance.md
+++ b/.claude/docs/data-provenance.md
@@ -44,7 +44,9 @@ prompts/
 
 **MongoDB `prompts` collection (source of truth for which version is active):**
 - Each prompt has: `name`, `type`, `version`, `is_default`, `content`, `content_hash`
-- Only one prompt per `(type, name)` should have `is_default: true`
+- `type` is one of: `ocr`, `translation`, `summary`, `image_extraction`, `english_modernization`
+- **Exactly one row per `type` has `is_default: true`** — not per `(type, name)`. Every lookup in the codebase is `findOne({ type, is_default: true })` (17 call sites; most pass no sort at all), so a second default makes the choice depend on natural order rather than intent. Enforced by a unique partial index on `{ type: 1 }` where `is_default: true`, so a duplicate now fails with E11000 instead of silently forking provenance (#3614).
+- **`version` is a NUMBER, never a string.** `'v1'` and `1` coexisting made every `sort({ version: -1 })` follow BSON type order, and printed defaults as `vundefined` and `vv1`. Pre-versioning rows from 2025-12 carry `version: 0`.
 - Old versions are NEVER deleted — they're the audit trail
 
 **Inline prompts** for index/summary generation are versioned via the `INDEX_PROMPT_VERSION` constant in `src/app/api/books/[id]/index/route.ts` (and the tenant variant) and the corresponding constant in `scripts/workers/enrich-worker.mjs`. Bump these when the prompt strings in those files change. The version is logged to `gemini_usage.prompt_version` and stored on the resulting `book.summary.prompt_version`.
@@ -91,22 +93,34 @@ For batch jobs the four fields are stamped on the `batch_jobs` row at submission
 ### How to create a new prompt version
 
 1. Query max version: `db.prompts.find({ type: 'TYPE', name: 'NAME' }).sort({ version: -1 }).limit(1)`
-2. Insert new doc with `version: max + 1`, `is_default: true`
-3. Set `is_default: false` on the old version
-4. VERIFY: `db.prompts.countDocuments({ type: 'TYPE', name: 'NAME', is_default: true })` must be exactly 1
+2. Insert new doc with `version: max + 1` **as a number**, `is_default: true`, and a `content_hash`
+3. Set `is_default: false` on the old default FIRST — the unique index rejects the insert otherwise
+4. VERIFY: `db.prompts.countDocuments({ type: 'TYPE', is_default: true })` must be exactly 1
 5. Save the prompt content to `prompts/` directory in git
-6. **NEVER edit or delete old versions**
+6. Update the table below, or `doc-enum-drift.mjs` will fail the next run
+7. **NEVER edit or delete old versions**
 
-### Current defaults (as of audit)
+Prefer the API (`POST /api/prompts`, `PATCH /api/prompts/[id]`, `POST /api/prompts/[id]` to set default) — it does steps 2–4 for you, including the version arithmetic that a hand-rolled insert got wrong twice.
+
+### Current defaults
+
+Verified against production by `node scripts/audit/doc-enum-drift.mjs` — this table is checked, not remembered. Last confirmed 2026-09-02.
 
 | Type | Name | Version | Key features |
 |------|------|---------|-------------|
-| OCR | Standard OCR | v10 | `<script>` tag, calibrated `<unclear>` (5-15%), manuscript rules |
-| Translation | Standard Translation | v8 | XML tags (`<note>`, `<term>`, `<gloss>`), no brackets, multilingual |
-| Translation | Latin | v2 | Neo-Latin specific |
-| Translation | German | v2 | Early Modern German specific |
-| Translation | Cuneiform | v1 | Sumerian/Akkadian specific |
+| `ocr` | Standard OCR | v15 | `<script>` tag, calibrated `<unclear>` (5-15%), manuscript rules |
+| `translation` | Standard Translation | v12 | XML tags (`<note>`, `<term>`, `<gloss>`), no brackets, multilingual |
+| `summary` | Standard Summary | v1 | Page-level 3–5 sentence summary, `<meta>` continuity marker |
+| `image_extraction` | Image Extraction | v2 | Illustration detection + museum-style metadata |
+| `english_modernization` | English Modernization | v1 | English books are modernized, not translated |
+
+Non-default prompts are selected by book language, not by the flag above (`LANGUAGE_OCR_PROMPT_NAMES` / `LANGUAGE_TRANSLATION_PROMPT_NAMES` in `src/lib/prompts.ts`): Latin OCR (Neo-Latin) v4, German OCR (Fraktur) v5, Hebrew OCR v1, Arabic OCR v1, Latin Translation (Neo-Latin) v2, German Translation (Early Modern) v3, Hebrew Translation v1, Arabic Translation v1, Cuneiform OCR/Translation v1.
+
+| Type | Name | Version | Key features |
+|------|------|---------|-------------|
 | Index/Summary | Inline | INDEX_PROMPT_VERSION = 'inline-2026-05' | Themes/quotes/people/places/concepts batch extraction |
+
+That last one is not in `prompts` at all — it is a constant in the route/worker, so it has no `is_default` and the audit cannot cover it. Bump it by hand.
 
 ## 2. Page Revisions — What Was on This Page Before?
 

--- a/.github/workflows/prompt-defaults-watch.yml
+++ b/.github/workflows/prompt-defaults-watch.yml
@@ -1,0 +1,92 @@
+name: Prompt defaults watch
+
+# The ratchet half of #3614. Two failures, both silent, both caught here:
+#
+#   1. Two `is_default: true` rows for one prompt `type`. Every OCR/translation/
+#      summary call resolves its prompt with `findOne({ type, is_default: true })`
+#      — 17 call sites, most with no sort — so a second default makes "which
+#      prompt produced this text" a matter of natural order. The unversioned
+#      summary row also stamped `prompt_version: undefined` onto its output.
+#   2. The "Current defaults" table in `.claude/docs/data-provenance.md` drifting
+#      away from the versions actually running. It said OCR v10 while production
+#      ran v15. Nothing caught it: the doc is living, referenced and undated, so
+#      it passes every check in doc-staleness.mjs.
+#
+# `prompts` holds ~55 documents, so unlike the enum half of the same script this
+# runs in a second from anywhere — hence `--only=defaults`. The enum half still
+# needs a Hetzner-scale scan of `pages` and stays a manual run.
+#
+# Findings go to a tracking issue, not a red X on a contributor's PR. Red is
+# reserved for the detector being unable to measure at all.
+
+on:
+  schedule:
+    # Weekly, Wednesdays 08:00 UTC.
+    - cron: '0 8 * * 3'
+  # Runs on PRs that touch the prompt path: the doc table and the write boundary
+  # are both editable in a PR, and this is the cheapest moment to notice.
+  pull_request:
+    paths:
+      - '.claude/docs/data-provenance.md'
+      - 'src/lib/prompts.ts'
+      - 'src/app/api/prompts/**'
+      - 'scripts/audit/doc-enum-drift.mjs'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  prompt-defaults:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci --ignore-scripts
+
+      - name: Audit active prompt defaults
+        id: run
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          set +e
+          node scripts/audit/doc-enum-drift.mjs --only=defaults --fail-on-findings > report.txt 2>&1
+          echo "fired=$?" >> "$GITHUB_OUTPUT"
+          cat report.txt
+
+      # Exit 1 is a measurement, exit 2 is the instrument. Branching on `!= 0`
+      # is the single line that filed three weeks of fabricated findings from a
+      # missing MONGODB_URI on a sibling workflow — see
+      # .claude/docs/invariants/measurement-instruments.md.
+      - name: File findings
+        if: steps.run.outputs.fired == '1' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Prompt defaults drift — $(date -u +'%Y-%m-%d')"
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "Either the \`prompts\` collection broke an invariant (two defaults for one type, or a non-numeric \`version\`) or the \"Current defaults\" table in \`.claude/docs/data-provenance.md\` no longer names the versions in production. Both are actionable and the report says which. Repair: \`node --env-file=.env.production.local scripts/maintenance/repair-prompt-defaults-3614.mjs\` for the rows, an edit for the table." \
+            "$(cat report.txt)")
+          EXISTING=$(gh issue list --search "Prompt defaults drift in:title" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label pipeline
+          fi
+
+      # On a PR the finding IS the review signal, so fail the check rather than
+      # filing an issue nobody links to the diff that caused it.
+      - name: Fail the PR check on findings
+        if: steps.run.outputs.fired == '1' && github.event_name == 'pull_request'
+        run: |
+          echo "::error::The documented prompt defaults no longer match production, or the collection broke an invariant. See the report above."
+          exit 1
+
+      - name: Fail if the audit could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::prompt-defaults audit could not run (exit ${{ steps.run.outputs.fired }}) — nothing was measured. Check the MONGODB_URI repo secret."
+          exit 1

--- a/scripts/audit/doc-enum-drift.mjs
+++ b/scripts/audit/doc-enum-drift.mjs
@@ -18,6 +18,17 @@
  * `doc-staleness.mjs`. Schema drift is a distinct failure mode: the prose stays
  * true-looking while the world adds a value underneath it.
  *
+ * SECOND CHECK: ACTIVE DEFAULTS (#3614). Same failure mode, different shape. The
+ * doc's "Current defaults" table is not an enum but a set of pointers at live
+ * rows, and it rotted the same way — it said OCR v10 while production ran v15,
+ * translation v8 while production ran v12. And underneath it the collection
+ * itself had drifted: TWO `is_default: true` rows for `summary`, so which prompt
+ * produced a summary was decided by natural order, and `version` was mixed
+ * string and number (`1` vs `'v1'`), which makes every `sort({version:-1})` in
+ * the codebase follow BSON type order rather than intent. So this half asserts
+ * three things: exactly one default per type, numeric versions, and a doc table
+ * that names the versions actually running.
+ *
  * THE CHECK. For each registered (collection, field, doc) triple: read the
  * distinct values from production, and require that each one appears SOMEWHERE
  * in the doc's text. That is deliberately crude — it does not parse structure,
@@ -28,14 +39,23 @@
  * fail the run: a legitimate enum value can simply have no rows yet, and a
  * writer that has not fired is not a documentation defect.
  *
- * Needs MONGODB_URI. WITHOUT IT THIS REPORTS "NOT RUN" AND EXITS NON-ZERO under
- * --fail-on-findings, rather than printing a clean pass — an unrun check that
- * looks green is how the leak audit in CLAUDE.md nearly shipped twice.
+ * EXIT CONTRACT (under --fail-on-findings), per
+ * `.claude/docs/invariants/measurement-instruments.md`:
  *
- * RUN IT ON HETZNER, not a laptop. The exact mode scans `pages` twice (19.1M
- * docs each) and takes longer than a consumer connection reliably stays up --
- * two of three attempts on 2026-08-04/05 died on a network blip mid-scan. The
- * scans are the point, so the fix is where you run it, not a weaker check.
+ *   0  ran, clean
+ *   1  ran, FOUND something — file the finding
+ *   2  COULD NOT RUN (no MONGODB_URI, connection died mid-scan) — go red
+ *
+ * Never branch a finding on `!= 0`. An unrun check that looks green, or an
+ * infrastructure failure filed as a corpus finding, are both how this family of
+ * detector has lied before.
+ *
+ * RUN THE ENUM HALF ON HETZNER, not a laptop. The exact mode scans `pages` twice
+ * (19.1M docs each) and takes longer than a consumer connection reliably stays
+ * up -- two of three attempts on 2026-08-04/05 died on a network blip mid-scan.
+ * The scans are the point, so the fix is where you run it, not a weaker check.
+ * The defaults half reads 55 documents and runs anywhere in a second, which is
+ * why `--only=defaults` is what the scheduled workflow uses.
  *
  *   set -a; source .env.production.local; set +a
  *   node scripts/audit/doc-enum-drift.mjs
@@ -43,6 +63,8 @@
  *   node scripts/audit/doc-enum-drift.mjs --json
  *   node scripts/audit/doc-enum-drift.mjs --fast     # sample big collections;
  *                                                    # can only find, never clear
+ *   node scripts/audit/doc-enum-drift.mjs --only=defaults   # active prompts only
+ *   node scripts/audit/doc-enum-drift.mjs --only=enums      # documented enums only
  */
 import { MongoClient } from 'mongodb';
 import { readFileSync, existsSync } from 'node:fs';
@@ -51,6 +73,13 @@ const args = process.argv.slice(2);
 const asJson = args.includes('--json');
 const failOnFindings = args.includes('--fail-on-findings');
 const fast = args.includes('--fast');   // opt IN to sampling; exact is the default
+const only = (args.find(a => a.startsWith('--only='))?.slice(7) || 'all');
+if (!['all', 'enums', 'defaults'].includes(only)) {
+  console.error(`unknown --only=${only} (expected: enums | defaults)`);
+  process.exit(2);
+}
+const runEnums = only === 'all' || only === 'enums';
+const runDefaults = only === 'all' || only === 'defaults';
 /** Above this many documents, discover values by $sample rather than a full scan. */
 const EXACT_MAX = 2_000_000;
 const SAMPLE_SIZE = 50_000;
@@ -65,6 +94,13 @@ const SAMPLE_SIZE = 50_000;
  * one-off typos); keep it near-empty and justified inline.
  */
 const REGISTRY = [
+  {
+    label: 'prompts.type (active defaults)',
+    collection: 'prompts',
+    field: 'type',
+    doc: '.claude/docs/data-provenance.md',
+    note: 'Prompt type vocabulary. See the separate active-defaults check below for the version/uniqueness invariants.',
+  },
   {
     label: 'page_revisions.source',
     collection: 'page_revisions',
@@ -100,15 +136,75 @@ const REGISTRY = [
   },
 ];
 
+/** Where the "Current defaults" table lives, and how a live default must appear in it. */
+const DEFAULTS_DOC = '.claude/docs/data-provenance.md';
+
+/**
+ * `'v12'` → 12, `12` → 12. Anything else (missing field, `'latest'`) → null,
+ * which this check reports rather than repairs — see
+ * `scripts/maintenance/repair-prompt-defaults-3614.mjs`.
+ */
+function parseVersion(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') { const m = /^v?(\d+)$/i.exec(v.trim()); if (m) return Number(m[1]); }
+  return null;
+}
+
+/**
+ * The active-prompt invariants. Deliberately three separate assertions, because
+ * they fail independently and a run that reports only the doc mismatch would
+ * have missed the live bug in #3614.
+ */
+async function checkPromptDefaults(db) {
+  const out = { doc: DEFAULTS_DOC, duplicates: [], missingDefault: [], nonNumeric: [], docDrift: [], defaults: [] };
+  const rows = await db.collection('prompts').find({}).toArray();
+  out.total = rows.length;
+
+  for (const p of rows) {
+    if (parseVersion(p.version) === null) {
+      out.nonNumeric.push({ id: String(p._id), type: p.type, name: p.name ?? null, version: p.version ?? null });
+    }
+  }
+
+  const types = [...new Set(rows.map(p => p.type).filter(Boolean))].sort();
+  for (const type of types) {
+    const defs = rows.filter(p => p.type === type && p.is_default === true);
+    if (defs.length === 0) { out.missingDefault.push(type); continue; }
+    if (defs.length > 1) {
+      out.duplicates.push({ type, rows: defs.map(p => ({ id: String(p._id), name: p.name ?? null, version: p.version ?? null })) });
+    }
+    for (const p of defs) out.defaults.push({ type, id: String(p._id), name: p.name ?? null, version: parseVersion(p.version), rawVersion: p.version ?? null });
+  }
+
+  // Doc table. Crude on purpose, exactly like the enum half: find a line that
+  // names the prompt, then check the version token on that line. A reformatted
+  // table still passes; a stale version number does not.
+  if (!existsSync(DEFAULTS_DOC)) {
+    out.docMissing = true;
+    return out;
+  }
+  const lines = readFileSync(DEFAULTS_DOC, 'utf8').split('\n');
+  for (const d of out.defaults) {
+    if (!d.name) { out.docDrift.push({ ...d, reason: 'live default has no `name` — nothing to match in the doc, and its output records prompt_name: undefined' }); continue; }
+    const line = lines.find(l => l.includes(d.name) && /\bv\d+\b/.test(l));
+    if (!line) { out.docDrift.push({ ...d, reason: `no line in the doc names "${d.name}" with a version` }); continue; }
+    const documented = [...line.matchAll(/\bv(\d+)\b/g)].map(m => Number(m[1]));
+    if (d.version === null || !documented.includes(d.version)) {
+      out.docDrift.push({ ...d, reason: `doc says v${documented.join('/v')}, production runs v${d.version}` });
+    }
+  }
+  return out;
+}
+
 async function main() {
   const uri = process.env.MONGODB_URI;
   if (!uri) {
-    const msg = 'NOT RUN — MONGODB_URI is unset. This check cannot pass without a database; treat this as a finding, not a skip.';
+    const msg = 'NOT RUN — MONGODB_URI is unset. This check cannot pass without a database; this is exit 2 (instrument failure), NOT a finding.';
     console.log(asJson ? JSON.stringify({ status: 'not_run', reason: msg }, null, 2) : `\n${msg}\n`);
     // process.exitCode, never process.exit(): exit() discards buffered stdout
     // when stdout is a PIPE rather than a tty, so the report vanishes in CI and
     // under any redirect -- the exact places this check is meant to speak up.
-    if (failOnFindings) process.exitCode = 1;
+    if (failOnFindings) process.exitCode = 2;
     return;
   }
 
@@ -122,8 +218,10 @@ async function main() {
   // hangs FOREVER. Observed 2026-08-04 -- a DNS blip left a run alive 2h43m,
   // printing its error and then simply never exiting.
   const findings = [];
+  let defaults = null;
   try {
-  for (const entry of REGISTRY) {
+  if (runDefaults) defaults = await checkPromptDefaults(db);
+  for (const entry of runEnums ? REGISTRY : []) {
     if (!existsSync(entry.doc)) {
       findings.push({ ...entry, kind: 'missing_doc', undocumented: [], phantom: [] });
       continue;
@@ -187,7 +285,7 @@ async function main() {
   }
 
   if (asJson) {
-    console.log(JSON.stringify({ status: 'ran', findings }, null, 2));
+    console.log(JSON.stringify({ status: 'ran', findings, prompt_defaults: defaults }, null, 2));
   } else {
     console.log('');
     for (const f of findings) {
@@ -217,11 +315,42 @@ async function main() {
       if (f.phantom.length) console.log(`    (documented but absent from production: ${f.phantom.join(', ')} — informational)`);
       console.log('');
     }
+
+    const d = defaults;
+    if (d) {
+    const head = `prompts active defaults  ->  ${d.doc}`;
+    const clean = !d.duplicates.length && !d.missingDefault.length && !d.nonNumeric.length && !d.docDrift.length && !d.docMissing;
+    console.log(clean ? `✓ ${head}` : `✗ ${head}`);
+    if (d.docMissing) console.log('    doc file does not exist');
+    for (const dup of d.duplicates) {
+      console.log(`    ${dup.type}: ${dup.rows.length} rows with is_default:true — the lookup picks one by natural order, not intent`);
+      for (const r of dup.rows) console.log(`      ${r.id}  "${r.name}"  version=${JSON.stringify(r.version)}`);
+    }
+    for (const t of d.missingDefault) console.log(`    ${t}: NO default — every lookup for this type silently falls back to the hardcoded prompt`);
+    if (d.nonNumeric.length) {
+      console.log(`    ${d.nonNumeric.length} rows whose \`version\` is not a number — sort({version:-1}) follows BSON type order, not intent:`);
+      for (const r of d.nonNumeric) console.log(`      ${r.id}  ${r.type}/${r.name}  version=${JSON.stringify(r.version)}`);
+    }
+    for (const dd of d.docDrift) console.log(`    ${dd.type} "${dd.name}": ${dd.reason}`);
+    if (clean) {
+      console.log(`    ${d.defaults.length} types, one default each, all documented at the running version:`);
+      for (const x of d.defaults) console.log(`      ${x.type.padEnd(22)} "${x.name}" v${x.version}`);
+    } else {
+      console.log('    Repair rows with: node --env-file=.env.production.local scripts/maintenance/repair-prompt-defaults-3614.mjs');
+      console.log(`    Repair the table by editing the "Current defaults" section of ${d.doc}`);
+    }
+    console.log('');
+    }
   }
 
   // A sampled entry never counts as passing, even with nothing found.
   const bad = findings.filter(f => f.kind !== 'ok' || f.sampled);
-  if (bad.length && failOnFindings) process.exitCode = 1;   // not process.exit() -- see above
+  const defaultsBad = defaults && (defaults.docMissing || defaults.duplicates.length ||
+    defaults.missingDefault.length || defaults.nonNumeric.length || defaults.docDrift.length);
+  if ((bad.length || defaultsBad) && failOnFindings) process.exitCode = 1;   // not process.exit() -- see above
 }
 
-main().catch(e => { console.error(e); process.exitCode = 1; });
+// An uncaught throw is an INSTRUMENT failure (exit 2), never a finding (exit 1):
+// a connection that dies mid-scan measured nothing, and filing that as a corpus
+// finding is precisely the mistake in measurement-instruments.md.
+main().catch(e => { console.error(e); process.exitCode = 2; });

--- a/scripts/maintenance/repair-prompt-defaults-3614.mjs
+++ b/scripts/maintenance/repair-prompt-defaults-3614.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Repair the `prompts` collection's provenance invariants (#3614).
+ *
+ * WHY THIS EXISTS. Every OCR/translation/summary/modernization call resolves its
+ * prompt with `findOne({ type, is_default: true })` — 17 call sites across
+ * `src/lib/prompts.ts`, the workers, and the batch scripts, most of them with no
+ * sort at all. That query is only well-defined if EXACTLY ONE row per type
+ * carries the flag. On 2026-09-02 `summary` had two, one of them with no
+ * `version` field, so which prompt produced a summary was decided by natural
+ * order — and the unversioned row stamps `prompt_version: undefined` onto the
+ * page, breaking the chain `.claude/docs/data-provenance.md` exists to
+ * guarantee.
+ *
+ * FOUR REPAIRS, each independently reported and skippable:
+ *
+ *   1. is_default  — keep exactly one per `type`. The keeper is the highest
+ *      normalised version, tie-broken by newest `created_at`. Losers are $set to
+ *      false (never deleted — prompts are immutable audit rows).
+ *   2. version     — normalise to a NUMBER. `'v1'` → `1`; a missing field → `0`
+ *      (these are pre-versioning rows from 2025-12 and sort oldest either way,
+ *      so 0 preserves the existing order while making every comparison typed).
+ *      Mixed string/number made `sort({version:-1})` follow BSON type order
+ *      rather than intent, and printed defaults as `vundefined` and `vv1`.
+ *   3. name        — two rows have no `name` at all, one of them the LIVE
+ *      image_extraction default, so its output records `prompt_name: undefined`.
+ *      Backfilled from the type's canonical name only when that name is
+ *      unambiguous for the type; otherwise reported and left alone.
+ *   4. content_hash — recomputed (md5 of content, same as `promptContentHash`)
+ *      where missing. The hash is the cryptographic verifier that ties stored
+ *      text back to the prompt that made it.
+ *
+ * THEN THE ACTUAL GUARD. With duplicates gone, `--apply` creates a UNIQUE
+ * PARTIAL INDEX on `{ type: 1 }` where `is_default: true`. From then on a writer
+ * that inserts a second default fails loudly with E11000 instead of silently
+ * forking provenance. Every existing writer already unsets the old default
+ * BEFORE inserting the new one, so none of them are broken by this. The index
+ * build will REFUSE if duplicates remain — that is the verification step, not a
+ * failure to work around.
+ *
+ * THIS ACTUATES THE PIPELINE. The `prompts` collection is read by the
+ * translate/OCR workers on every job. Read the dry run before applying and
+ * confirm the keeper is the prompt you want live.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/repair-prompt-defaults-3614.mjs           # dry run
+ *   node --env-file=.env.production.local scripts/maintenance/repair-prompt-defaults-3614.mjs --apply   # write
+ *   ... --apply --skip-index      # repair rows but do not create the unique index
+ */
+import { MongoClient } from 'mongodb';
+import { createHash } from 'crypto';
+
+const APPLY = process.argv.includes('--apply');
+const SKIP_INDEX = process.argv.includes('--skip-index');
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+/**
+ * The one canonical prompt name per type, used ONLY to backfill a missing
+ * `name`. A type absent from this map, or one whose rows disagree with it, is
+ * reported rather than guessed.
+ */
+const CANONICAL_NAME_BY_TYPE = {
+  ocr: 'Standard OCR',
+  translation: 'Standard Translation',
+  summary: 'Standard Summary',
+  image_extraction: 'Image Extraction',
+  english_modernization: 'English Modernization',
+};
+
+/** `'v12'` → 12, `12` → 12, missing → 0. Anything else → null (report, don't guess). */
+function normalizeVersion(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (v === undefined || v === null) return 0;
+  if (typeof v === 'string') {
+    const m = /^v?(\d+)$/i.exec(v.trim());
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const prompts = db.collection('prompts');
+
+const rows = await prompts.find({}).toArray();
+console.log(`\n${rows.length} prompt rows${APPLY ? '' : '  (DRY RUN — no writes)'}\n`);
+
+const writes = [];   // { _id, set: {...}, why }
+let unparseable = 0;
+
+// --- 2. version typing (computed first: repairs 1 and 3 both depend on it) ---
+const versionOf = new Map();
+for (const p of rows) {
+  const norm = normalizeVersion(p.version);
+  if (norm === null) {
+    console.log(`✗ version unparseable, left alone: ${p._id} ${p.type}/${p.name} version=${JSON.stringify(p.version)}`);
+    unparseable++;
+    versionOf.set(String(p._id), -1);
+    continue;
+  }
+  versionOf.set(String(p._id), norm);
+  if (p.version !== norm) {
+    writes.push({ _id: p._id, set: { version: norm },
+      why: `version ${JSON.stringify(p.version)} (${typeof p.version}) → ${norm}` });
+  }
+}
+
+// --- 1. exactly one is_default per type ---
+const byType = new Map();
+for (const p of rows) {
+  if (p.is_default !== true) continue;
+  if (!byType.has(p.type)) byType.set(p.type, []);
+  byType.get(p.type).push(p);
+}
+for (const [type, defaults] of byType) {
+  if (defaults.length === 1) {
+    const [p] = defaults;
+    console.log(`✓ ${type}: one default — "${p.name}" v${versionOf.get(String(p._id))} (${p._id})`);
+    continue;
+  }
+  // Keeper: highest normalised version, tie-broken by newest created_at.
+  const sorted = [...defaults].sort((a, b) => {
+    const dv = versionOf.get(String(b._id)) - versionOf.get(String(a._id));
+    if (dv !== 0) return dv;
+    return new Date(b.created_at || 0) - new Date(a.created_at || 0);
+  });
+  const [keeper, ...losers] = sorted;
+  console.log(`✗ ${type}: ${defaults.length} rows with is_default:true`);
+  console.log(`    KEEP  "${keeper.name}" v${versionOf.get(String(keeper._id))} (${keeper._id}) created ${keeper.created_at?.toISOString?.().slice(0, 10)}`);
+  for (const l of losers) {
+    console.log(`    UNSET "${l.name}" v${versionOf.get(String(l._id))} (${l._id}) created ${l.created_at?.toISOString?.().slice(0, 10)}`);
+    writes.push({ _id: l._id, set: { is_default: false },
+      why: `${type}: demoted duplicate default "${l.name}"` });
+  }
+}
+for (const type of Object.keys(CANONICAL_NAME_BY_TYPE)) {
+  const present = rows.some(p => p.type === type);
+  if (present && !byType.has(type)) console.log(`✗ ${type}: NO default at all — every lookup for this type falls back to the hardcoded prompt`);
+}
+
+// --- 3. missing name ---
+for (const p of rows) {
+  if (typeof p.name === 'string' && p.name.trim()) continue;
+  const canonical = CANONICAL_NAME_BY_TYPE[p.type];
+  if (!canonical) { console.log(`✗ nameless row ${p._id} type=${p.type} — no canonical name for this type, left alone`); continue; }
+  console.log(`✗ nameless row ${p._id} type=${p.type} v${versionOf.get(String(p._id))} → "${canonical}"${p.is_default ? '  (this is the LIVE default — its output records prompt_name: undefined)' : ''}`);
+  writes.push({ _id: p._id, set: { name: canonical }, why: `name backfilled → "${canonical}"` });
+}
+
+// --- 4. missing content_hash ---
+for (const p of rows) {
+  if (typeof p.content_hash === 'string' && p.content_hash) continue;
+  if (typeof p.content !== 'string' || !p.content) { console.log(`✗ ${p._id} ${p.type}/${p.name} has no content — cannot hash, left alone`); continue; }
+  const hash = createHash('md5').update(p.content).digest('hex');
+  console.log(`✗ ${p._id} ${p.type}/${p.name} v${versionOf.get(String(p._id))} missing content_hash → ${hash}`);
+  writes.push({ _id: p._id, set: { content_hash: hash }, why: 'content_hash recomputed' });
+}
+
+// --- report + write ---
+const merged = new Map();
+for (const w of writes) {
+  const k = String(w._id);
+  if (!merged.has(k)) merged.set(k, { _id: w._id, set: {}, why: [] });
+  Object.assign(merged.get(k).set, w.set);
+  merged.get(k).why.push(w.why);
+}
+
+console.log(`\n${merged.size} rows to update, ${writes.length} field changes` + (unparseable ? `, ${unparseable} unparseable versions skipped` : ''));
+
+if (!APPLY) {
+  console.log('\nDry run. Re-run with --apply to write.\n');
+} else if (merged.size) {
+  const ops = [...merged.values()].map(m => ({ updateOne: { filter: { _id: m._id }, update: { $set: m.set } } }));
+  const res = await prompts.bulkWrite(ops, { ordered: false });
+  console.log(`\napplied: ${res.modifiedCount} rows modified`);
+}
+
+// --- the guard: unique partial index on the default flag ---
+const INDEX_NAME = 'uniq_default_per_type';
+if (APPLY && !SKIP_INDEX) {
+  const existing = await prompts.indexes();
+  if (existing.some(i => i.name === INDEX_NAME)) {
+    console.log(`index ${INDEX_NAME} already present`);
+  } else {
+    try {
+      await prompts.createIndex({ type: 1 }, {
+        name: INDEX_NAME,
+        unique: true,
+        partialFilterExpression: { is_default: true },
+      });
+      console.log(`index ${INDEX_NAME} created — a second is_default:true for a type now fails with E11000`);
+    } catch (e) {
+      console.error(`\nINDEX BUILD FAILED — duplicates remain. Do not work around this; fix the data.\n${e.message}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+// --- verify ---
+const after = await prompts.aggregate([
+  { $match: { is_default: true } },
+  { $group: { _id: '$type', n: { $sum: 1 }, names: { $push: '$name' } } },
+  { $sort: { _id: 1 } },
+]).toArray();
+console.log('\ndefaults per type' + (APPLY ? '' : ' (unchanged — dry run)') + ':');
+for (const t of after) console.log(`  ${t.n === 1 ? '✓' : '✗'} ${t._id}: ${t.n}  ${t.names.join(', ')}`);
+if (after.some(t => t.n !== 1)) process.exitCode = 1;
+
+await client.close();

--- a/src/app/api/prompts/[id]/route.ts
+++ b/src/app/api/prompts/[id]/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import type { Prompt } from '@/lib/types';
 import { withAuth } from '@/lib/auth-helpers';
-import { promptContentHash } from '@/lib/prompts';
+import { promptContentHash, nextPromptVersion } from '@/lib/prompts';
 
 // Helper to extract variables from prompt text
 function extractVariables(text: string): string[] {
@@ -62,13 +62,13 @@ export const PATCH = withAuth(async (
       return NextResponse.json({ error: 'Prompt not found' }, { status: 404 });
     }
 
-    // Get the latest version for this prompt name
-    const latestVersion = await collection.findOne(
-      { name: existingPrompt.name },
-      { sort: { version: -1 } }
+    // Scoped to (type, name) and parsed, not `+ 1` on a raw field: the raw form
+    // turned `'v1'` into `'v11'` and a missing version into `NaN` (#3614).
+    const newVersion = await nextPromptVersion(
+      collection,
+      existingPrompt.type as string,
+      existingPrompt.name as string
     );
-
-    const newVersion = (latestVersion?.version || 0) + 1;
 
     // If setting as default, unset current default for this type
     if (setAsDefault) {

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { DEFAULT_PROMPTS, LATIN_PROMPTS, GERMAN_PROMPTS } from '@/lib/types';
 import type { Prompt, PromptType } from '@/lib/types';
 import { withAuth, getSession } from '@/lib/auth-helpers';
-import { promptContentHash } from '@/lib/prompts';
+import { promptContentHash, nextPromptVersion } from '@/lib/prompts';
 
 // Helper to extract variables from prompt text
 function extractVariables(text: string): string[] {
@@ -97,13 +97,13 @@ export const POST = withAuth(async (request: NextRequest) => {
     const db = await getDb();
     const collection = db.collection('prompts');
 
-    // Get the latest version for this name
+    // Version arithmetic goes through the shared helper: `latestVersion.version + 1`
+    // turned `'v1'` into `'v11'` and a missing field into `NaN` (#3614).
     const latestVersion = await collection.findOne(
-      { name },
-      { sort: { version: -1 } }
+      { type, name },
+      { sort: { version: -1, created_at: -1 } }
     );
-
-    const newVersion = latestVersion ? latestVersion.version + 1 : 1;
+    const newVersion = await nextPromptVersion(collection, type, name);
     const variables = extractVariables(promptText);
 
     // If setting as default, unset current default for this type

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -9,6 +9,40 @@ export function promptContentHash(content: string): string {
 }
 
 /**
+ * Coerce a stored `prompts.version` to a number.
+ *
+ * The field held a mix of numbers, `'v1'` strings, and nothing at all until
+ * #3614, which is how `latestVersion.version + 1` produced `'v11'` from `'v1'`
+ * and `NaN` from a missing field, and how `sort({ version: -1 })` came to follow
+ * BSON type order rather than intent. Pre-versioning rows are 0.
+ */
+export function parsePromptVersion(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') {
+    const m = /^v?(\d+)$/i.exec(v.trim());
+    if (m) return Number(m[1]);
+  }
+  return 0;
+}
+
+/**
+ * Next version number for a prompt lineage, scoped to (type, name).
+ *
+ * Scoped, because `name` alone collides across types the moment two types share
+ * a name; and computed with $max over parsed values rather than a sort, so one
+ * unrepaired string row cannot decide the answer.
+ */
+export async function nextPromptVersion(
+  collection: { find: (q: Record<string, unknown>, o?: Record<string, unknown>) => { toArray: () => Promise<Array<{ version?: unknown }>> } },
+  type: string,
+  name: string
+): Promise<number> {
+  const rows = await collection.find({ type, name }, { projection: { version: 1 } }).toArray();
+  const max = rows.reduce((acc, r) => Math.max(acc, parsePromptVersion(r.version)), 0);
+  return max + 1;
+}
+
+/**
  * Result of looking up a prompt - includes both the text and a reference for storage
  */
 export interface PromptLookupResult {
@@ -55,16 +89,20 @@ export async function getPrompt(
       const { ObjectId } = await import('mongodb');
       prompt = await collection.findOne({ _id: new ObjectId(options.id) });
     } else if (options?.name) {
-      // Look up by name (get latest version)
+      // Look up by name (get latest version). Scoped by type: `name` alone
+      // collides the moment two types share one.
       prompt = await collection.findOne(
-        { name: options.name },
-        { sort: { version: -1 } }
+        { type, name: options.name },
+        { sort: { version: -1, created_at: -1 } }
       );
     } else {
-      // Get default prompt for this type
+      // Get default prompt for this type. Exactly one row per type should carry
+      // the flag (unique partial index, #3614) — the sort is the tie-break that
+      // keeps this deterministic if that ever slips again, rather than letting
+      // natural order decide which prompt made a reader-facing text.
       prompt = await collection.findOne(
         { type, is_default: true },
-        { sort: { version: -1 } }
+        { sort: { version: -1, created_at: -1 } }
       );
     }
 
@@ -75,7 +113,10 @@ export async function getPrompt(
         reference: {
           id: prompt._id?.toString() || 'unknown',
           name: prompt.name as string,
-          version: (prompt.version as number) || 1,
+          // parse, don't `|| 1`: an unversioned row used to record itself as v1,
+          // pointing provenance at a prompt that never produced the text. 0 is
+          // the established "no real DB version" sentinel (see fallbacks below).
+          version: parsePromptVersion(prompt.version),
           content_hash: (prompt.content_hash as string) || promptContentHash(content),
         },
       };
@@ -192,7 +233,7 @@ export async function getTranslationPrompt(
       const db = await getDb();
       const doc = await db.collection('prompts').findOne(
         { type: 'english_modernization', is_default: true },
-        { sort: { version: -1 } }
+        { sort: { version: -1, created_at: -1 } }
       );
       if (doc?.content) {
         const content = doc.content as string;
@@ -201,7 +242,7 @@ export async function getTranslationPrompt(
           reference: {
             id: doc._id?.toString() || 'unknown',
             name: (doc.name as string) || 'English Modernization',
-            version: (doc.version as number) || 1,
+            version: parsePromptVersion(doc.version),
             content_hash: (doc.content_hash as string) || promptContentHash(content),
           },
         };

--- a/tests/unit/prompt-version.test.ts
+++ b/tests/unit/prompt-version.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { parsePromptVersion, nextPromptVersion } from '@/lib/prompts';
+
+/**
+ * #3614. `prompts.version` held numbers, `'v1'` strings, and nothing at all, so
+ * `latestVersion.version + 1` produced `'v11'` from `'v1'` and `NaN` from a
+ * missing field, and `sort({version: -1})` followed BSON type order rather than
+ * intent. These are the two functions that now stand between that mix and every
+ * new prompt version.
+ */
+describe('parsePromptVersion', () => {
+  it('passes numbers through', () => {
+    expect(parsePromptVersion(12)).toBe(12);
+    expect(parsePromptVersion(0)).toBe(0);
+  });
+
+  it('parses the `v`-prefixed strings that were mixed into the collection', () => {
+    expect(parsePromptVersion('v1')).toBe(1);
+    expect(parsePromptVersion('V12')).toBe(12);
+    expect(parsePromptVersion(' 3 ')).toBe(3);
+  });
+
+  it('returns 0 — not 1 — for a pre-versioning row', () => {
+    // The old `x || 1` recorded an unversioned row as v1, pointing provenance at
+    // a prompt that never produced the text. 0 is the "no real DB version"
+    // sentinel the hardcoded fallbacks already use.
+    expect(parsePromptVersion(undefined)).toBe(0);
+    expect(parsePromptVersion(null)).toBe(0);
+    expect(parsePromptVersion('latest')).toBe(0);
+    expect(parsePromptVersion(NaN)).toBe(0);
+  });
+});
+
+describe('nextPromptVersion', () => {
+  const fakeCollection = (rows: Array<{ version?: unknown }>) => ({
+    find: () => ({ toArray: async () => rows }),
+  });
+
+  it('is max + 1 over PARSED versions, not over raw sort order', async () => {
+    // The exact mix that was live: a string, a number, and a missing field.
+    const coll = fakeCollection([{ version: 'v1' }, { version: 12 }, {}]);
+    expect(await nextPromptVersion(coll, 'translation', 'Standard Translation')).toBe(13);
+  });
+
+  it('starts a new lineage at 1', async () => {
+    expect(await nextPromptVersion(fakeCollection([]), 'ocr', 'Brand New OCR')).toBe(1);
+  });
+
+  it('never returns a string, whatever the rows hold', async () => {
+    const next = await nextPromptVersion(fakeCollection([{ version: 'v9' }]), 'ocr', 'Standard OCR');
+    expect(typeof next).toBe('number');
+    expect(next).toBe(10);
+  });
+
+  it('scopes the query to (type, name) — name alone collides across types', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const coll = {
+      find: (q: Record<string, unknown>) => { seen.push(q); return { toArray: async () => [] }; },
+    };
+    await nextPromptVersion(coll, 'summary', 'Standard Summary');
+    expect(seen).toEqual([{ type: 'summary', name: 'Standard Summary' }]);
+  });
+});


### PR DESCRIPTION
Closes #3614.

## The live bug

`summary` had **two rows with `is_default: true`**. Every prompt lookup in the codebase is `findOne({ type, is_default: true })` — 17 call sites across `src/lib/prompts.ts`, the workers and the batch scripts, and most pass no sort at all — so which prompt produced a summary was decided by natural order rather than intent. The loser had no `version` field, so anything resolved through it recorded `prompt_version: undefined`, breaking the chain `data-provenance.md` exists to guarantee.

Underneath it, `prompts.version` was mixed string and number (`1` vs `'v1'`) and absent on eight rows. That made every `sort({ version: -1 })` follow BSON type order, printed defaults as `vundefined` and `vv1`, and turned the API's `latestVersion.version + 1` into `'v11'`.

## Applied to production

`scripts/maintenance/repair-prompt-defaults-3614.mjs` (dry run by default), run 2026-09-02 — 12 rows, 13 field changes:

- demoted the duplicate `summary` default. Keeper is `69507193…` v1, which is what both natural and sorted order already returned, so **nothing changed about what the workers serve**.
- normalised 9 `version` values to numbers (pre-versioning rows → `0`).
- backfilled two missing `name`s. One is the **live `image_extraction` default**, so its output was recording `prompt_name: undefined`.
- recomputed one missing `content_hash`.

Then it creates a **unique partial index** on `{ type: 1 }` where `is_default: true`. Verified by attempting a duplicate insert: `E11000 … index: uniq_default_per_type`, 55 rows before and after. Every existing writer already unsets the old default before inserting, so none of them are broken by it.

## So it cannot come back

- **`doc-enum-drift.mjs`** now asserts the invariant instead of the doc asking a human to remember it: one default per type, numeric versions, and a "Current defaults" table that names the versions actually running. It also picks up the 0/1/2 exit contract from `measurement-instruments.md` (2 = could not run) — verified by removing `MONGODB_URI` and seeing exit 2 — and a `--only=defaults` mode, because that half reads 55 documents and runs anywhere in a second while the enum half still needs a Hetzner-scale scan of `pages`.
- **`prompt-defaults-watch.yml`**: weekly, plus a PR check on the prompt path. Files an issue on a finding; red only when it cannot measure.
- **Write boundary**: `parsePromptVersion` / `nextPromptVersion` in `src/lib/prompts.ts`, scoped to `(type, name)` and `$max` over parsed values. Lookups are type-scoped and tie-broken by `created_at`. `version: x || 1` no longer fabricates a v1 for an unversioned row. Seven unit tests pin the contract.
- **Doc**: table refreshed (OCR v10→**v15**, translation v8→**v12**, plus the summary / image_extraction / english_modernization rows it never had), and the invariant restated as per-`type`, not per-`(type, name)` — the original wording was wrong about the thing it was guarding.

## Out of scope

The audit surfaced **4 more undocumented `page_revisions.source` values** (`shift-repair-bulkjp2-2026-08` on ~5,024 rows, `health-gate-refused`, `quarantine-fabricated-2026-08`, `blank-guard-refused-2026-08`). That is the enum half of the same script doing its job on a different subject; documenting them belongs in its own PR against `data-provenance.md`, not bundled with a provenance fix.

Also untouched: `Standard Translation` has two rows numbered v12 (one default, one not) and `Standard OCR` skips 4, 7 and 11. Historical, harmless now that lookups are by flag rather than by max version, and renumbering an immutable audit trail would be worse than the gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
