### PR TITLE
fix(ai): disable Gemini thinking on all pipeline paths; meter counts thought tokens (#4581)

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PROMPTS, DEFAULT_MODEL, ENGLISH_MODERNIZATION_PROMPT } from './types';
 import { getGeminiClient } from './gemini-client';
 import { images } from './api-client/images';
-import { HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { HarmCategory, HarmBlockThreshold, type GenerationConfig } from '@google/generative-ai';
 import { sanitizeTranslationTags } from './sanitize-translation-tags';
 
 // Safety settings for OCR/transcription - disable all filters for historical texts
@@ -27,6 +27,24 @@ const OCR_SAFETY_SETTINGS = [
     threshold: HarmBlockThreshold.BLOCK_NONE,
   },
 ];
+
+// Gemini 3.x runs thinking by default and bills thought tokens at the output rate,
+// while candidatesTokenCount excludes them — so thinking must be explicitly disabled
+// or the meter under-reports the bill (17x in Aug 2026, #4581). The batch writers
+// (pipeline-orchestrator.mjs) already set thinkingBudget: 0; this covers the
+// realtime/Lambda path. thinkingConfig is not in @google/generative-ai 0.24.x types
+// but is passed through verbatim to the API (verified by live probe: thoughtsTokenCount
+// 61 -> absent).
+const THINKING_OFF_CONFIG = {
+  thinkingConfig: { thinkingBudget: 0 },
+} as unknown as GenerationConfig;
+
+function getThinkingOffModel(modelId: string) {
+  return getGeminiClient().getGenerativeModel({
+    model: modelId,
+    generationConfig: THINKING_OFF_CONFIG,
+  });
+}
 
 // Model pricing per 1M tokens (USD)
 export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
@@ -72,7 +90,7 @@ export async function performOCRWithBuffer(
   previousPageOcr?: string,
   modelId: string = DEFAULT_MODEL
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   let prompt = promptText;
 
@@ -103,7 +121,8 @@ export async function performOCRWithBuffer(
 
     const usageMetadata = result.response.usageMetadata;
     const inputTokens = usageMetadata?.promptTokenCount || 0;
-    const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+    const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+      ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
     return {
       text: result.response.text(),
@@ -130,7 +149,7 @@ export async function performOCR(
   previousPageOcr?: string,
   modelId: string = DEFAULT_MODEL
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   let prompt = promptText;
 
@@ -174,7 +193,8 @@ export async function performOCR(
 
     const usageMetadata = result.response.usageMetadata;
     const inputTokens = usageMetadata?.promptTokenCount || 0;
-    const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+    const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+      ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
     return {
       text: result.response.text(),
@@ -200,7 +220,7 @@ export async function performTranslation(
   modelId: string = DEFAULT_MODEL,
   bookContext?: { title?: string; author?: string; year?: number | string }
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   // English books get modernized (Early Modern → Modern English) instead of translated
   const isEnglish = sourceLanguage.toLowerCase() === 'english';
@@ -240,7 +260,8 @@ export async function performTranslation(
 
   const usageMetadata = result.response.usageMetadata;
   const inputTokens = usageMetadata?.promptTokenCount || 0;
-  const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+  const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+    ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
   // Carry manuscript warnings through to the translation so both panels show them
   let translationText = sanitizeTranslationTags(result.response.text());
@@ -266,7 +287,7 @@ export async function generateSummary(
   customPrompt?: string,
   modelId: string = DEFAULT_MODEL
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   let prompt = customPrompt || DEFAULT_PROMPTS.summary;
   prompt += `\n\n**Translated text:**\n${translatedText}`;
@@ -279,7 +300,8 @@ export async function generateSummary(
 
   const usageMetadata = result.response.usageMetadata;
   const inputTokens = usageMetadata?.promptTokenCount || 0;
-  const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+  const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+    ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
   return {
     text: result.response.text(),
@@ -345,7 +367,7 @@ export async function performModernization(
   customPrompt?: string,
   modelId: string = DEFAULT_MODEL
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   let prompt = customPrompt || MODERNIZATION_PROMPT;
 
@@ -363,7 +385,8 @@ export async function performModernization(
 
   const usageMetadata = result.response.usageMetadata;
   const inputTokens = usageMetadata?.promptTokenCount || 0;
-  const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+  const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+    ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
   return {
     text: result.response.text(),
@@ -441,7 +464,7 @@ export async function performTransliteration(
   sourceScript: string,
   modelId: string = DEFAULT_MODEL
 ): Promise<AIResult> {
-  const model = getGeminiClient().getGenerativeModel({ model: modelId });
+  const model = getThinkingOffModel(modelId);
 
   // Preprocess: strip metadata, convert column headers to <column-break/>
   const cleanedOcr = preprocessOcrForTransliteration(ocrText);
@@ -461,7 +484,8 @@ export async function performTransliteration(
 
   const usageMetadata = result.response.usageMetadata;
   const inputTokens = usageMetadata?.promptTokenCount || 0;
-  const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+  const outputTokens = (usageMetadata?.candidatesTokenCount || 0) +
+    ((usageMetadata as { thoughtsTokenCount?: number } | undefined)?.thoughtsTokenCount || 0);
 
   return {
     text: result.response.text(),


### PR DESCRIPTION
Fixes the largest single cost finding of the 2026-09-02 spend audit (#4581).

## What
Gemini 3.x enables thinking by default and bills thought tokens at the **output** rate, while `candidatesTokenCount` excludes them. The six pipeline entry points in `src/lib/ai.ts` (`performOCRWithBuffer`, `performOCR`, `performTranslation`, `generateSummary`, `performModernization`, `performTransliteration`) passed no `generationConfig` — so the realtime/Lambda pipeline paid for thinking that the internal meter could not see. August: metered $499.74 vs billed $8,389.32 (**17×**). The Aug 27–30 relit run alone burned ~690M thinking-on output tokens (~$3.3K in 4 days) through this path; the batch writers (`pipeline-orchestrator.mjs`) already set `thinkingBudget: 0` and are unaffected.

- All six functions now build their model via `getThinkingOffModel()`, which passes `thinkingConfig: { thinkingBudget: 0 }`. The legacy `@google/generative-ai` 0.24.x SDK lacks the type but passes the field through verbatim.
- `outputTokens` now adds `thoughtsTokenCount` when present, so if thinking is ever re-enabled anywhere the meter **sees** it instead of going blind again.

## Verification
Live probe on `gemini-3-flash-preview`, same prompt through the same SDK:
- WITH budget 0: `{candidatesTokenCount: 5, totalTokenCount: 16}` — no thoughts field
- WITHOUT config: `{candidatesTokenCount: 5, thoughtsTokenCount: 61, totalTokenCount: 77}`

September's batch-path tokens already reconcile with page-recorded candidates (25.4M metered vs 27.8M recorded, timing skew), confirming budget-0 requests bill no thinking. `npx tsc --noEmit` passes.

## Out of scope (deliberately)
~40 other `getGenerativeModel` sites in `src/` (chat/ask/explain routes, index generation, chapter-extraction, quality-scoring, collection-relevance, metadata-enrichment, cover-selection, tweet-generator, word-alignment, split detection). These are interactive or lower-volume, and some may *want* thinking for quality. They should be triaged as a follow-up — the enrichment-worker helpers (chapter-extraction, quality-scoring, collection-relevance, metadata-enrichment) run at volume and are the next candidates. Inventory posted to #4581.

## Quality note
OCR/translation prompts ask for transcription, not deliberation, and the batch lane has run these same models with `thinkingBudget: 0` for months with accepted quality — this brings the realtime lane to parity. If a regression is suspected, compare a re-run page sample against batch output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsexXhYKKtEXN73km7dahV