### PR TITLE
archive-gallica + archive-iiif-local: --book-ids for targeted runs

### DIFF
--- a/.claude/handoffs/2026-09-02-scope-envelopes-forum-run.md
+++ b/.claude/handoffs/2026-09-02-scope-envelopes-forum-run.md
@@ -1,0 +1,65 @@
+# Scope envelopes shipped + Forum of Conscience run + the bug family it exposed — 2026-09-01/02
+
+Session: scope-progress worktree. Everything below is merged or PR'd; tree is clean.
+
+## What shipped (all merged unless noted)
+
+- **#4540 scope envelopes** — PR #4556 (+#4557 additive `--books`): `allow_scopes.<tag>.budget_usd`
+  opens a confined dispatch lane past the closed daily dial, measured per run from both
+  usage stores by book_id since scope `created_at`; fails closed per lane. Orchestrator
+  decides mode at run start ("ENVELOPE MODE" in pipeline.log); 3 workers gate + confine.
+  Tools: `scripts/maintenance/set-scope.mjs`, `scripts/audit/scope-progress.mjs` (#4551).
+- **#4563** — Phase 2 OCR $project dropped `language` → every full OCR routed flash-preview
+  (2.75×). **#4565** — ten more projection-starvation bugs (manual-cover overwrites,
+  publisher clobbers w/ lying provenance, Phase 4 infinite ocr↔archive bounce, dead
+  translate circuit breaker, blind artwork embeddings, 4 `--book` override twins).
+  Structural fix still open: named projection const per phase shared with applyBookOverride.
+- **PR #4583 — OPEN, green, awaiting Derek**: `--book-ids` on archive-gallica +
+  archive-iiif-local, plus the dangling-`buffer` fix — **archive-iiif-local archived 0
+  pages since the #4406 refactor** (uploads to R2 then throws pre-record). ~2,300
+  generic-IIIF stalled books wait on this worker; merge unblocks them.
+- Issues filed: #4561 (opj_decompress OOM guard), #4566 (pooled batch charges pool cost to
+  book_ids[0] — 16% of 48h spend misattributed at book grain), #4567 ($0 placeholders until
+  collect, ~12min committed-unpriced), #4579 (Hetzner deploy green-but-dead).
+
+## Infra fixed live on Hetzner (not in git)
+
+- cron.service OOM-killed 09-01 (opj swarm, 14.7G) → `/etc/systemd/system/cron.service.d/resilience.conf`
+  (OOMPolicy=continue, Restart=on-failure). App-layer memory bound = #4561.
+- Box git remote had an **expired embedded ghp_ token** → every fetch 401'd while the
+  deploy action stayed green (reset to stale ref "succeeds"). Fixed: anonymous https
+  (repo is public, box never pushes). Hardening = #4579. Token needs revocation check.
+
+## Forum run (#4541) state at close — envelope CLOSED by Derek ("closed", 2026-09-02)
+
+- Spent ≈ $65–72 final (committed tail of 6 translate jobs was draining at gnite;
+  settle-watcher may still be running — harmless, read-only).
+- **OCR ~97% done** (~799 pages left of 25K). **Translation ~9,000 pages remain.**
+  5/34 books complete through every stage. Ledger artifact:
+  https://claude.ai/code/artifact/11701b6d-10ef-4568-a7dc-dc3e83aea170
+- **To resume:** `set-scope.mjs --tag forum-of-conscience --budget <n> --by ...` — honest
+  remaining price ≈ **$30–35** at measured rates. Monitor:
+  `scripts/audit/scope-progress.mjs --scope forum-of-conscience`.
+- Unsticks done en route: 6 books reset from images_complete strand (July Lambda), 10
+  requeued from needs_attention (quality gate misreads 25-page PREVIEW coverage as bad
+  OCR — design wart, unfiled), MDZ+iiif books hand-archived to 100% via new --book-ids,
+  IA book via archive-bulk --book-id (check it finished), 2 gallica books DEFERRED
+  (Gallica throttling this IP to ~1KB/s — retry later).
+
+## Measured facts that supersede folklore
+
+- **$0.00079/page batch OCR is STALE ~2.3×**: measured 09-02 = **$0.00178/pg** lite batch
+  OCR, **$0.00285/pg** lite realtime translation. (Memory updated.)
+- Envelope meter = instrument: surfaced the 2.75× anomaly in 2h.
+- `ft_ladder_skeptic` spent **through the closed dial again** ($5.47 on 09-02, $13 on
+  09-01) — ungated caller, another session's workstream, unowned fix.
+
+## Open threads for whoever picks this up
+
+1. Merge PR #4583 (one click, unblocks 2,300-book IIIF backlog).
+2. #4566/#4567 envelope-metering hardening; #4561 memory bound; #4579 deploy assertion.
+3. Quality-gate wart: parks preview-only books as "very low OCR coverage" — should
+   distinguish preview from failure (unfiled).
+4. Named-projection-constant refactor (the structural fix for the #4565 class).
+5. Forum: gallica ×2 archiving retry; then the B3/B4/B5 publish steps in #4541 once
+   books are readable.

--- a/scripts/audit/scope-progress.mjs
+++ b/scripts/audit/scope-progress.mjs
@@ -198,15 +198,21 @@ await withMongo(async (db) => {
   const books = await db.collection('books')
     .find({ id: { $in: ids } })
     .project({
-      id: 1, title: 1, resource_type: 1, visible: 1, hidden: 1, processing_priority: 1,
+      id: 1, title: 1, resource_type: 1, content_type: 1, visible: 1, hidden: 1, processing_priority: 1,
       pages_count: 1, pages_archived: 1, pages_ocr: 1, pages_translated: 1, pages_translatable: 1,
       summary: 1, chapters: 1, detected_images_count: 1, cover_page: 1, pipeline_auto: 1,
     })
     .toArray();
   const foundIds = new Set(books.map((b) => b.id));
   const missing = ids.filter((id) => !foundIds.has(id));
-  const artworks = books.filter((b) => b.resource_type);
-  const texts = books.filter((b) => !b.resource_type);
+  // Mirrors the orchestrator's ARTWORK_MATCH: content_type is AUTHORITATIVE
+  // ('book' is never artwork, even with an object-ish resource_type — textual
+  // papyri); resource_type is only a fallback, and only for the artwork types.
+  const ARTWORK_TYPES = new Set(['painting', 'print', 'drawing', 'fresco', 'object']);
+  const isArtwork = (b) => b.content_type !== 'book'
+    && (b.content_type === 'artwork' || ARTWORK_TYPES.has(b.resource_type));
+  const artworks = books.filter(isArtwork);
+  const texts = books.filter((b) => !isArtwork(b));
 
   const verified = flag('verify') ? await verifyFromPages(db, texts.map((b) => b.id)) : null;
 

--- a/scripts/workers/archive-gallica.mjs
+++ b/scripts/workers/archive-gallica.mjs
@@ -137,6 +137,14 @@ async function main() {
     SCOPE_FILTER = { id: { $in: scopeIds } };
     console.log(`[archive-gallica] PAUSED globally, scope active — confining to ${scopeIds.length} allowlisted book(s).`);
   }
+  // --book-ids=a,b,c: targeted one-off, same intent as archive-bulk's --book-id.
+  // Named books jump the (multi-thousand-book, arbitrarily ordered) queue —
+  // without this there is no way to archive a specific stalled book.
+  const BOOK_IDS = (getArg('book-ids') || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (BOOK_IDS.length) {
+    SCOPE_FILTER = { id: { $in: BOOK_IDS } };
+    console.log(`[archive-gallica] Targeted run: ${BOOK_IDS.length} book(s) by --book-ids.`);
+  }
 
   // Find Gallica books with unarchived pages
   const gallicaBooks = await db.collection('books')

--- a/scripts/workers/archive-iiif-local.mjs
+++ b/scripts/workers/archive-iiif-local.mjs
@@ -259,11 +259,11 @@ async function main() {
             ...dimFields,
             'archive_metadata.archived_at': new Date(),
             'archive_metadata.source_url': url,
-            'archive_metadata.bytes': buffer.byteLength,
+            'archive_metadata.bytes': master.buffer.byteLength,
             updated_at: new Date(),
           },
         });
-        archived++; totalBytes += buffer.byteLength; touchedBookIds.add(page.book_id);
+        archived++; totalBytes += master.buffer.byteLength; touchedBookIds.add(page.book_id);
         consecutiveFails = 0; bookFails.delete(page.book_id);
       } catch (err) {
         failed++; consecutiveFails++;

--- a/scripts/workers/archive-iiif-local.mjs
+++ b/scripts/workers/archive-iiif-local.mjs
@@ -182,7 +182,13 @@ async function main() {
   // state the book is in. Same predicate archive-harvard.mjs and archive-bulk.mjs
   // already use. Safe because mayAdvanceToArchiveComplete() refuses to move an
   // advanced book backward — see that function.
-  const bookFilter = ANY_STATUS
+  // --book-ids=a,b,c: targeted one-off, same intent as archive-bulk's --book-id.
+  // Named books jump the (multi-thousand-book) queue; provider filter is dropped
+  // for them — this worker archives whatever photo URL the page carries anyway.
+  const BOOK_IDS = (getArg('book-ids') || '').split(',').map(s => s.trim()).filter(Boolean);
+  const bookFilter = BOOK_IDS.length
+    ? { id: { $in: BOOK_IDS }, pages_count: { $gt: 0 } }
+    : ANY_STATUS
     ? {
         'image_source.provider': { $in: PROVIDERS },
         pages_count: { $gt: 0 },
@@ -193,6 +199,7 @@ async function main() {
         'image_source.provider': { $in: PROVIDERS },
         pages_count: { $gt: 0 },
       };
+  if (BOOK_IDS.length) console.log(`[archive-iiif] Targeted run: ${BOOK_IDS.length} book(s) by --book-ids.`);
 
   const books = await db.collection('books')
     .find(bookFilter, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1, 'pipeline_auto.status': 1 } })

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -1547,7 +1547,15 @@ async function main() {
       books = await db.collection('books')
         .find({ 'pipeline_auto.status': 'translate_complete', ...SCOPE_FILTER })
         .sort({ is_first_translation: -1, pages_count: 1, 'pipeline_auto.retry_count': 1 })  // First translations first, then small books
-        .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, chapters: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1, pages_count: 1 })
+        // The embedding path (composeBookEmbeddingText + upsertBookEmbedding)
+        // reads far more than the enrich loop itself: published/categories go
+        // into the embedded text, content_type + commons_* + resource_type +
+        // medium are the whole descriptive signal for artworks, quality_score/
+        // collections land in the stored metadata. Projected away, artworks got
+        // generic embeddings and book_embeddings.year/categories were always
+        // null/[] — the single-book --book lane (unprojected findOne) was
+        // correct while this batch lane silently wasn't.
+        .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, published: 1, categories: 1, quality_score: 1, content_type: 1, resource_type: 1, medium: 1, collections: 1, commons_description: 1, commons_categories: 1, chapters: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1, pages_count: 1 })
         .limit(PHASE_6_LIMIT)
         .toArray();
     }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3374,12 +3374,17 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
           'ai_metadata.enriched_at': { $exists: false },
         })
         .sort({ 'pipeline_auto.likely_first_translation': -1, hidden: 1 })
+        // place_of_publication + publisher must survive the projection:
+        // verifyMetadataInline guards on them ("only fill if absent"), and a
+        // projected-away field made the guard always pass — overwriting real
+        // values and recording previous_value: null in field_provenance.
         .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1,
                    description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1,
+                   place_of_publication: 1, publisher: 1,
                    field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 })
         .limit(METADATA_ENRICH_LIMIT)
         .toArray();
-      if (SCOPE_ACTIVE) readyForMetadata = await applyBookOverride(db, readyForMetadata, { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1, field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 });
+      if (SCOPE_ACTIVE) readyForMetadata = await applyBookOverride(db, readyForMetadata, { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, description: 1, categories: 1, is_first_translation: 1, source_work_dates: 1, place_of_publication: 1, publisher: 1, field_provenance: 1, subject_keywords: 1, 'translation_verification.source': 1 });
 
       console.log(`  Books ready for AI metadata: ${readyForMetadata.length}`);
       let metadataEnriched = 0;
@@ -3965,7 +3970,7 @@ Rules:
             { $limit: ocrLimit },
           ])
           .toArray();
-        if (SCOPE_ACTIVE) previewCandidates = await applyBookOverride(db, previewCandidates, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, pipeline_auto: 1 });
+        if (SCOPE_ACTIVE) previewCandidates = await applyBookOverride(db, previewCandidates, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, language: 1, image_source: 1, pipeline_auto: 1 });
 
         const dedupedPreview = await filterDuplicateWorks(db, previewCandidates);
 
@@ -4071,7 +4076,7 @@ Rules:
           { $limit: ocrLimit },
         ])
         .toArray() : [];
-      if (SCOPE_ACTIVE) readyForOcr = await applyBookOverride(db, readyForOcr, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, pipeline_auto: 1 });
+      if (SCOPE_ACTIVE) readyForOcr = await applyBookOverride(db, readyForOcr, { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, language: 1, image_source: 1, pipeline_auto: 1 });
 
       const dedupedFull = await filterDuplicateWorks(db, readyForOcr);
 
@@ -4172,9 +4177,12 @@ Rules:
 
       let ocrPending = await db.collection('books')
         .find({ 'pipeline_auto.status': 'ocr_submitted' })
-        .project({ id: 1, title: 1, 'pipeline_auto.ocr_job_name': 1, 'pipeline_auto.ocr_job_id': 1, 'pipeline_auto.ocr_loop_count': 1 })
+        // thumbnail_source must survive the projection: the early-cover guard
+        // below reads it, and a missing field made "!== 'manual'" always true —
+        // silently overwriting human-chosen covers on every run.
+        .project({ id: 1, title: 1, thumbnail_source: 1, 'pipeline_auto.ocr_job_name': 1, 'pipeline_auto.ocr_job_id': 1, 'pipeline_auto.ocr_loop_count': 1 })
         .toArray();
-      if (SCOPE_ACTIVE) ocrPending = await applyBookOverride(db, ocrPending, { id: 1, title: 1, pipeline_auto: 1 });
+      if (SCOPE_ACTIVE) ocrPending = await applyBookOverride(db, ocrPending, { id: 1, title: 1, thumbnail_source: 1, pipeline_auto: 1 });
 
       console.log(`  Books waiting for OCR: ${ocrPending.length}`);
 
@@ -4601,10 +4609,13 @@ Rules:
           // then first translations, then speed tier. Descending sort puts books
           // without the field last.
           { $sort: { processing_priority: -1, _isBph: 1, is_first_translation: -1, _speedTier: 1, _bigBook: 1, hidden: 1 } },
-          { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+          // pages_ocr must survive the projection: the "OCR incomplete" guard
+          // reads it, and a projected-away field read as 0 — bouncing every
+          // fully-translated >30-page book back to archive_complete forever.
+          { $project: { id: 1, title: 1, pages_count: 1, pages_ocr: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
-        if (SCOPE_ACTIVE) freshBooks = await applyBookOverride(db, freshBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1, image_source: 1 });
+        if (SCOPE_ACTIVE) freshBooks = await applyBookOverride(db, freshBooks, { id: 1, title: 1, pages_count: 1, pages_ocr: 1, language: 1, pipeline_auto: 1, image_source: 1 });
 
         // If no fresh books, re-queue partially-translated books (gap-fill)
         // Includes books at ANY pipeline stage with incomplete translation — not just translate_partial.
@@ -4622,13 +4633,13 @@ Rules:
             { $match: { _denominator: { $gt: 0 }, $expr: { $lt: [{ $divide: [{ $ifNull: ['$pages_translated', 0] }, '$_denominator'] }, 0.9] } } },
             // processing_priority + pages_translated must survive the projection
             // for the sort below to see them (#3756).
-            { $project: { id: 1, title: 1, pages_count: 1, pages_translated: 1, processing_priority: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
+            { $project: { id: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, processing_priority: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
             { $addFields: { _isBph: { $cond: [{ $eq: ['$image_source.provider', 'bph'] }, 0, 1] } } },
             // Reader requests first (#3750) — see the fresh-books sort above.
             { $sort: { processing_priority: -1, _isBph: 1, pages_translated: -1 } },
             { $limit: effectiveLimit },
           ]).toArray();
-          if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, language: 1, pipeline_auto: 1 });
+          if (SCOPE_ACTIVE) partialBooks = await applyBookOverride(db, partialBooks, { id: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, language: 1, image_source: 1, pipeline_auto: 1 });
           if (partialBooks.length > 0) {
             console.log(`  No fresh books — gap-filling ${partialBooks.length} under-translated books`);
           }
@@ -5443,7 +5454,7 @@ Rules:
         .project({ id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1 })
         .limit(FINALIZE_LIMIT)
         .toArray();
-      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1 });
+      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1, content_type: 1 });
 
       console.log(`  Books ready to finalize: ${readyToFinalize.length}`);
 

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -1294,7 +1294,10 @@ async function main() {
   // Grouping similar workloads per batch minimizes convoy tail waste.
   // Books with <10 pages remaining are auto-completed (overhead not worth it).
   const MIN_REMAINING = 1;
-  const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1 };
+  // last_translation_at must survive the projection: the circuit breaker
+  // branches on it, and a projected-away field made both breaker conditions
+  // permanently false — zero-progress books re-billed forever, never parked.
+  const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1, last_translation_at: 1 };
 
   // Auto-complete near-zero books — job setup overhead exceeds the work
   const nearZero = await db.collection('books').aggregate([


### PR DESCRIPTION
There was no lane to archive a NAMED stalled book on the IIIF-family providers: `archive-bulk` has `--book-id` (IA only); these two workers drain multi-thousand-book queues in arbitrary — or wrong-for-stalled (`pages_archived DESC`) — order. Five #4541 books sat at `archiving` untouched for 36h behind 166K–598K-page provider backlogs.

Adds `--book-ids=a,b,c` to both, mirroring archive-bulk's existing flag: named books jump the queue; the provider filter is dropped for them (iiif-local archives whatever photo URL the page carries by design). 16 lines.

Already exercised live from the Mac (both workers' designed home) on the four stalled non-IA Forum books — targeted runs in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SER4WMgwsMDLXik34yb16k