### PR TITLE
fix(ci): prompt-defaults audit off pull_request (#4570 follow-up)

### DIFF
--- a/.github/workflows/prompt-defaults-watch.yml
+++ b/.github/workflows/prompt-defaults-watch.yml
@@ -19,18 +19,21 @@ name: Prompt defaults watch
 # Findings go to a tracking issue, not a red X on a contributor's PR. Red is
 # reserved for the detector being unable to measure at all.
 
+# NOT on pull_request. The audit reads production, and a PR-time DB read cannot
+# work: GitHub withholds secrets from fork PRs, so `MONGODB_URI` is empty there
+# and the run lands in the exit-2 branch below — a red X reading "check the
+# MONGODB_URI repo secret" on a contributor's diff, for a secret they were never
+# meant to have. The first PR to fire this check (#4570) went red for the
+# adjacent reason: the CI Atlas user is collection-scoped and had no read grant
+# on `bookstore.prompts`, which the schedule needs regardless. Same shape as
+# field-sprawl-watch.yml, which keeps its production census off pull_request and
+# gates PRs with a static, no-secrets lint instead. There is no static half of
+# this check to offer — the whole point is comparing the doc table against the
+# rows actually running — so the schedule is the signal.
 on:
   schedule:
     # Weekly, Wednesdays 08:00 UTC.
     - cron: '0 8 * * 3'
-  # Runs on PRs that touch the prompt path: the doc table and the write boundary
-  # are both editable in a PR, and this is the cheapest moment to notice.
-  pull_request:
-    paths:
-      - '.claude/docs/data-provenance.md'
-      - 'src/lib/prompts.ts'
-      - 'src/app/api/prompts/**'
-      - 'scripts/audit/doc-enum-drift.mjs'
   workflow_dispatch: {}
 
 permissions:
@@ -62,7 +65,7 @@ jobs:
       # missing MONGODB_URI on a sibling workflow — see
       # .claude/docs/invariants/measurement-instruments.md.
       - name: File findings
-        if: steps.run.outputs.fired == '1' && github.event_name != 'pull_request'
+        if: steps.run.outputs.fired == '1'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -77,16 +80,8 @@ jobs:
             gh issue create --title "$TITLE" --body "$BODY" --label pipeline
           fi
 
-      # On a PR the finding IS the review signal, so fail the check rather than
-      # filing an issue nobody links to the diff that caused it.
-      - name: Fail the PR check on findings
-        if: steps.run.outputs.fired == '1' && github.event_name == 'pull_request'
-        run: |
-          echo "::error::The documented prompt defaults no longer match production, or the collection broke an invariant. See the report above."
-          exit 1
-
       - name: Fail if the audit could not run
         if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
         run: |
-          echo "::error::prompt-defaults audit could not run (exit ${{ steps.run.outputs.fired }}) — nothing was measured. Check the MONGODB_URI repo secret."
+          echo "::error::prompt-defaults audit could not run (exit ${{ steps.run.outputs.fired }}) — nothing was measured. Check the MONGODB_URI repo secret, and that its Atlas user has a read grant on bookstore.prompts (a 'not authorized on bookstore ... find: \"prompts\"' error in the report above means the grant, not the secret)."
           exit 1


### PR DESCRIPTION
Follow-up to #4570. The `Prompt defaults watch` check that PR added went red on the PR itself ([run 33619624620](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/actions/runs/33619624620)). It was not a finding — it was the exit-2 "instrument could not measure" branch doing exactly what it is there for.

## What actually failed

```
MongoServerError: not authorized on bookstore to execute command
{ find: "prompts", filter: {}, ... }  code: 13, codeName: 'Unauthorized'
```

Authentication **succeeded** — the error carries a signed `$clusterTime`. The CI Atlas user is collection-scoped and simply has no read grant on `bookstore.prompts`. Every sibling workflow using the same `MONGODB_URI` secret is green today (corpus-integrity-watch, field-sprawl-watch, master-copy-watch); they only read `books`, `pages` and `feedback`. `prompts` is a collection CI had never touched, so #4570 was the first thing to find the gap.

The audit and the doc table are both correct. Run against production:

```
✓ prompts active defaults  ->  .claude/docs/data-provenance.md
    5 types, one default each, all documented at the running version:
      english_modernization  "English Modernization" v1
      image_extraction       "Image Extraction" v2
      ocr                    "Standard OCR" v15
      summary                "Standard Summary" v1
      translation            "Standard Translation" v12
```

## In scope

Drops the `pull_request` trigger from the DB-reading job, plus the now-dead "Fail the PR check on findings" step, and names the authorization case in the exit-2 message.

The trigger could never have worked, independently of the Atlas grant: **GitHub withholds secrets from fork PRs**, so an external contributor touching `src/lib/prompts.ts` gets a red X telling them to check a secret they were never meant to have. [field-sprawl-watch.yml](.github/workflows/field-sprawl-watch.yml#L45-L48) already settled this shape — production census on the schedule, a static no-secrets lint at PR time. There is no static half of *this* check to offer, since the whole point is comparing the documented table against the rows actually running, so the weekly schedule is the signal. Findings still go to a tracking issue; red stays reserved for the detector being unable to measure.

## Out of scope — needs a human with Atlas access

**The weekly run is still dead until the CI Atlas user gets a read grant on `bookstore.prompts`.** This PR stops the contributor-facing red X; it does not and cannot fix the authorization. Every Wednesday 08:00 UTC run will exit 2 and file nothing until that grant exists. Worth doing before assuming the #3614 ratchet is live.

Also noticed and deliberately left alone: `daily-quote.yml` has been failing on the schedule since at least 2026-08-30 with `Cannot find module './daily-quote-bot.ts'`. Unrelated to #4570 and to this change — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
