### PR TITLE
Standing 'unverified transcription' notice on hieroglyphic pages (#4584)

### DIFF
--- a/src/components/reader/PageMetadataPanel.tsx
+++ b/src/components/reader/PageMetadataPanel.tsx
@@ -189,6 +189,23 @@ function TagList({ tags, color = 'stone' }: { tags: string[]; color?: 'stone' | 
   );
 }
 
+/**
+ * Scripts whose automated transcription has tested unreliable here, each
+ * earning a standing notice on the page. Matched against the page's detected
+ * OCR language, then the edition's.
+ *
+ * - Tibetan (#4523): repeat OCR runs on the same folio agree on only 31-35% of
+ *   the text, against 87-93% for printed Latin — the reading is not verified.
+ * - Egyptian hieroglyphs (#4584): the transcription phase leaves glyph blocks
+ *   unread, and the translation phase has been observed supplying invented
+ *   text in their place (Urkunden IV p.24 rendered twenty unread lines as
+ *   twenty lines of English funerary formulae).
+ */
+const UNVERIFIED_TRANSCRIPTION_SCRIPTS: Array<{ match: RegExp; label: string }> = [
+  { match: /tibetan/i, label: 'Tibetan — especially handwritten manuscripts —' },
+  { match: /hieroglyph/i, label: 'Egyptian hieroglyphs' },
+];
+
 export default function PageMetadataPanel({
   page,
   onClose,
@@ -228,18 +245,22 @@ export default function PageMetadataPanel({
             </div>
           )}
 
-          {/* Standing honesty notice for Tibetan transcriptions (#4523): repeat
-              OCR runs on the same folio disagree on most of the text, so the
-              transcription is not a verified reading. The image is authoritative. */}
-          {/tibetan/i.test(ocrMeta.language || page.ocr?.language || editionBook?.language || '') && (
-            <div className="mx-4 mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
-              <strong>Unverified transcription:</strong> automated reading of
-              Tibetan — especially handwritten manuscripts — has tested
-              unreliable in this collection. Treat the page image as the
-              authoritative source; the transcription and its translation may
-              not correspond to it.
-            </div>
-          )}
+          {/* Standing honesty notice for scripts whose automated transcription
+              has tested unreliable in this collection. The page image is the
+              authoritative object; the transcription may not correspond to it. */}
+          {(() => {
+            const lang = ocrMeta.language || page.ocr?.language || editionBook?.language || '';
+            const notice = UNVERIFIED_TRANSCRIPTION_SCRIPTS.find((s) => s.match.test(lang));
+            if (!notice) return null;
+            return (
+              <div className="mx-4 mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
+                <strong>Unverified transcription:</strong> automated reading of{' '}
+                {notice.label} has tested unreliable in this collection. Treat the
+                page image as the authoritative source; the transcription and its
+                translation may not correspond to it.
+              </div>
+            );
+          })()}
 
           {/* Summary if present */}
           {translationMeta.summary && (


### PR DESCRIPTION
## Why

While importing Sethe's *Urkunden des Alten Reichs* for the Harkhuf material, I checked the sibling volume we already serve — Urkunden IV — and found live fabricated text.

On [p. 24](https://sourcelibrary.org/q/BiX3lunYwsGV9PQm3Dc) the OCR phase behaved **correctly**: it read the handwritten German apparatus cleanly (diacritics, museum numbers, bibliographic abbreviations) and recorded the glyph block honestly as `[Hieroglyphic text lines x+1 through 20]` — *I did not read this*. The translation phase then rendered those twenty unread lines as twenty lines of English:

> x+3. …I was one who spoke the truth before the Lord of the Two Lands.
> x+9. …my name shall endure upon this stone.

No source. And x+3 was promoted into the book's `reading_summary.quotes` with page 24 attached, so it surfaces as a featured quotation of Sethe.

Separately, p. 118 loops a glyph and prints "Ra, Ra, Ra, Ra…"; p. 182 repeats "Father, behold;" dozens of times.

## What this does

Adds the standing notice to hieroglyphic pages, and generalises the Tibetan notice (#4523) into a small table so a third script is one line rather than a third copy of the markup. Same markup, same amber treatment, no new design primitives.

Gated on `/hieroglyph/i` rather than `/egyptian/i` — that matches leaves which are actually hieroglyphic and leaves the Edwin Smith facsimile's English apparatus alone.

## What this does NOT do

It labels; it does not repair. The root cause is in the prompts, tracked in #4584: the OCR prompt's gap rules are all word-scale ("2-3 words", "5-15% of words") with nothing for "this whole block is a notation I cannot transcribe", and the translation prompt bans square brackets and says translate everything — which is precisely how a bracketed *I couldn't read this* became prose.

## Out of scope

- Prompt changes (#4584) — the `prompts` collection is versioned and DB-driven, no deploy needed; separate change so this notice isn't gated behind it.
- Triage of the existing Urkunden IV translations. A length screen flags 160 of 266 translated pages at >2x their readable source, but the top of that list is the repetition artifact and fabrications like p. 24 sit mid-distribution — the metric can't separate the cases, so a person has to read them.
- Whether to hide the volume pending that triage. Derek's call; the notice is the reversible half.

## Test

`npx tsc --noEmit` clean. Notice is presentation-only, gated on an existing language field.