### PR TITLE
IIIF import: stop naming books after a shelf, and use the year we already extracted (#4572)

### DIFF
--- a/scripts/maintenance/repair-manifest-metadata-4572.mjs
+++ b/scripts/maintenance/repair-manifest-metadata-4572.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Repair sweep for #4572 — two metadata defects left by IIIF-manifest importers.
+ *
+ * 1. SHELFMARK AS DISPLAY TITLE. Gallica publishes the holding statement as the
+ *    manifest `label`, and the importers wrote it to `display_title`. The reader,
+ *    the library grid and the card all render `display_title ?? title`, so 977
+ *    books are named after a shelf — 216 of them live and publicly readable.
+ *    Repair: `$unset display_title`, so the correct `title` (which was captured
+ *    correctly all along) shows through.
+ *
+ * 2. RECOVERABLE YEAR LEFT UNREAD. 1,698 books carry `published: 'Unknown'`
+ *    while `catalog_metadata.publication_date` holds the year the importer had
+ *    already extracted. 389 are live. They are invisible to every date-bounded
+ *    query (`year_from`/`year_to` on /books/library and the MCP list_books tool)
+ *    with the answer sitting in their own document.
+ *    Repair: promote the catalog date into `published` + `year`.
+ *
+ * The code fixes (src/lib/manifest-label.ts, wired into src/lib/import-utils.ts
+ * and src/app/api/import/iiif/route.ts) stop NEW imports doing this. This sweep
+ * cleans up what already landed. Both are needed — a fix without a sweep leaves
+ * 216 books named after a shelf forever.
+ *
+ * SAFETY
+ *   - Never unsets `display_title` unless `title` is present, non-empty, and is
+ *     not itself a holding statement. A book with two junk names must be looked
+ *     at by a person, not silently left with none.
+ *   - Writes a numeric `year` ONLY when the catalogue string names exactly one
+ *     year. Ranges, centuries and open bounds get an honest `published` string
+ *     and no `year`, so date-bounded queries are never answered with a
+ *     fabricated precision (see parseCatalogDate below).
+ *   - Records a ROW per book in `sweep_log` (#3969), not a new column on `books`.
+ *   - `--dry-run` by default in spirit: pass `--apply` to write.
+ *
+ * AFTER RUNNING: the ~216 visible books whose name changes need the usual
+ * three steps, not just the Mongo write — Supabase catalog sync (with an
+ * `updated_at` bump, else the write is inert) and an ISR/Cloudflare purge.
+ * The script prints the affected slugs so that can be scoped rather than
+ * purging the world.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/repair-manifest-metadata-4572.mjs            # report only
+ *   node scripts/maintenance/repair-manifest-metadata-4572.mjs --apply
+ *   node scripts/maintenance/repair-manifest-metadata-4572.mjs --apply --only=titles
+ *   node scripts/maintenance/repair-manifest-metadata-4572.mjs --apply --only=dates
+ */
+
+import { MongoClient } from 'mongodb';
+import { recordSweepAction } from '../lib/sweep-log.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const ONLY = (process.argv.find(a => a.startsWith('--only=')) || '').split('=')[1] || 'both';
+const SWEEP = 'manifest-metadata-repair-4572';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+// ── the same guard the importers now use, inlined so this script stays
+// dependency-free (scripts/ cannot import from src/lib without a build step).
+// Kept deliberately in step with src/lib/manifest-label.ts.
+const REPOSITORY_PREFIXES = [
+  'bnf', 'bibliotheque nationale de france', 'bibliotheca', 'bayerische staatsbibliothek',
+  'staatsbibliothek zu berlin', 'osterreichische nationalbibliothek', 'koninklijke bibliotheek',
+  'british library', 'bodleian library', 'biblioteca nazionale', 'biblioteca apostolica vaticana',
+  'library of congress', 'universitatsbibliothek', 'universiteitsbibliotheek',
+];
+const SHELF_MARKERS = [
+  'departement philosophie', 'departement litterature', 'departement droit', 'departement sciences',
+  'departement reserve', 'departement des manuscrits', 'departement de la musique',
+  'reserve des livres rares',
+];
+const fold = s => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+const stripRepo = f => {
+  for (const p of REPOSITORY_PREFIXES) if (f.startsWith(p + ' ')) return f.slice(p.length + 1).trim();
+  return f;
+};
+function isHoldingStatement(label, callNumber) {
+  if (!label) return false;
+  const l = stripRepo(fold(label));
+  if (!l) return false;
+  if (callNumber) {
+    const c = stripRepo(fold(callNumber));
+    if (c && (c === l || c.includes(l) || l.includes(c))) return true;
+  }
+  if (SHELF_MARKERS.some(m => l.includes(m))) return true;
+  if (REPOSITORY_PREFIXES.includes(fold(label))) return true;
+  return false;
+}
+
+/**
+ * Split a catalogue date string into an honest `published` and — only when the
+ * string really names ONE year — a numeric `year`.
+ *
+ * This deliberately does NOT match `publishedToYear` in src/lib/resolve-language.ts,
+ * which takes the first 3–4 digit run it finds. That rule is fine for a caller
+ * hint typed by a curator; run over catalogue strings it fabricates precision:
+ *
+ *   "1601-1700"                                  → 1601   (a century, not a year)
+ *   "after 1599/1st half of the 17th century"    → 1599   (the one year it is NOT)
+ *   "1301-1500 / 1401-1500 / 1301-1400"          → 1301   (three overlapping ranges)
+ *
+ * A book with a century-range imprint genuinely has no year, and saying 1601
+ * would make it answer a `year_from=1601&year_to=1601` query with false
+ * confidence. Better: give it an honest `published` string so the catalogue
+ * shows a date, and leave `year` unset so date-bounded queries don't lie.
+ */
+function parseCatalogDate(raw) {
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  if (!s || /^unknown$/i.test(s)) return null;
+
+  const plausible = n => Number.isFinite(n) && n >= 800 && n <= new Date().getFullYear();
+
+  // Anything expressing a span, a century, or an open bound gets `published`
+  // only. Checked BEFORE the single-year match so "after 1599" can't slip past.
+  const isSpan = /(\d{3,4})\s*[-–—/]\s*(\d{3,4})/.test(s)          // 1601-1700, 1301/1400
+    || /\bcentur(y|ies)\b|\bsiècle\b|\bjh\.?\b|\bjahrhundert\b/i.test(s)
+    || /\b(after|before|nach|vor|post|ante|not before|not after)\b/i.test(s)
+    || /\b(quarter|half|third)\b/i.test(s);
+
+  const singleYear = s.match(/^\s*(?:ca\.?|circa|around|about|approx\.?|vers|um|c\.)?\s*\[?\s*(\d{3,4})\s*\]?\s*\.?\s*$/i);
+
+  if (!isSpan && singleYear) {
+    const n = parseInt(singleYear[1], 10);
+    if (plausible(n)) return { published: s, year: n, precision: 'year' };
+  }
+
+  // Keep the honest string if it contains any plausible year at all, so the
+  // catalogue can show something true even when we can't pin a number.
+  const anyYear = [...s.matchAll(/(?<!\d)\d{3,4}(?!\d)/g)].map(m => parseInt(m[0], 10)).filter(plausible);
+  if (anyYear.length) return { published: s, year: null, precision: 'range' };
+
+  return null;
+}
+
+async function repairTitles(db, books) {
+  console.log('\n=== 1. Shelfmark in display_title ===');
+  const candidates = await books.find(
+    { display_title: { $type: 'string', $ne: '' } },
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, 'catalog_metadata.call_number': 1 } },
+  ).toArray();
+
+  const toFix = [];
+  const skipped = [];
+  for (const b of candidates) {
+    if (!isHoldingStatement(b.display_title, b.catalog_metadata?.call_number)) continue;
+    // Refuse to leave a book with no usable name at all.
+    const title = typeof b.title === 'string' ? b.title.trim() : '';
+    if (!title || isHoldingStatement(title, b.catalog_metadata?.call_number)) {
+      skipped.push(b);
+      continue;
+    }
+    toFix.push(b);
+  }
+
+  console.log(`shelfmark display_titles found: ${toFix.length + skipped.length}`);
+  console.log(`  repairable (real title behind them): ${toFix.length}  (visible: ${toFix.filter(b => b.visible).length})`);
+  console.log(`  SKIPPED — title is junk too, needs a person: ${skipped.length}`);
+  for (const b of skipped.slice(0, 10)) console.log(`    ${b.id}  title=${JSON.stringify(b.title)}  display=${JSON.stringify(b.display_title)}`);
+
+  console.log('\n  sample repairs:');
+  for (const b of toFix.slice(0, 5)) {
+    console.log(`    ${b.id} ${b.visible ? '[LIVE]' : '      '} ${JSON.stringify(b.display_title)}`);
+    console.log(`      → falls back to: ${JSON.stringify(b.title)}`);
+  }
+
+  if (!APPLY) return { fixed: 0, visibleSlugs: [] };
+
+  let fixed = 0;
+  const visibleSlugs = [];
+  for (const b of toFix) {
+    const res = await books.updateOne(
+      { _id: b._id },
+      { $unset: { display_title: '' }, $currentDate: { updated_at: true } },
+    );
+    if (res.modifiedCount === 1) {
+      fixed++;
+      if (b.visible && b.slug) visibleSlugs.push(b.slug);
+      await recordSweepAction(db, {
+        sweep: SWEEP,
+        book_id: String(b.id),
+        action: 'unset-shelfmark-display-title',
+        detail: { was: b.display_title, now_shows: b.title, was_visible: Boolean(b.visible) },
+      });
+    }
+  }
+  console.log(`\n  APPLIED: ${fixed} display_titles unset (${visibleSlugs.length} on live books)`);
+  return { fixed, visibleSlugs };
+}
+
+async function repairDates(db, books) {
+  console.log('\n=== 2. published Unknown with a recoverable catalog date ===');
+  const candidates = await books.find(
+    {
+      $or: [{ published: 'Unknown' }, { published: { $exists: false } }, { published: null }, { published: '' }],
+      'catalog_metadata.publication_date': { $exists: true, $nin: [null, ''] },
+    },
+    { projection: { id: 1, slug: 1, title: 1, published: 1, year: 1, visible: 1, 'catalog_metadata.publication_date': 1, 'image_source.provider': 1 } },
+  ).toArray();
+
+  const toFix = [];
+  const unparseable = [];
+  for (const b of candidates) {
+    const raw = b.catalog_metadata.publication_date;
+    const parsed = parseCatalogDate(raw);
+    if (!parsed) { unparseable.push({ id: b.id, raw }); continue; }
+    toFix.push({ ...b, _parsed: parsed });
+  }
+
+  const exact = toFix.filter(b => b._parsed.precision === 'year');
+  const ranged = toFix.filter(b => b._parsed.precision === 'range');
+  console.log(`candidates: ${candidates.length}  (visible: ${candidates.filter(b => b.visible).length})`);
+  console.log(`  repairable: ${toFix.length}  (visible: ${toFix.filter(b => b.visible).length})`);
+  console.log(`    exact year  → published + year: ${exact.length}  (visible: ${exact.filter(b => b.visible).length})`);
+  console.log(`    range/century → published ONLY, year left unset: ${ranged.length}  (visible: ${ranged.filter(b => b.visible).length})`);
+  console.log(`  SKIPPED — no plausible year in the string at all: ${unparseable.length}`);
+  for (const u of unparseable.slice(0, 10)) console.log(`    ${u.id}  ${JSON.stringify(u.raw)}`);
+
+  console.log('\n  range samples (deliberately get NO year):');
+  for (const b of ranged.slice(0, 5)) console.log(`    ${b.id}  ${JSON.stringify(b._parsed.published)}`);
+
+  const byProvider = {};
+  for (const b of toFix) byProvider[b.image_source?.provider || 'none'] = (byProvider[b.image_source?.provider || 'none'] || 0) + 1;
+  console.log('  by provider:', Object.entries(byProvider).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join(' '));
+
+  console.log('\n  sample repairs (exact):');
+  for (const b of exact.slice(0, 5)) {
+    console.log(`    ${b.id} ${b.visible ? '[LIVE]' : '      '} ${String(b.title || '').slice(0, 50)}`);
+    console.log(`      published: ${JSON.stringify(b.published ?? null)} → ${JSON.stringify(b._parsed.published)}   year → ${b._parsed.year}`);
+  }
+
+  if (!APPLY) return { fixed: 0, visibleSlugs: [] };
+
+  let fixed = 0;
+  const visibleSlugs = [];
+  for (const b of toFix) {
+    const set = { published: b._parsed.published };
+    // Only claim a numeric year when the catalogue string names exactly one.
+    if (b._parsed.year !== null) set.year = b._parsed.year;
+    const res = await books.updateOne(
+      { _id: b._id },
+      { $set: set, $currentDate: { updated_at: true } },
+    );
+    if (res.modifiedCount === 1) {
+      fixed++;
+      if (b.visible && b.slug) visibleSlugs.push(b.slug);
+      await recordSweepAction(db, {
+        sweep: SWEEP,
+        book_id: String(b.id),
+        action: 'promote-catalog-publication-date',
+        detail: {
+          published: b._parsed.published,
+          year: b._parsed.year,
+          precision: b._parsed.precision,
+          source: 'catalog_metadata.publication_date',
+          was_visible: Boolean(b.visible),
+        },
+      });
+    }
+  }
+  console.log(`\n  APPLIED: ${fixed} dates promoted (${visibleSlugs.length} on live books)`);
+  return { fixed, visibleSlugs };
+}
+
+async function main() {
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  console.log(`=== #4572 manifest metadata repair — ${APPLY ? 'APPLY' : 'REPORT ONLY (pass --apply to write)'} ===`);
+  console.log(`scope: ${ONLY}`);
+
+  const titles = ONLY === 'dates' ? { fixed: 0, visibleSlugs: [] } : await repairTitles(db, books);
+  const dates = ONLY === 'titles' ? { fixed: 0, visibleSlugs: [] } : await repairDates(db, books);
+
+  if (APPLY) {
+    const slugs = [...new Set([...titles.visibleSlugs, ...dates.visibleSlugs])];
+    console.log('\n=== FOLLOW-UP REQUIRED ===');
+    console.log(`${slugs.length} LIVE books changed. A Mongo write alone does not reach readers:`);
+    console.log('  1. Supabase catalog sync (the grid reads Supabase, not Mongo)');
+    console.log('  2. ISR revalidate + Cloudflare purge for each /book/<slug>');
+    if (slugs.length) {
+      console.log('\nAffected live slugs:');
+      for (const s of slugs) console.log(`  ${s}`);
+    }
+  }
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { withCuratorAuth } from '@/lib/auth-helpers';
 import { publishedToYear } from '@/lib/resolve-language';
+import { usableManifestLabel } from '@/lib/manifest-label';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint } from '@/lib/dedup';
 import { acquisitionGate, confirmClaims } from '@/lib/acquisition-guard';
@@ -495,12 +496,19 @@ export const POST = withCuratorAuth(async (request, session) => {
       id: bookIdStr,
       slug,
       title,
-      display_title: display_title || manifestLabel || null,
+      // usableManifestLabel drops a label that is really a holding statement.
+      // Gallica publishes the shelfmark as the manifest label, so taking it
+      // verbatim named books after a shelf (#4572).
+      display_title: display_title || usableManifestLabel(manifestLabel, iiifCallNumber) || null,
       author,
       language: language || 'Unknown',
-      published: published || 'Unknown',
-      ...(publishedToYear(typeof year === 'number' ? year : published) !== null
-        ? { year: publishedToYear(typeof year === 'number' ? year : published)! }
+      // The manifest's own publication date is the last resort before giving up
+      // and writing 'Unknown'. It was already extracted for catalog_metadata
+      // above, so refusing to use it here left the year sitting unread in the
+      // same document while the book fell out of every date-bounded query.
+      published: published || iiifPubDate || 'Unknown',
+      ...(publishedToYear(typeof year === 'number' ? year : (published || iiifPubDate)) !== null
+        ? { year: publishedToYear(typeof year === 'number' ? year : (published || iiifPubDate))! }
         : {}),
       categories: categories || [],
       ...(requestCollections?.length ? { collections: requestCollections } : {}),

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -10,6 +10,7 @@ import { computeIdentityFields } from '@/lib/identity-fields';
 import { resolveLanguage, resolveDate, publishedToYear } from '@/lib/resolve-language';
 import { storeImportedManifest } from '@/lib/iiif-manifest-store';
 import { applyTextRole } from '@/lib/text-role';
+import { usableManifestLabel } from '@/lib/manifest-label';
 
 // IIIF v2 manifest shape (covers most digital library providers)
 export interface IIIFManifest {
@@ -145,6 +146,25 @@ export function extractPlace(manifest: IIIFManifest): string | null {
   for (const entry of manifest.metadata) {
     const label = extractLabel(entry.label as string | Record<string, string[]>)?.toLowerCase();
     if (label && placeLabels.some(p => label.includes(p))) {
+      const value = extractLabel(entry.value as string | Record<string, string[]>);
+      if (value) return value.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the shelfmark / call number from a IIIF manifest metadata array.
+ *
+ * Used to recognise a manifest `label` that is really a holding statement — see
+ * `usableManifestLabel` in `src/lib/manifest-label.ts` and #4572.
+ */
+export function extractCallNumber(manifest: IIIFManifest): string | null {
+  if (!Array.isArray(manifest.metadata)) return null;
+  const callLabels = ['call number', 'shelfmark', 'shelf mark', 'signatur', 'cote', 'segnatura'];
+  for (const entry of manifest.metadata) {
+    const label = extractLabel(entry.label as string | Record<string, string[]>)?.toLowerCase();
+    if (label && callLabels.some(c => label.includes(c))) {
       const value = extractLabel(entry.value as string | Record<string, string[]>);
       if (value) return value.trim();
     }
@@ -355,6 +375,7 @@ export async function importBookFromIIIF(
   // Extract metadata from manifest
   const manifestDate = extractDate(manifest);
   const manifestLabel = extractLabel(manifest.label);
+  const manifestCallNumber = extractCallNumber(manifest);
   const manifestPublisher = extractPublisher(manifest);
   const manifestPlace = extractPlace(manifest);
   const rawLicenseUrl = manifest.rights
@@ -389,7 +410,9 @@ export async function importBookFromIIIF(
     id: bookIdStr,
     slug,
     title: config.title,
-    display_title: config.display_title || manifestLabel || null,
+    // A manifest label that is really a shelfmark must not become the name the
+    // reader sees (#4572) — same guard as the /api/import/iiif route.
+    display_title: config.display_title || usableManifestLabel(manifestLabel, manifestCallNumber) || null,
     author: config.author,
     language: lang.language,
     ...(lang.original_language ? { original_language: lang.original_language } : {}),

--- a/src/lib/manifest-label.ts
+++ b/src/lib/manifest-label.ts
@@ -1,0 +1,117 @@
+/**
+ * A IIIF manifest `label` is not reliably a title.
+ *
+ * Gallica sets it to the holding statement — "BnF, département Réserve des
+ * livres rares, J-3263 (BIS,1)" — while the actual title ("De Bosphoro Thracio
+ * libri III") lives in the OAI/dc record and in the manifest's own `Title`
+ * metadata pair. Importers that took `label` as a display title therefore named
+ * 977 books after a shelf, 216 of them live and publicly readable (#4572).
+ *
+ * `display_title` is what the reader, the library grid and the card render
+ * (`display_title ?? title`), so a wrong value here is not cosmetic — it is the
+ * name of the book everywhere a reader meets it.
+ *
+ * The check lives in its own module because two importers construct book docs
+ * from a manifest (`src/lib/import-utils.ts` and `src/app/api/import/iiif/
+ * route.ts`) and a guard applied to only one of them is how the same defect
+ * ships twice.
+ */
+
+/** Repository names that prefix a holding statement rather than name a work. */
+const REPOSITORY_PREFIXES = [
+  'bnf',
+  'bibliotheque nationale de france',
+  'bibliotheca',
+  'bayerische staatsbibliothek',
+  'staatsbibliothek zu berlin',
+  'osterreichische nationalbibliothek',
+  'koninklijke bibliotheek',
+  'british library',
+  'bodleian library',
+  'biblioteca nazionale',
+  'biblioteca apostolica vaticana',
+  'library of congress',
+  'universitatsbibliothek',
+  'universiteitsbibliotheek',
+];
+
+/**
+ * Department words that only appear in a shelf location. Deliberately narrow:
+ * "département" alone is enough on a Gallica label, but a real title could
+ * plausibly contain "collection" or "library", so those are not listed.
+ */
+const SHELF_MARKERS = [
+  'departement philosophie',
+  'departement litterature',
+  'departement droit',
+  'departement sciences',
+  'departement reserve',
+  'departement des manuscrits',
+  'departement de la musique',
+  'reserve des livres rares',
+];
+
+/** Lowercase, strip diacritics and punctuation, collapse whitespace. */
+function fold(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Drop a leading repository name so "BnF, département X" compares to "…département X". */
+function stripRepositoryPrefix(folded: string): string {
+  for (const p of REPOSITORY_PREFIXES) {
+    if (folded.startsWith(p + ' ')) return folded.slice(p.length + 1).trim();
+  }
+  return folded;
+}
+
+/**
+ * True when `label` reads as a holding statement (shelfmark / call number)
+ * rather than the name of a work.
+ *
+ * `callNumber` is the manifest's own `Call Number` / `Shelfmark` metadata value
+ * when it has one. That is the strongest signal available: Gallica publishes
+ * both, and the label is the call number with the repository name abbreviated,
+ * so after folding and stripping the prefix one contains the other.
+ */
+export function isHoldingStatement(
+  label: string | null | undefined,
+  callNumber?: string | null,
+): boolean {
+  if (!label) return false;
+  const l = stripRepositoryPrefix(fold(label));
+  if (!l) return false;
+
+  // Strongest signal: the manifest itself says this string is the shelfmark.
+  if (callNumber) {
+    const c = stripRepositoryPrefix(fold(callNumber));
+    if (c && (c === l || c.includes(l) || l.includes(c))) return true;
+  }
+
+  // Failing that, a department name only ever appears in a shelf location.
+  if (SHELF_MARKERS.some(m => l.includes(m))) return true;
+
+  // A bare repository name with nothing else ("BnF") is not a title either.
+  const raw = fold(label);
+  if (REPOSITORY_PREFIXES.includes(raw)) return true;
+
+  return false;
+}
+
+/**
+ * The manifest label if it is usable as a display title, otherwise null.
+ *
+ * Callers should keep their existing precedence — an explicit caller-supplied
+ * `display_title` still wins; this only filters the manifest fallback.
+ */
+export function usableManifestLabel(
+  label: string | null | undefined,
+  callNumber?: string | null,
+): string | null {
+  if (!label) return null;
+  return isHoldingStatement(label, callNumber) ? null : label;
+}

--- a/tests/unit/manifest-label.test.ts
+++ b/tests/unit/manifest-label.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { isHoldingStatement, usableManifestLabel } from '@/lib/manifest-label';
+
+/**
+ * Regression guard for #4572 — Gallica publishes the shelfmark as the IIIF
+ * manifest `label`, and importers wrote it into `display_title`, which is the
+ * name the reader sees. 977 books were named after a shelf, 216 of them live.
+ *
+ * The negative cases matter as much as the positive ones: these are real titles
+ * from the corpus, and a guard that eats them replaces one defect with a worse
+ * one (a silently missing display title).
+ */
+describe('isHoldingStatement', () => {
+  it('rejects a Gallica label that matches the manifest call number', () => {
+    // The exact pair from the reported book: label abbreviates the repository,
+    // call number spells it out. Neither string equals the other.
+    expect(
+      isHoldingStatement(
+        'BnF, département Réserve des livres rares, J-3263 (BIS,1)',
+        'Bibliothèque nationale de France, département Réserve des livres rares, J-3263 (BIS,1)',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a Gallica-shaped label even with no call number to compare against', () => {
+    expect(isHoldingStatement('BnF, département Réserve des livres rares, YC-1765')).toBe(true);
+    expect(isHoldingStatement('BnF, département Philosophie, histoire, sciences de l’homme, R-25681')).toBe(true);
+    expect(isHoldingStatement('BnF, département Droit, économie, politique, F-8740')).toBe(true);
+  });
+
+  it('rejects a bare repository name', () => {
+    expect(isHoldingStatement('BnF')).toBe(true);
+    expect(isHoldingStatement('Bibliothèque nationale de France')).toBe(true);
+  });
+
+  it('keeps real titles that merely mention a library or a place', () => {
+    expect(isHoldingStatement('De Bosphoro Thracio libri III')).toBe(false);
+    expect(isHoldingStatement('Carminum libri duo, quorum unus epicorum est, alter elegiarum')).toBe(false);
+    expect(isHoldingStatement('Catalogue de la bibliothèque de feu M. le duc de La Vallière')).toBe(false);
+    expect(isHoldingStatement('Bibliotheca chemica curiosa')).toBe(false);
+    expect(isHoldingStatement('Histoire de la Bibliothèque nationale')).toBe(false);
+  });
+
+  it('does not reject a title just because a call number exists', () => {
+    // A well-behaved manifest: label is the title, call number is separate.
+    expect(isHoldingStatement('Fama remissa ad fratres Roseae crucis', 'E folio 42')).toBe(false);
+  });
+
+  it('handles empty and missing input without throwing', () => {
+    expect(isHoldingStatement(null)).toBe(false);
+    expect(isHoldingStatement(undefined)).toBe(false);
+    expect(isHoldingStatement('')).toBe(false);
+    expect(isHoldingStatement('   ')).toBe(false);
+  });
+});
+
+describe('usableManifestLabel', () => {
+  it('passes a real title through unchanged', () => {
+    expect(usableManifestLabel('De Bosphoro Thracio libri III')).toBe('De Bosphoro Thracio libri III');
+  });
+
+  it('returns null for a holding statement so the caller falls back to title', () => {
+    expect(
+      usableManifestLabel(
+        'BnF, département Réserve des livres rares, J-3263 (BIS,1)',
+        'Bibliothèque nationale de France, département Réserve des livres rares, J-3263 (BIS,1)',
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for absent input', () => {
+    expect(usableManifestLabel(null)).toBeNull();
+    expect(usableManifestLabel(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes the import half of #4572 and ships the repair sweep for what already landed.

## The defect

The IIIF import path reads each manifest **twice** — carefully for `catalog_metadata` (with label synonyms) and loosely for the book fields (top-level `label` only). The careful read had the right answer both times.

**1. The shelfmark became the book's name.** Gallica publishes the holding statement as the manifest `label`:

| field | value |
|---|---|
| `title` | `De Bosphoro Thracio libri III` |
| `display_title` | `BnF, département Réserve des livres rares, J-3263 (BIS,1)` |

Readers, the library grid and the card all render `display_title ?? title`. Measured against production: **1,383 books, 366 of them live.** Not a Gallica-only shape either — the sweep's dry run turned up Vatican (`Reg.lat.1344`, hiding *Picatrix Fragment, Steganographia, Paracelsus & Chemical Secrets*), Bodleian and e-codices.

**2. A year we already had, unread.** `published` never fell back to `catalog_metadata.publication_date`, which the same route extracts sixty lines earlier. **1,698 books say "Unknown" with the year in their own document; 389 are live.** They are invisible to `year_from`/`year_to` on `/books/library` and to the MCP `list_books` tool.

## What changed

- **`src/lib/manifest-label.ts`** (new) — `isHoldingStatement` / `usableManifestLabel`. The strongest signal is the manifest's own `Call Number` / `Shelfmark` pair: fold both, strip the repository prefix, and if one contains the other the label is a shelf location. Falls back to department markers and bare repository names.
- Wired into **both** manifest importers — `src/lib/import-utils.ts` and `src/app/api/import/iiif/route.ts`. Guarding one and calling it done is exactly how the R2 book-scope bug shipped twice in the same week.
- `extractCallNumber()` added alongside the existing `extractDate` / `extractPublisher` / `extractPlace` extractors.
- `published` now falls back to the manifest publication date before writing `'Unknown'`.
- **9 unit tests**, half of them negative controls: *Bibliotheca chemica curiosa*, *Catalogue de la bibliothèque de feu M. le duc de La Vallière* and *Histoire de la Bibliothèque nationale* must all survive the guard. A guard that eats real titles replaces one defect with a worse one.

## The repair sweep

`scripts/maintenance/repair-manifest-metadata-4572.mjs` — reports by default, writes on `--apply`.

**It deliberately does not reuse `publishedToYear`.** That helper takes the first 3–4 digit run, which is fine for a curator-typed hint and fabricates precision over catalogue strings:

| catalogue string | `publishedToYear` | this sweep |
|---|---|---|
| `1601-1700` | 1601 | published only, no year |
| `after 1599/1st half of the 17th century` | **1599** — the one year it isn't | published only, no year |
| `1301-1500 / 1401-1500 / 1301-1400` | 1301 | published only, no year |
| `ca. 1524` | 1524 | 1524 |

Dry-run split: **1,495 get an exact year** (285 live), **121 get an honest `published` string and no `year`** (50 live), 82 skipped as unparseable. A century-range book genuinely has no year, and answering `year_from=1601&year_to=1601` with it would be a number nobody measured.

Other safety: refuses to unset `display_title` when `title` is *also* a shelfmark (100 books — `Bodleian Library MS. Barocci 229` in both fields — those need a person); records a row per book in `sweep_log` rather than stamping a column (#3969); prints the affected live slugs, because a Mongo write alone does not reach readers behind Supabase and the CDN.

Reversible: every `sweep_log` row carries the previous value under `detail.was`.

## Out of scope

- The 100 books whose `title` is also a shelfmark — they need real titles from the source catalogue, not a script.
- The 82 unparseable dates (`third quarter of the 15th century`, `13th century, late - 14th century, early`). Representing fuzzy imprint dates properly is its own question and probably belongs with #4043.
- Whether the 2026-08-30/31 import wave was driven through the Vercel route rather than a direct script on Hetzner — flagged in #4572, not addressed here.
