### PR TITLE
MCP list_books: add work_id filter; document /explore in llms.txt and /developers (#4576, #4574)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -218,6 +218,31 @@ GET /books
 
 Returns all books in the library with metadata.
 
+### Entities: People, Places and Concepts
+
+```
+https://sourcelibrary.org/explore
+https://sourcelibrary.org/explore/map
+```
+
+Over a million named entities — people, places and concepts — extracted from the
+AI-generated indexes of the books themselves, with a growing subset aligned to
+Wikidata (QIDs, birth/death years, coordinates). `/explore/map` plots the places
+that carry coordinates.
+
+Two things worth knowing before you build on it. Alignment is by Wikipedia-URL
+match or exact name string, so most entities are extracted but not yet aligned;
+treat an unaligned entity as "we found this name", not "we identified this
+thing". And because the source is a book's index rather than its body text, a
+place discussed in a book but absent from its index is invisible here.
+
+Ancient toponyms are the known weak spot: the same place is written differently
+in every tradition that names it (Magan / Makkan / Majan / Ṣuḥār / 甕蠻 / Oman),
+and matching on strings cannot join those. If you are chasing a place across
+languages, search co-occurring names rather than the place itself — a query for
+a lone toponym also collects homographs in unrelated languages, while a pair
+like `Dilmun Meluhha` returns near-pure signal.
+
 ### Distributed Text Services (DTS) API
 
 Source Library implements the [DTS v1.0 specification](https://distributed-text-services.github.io/specifications/) for standards-compliant text citation and passage retrieval.

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -298,6 +298,13 @@ async function listBooks(args: Record<string, unknown>) {
   // follow-up "all books by this person" call needs no separate lookup.
   if (args.author_id) params.set('author_id', String(args.author_id));
   if (args.edition_key) params.set('edition_key', String(args.edition_key));
+  // Every witness of ONE work. list_editions already answers "give me the
+  // siblings of this book", but only as a whole set — without this filter an
+  // agent holding a work_id cannot combine it with language, year or sort, so
+  // it falls back to a title search. That is exactly how the Sancai Tuhui reads
+  // as 18 books instead of 108: most witnesses are titled "Collected
+  // Illustrations of the Three Realms" and contain no "Sancai" string (#4576).
+  if (args.work_id) params.set('work_id', String(args.work_id));
   if (typeof args.year_from === 'number' && Number.isFinite(args.year_from)) params.set('year_from', String(Math.trunc(args.year_from)));
   if (typeof args.year_to === 'number' && Number.isFinite(args.year_to)) params.set('year_to', String(Math.trunc(args.year_to)));
   // `has_edition` filters by a language the book can be READ in; `language`
@@ -1108,6 +1115,7 @@ const TOOLS: Tool[] = [
         search: { type: 'string', description: 'Free-text filter matching title or author (relevance-ranked, may include title matches). For exactly one person\'s books use author_id instead.' },
         author_id: { type: 'string', description: 'Canonical author slug, e.g. "jan-hus" — filters to exactly that person\'s books via the author thesaurus (variant slugs resolve to the canonical person). Every book row in results carries its author_id; the response echoes the canonicalized author.' },
         edition_key: { type: 'string', description: 'Other digitizations of ONE printing — pass the edition_key from a result row. Only full-quality keys match on both sides, so this answers "what other scans of this exact edition do you hold?" and never merges different printings of the same title.' },
+        work_id: { type: 'string', description: 'Every witness of one WORK, across editions, languages and centuries — pass the work_id from a result row or from get_book. Use this instead of a title search whenever you already hold the identifier: witnesses of one work are often titled differently in each language, so a title search finds only the subset that happens to share your wording. Unlike list_editions (which returns the whole set), this composes with language, year_from/year_to and sort.' },
         year_from: { type: 'number', description: 'Earliest edition year (inclusive). Matches only books with a known numeric year — ~60% of the library.' },
         year_to: { type: 'number', description: 'Latest edition year (inclusive).' },
         language: { type: 'string' }, category: { type: 'string' },

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -628,6 +628,41 @@ source-library search "alchemy" --json | jq .results`}
         </div>
       </section>
 
+      {/* Entity layer */}
+      <section className="mb-16">
+        <h2 className="text-2xl font-semibold text-primary mb-2">Entities: people, places and concepts</h2>
+        <p className="text-secondary mb-6 max-w-2xl">
+          Over a million named entities extracted from the AI-generated indexes of the books
+          themselves, browsable at{' '}
+          <a href="/explore" className="underline">/explore</a>, with the subset that carries
+          coordinates plotted at <a href="/explore/map" className="underline">/explore/map</a>.
+          A growing share is aligned to Wikidata, which brings QIDs, birth and death years,
+          and coordinates with it.
+        </p>
+
+        <div className="bg-white rounded-xl border border-border-light p-6 max-w-2xl">
+          <h3 className="text-base font-semibold text-primary mb-2">Two limits worth knowing before you build on it</h3>
+          <ul className="text-secondary text-sm space-y-3">
+            <li>
+              <strong className="text-primary">Most entities are extracted, not identified.</strong>{' '}
+              Alignment is by Wikipedia-URL match or exact name string. An unaligned entity means
+              &ldquo;we found this name&rdquo;, not &ldquo;we know what this is&rdquo;.
+            </li>
+            <li>
+              <strong className="text-primary">The source is the index, not the body.</strong>{' '}
+              A place discussed in a book but missing from that book&apos;s index is invisible here.
+            </li>
+          </ul>
+          <p className="text-secondary text-sm mt-4">
+            Ancient toponyms are the known weak spot. The same place is written differently in
+            every tradition that names it — Magan / Makkan / Majan / Ṣuḥār / 甕蠻 / Oman — and
+            string matching cannot join those. Chasing a place across languages works better if
+            you search co-occurring names: a lone toponym also collects homographs in unrelated
+            languages, while a pair like <code>Dilmun Meluhha</code> returns near-pure signal.
+          </p>
+        </div>
+      </section>
+
       {/* Bulk dataset access */}
       <section className="mb-16">
         <h2 className="text-2xl font-semibold text-primary mb-2">Bulk dataset access</h2>


### PR DESCRIPTION
Closes the two small, verified items from the 2026-09-01 MCP feedback pair. Both are cases of an agent being unable to reach something we already have.

## 1. `list_books` gains a `work_id` filter

`/api/books/library?work_id=Q1761479` has always worked and returns **108** witnesses of the Sancai Tuhui. The MCP tool schema exposed `search`, `author_id` and `edition_key` — and not `work_id`.

The consequence is measurable: `list_books(search="Sancai")` returns **18 of the 108**, because most witnesses are titled *Collected Illustrations of the Three Realms* and contain no "Sancai" string. The work is reachable if you already hold the identifier, and not otherwise.

To be fair to the existing tools, the reporter slightly overstated this: `list_editions(book_id=…)` **is** the route from one juan to the whole work. What was genuinely missing is *composing* a work identifier with the other filters — `work_id` + `language`, `work_id` + `year_from`. No backend change; the parameter is passed through to a route that already accepts it.

The description tells the caller when to reach for it, because that is the part a model gets wrong: witnesses of one work are often titled differently in each language, so a title search finds only the subset that happens to share your wording.

## 2. `/explore` is now documented where agents actually look

An agent read `llms.txt` and `/developers`, found no entity layer in either, and proposed that we build one. It then found `/explore` by other means and retracted its own proposal. The docs gap caused the wasted proposal, so it is the thing fixed here.

Both pages now describe the entity layer — **1,023,584 entities** extracted from AI-generated book indexes, the Wikidata-aligned subset, and `/explore/map` — and, more usefully, both state the two limits that decide whether you can build on it:

- **Most entities are extracted, not identified.** Alignment is by Wikipedia-URL match or exact name string, so an unaligned entity means "we found this name", not "we know what this is".
- **The source is the index, not the body.** A place discussed in a book but absent from that book's index is invisible to the layer.

Both pages also carry the toponym-homograph workaround, which is the practically valuable part. `search_translations("Magan")` returns 63 matches of which roughly 7 are the Bronze Age polity; the rest are Old English *magan* ("to be able", in Beowulf), Hebrew מָגַן in Reuchlin, Chinese 馬肝 (horse liver), Tamil *magan* ("son"), an Aramaic adverb, a Malay charm word and a Spanish Jesuit's surname. Searching co-occurring toponyms (`Dilmun Meluhha`) returns near-pure signal. Documenting that costs nothing and saves every caller the same discovery — the trap is identical for Ophir, Punt, Saba, Thule and Aratta.

## Out of scope

- The place-authority work itself (Pleiades anchors, typed variant edges) — that is #4574 and it is a design question, not a schema line.
- The `year`/`published` disagreement also filed in #4576 (13 of 108 Sancai juan carry `published: "1609"` with `year: 1607`). It is a data sweep, not a tool contract, and probably belongs with #4043.
