### PR TITLE
feat(libraries): holding libraries vs digital platforms + curated tile images

### DIFF
--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -241,10 +241,14 @@ export default async function LibrariesPage() {
   const totalBooks = partners.reduce((s, p) => s + p.count, 0);
   const totalInstitutions = contributingLibraries.length;
 
-  // Separate BPH (home library) and IA (featured) from the rest
+  // The page credits two different kinds of source, in two sections: HOLDING
+  // institutions (they own and digitized what we show) and digital PLATFORMS
+  // (aggregators whose scans depict books physically held elsewhere — those
+  // holders appear in Contributing Institutions below). BPH keeps its
+  // home-library hero at the top.
   const bph = partners.find(p => p.providerKey === 'bph');
-  const ia = partners.find(p => p.providerKey === 'internet_archive');
-  const rest = partners.filter(p => p.providerKey !== 'bph' && p.providerKey !== 'internet_archive');
+  const holdingLibraries = partners.filter(p => p.providerKey !== 'bph' && p.kind !== 'platform');
+  const platforms = partners.filter(p => p.kind === 'platform');
 
   return (
     <div className="min-h-screen bg-stone-50">
@@ -285,22 +289,16 @@ export default async function LibrariesPage() {
           </section>
         )}
 
-        {/* Internet Archive — Featured (full-width spread) */}
-        {ia && (
-          <section className="mb-12">
-            <PartnerCard partner={ia} heroImage={ia.heroImage} count={ia.count} languages={ia.languages} size="featured" />
-          </section>
-        )}
-
-        {/* Other Digital Sources — 2-column grid */}
+        {/* Holding libraries — institutions that own and digitized the books */}
         <section className="mb-16">
-          <h2 className="text-2xl font-display text-primary mb-2">Digital Sources</h2>
-          <p className="text-sm text-muted mb-6">
-            Libraries and platforms whose digitized collections we import, translate, and preserve.
+          <h2 className="text-2xl font-display text-primary mb-2">Libraries &amp; Archives</h2>
+          <p className="text-sm text-muted mb-6 max-w-3xl">
+            The institutions whose collections we read from — each holds the books it digitized.
+            Every card links to their holdings on Source Library.
           </p>
 
           <div className="grid gap-4 sm:gap-5 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
-            {rest.map((partner) => (
+            {holdingLibraries.map((partner) => (
               <PartnerCard
                 key={partner.slug}
                 partner={partner}
@@ -311,6 +309,29 @@ export default async function LibrariesPage() {
             ))}
           </div>
         </section>
+
+        {/* Digital platforms — aggregators; the physical holders are credited below */}
+        {platforms.length > 0 && (
+          <section className="mb-16">
+            <h2 className="text-2xl font-display text-primary mb-2">Digital Archives &amp; Platforms</h2>
+            <p className="text-sm text-muted mb-6 max-w-3xl">
+              Portals and aggregators through which we source scans. The books themselves live in
+              the contributing institutions credited beneath — and on each book&apos;s own page.
+            </p>
+
+            <div className="grid gap-4 sm:gap-5 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+              {platforms.map((partner) => (
+                <PartnerCard
+                  key={partner.slug}
+                  partner={partner}
+                  heroImage={partner.heroImage}
+                  count={partner.count}
+                  languages={partner.languages}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Contributing Institutions */}
         {contributingLibraries.length > 0 && (

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -106,6 +106,11 @@ async function fetchContributingLibraries(): Promise<ContributingLibrary[]> {
   for (const row of allRows) {
     const name = (row.contributing_library as string || '').trim();
     if (!name || excludeNames.has(name)) continue;
+    // Some importers stored a serialized object instead of a name — a chip
+    // reading {"name":"Internet Archive","url":…} is a data bug, not an
+    // institution. Skip anything JSON-shaped; the source rows need a repair
+    // sweep, but the page shouldn't render the bug meanwhile.
+    if (name.startsWith('{') || name.startsWith('[')) continue;
     counts.set(name, (counts.get(name) || 0) + 1);
   }
 

--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -12,6 +12,12 @@ export interface LibraryPartner {
    *  a duplicate tile. Query with getProviderKeys(partner), never providerKey
    *  alone, on any surface that filters books by provider. */
   aliasProviderKeys?: ImageSourceProvider[];
+  /** 'platform' marks an aggregator or digital portal (Internet Archive,
+   *  Google Books, e-rara…) whose scans depict books physically held
+   *  ELSEWHERE — the holders are credited per-book via contributing_library.
+   *  Unset means a holding institution: the library/museum both owns and
+   *  digitized what we show. /libraries renders the two as separate sections. */
+  kind?: 'platform';
   url: string;
   description: string;
   color: 'rust' | 'sage' | 'violet' | 'gold';
@@ -36,6 +42,7 @@ export interface LibraryPartner {
 export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   'internet-archive': {
     slug: 'internet-archive',
+    kind: 'platform',
     name: 'Internet Archive',
     shortName: 'IA',
     providerKey: 'internet_archive',
@@ -103,6 +110,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'e-rara': {
     slug: 'e-rara',
+    kind: 'platform',
     name: 'e-rara',
     shortName: 'e-rara',
     providerKey: 'e-rara',
@@ -145,6 +153,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'google-books': {
     slug: 'google-books',
+    kind: 'platform',
     name: 'Google Books',
     shortName: 'Google',
     providerKey: 'google_books',
@@ -155,6 +164,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'hathi-trust': {
     slug: 'hathi-trust',
+    kind: 'platform',
     name: 'HathiTrust Digital Library',
     shortName: 'HathiTrust',
     providerKey: 'hathi_trust',
@@ -164,6 +174,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'europeana': {
     slug: 'europeana',
+    kind: 'platform',
     name: 'Europeana',
     shortName: 'Europeana',
     providerKey: 'europeana',
@@ -226,6 +237,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'e-codices': {
     slug: 'e-codices',
+    kind: 'platform',
     name: 'e-codices',
     shortName: 'e-codices',
     providerKey: 'e-codices',
@@ -286,6 +298,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'imslp': {
     slug: 'imslp',
+    kind: 'platform',
     name: 'IMSLP / Petrucci Music Library',
     shortName: 'IMSLP',
     providerKey: 'imslp',
@@ -395,6 +408,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'bdrc': {
     slug: 'bdrc',
+    kind: 'platform',
     name: 'Buddhist Digital Resource Center',
     shortName: 'BDRC',
     providerKey: 'bdrc',
@@ -441,6 +455,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'qatar-digital-library': {
     slug: 'qatar-digital-library',
+    kind: 'platform',
     name: 'Qatar Digital Library',
     shortName: 'QDL',
     providerKey: 'qdl',
@@ -461,6 +476,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'sat-daizokyo': {
     slug: 'sat-daizokyo',
+    kind: 'platform',
     name: 'SAT Daizokyo',
     shortName: 'SAT',
     providerKey: 'sat_daizokyo',
@@ -480,6 +496,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
   },
   'oraec': {
     slug: 'oraec',
+    kind: 'platform',
     name: 'ORAEC (Ancient Egyptian Texts)',
     shortName: 'ORAEC',
     providerKey: 'oraec',

--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -88,7 +88,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://cudl.lib.cam.ac.uk',
     description: 'The Cambridge University Digital Library provides free online access to some of the University of Cambridge\'s most important collections, including Isaac Newton\'s papers, medieval manuscripts, and early printed books.',
     color: 'violet',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69907bdc5f855ec553e7177b/0001.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69907bdc5f855ec553e7177b/69907bdd5f855ec553e717bf-0.jpg?v=1784234836198',
   },
   'bibliotheca-philosophica-hermetica': {
     slug: 'bibliotheca-philosophica-hermetica',
@@ -119,7 +119,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://wellcomecollection.org',
     description: 'Wellcome Collection in London is a free museum and library exploring health, life, and our place in the world. Their digital collections include medical manuscripts, alchemical texts, and works on the history of science and medicine.',
     color: 'rust',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/6991d8978c1030b12444c035/0047.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69905e2c2fd6a039938a1705/69905e2c2fd6a039938a171a-0.jpg',
     logo: 'https://upload.wikimedia.org/wikipedia/commons/c/ce/Wellcome_Collection_logo.svg',
   },
   'hab-wolfenbuettel': {
@@ -302,6 +302,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://digital.staatsbibliothek-berlin.de',
     description: 'The Staatsbibliothek zu Berlin is one of the largest academic libraries in the German-speaking world. Its digital collections include VD16/VD17 early printed books, the Diez collection (Arabic, Persian, Turkish), and Hamilton manuscripts.',
     color: 'sage',
+    heroImageOverride: 'https://images.sourcelibrary.org/archived/6a243d100f0e4f405e62fa43/7.jpg',
   },
   'austrian-national-library': {
     slug: 'austrian-national-library',
@@ -349,6 +350,9 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://sc.lib.byu.edu',
     description: 'The L. Tom Perry Special Collections at Brigham Young University holds the William Gates papers (MSS 279) — the working archive of the Maya scholar and publisher William E. Gates (1863-1940), who spent decades photographing and photostatting Mesoamerican manuscripts. For several of the Books of Chilam Balam, the Yucatec Maya manuscript books of prophecy, chronicle, medicine and the calendar, the copies Gates made are the only surviving witness to originals that have since been lost.',
     color: 'violet',
+    // A Gates photostat zodiac figure from the Chilam Balam of Ixil — muted
+    // grey because the surviving witnesses ARE photostats; that's the archive.
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/6a878ac1d71f2514794f9e40/6a879ba86f4a03d5d89ad507-0.jpg?v=1788147109763',
   },
   'huntington': {
     slug: 'huntington',
@@ -387,7 +391,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://digi.ub.uni-heidelberg.de',
     description: 'Heidelberg University Library holds the Codex Manesse and important collections of medieval manuscripts, alchemical texts, and early printed books from one of Germany\'s oldest universities (founded 1386).',
     color: 'violet',
-    heroImageOverride: 'https://images.sourcelibrary.org/hero/heidelberg.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69cfb6fe709cb88a028365a4/69cfb6fe709cb88a028365aa-0.jpg?v=1781645688188',
   },
   'bdrc': {
     slug: 'bdrc',
@@ -397,7 +401,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://www.bdrc.io',
     description: 'The Buddhist Digital Resource Center preserves and provides access to Buddhist literary heritage across Asia — Tibetan, Chinese, Sanskrit, and Pali manuscripts from monasteries, libraries, and private collections.',
     color: 'gold',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69dfee8cce6bb8619e07ff08/0003.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69dfee86ce6bb8619e07f683/69dfee87ce6bb8619e07f686-0.jpg?v=1780586270680',
   },
   'met-museum': {
     slug: 'met-museum',
@@ -443,7 +447,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://www.qdl.qa',
     description: 'The Qatar Digital Library, a partnership between the British Library and Qatar Foundation, provides access to Arabic scientific manuscripts, historical records of the Gulf region, and maps from British India Office archives.',
     color: 'gold',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69a5efb5bfd8cafd91e44089/0003.jpg',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69a5ea0d815633a563894d0e/69a5ea0d815633a563894dbf-0.jpg',
   },
   'escorial': {
     slug: 'escorial',
@@ -463,6 +467,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     url: 'https://21dzk.l.u-tokyo.ac.jp/SAT/',
     description: 'The SAT Daizokyo Text Database at the University of Tokyo provides digital access to the Taishō Shinshū Daizōkyō, the standard modern edition of the Chinese Buddhist canon containing over 3,000 texts.',
     color: 'gold',
+    heroImageOverride: 'https://images.sourcelibrary.org/gallery/69f13428c8d07a6810653407/69f13428c8d07a6810653416-0.jpg?v=1781723654028',
   },
   'tu-darmstadt': {
     slug: 'tu-darmstadt',


### PR DESCRIPTION
Two commits, both from Derek's review of /libraries.

## 1. Curated tile images
Hand-reviewed replacements from the top-`gallery_quality` plates in `gallery_images`: Cambridge, Wellcome, Heidelberg, BDRC, SAT Daizokyo, SBB Berlin, BYU, Qatar Digital Library. BYU (5 visible books — the William Gates photostat archive of the Chilam Balam manuscripts) and Qatar (2 books) hold no colorful material; the picks are the most characterful pages that exist.

## 2. Holding libraries vs digital platforms (Derek's call, this session)
The page is where we credit institutions and link to their holdings — but it dressed aggregators as libraries. Of IA's 22K books, the physical copies sit at Zhejiang University (CADAL ~12K), the National Central Libraries of Rome/Florence, Wellcome, and dozens more.

- New `kind: 'platform'` flag in the partner registry marks the 11 aggregators/portals (IA, Google Books, HathiTrust, Europeana, e-rara, e-codices, IMSLP, BDRC, QDL, SAT, ORAEC).
- /libraries renders **Libraries & Archives** (holding institutions) and **Digital Archives & Platforms** as separate sections with explanatory lines. IA's full-width featured spread is gone — it leads the platforms grid. BPH keeps the home-library hero.

## Out of scope
- Promoting top contributing institutions (Zhejiang etc.) to first-class cards — needs a contributing_library normalization pass first ('Bayerische Staatsbibliothek (Munich)' and 'Bayerische Staatsbibliothek' currently count as two institutions).
- A minimum-books threshold for tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjAU6kQKngdU3X5JJEsSGg