### PR TITLE
feat(review): serve for consensus, and the button volunteers kept typing

### DIFF
--- a/src/lib/review-candidates.ts
+++ b/src/lib/review-candidates.ts
@@ -13,7 +13,24 @@ import { supabaseAdmin } from '@/lib/supabase';
  * in production (17-23s) and gallery-quality took 8.2s. Precomputing the pool
  * moves that cost off the request path entirely. Never reintroduce a `$sample`
  * over `pages` here.
+ *
+ * SELECTION POLICY (2026-09-01). Serving was a plain `$sample` over the pool —
+ * uniformly random, so votes scattered. Measured on the first 104 submissions:
+ * 100 distinct items, 96 with exactly one vote, 4 with two, none with three.
+ * A single vote is an opinion; nothing downstream can use it, so the queue was
+ * accumulating effort and producing no decisions. Selection now prefers items
+ * that are STARTED BUT NOT DECIDED, which turns the same volunteer minutes into
+ * settled items instead of a wider thin spread. Order of preference:
+ *
+ *   1. items with 1..CONSENSUS_TARGET-1 votes  — finish what's started
+ *   2. items with no votes at all              — open a new one
+ *   3. anything else unrated by this volunteer — never stall the queue
  */
+
+/** How many independent judgments make an item decided. One vote is an
+ *  opinion, not a measurement; three is the threshold the gallery-quality
+ *  strategy specifies before a human value may override an AI one. */
+export const CONSENSUS_TARGET = 3;
 
 export type ReviewCandidate = {
   item_id: string;
@@ -59,24 +76,128 @@ async function alreadyRated(queue: string, volunteerId: string): Promise<Set<str
   return seen;
 }
 
+/** How many scored judgments each item in this queue already has.
+ *
+ *  Note-only rows carry `rating IS NULL` and are deliberately NOT counted: a
+ *  note is a report, not a vote, and counting one would mark an item decided
+ *  that nobody actually scored.
+ *
+ *  supabase-js silently caps a select at 1,000 rows — no error, just a short
+ *  array — so this pages explicitly. If the ceiling is ever reached the counts
+ *  are partial, which degrades selection to roughly-random rather than
+ *  producing a wrong answer, and it says so in the log.
+ */
+const VOTE_PAGE = 1000;
+const VOTE_MAX_PAGES = 20;
+const VOTE_CACHE_MS = 30_000;
+const voteCache = new Map<string, { at: number; counts: Map<string, number> }>();
+
+async function voteCounts(queue: string): Promise<Map<string, number>> {
+  const cached = voteCache.get(queue);
+  if (cached && Date.now() - cached.at < VOTE_CACHE_MS) return cached.counts;
+
+  const counts = new Map<string, number>();
+  if (!supabaseAdmin) return counts;
+
+  for (let page = 0; page < VOTE_MAX_PAGES; page++) {
+    const from = page * VOTE_PAGE;
+    const { data, error } = await supabaseAdmin
+      .from('volunteer_ratings')
+      .select('item_id')
+      .eq('queue', queue)
+      .not('rating', 'is', null)
+      .range(from, from + VOTE_PAGE - 1);
+    if (error) {
+      // Fail open: a partial map just means selection falls back to random,
+      // which is exactly the behaviour this replaced.
+      console.error(`[review-candidates] vote-count failed for ${queue}:`, error.message);
+      break;
+    }
+    for (const row of data ?? []) {
+      const id = row.item_id as string;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    if ((data?.length ?? 0) < VOTE_PAGE) break;
+    if (page === VOTE_MAX_PAGES - 1) {
+      console.warn(
+        `[review-candidates] vote-count hit the ${VOTE_MAX_PAGES * VOTE_PAGE}-row ceiling for ${queue}; counts are partial`,
+      );
+    }
+  }
+
+  voteCache.set(queue, { at: Date.now(), counts });
+  return counts;
+}
+
+/** Up to `n` ids chosen at random, without mutating the caller's array. */
+function sampleOf(ids: string[], n: number): string[] {
+  if (ids.length <= n) return ids;
+  const picked = new Set<number>();
+  const out: string[] = [];
+  while (out.length < n) {
+    const i = Math.floor(Math.random() * ids.length);
+    if (picked.has(i)) continue;
+    picked.add(i);
+    out.push(ids[i]);
+  }
+  return out;
+}
+
 export type NextItemResult =
   | { item: ReviewCandidate; poolEmpty?: false }
   | { item: null; message: string; poolEmpty: boolean };
 
+type PooledDoc = ReviewCandidate & { gold_answer?: unknown };
+
+/** `gold_answer` is the expected response for attention-check items. It must
+ *  never reach the client, or the check measures nothing. */
+function serve(doc: PooledDoc): NextItemResult {
+  const { gold_answer: _gold, ...safe } = doc;
+  void _gold;
+  return { item: safe as ReviewCandidate };
+}
+
 /**
- * Pick one unrated candidate for this volunteer.
+ * Pick one candidate for this volunteer, preferring items that are one or two
+ * votes short of a decision. See SELECTION POLICY above.
  *
  * `$sample` is safe here because the pool is a few thousand documents, not
  * 19 million. We over-fetch and filter in JS so a volunteer deep into a queue
  * still gets an item without a second round trip.
  */
 export async function nextCandidate(queue: string, volunteerId: string): Promise<NextItemResult> {
-  const [rated, db] = await Promise.all([alreadyRated(queue, volunteerId), getReadDb()]);
+  const [rated, counts, db] = await Promise.all([
+    alreadyRated(queue, volunteerId),
+    voteCounts(queue),
+    getReadDb(),
+  ]);
 
-  const docs = (await db
-    .collection('review_candidates')
+  const pool = db.collection('review_candidates');
+
+  // 1. Finish what's started: items short of consensus that this volunteer has
+  //    not already judged. Capped so the $in list stays small.
+  const undecided: string[] = [];
+  for (const [itemId, n] of counts) {
+    if (n > 0 && n < CONSENSUS_TARGET && !rated.has(itemId)) undecided.push(itemId);
+  }
+  if (undecided.length > 0) {
+    const docs = (await pool
+      .aggregate([
+        { $match: { queue, item_id: { $in: sampleOf(undecided, 200) } } },
+        { $sample: { size: 20 } },
+        { $project: { _id: 0 } },
+      ])
+      .toArray()) as unknown as PooledDoc[];
+    for (const doc of docs) {
+      if (!rated.has(doc.item_id)) return serve(doc);
+    }
+  }
+
+  // 2/3. Otherwise sample the pool, preferring an item nobody has voted on and
+  //      falling back to an already-decided one rather than stalling.
+  const docs = (await pool
     .aggregate([{ $match: { queue } }, { $sample: { size: 40 } }, { $project: { _id: 0 } }])
-    .toArray()) as unknown as (ReviewCandidate & { gold_answer?: unknown })[];
+    .toArray()) as unknown as PooledDoc[];
 
   if (docs.length === 0) {
     return {
@@ -87,14 +208,13 @@ export async function nextCandidate(queue: string, volunteerId: string): Promise
     };
   }
 
+  let decidedFallback: PooledDoc | null = null;
   for (const doc of docs) {
     if (rated.has(doc.item_id)) continue;
-    // `gold_answer` is the expected response for attention-check items. It must
-    // never reach the client, or the check measures nothing.
-    const { gold_answer: _gold, ...safe } = doc;
-    void _gold;
-    return { item: safe as ReviewCandidate };
+    if ((counts.get(doc.item_id) ?? 0) === 0) return serve(doc);
+    if (!decidedFallback) decidedFallback = doc;
   }
+  if (decidedFallback) return serve(decidedFallback);
 
   return {
     item: null,

--- a/src/lib/review-queue.ts
+++ b/src/lib/review-queue.ts
@@ -30,6 +30,14 @@ export const QUEUE_RATINGS: Record<string, RatingOption[]> = {
     { key: 'm', rating: 'microfilm',        label: '⚠ microfilm',        color: '#f59e0b', hint: 'Microfilm/microfiche, washed out, low contrast' },
     { key: 'j', rating: 'degraded',         label: '✗ degraded',         color: '#ef4444', hint: 'Blurry / cropped / corrupt — unusable' },
     { key: 'n', rating: 'blank',            label: '∅ blank',            color: '#6b7280', hint: 'Effectively blank page' },
+    // Added 2026-09-01 because volunteers kept typing it. Of the three
+    // qualitative notes this queue has ever received, all three said the same
+    // thing — "This is not a page" — because every button above assumes the
+    // image IS a page of the book and only asks how well it scanned. A rater
+    // looking at a colour target or a ruler had no honest answer, so the
+    // signal arrived as prose that nothing reads. If a queue's notes keep
+    // repeating one sentence, that sentence is a missing option.
+    { key: 'x', rating: 'not-a-page',       label: '⊘ not a page',       color: '#6366f1', hint: 'Colour chart, ruler, scanner furniture, box or shelf — not a page of the book' },
     { key: 'u', rating: 'unclear',          label: '? unclear',          color: '#9ca3af', hint: "Can't tell" },
   ],
   // UI copy, not book pages. The item is a translated interface string and the


### PR DESCRIPTION
Two small changes to the volunteer review queues, both driven by what the first 104 submissions actually contain.

## Why now

Measured 2026-09-01 against production:

- **104 ratings, ever, from 8 people** (two of whom account for 81 of them), against 8,913 pooled candidates.
- **100 distinct items rated: 96 with one vote, 4 with two, none with three.** No item has ever reached a consensus threshold.
- **Nothing consumes `volunteer_ratings`.** Its only readers are the stats route, the candidate de-duper, and the Wikipedia event log. No rating has ever changed a value in the library.
- **Zero gold items exist** — `is_gold`/`gold_answer` are fully plumbed (the serving path strips `gold_answer` before it reaches the client), but the builder hardcodes `is_gold: false`.
- Of five notes, one is our own test row and **three say the same sentence: "This is not a page."**

## What this PR changes

**Selection (`src/lib/review-candidates.ts`).** Serving was a uniform `$sample` over the pool, so votes scattered and no item could converge. Selection now prefers items that are *started but not decided* (1..`CONSENSUS_TARGET`-1 votes), then unvoted items, then anything unrated by this volunteer so the queue can never stall. The same volunteer minutes settle items instead of spreading thinner — on the existing data this is the difference between 100 undecidable items and ~33 decidable ones.

Implementation notes:
- Vote counts are **paged explicitly** — supabase-js silently caps a select at 1,000 rows — with a 20,000-row ceiling that logs when hit and degrades to roughly-random rather than a wrong answer.
- Counts are cached 30s per queue so the extra lookup does not ride on every item fetch. Bounded staleness costs at most an occasional extra vote.
- **Note-only rows (`rating IS NULL`) are not counted.** A note is a report, not a vote; counting one would mark an item decided that nobody scored.
- Every failure path falls open to the previous random behaviour.

**Vocabulary (`src/lib/review-queue.ts`).** Added `not-a-page` to scan-quality (key `X`, no collision with `p k b m j n u`, `space`, `o`). Every existing option assumes the image *is* a page and only asks how well it scanned, so a rater looking at a colour target or a ruler had no honest button and the signal arrived as prose that nothing reads. `rating` is a plain text column with no CHECK constraint, and validation runs through the shared `isValidRating`, so client and server pick this up together. Verified no other consumer enumerates this vocabulary — the `bitonal`/`microfilm` hits elsewhere are the AI's separate `scan_quality.scan_class` namespace.

## Out of scope, deliberately

- **A consumer.** Nothing reads these ratings to change a value in the library. That is the larger next piece — scan-quality → a human override the read path prefers — and it needs `.claude/docs/invariants/image-quality-and-bboxes.md` read first.
- **Seeding gold items.** One-line change in the builder plus a source of unarguable answers; without it, reliability stays unmeasurable and speed-clicking undetectable.
- **Teaching the builder about page-check and spanish-copy**, which is why those pools hold 67 and 54 items and cannot be topped up.
- **The stats endpoint**, which returns three counters that can only go up — effort, not coverage.

Each is its own concern and its own PR.

## Testing

`npx tsc --noEmit` clean. Not exercised against production data — the selection change is read-path only and falls open at every step, but a preview smoke test on `/review/scan-quality` (signed in, since writes require an account) is worth doing before merge.

Refs #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)