### PR TITLE
Profile-photo modal: reachable controls on iPhone and iPad (#4577)

### DIFF
--- a/src/components/account/ProfilePhotoEditor.tsx
+++ b/src/components/account/ProfilePhotoEditor.tsx
@@ -385,7 +385,11 @@ export default function ProfilePhotoEditor({ name, initialImage, size = 'md', th
             role="dialog"
             aria-modal="true"
             aria-labelledby="photo-editor-title"
-            className="rounded-xl shadow-2xl w-full max-w-lg max-h-[85vh] overflow-hidden flex flex-col"
+            /* dvh, not vh: iOS Safari resolves `vh` against the LARGE viewport
+               (URL bar hidden), so 85vh is taller than the screen whenever the
+               bar is showing — which is how the controls ended up off-screen
+               with no way to reach them (#4577). */
+            className="rounded-xl shadow-2xl w-full max-w-lg max-h-[85dvh] overflow-hidden flex flex-col"
             style={{ background: 'white' }}
           >
             <div className="flex items-center justify-between p-4" style={{ borderBottom: '1px solid var(--border-light)' }}>
@@ -405,7 +409,7 @@ export default function ProfilePhotoEditor({ name, initialImage, size = 'md', th
 
             {cropSource ? (
               /* ---- Crop stage ---- */
-              <div className="p-4 flex flex-col items-center gap-4 overflow-y-auto">
+              <div className="p-4 flex flex-col items-center gap-4 overflow-y-auto min-h-0">
                 <div
                   className="relative overflow-hidden touch-none select-none cursor-move shrink-0"
                   style={{ width: VIEW, height: VIEW, background: 'var(--bg-warm)' }}
@@ -481,7 +485,7 @@ export default function ProfilePhotoEditor({ name, initialImage, size = 'md', th
               </div>
             ) : (
               /* ---- Source picker ---- */
-              <div className="flex flex-col overflow-hidden">
+              <div className="flex flex-col overflow-hidden min-h-0">
                 <div className="flex gap-1 px-4 pt-3">
                   {(['library', 'upload'] as const).map(t => (
                     <button
@@ -521,7 +525,7 @@ export default function ProfilePhotoEditor({ name, initialImage, size = 'md', th
                     />
                   </div>
                 ) : (
-                  <div className="flex flex-col overflow-hidden">
+                  <div className="flex flex-col overflow-hidden min-h-0">
                     <div className="px-4 pt-3 pb-2">
                       <div className="relative">
                         <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-faint)' }} aria-hidden="true" />
@@ -536,7 +540,7 @@ export default function ProfilePhotoEditor({ name, initialImage, size = 'md', th
                       </div>
                     </div>
 
-                    <div className="px-4 pb-4 overflow-y-auto" style={{ maxHeight: '50vh' }}>
+                    <div className="px-4 pb-4 overflow-y-auto min-h-0 flex-1" style={{ maxHeight: '50dvh' }}>
                       {loadingLibrary ? (
                         <div className="flex justify-center py-10">
                           <Loader2 className="w-6 h-6 animate-spin" style={{ color: 'var(--text-muted)' }} aria-hidden="true" />


### PR DESCRIPTION
Fixes #4577, reported by a reader through the feedback widget:

> Oh the profile page when you add the profile photo, you get stuck on the iPad or iPhone browser, since the whole menu isn't visible.

## Two independent causes

Both put the **Back** / **Use photo** buttons past the bottom edge of a dialog that clips its overflow — so there is no way to reach them and no way to dismiss the modal. Either one alone reproduces the report.

**1. `max-h-[85vh]` on the dialog.** iOS Safari resolves `vh` against the *large* viewport — the one with the URL bar hidden — so `85vh` is taller than the actual screen whenever the bar is showing. Now `85dvh`, the dynamic viewport unit that exists for exactly this.

**2. The flexbox `min-height: auto` trap.** The dialog is `overflow-hidden flex flex-col`; the crop stage inside it is `overflow-y-auto`. But a flex child defaults to `min-height: auto` and refuses to shrink below its content — so it never gets smaller than it wants to be, `overflow-y-auto` never engages, and the content grows straight past the clipped edge instead of scrolling.

The crop stage is a fixed 280px viewport plus a zoom slider, a hint line and the action row. That is comfortably taller than a phone's usable height once the dialog is height-capped. Adding `min-h-0` to the scrollable columns lets them shrink so the scrollbar can do its job.

Also switched the picker grid's `maxHeight: '50vh'` to `50dvh` for the same reason as (1), and gave it `flex-1` so it shares the dialog's height rather than asserting an absolute one.

## Scope

CSS only — five class/style changes in `ProfilePhotoEditor.tsx`. No behaviour, state, or upload-path changes. `dvh` is supported on Safari 15.4+, Chrome 108+, Firefox 101+.

**Not verified on a physical device.** The diagnosis is from the layout rules rather than a reproduction, which is worth knowing before merging — but both causes are real and each independently produces the exact symptom described. Worth a check on an actual iPhone before the reporter gets a reply.

The submitter left an email, so this one is worth closing the loop on once it ships.
