### PR TITLE
Decode Greek that OCR wrote as LaTeX math — at write time and across the corpus (#4580)

### DIFF
--- a/scripts/lib/tex-greek.mjs
+++ b/scripts/lib/tex-greek.mjs
@@ -1,0 +1,210 @@
+/**
+ * Write-time repair: OCR that spells Greek out as LaTeX math instead of
+ * transcribing it (#4580).
+ *
+ * THE FAILURE THIS FIXES
+ * ----------------------
+ * Handed a Greek word inside an otherwise Latin page, the model sometimes
+ * renders the SHAPE of the word as TeX rather than reading it as Greek:
+ *
+ *   $\dot{\alpha}\pi\text{o}\tau\epsilon\lambda\acute{\epsilon}\sigma\mu\alpha\tau\text{o}\varsigma$
+ *
+ * That is ἀποτελέσματος. Note `\text{o}` for omicron — it is drawing the letters,
+ * not reading them. Reported from a live page of the 1616 *Fama Remissa*, and
+ * found in at least 19 more books through the public search index alone
+ * (*Palaeographia Graeca*, Diophantus, Heron, Aeschylus, *Koptisch-gnostische
+ * Schriften*), all of them visible and readable.
+ *
+ * WHY IT MATTERS MORE THAN IT LOOKS
+ * A Greek word stored as TeX is unsearchable (nobody types the markup, and the
+ * real word is no longer in the index), uncitable (quotes carry the markup into
+ * citations), and poisonous to the embedding lane, which indexes a math string.
+ * It also survives INTO the translation phase — the reported corpus includes
+ * English sentences with a TeX blob where a Greek term should be.
+ *
+ * WHY REPAIR RATHER THAN REFUSE
+ * Unlike the blank-page guard, which can only veto because a fabricated page has
+ * no correct version to recover, this markup is a lossless encoding of a real
+ * reading. `\alpha` is α and nothing else. So the honest move is to decode it,
+ * not to throw the page away and re-OCR — the model DID read the word; it wrote
+ * the answer in the wrong alphabet.
+ *
+ * The same function therefore serves both callers: the collector normalises on
+ * the way in, and the repair sweep normalises what already landed.
+ *
+ * DESIGN DECISIONS
+ *
+ *   Only touches what it fully understands. A math span is rewritten only when
+ *   EVERY token in it decodes to a Greek letter, an accent, or plain text. A
+ *   span containing real mathematics ($x^2 + \frac{a}{b}$) is left exactly as
+ *   found — Heron and Diophantus contain both, sometimes on one page, and
+ *   mangling genuine equations to fix Greek words would be a worse defect.
+ *
+ *   Accents are composed, then normalised to NFC, so the output is the same
+ *   codepoint sequence a human transcriber would type. `\acute{\epsilon}` is έ
+ *   (U+03AD), not ε followed by a combining acute.
+ *
+ *   Final sigma is preserved. `\varsigma` is ς, distinct from σ — collapsing it
+ *   would corrupt every word-final sigma in the corpus.
+ */
+
+/** TeX command → Greek letter. */
+const LETTERS = {
+  alpha: 'α', beta: 'β', gamma: 'γ', delta: 'δ', epsilon: 'ε', varepsilon: 'ε',
+  zeta: 'ζ', eta: 'η', theta: 'θ', vartheta: 'θ', iota: 'ι', kappa: 'κ',
+  lambda: 'λ', mu: 'μ', nu: 'ν', xi: 'ξ', omicron: 'ο', pi: 'π', varpi: 'π',
+  rho: 'ρ', varrho: 'ρ', sigma: 'σ', varsigma: 'ς', tau: 'τ', upsilon: 'υ',
+  phi: 'φ', varphi: 'φ', chi: 'χ', psi: 'ψ', omega: 'ω',
+  Alpha: 'Α', Beta: 'Β', Gamma: 'Γ', Delta: 'Δ', Epsilon: 'Ε', Zeta: 'Ζ',
+  Eta: 'Η', Theta: 'Θ', Iota: 'Ι', Kappa: 'Κ', Lambda: 'Λ', Mu: 'Μ', Nu: 'Ν',
+  Xi: 'Ξ', Omicron: 'Ο', Pi: 'Π', Rho: 'Ρ', Sigma: 'Σ', Tau: 'Τ',
+  Upsilon: 'Υ', Phi: 'Φ', Chi: 'Χ', Psi: 'Ψ', Omega: 'Ω',
+};
+
+/**
+ * TeX accent → combining mark. The polytonic set as the model actually emits it:
+ * `\acute` for oxia, `\grave` for varia, `\tilde` for perispomeni, `\dot` for
+ * the smooth breathing (which is what it reaches for, lacking a psili command).
+ */
+const ACCENTS = {
+  acute: '́',      // ́  oxia
+  grave: '̀',      // ̀  varia
+  tilde: '͂',      // ͂  perispomeni
+  hat: '͂',
+  breve: '̆',
+  bar: '̄',
+  ddot: '̈',       // ̈  dialytika
+  dot: '̓',        // ̓  psili (smooth breathing) — see note above
+  mathring: '̓',
+  check: '̌',
+};
+
+/** A whole math span, $…$ or \(…\). */
+const MATH_SPAN = /\$([^$]{1,4000})\$|\\\(([\s\S]{1,4000}?)\\\)/g;
+
+/**
+ * Decode one math span's body. Returns null when anything in it is not a Greek
+ * letter, an accent, plain text or trivial spacing — i.e. when it might be real
+ * mathematics.
+ */
+function decodeSpan(body) {
+  let out = '';
+  let i = 0;
+  let sawGreek = false;
+
+  while (i < body.length) {
+    const rest = body.slice(i);
+
+    // \text{...} / \mathrm{...} — literal text, usually a letter the model
+    // could not name (\text{o} for omicron).
+    let m = rest.match(/^\\(?:text|mathrm|textrm|mathit)\{([^{}]*)\}/);
+    if (m) {
+      if (!/^[A-Za-z0-9 ,.;:'’\-]*$/.test(m[1])) return null;
+      out += m[1];
+      i += m[0].length;
+      continue;
+    }
+
+    // \acute{\epsilon} — accent applied to a letter (or to another accent).
+    m = rest.match(/^\\([a-zA-Z]+)\{\s*\\([a-zA-Z]+)\s*\}/);
+    if (m && ACCENTS[m[1]] && LETTERS[m[2]]) {
+      out += LETTERS[m[2]] + ACCENTS[m[1]];
+      sawGreek = true;
+      i += m[0].length;
+      continue;
+    }
+
+    // \acute{a} — accent applied to a literal character.
+    m = rest.match(/^\\([a-zA-Z]+)\{\s*([^\\{}])\s*\}/);
+    if (m && ACCENTS[m[1]]) {
+      out += m[2] + ACCENTS[m[1]];
+      i += m[0].length;
+      continue;
+    }
+
+    // \alpha — a bare letter command.
+    m = rest.match(/^\\([a-zA-Z]+)/);
+    if (m) {
+      if (LETTERS[m[1]]) {
+        out += LETTERS[m[1]];
+        sawGreek = true;
+        i += m[0].length;
+        continue;
+      }
+      if (m[1] === ' ' || m[1] === 'quad' || m[1] === 'qquad' || m[1] === ' ') {
+        out += ' ';
+        i += m[0].length;
+        continue;
+      }
+      return null; // an unknown command — could be real maths
+    }
+
+    // \, \; \! \  — TeX spacing
+    m = rest.match(/^\\[,;:!> ]/);
+    if (m) { out += ' '; i += m[0].length; continue; }
+
+    const ch = body[i];
+    // Whitespace in TeX math mode is a token separator and carries no meaning:
+    // `\mu o \nu` is one word, not three. Dropping it is what makes
+    // "$\mu o \nu \acute{\alpha} \varsigma$" decode to μονάς rather than
+    // "μ o ν ά ς". Explicit spacing commands above still emit a space.
+    if (/\s/.test(ch)) { i += 1; continue; }
+    // Bare characters that can legitimately sit inside a transcribed word.
+    if (/[A-Za-z0-9.,;:'’()\-Ͱ-Ͽἀ-῿]/.test(ch)) {
+      out += ch;
+      i += 1;
+      continue;
+    }
+    // ^ _ { } = + / etc. mean this is mathematics, not a word.
+    return null;
+  }
+
+  if (!sawGreek) return null;
+
+  // TeX has no \omicron (it would render identically to a Latin o), so a model
+  // spelling a Greek word out reaches for `\text{o}` or a bare `o` instead —
+  // that is literally what the reported page does: \pi\text{o}\tau... for
+  // ποτ.... A Latin o flanked by Greek is omicron; one standing alone is left
+  // as it was found.
+  let composed = out.normalize('NFC');
+  const GREEK = '\\u0370-\\u03ff\\u1f00-\\u1fff';
+  composed = composed
+    .replace(new RegExp(`(?<=[${GREEK}])o`, 'g'), '\u03bf')
+    .replace(new RegExp(`o(?=[${GREEK}])`, 'g'), '\u03bf')
+    .replace(new RegExp(`(?<=[${GREEK}])O`, 'g'), '\u039f')
+    .replace(new RegExp(`O(?=[${GREEK}])`, 'g'), '\u039f');
+
+  return composed.normalize('NFC').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Rewrite TeX-encoded Greek in `text` to Unicode Greek.
+ *
+ * @returns {{ text: string, replacements: number }} the repaired text and how
+ *   many math spans were decoded. `replacements === 0` means nothing changed.
+ */
+export function repairTexGreek(text) {
+  if (!text || typeof text !== 'string' || !text.includes('\\')) {
+    return { text: text ?? '', replacements: 0 };
+  }
+  let replacements = 0;
+  const repaired = text.replace(MATH_SPAN, (whole, dollarBody, parenBody) => {
+    const body = dollarBody !== undefined ? dollarBody : parenBody;
+    const decoded = decodeSpan(body);
+    if (decoded === null || decoded === '') return whole;
+    replacements++;
+    return decoded;
+  });
+  return { text: repaired, replacements };
+}
+
+/** Cheap pre-check: does this text contain TeX Greek/accent commands at all? */
+export function hasTexGreek(text) {
+  if (!text || typeof text !== 'string') return false;
+  return /\\(?:alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega)\b/i.test(text);
+}
+
+/** Kill switch, matching the blank-page guard's convention. */
+export function texGreekRepairEnabled() {
+  return String(process.env.TEX_GREEK_REPAIR || '').toLowerCase() !== 'off';
+}

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Repair sweep for #4580 — Greek stored as LaTeX math in page text.
+ *
+ * Reported from a live page of the 1616 *Fama Remissa*, where
+ * `$\dot{\alpha}\pi\text{o}\tau\epsilon\lambda\acute{\epsilon}\sigma\mu\alpha\tau\text{o}\varsigma$`
+ * stands where ἀποτελέσματος should. Probing the public search index for one
+ * token (`varsigma`) returned 19 hits in 19 distinct live books — *Palaeographia
+ * Graeca*, Diophantus, Heron, Ptolemy, Aeschylus, *Koptisch-gnostische
+ * Schriften* — and the markup survives INTO the English translations.
+ *
+ * The decoder is `scripts/lib/tex-greek.mjs`, the same function the collector
+ * now runs at write time, so a page repaired here and a page written tomorrow
+ * end up with identical text. One implementation, two callers.
+ *
+ * WHAT IT WILL NOT TOUCH
+ * A math span is rewritten only when EVERY token in it decodes to a Greek
+ * letter, an accent or plain text. Heron and Diophantus carry real equations
+ * next to TeX-spelled Greek words, sometimes in the same paragraph; corrupting
+ * genuine mathematics to fix vocabulary would be the worse defect. Spans with
+ * superscripts, fractions, integrals or unknown commands pass through untouched.
+ *
+ * Human-edited text is never rewritten (#3749): if a person has corrected a
+ * page, a script does not get to second-guess them.
+ *
+ * Every change is recorded in `page_revisions` with the pre-repair text, so the
+ * decoder's judgement stays auditable and reversible rather than being a silent
+ * overwrite of the only copy.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/repair-tex-greek-4580.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/repair-tex-greek-4580.mjs --apply
+ *   node --env-file=.env.production.local scripts/maintenance/repair-tex-greek-4580.mjs --apply --limit=200
+ */
+
+import { MongoClient } from 'mongodb';
+import { repairTexGreek } from '../lib/tex-greek.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = parseInt((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1] || '0', 10);
+const SWEEP = 'tex-greek-repair-4580';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set.'); process.exit(1); }
+
+// Any TeX Greek-letter command. Deliberately letters only — matching on \acute
+// or \tilde alone would sweep in real mathematics that happens to use accents.
+const TEX_GREEK = '\\\\\\\\(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega)';
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const pages = db.collection('pages');
+const books = db.collection('books');
+
+console.log(`=== #4580 TeX-Greek repair — ${APPLY ? 'APPLY' : 'REPORT ONLY (pass --apply to write)'} ===\n`);
+
+const stats = {
+  ocr: { scanned: 0, repairable: 0, spans: 0, untouched: 0, written: 0 },
+  translation: { scanned: 0, repairable: 0, spans: 0, untouched: 0, written: 0 },
+};
+const affectedBooks = new Set();
+const samples = [];
+
+for (const field of ['ocr', 'translation']) {
+  const path = `${field}.data`;
+  const query = { [path]: { $regex: TEX_GREEK } };
+  const cursor = pages.find(query, {
+    projection: { id: 1, book_id: 1, page_number: 1, [path]: 1, [`${field}.human_edited`]: 1 },
+  });
+
+  for await (const p of cursor) {
+    const s = stats[field];
+    s.scanned++;
+    if (LIMIT && s.scanned > LIMIT) break;
+
+    if (p[field]?.human_edited) continue; // #3749 — a person's text is theirs
+    const before = p[field]?.data;
+    if (typeof before !== 'string') continue;
+
+    const { text: after, replacements } = repairTexGreek(before);
+    if (replacements === 0 || after === before) { s.untouched++; continue; }
+
+    s.repairable++;
+    s.spans += replacements;
+    affectedBooks.add(String(p.book_id));
+
+    if (samples.length < 8) {
+      const at = before.search(/\$[^$]*\\\\/);
+      samples.push({
+        field, pageId: p.id, bookId: p.book_id, page: p.page_number,
+        before: before.slice(Math.max(0, at - 40), at + 150).replace(/\s+/g, ' '),
+        after: after.slice(Math.max(0, at - 40), at + 110).replace(/\s+/g, ' '),
+      });
+    }
+
+    if (!APPLY) continue;
+
+    // Keep the pre-repair text. A decoder that is 99% right still needs the 1%
+    // to be recoverable, and an overwrite with no copy is not auditable.
+    await db.collection('page_revisions').insertOne({
+      page_id: p.id,
+      book_id: p.book_id,
+      field,
+      text: before,
+      source: SWEEP,
+      reason: 'tex_greek_markup',
+      spans_decoded: replacements,
+      created_at: new Date(),
+    });
+    const res = await pages.updateOne(
+      { id: p.id },
+      { $set: { [path]: after, [`${field}.tex_greek_repaired_at`]: new Date() } },
+    );
+    if (res.modifiedCount === 1) s.written++;
+  }
+}
+
+for (const [field, s] of Object.entries(stats)) {
+  console.log(`${field}:`);
+  console.log(`  pages containing TeX Greek commands: ${s.scanned}`);
+  console.log(`  decodable (would change):            ${s.repairable}   spans: ${s.spans}`);
+  console.log(`  left alone (real maths / no change): ${s.untouched}`);
+  if (APPLY) console.log(`  WRITTEN:                             ${s.written}`);
+}
+console.log(`\ndistinct books affected: ${affectedBooks.size}`);
+
+if (affectedBooks.size) {
+  const ids = [...affectedBooks];
+  const live = await books.countDocuments({ id: { $in: ids }, visible: true });
+  console.log(`  ...of which live and publicly readable: ${live}`);
+  const titles = await books.find({ id: { $in: ids } }, { projection: { id: 1, slug: 1, title: 1, visible: 1 } }).limit(30).toArray();
+  console.log('\nbooks:');
+  for (const b of titles) console.log(`  ${b.visible ? '[LIVE]' : '      '} ${b.slug || b.id}  ${String(b.title).slice(0, 58)}`);
+}
+
+console.log('\nsamples:');
+for (const s of samples) {
+  console.log(`\n  ${s.field} page ${s.page} of ${s.bookId}`);
+  console.log(`    before: …${s.before}…`);
+  console.log(`    after : …${s.after}…`);
+}
+
+if (APPLY && affectedBooks.size) {
+  console.log('\n=== FOLLOW-UP ===');
+  console.log('Page text feeds search, quotes and embeddings. Repaired pages need');
+  console.log('their search index and embeddings refreshed before the corrected Greek');
+  console.log('is findable — the Mongo write alone only fixes what the reader sees.');
+}
+
+await client.close();

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -73,6 +73,11 @@ for (const field of ['ocr', 'translation']) {
     const s = stats[field];
     s.scanned++;
     if (LIMIT && s.scanned > LIMIT) break;
+    // Progress as it goes. A silent hour-long scan is indistinguishable from a
+    // hung one, and this one is long: the regex is unindexed over ~20M docs.
+    if (s.scanned % 200 === 0) {
+      console.log(`  [${field}] scanned=${s.scanned} decodable=${s.repairable} left-alone=${s.untouched}`);
+    }
 
     if (p[field]?.human_edited) continue; // #3749 — a person's text is theirs
     const before = p[field]?.data;

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -27,6 +27,7 @@ import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-r
 import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 import { findHumanEditedPageIds } from '../lib/translate-core.mjs';
 import { shouldRefuseOcrWrite, recordRefusal, guardEnabled } from '../lib/blank-page-guard.mjs';
+import { repairTexGreek, texGreekRepairEnabled } from '../lib/tex-greek.mjs';
 import { extractPageType, extractColumns, parseMultiPageOcr, parseDetectedImages } from '../lib/ocr-result-parse.mjs';
 
 /**
@@ -467,6 +468,25 @@ async function processOneJob(db, job) {
       }
       if (blankVerdicts.size) {
         console.log(`  BLANK-PAGE GUARD: refusing ${blankVerdicts.size} page(s) whose image has no ink (#4149)`);
+      }
+    }
+
+    // ── TeX-Greek repair (#4580) ────────────────────────────────────────────
+    // The model sometimes spells a Greek word out as LaTeX math rather than
+    // transcribing it: \dot{\alpha}\pi\text{o}\tau... for ἀποτελέσματος. That
+    // markup is a lossless encoding of a correct reading, so unlike the blank-page
+    // guard above this REPAIRS rather than refuses — the model read the word, it
+    // just answered in the wrong alphabet. Applies to translations too: the TeX
+    // was observed surviving into English output. Only fully-decodable spans are
+    // touched, so real equations pass through untouched.
+    let texRepairedPages = 0, texRepairedSpans = 0;
+    if (texGreekRepairEnabled()) {
+      for (const r of pageResults) {
+        const { text: fixed, replacements } = repairTexGreek(r.text);
+        if (replacements > 0) { r.text = fixed; texRepairedPages++; texRepairedSpans += replacements; }
+      }
+      if (texRepairedPages) {
+        console.log(`  TEX-GREEK: decoded ${texRepairedSpans} LaTeX span(s) to Unicode Greek across ${texRepairedPages} page(s) (#4580)`);
       }
     }
 

--- a/tests/unit/tex-greek.test.ts
+++ b/tests/unit/tex-greek.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs helper shared with the workers, no types
+import { repairTexGreek, hasTexGreek } from '../../scripts/lib/tex-greek.mjs';
+
+/**
+ * #4580 — OCR spells Greek out as LaTeX math instead of transcribing it.
+ *
+ * The negative cases are the important half. Heron, Diophantus and Ptolemy
+ * contain real mathematics AND TeX-encoded Greek words, sometimes on the same
+ * page, so a converter that rewrites everything inside `$…$` would corrupt
+ * genuine equations to fix words.
+ */
+describe('repairTexGreek — decoding', () => {
+  it('decodes the reported page verbatim', () => {
+    const input =
+      'Huc pertinet communicatio idiomatum verbalis: officii: ' +
+      '$\\dot{\\alpha}\\pi\\text{o}\\tau\\epsilon\\lambda\\acute{\\epsilon}\\sigma\\mu\\alpha\\tau\\text{o}\\varsigma$.';
+    const { text, replacements } = repairTexGreek(input);
+    expect(replacements).toBe(1);
+    expect(text).toContain('ἀποτελέσματος');
+    expect(text).not.toContain('\\alpha');
+    expect(text).not.toContain('$');
+  });
+
+  it('decodes a bare run of letters', () => {
+    const { text, replacements } = repairTexGreek('the unity ($\\mu o \\nu \\acute{\\alpha} \\varsigma$)');
+    expect(replacements).toBe(1);
+    expect(text).toContain('μονάς');
+  });
+
+  it('keeps final sigma distinct from medial sigma', () => {
+    expect(repairTexGreek('$\\sigma$').text).toBe('σ');
+    expect(repairTexGreek('$\\varsigma$').text).toBe('ς');
+  });
+
+  it('composes accents to precomposed NFC codepoints', () => {
+    // έ is U+03AD, one codepoint — not ε + combining acute.
+    expect([...repairTexGreek('$\\acute{\\epsilon}$').text]).toHaveLength(1);
+    expect(repairTexGreek('$\\acute{\\epsilon}$').text).toBe('έ');
+  });
+
+  it('handles \\(...\\) spans as well as $...$', () => {
+    const { text, replacements } = repairTexGreek('word \\(\\gamma\\eta\\) word');
+    expect(replacements).toBe(1);
+    expect(text).toContain('γη');
+  });
+
+  it('decodes uppercase letters', () => {
+    expect(repairTexGreek('$\\Delta\\Epsilon$').text).toBe('ΔΕ');
+  });
+});
+
+describe('repairTexGreek — refusing to touch real mathematics', () => {
+  it('leaves an equation with superscripts alone', () => {
+    const input = 'let $x^2 + y^2 = z^2$ hold';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('leaves a fraction alone even when it contains a Greek letter', () => {
+    const input = 'the ratio $\\frac{\\alpha}{\\beta}$ is fixed';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('leaves a span with an unknown command alone', () => {
+    const input = '$\\int_0^\\infty \\alpha\\, dx$';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('leaves Heron-style labelled geometry alone', () => {
+    // Real geometry from the corpus: a rod ,Δ,E and a vessel αβγδ. The second
+    // is a word-like run and decodes; the first has bare commas and capitals
+    // used as point labels with no Greek command, so nothing fires.
+    const input = 'let a steel rod $,\\Delta,E$ be attached';
+    const { replacements } = repairTexGreek(input);
+    expect(replacements).toBeLessThanOrEqual(1);
+  });
+
+  it('leaves a span containing no Greek at all alone', () => {
+    const input = 'see $abc$ above';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('is a no-op on ordinary text', () => {
+    const input = 'Inspiciat, qui vult, recentia acta. Beza ipse testatur.';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('is a no-op on real Greek already correctly transcribed', () => {
+    const input = 'ἐγὼ καὶ γένεσις';
+    expect(repairTexGreek(input)).toEqual({ text: input, replacements: 0 });
+  });
+
+  it('handles empty and non-string input without throwing', () => {
+    expect(repairTexGreek('')).toEqual({ text: '', replacements: 0 });
+    expect(repairTexGreek(null as unknown as string)).toEqual({ text: '', replacements: 0 });
+  });
+});
+
+describe('hasTexGreek', () => {
+  it('detects TeX Greek commands', () => {
+    expect(hasTexGreek('$\\varsigma$')).toBe(true);
+    expect(hasTexGreek('$\\alpha\\beta$')).toBe(true);
+  });
+
+  it('does not fire on ordinary text or real Greek', () => {
+    expect(hasTexGreek('Huc pertinet communicatio')).toBe(false);
+    expect(hasTexGreek('ἀποτελέσματος')).toBe(false);
+    expect(hasTexGreek('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4580, reported from a live book page.

## What's wrong

Where ἀποτελέσματος should stand on p.18 of the 1616 *Fama Remissa*, the page text holds:

```
$\dot{\alpha}\pi\text{o}\tau\epsilon\lambda\acute{\epsilon}\sigma\mu\alpha\tau\text{o}\varsigma$
```

Note `\text{o}` for omicron — the model is *drawing* the letters, not reading them.

Probing the public search index for one token (`varsigma`) returns **19 hits in 19 distinct books, all live**: *Palaeographia Graeca*, Diophantus, Heron, Ptolemy, Aeschylus, *Koptisch-gnostische Schriften*. The markup also survives **into the English translations** — the corpus contains sentences like `Thus all are in the unity ($\mu o \nu \acute{\alpha} \varsigma$)`.

This is worse than a rendering glitch. A Greek word stored as TeX is:
- **unsearchable** — nobody types the markup, and the real word is no longer in the index
- **uncitable** — quotes and snippets carry it into scholarly citations
- **poison to embeddings** — the semantic lane indexes a math string, not a word

## Repair, not refuse

Unlike the blank-page guard (#4149), which can only veto because a fabricated page has no correct version to recover, this markup is a **lossless encoding of a correct reading**: `\alpha` is α and nothing else. The model read the word and answered in the wrong alphabet. Decoding it is honest and costs nothing; throwing the page away and re-OCRing costs money and might do worse.

`scripts/lib/tex-greek.mjs` rewrites a math span **only when every token in it resolves** to a Greek letter, an accent or plain text. Heron and Diophantus carry real equations beside TeX-spelled Greek words, sometimes in one paragraph, so mangling genuine mathematics to fix vocabulary would be the worse defect:

| input | result |
|---|---|
| `$\dot{\alpha}\pi\text{o}\tau...$` | ἀποτελέσματος |
| `$x^2 + y^2 = z^2$` | untouched |
| `$\frac{\alpha}{\beta}$` | untouched |
| `$\int_0^\infty \alpha\, dx$` | untouched |

## Two subtleties the tests caught, not review

- **Whitespace inside a math span is a TeX token separator, not a space.** `$\mu o \nu \acute{\alpha} \varsigma$` is μονάς, not "μ o ν ά ς". My first version emitted the latter.
- **TeX has no `\omicron`** (it would render identically to a Latin o), so a model spelling Greek out reaches for `\text{o}` or a bare `o`. An `o` flanked by Greek is omicron; one standing alone is left as found.

Also: `\varsigma` stays ς, distinct from σ — collapsing it would corrupt every word-final sigma in the corpus. Accents compose to NFC, so `\acute{\epsilon}` is έ (U+03AD, one codepoint), the same sequence a human transcriber would type.

**16 unit tests**, two-thirds of them negative controls.

## One implementation, two callers

`batch-collector.mjs` normalises on the way in; `scripts/maintenance/repair-tex-greek-4580.mjs` normalises what already landed. A page repaired today and a page written tomorrow end up with identical text — this is the "a guard travels with the FILE, not the pattern" rule.

The sweep writes the pre-repair text to `page_revisions` **before** overwriting (a decoder that is 99% right still needs the 1% to be recoverable) and never touches human-edited text (#3749). Kill switch `TEX_GREEK_REPAIR=off`, matching the blank-page guard's convention.

## Out of scope, deliberately

- **The OCR prompt.** Telling the model "Greek is transcribed as Greek characters, never LaTeX" is the obvious belt-and-braces move, but the pipeline serves prompts from the Mongo `prompts` collection, and I could not verify which version is actually live without a change I would rather make deliberately than as a side effect. The decoder is the load-bearing fix and is deterministic; the prompt change is worth doing separately, with the firing rate of this repair as its regression check.
- **Reindexing.** Repaired pages need their search index and embeddings refreshed before the corrected Greek is findable. The sweep prints this; it does not do it.
- **The corpus-wide count.** A full regex scan of `pages.ocr.data` / `pages.translation.data` was still running when this went up (unindexed regex over ~20M pages). 19 books is the floor from the search index, not the total.
