### PR TITLE
WebMCP: read-only reader + search tools for in-browser agents (#4594)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -35,6 +35,7 @@ import { tenantBookUrl } from '@/lib/slugify';
 import { matchKnownEntity } from '@/lib/known-entities';
 import { assessMatchQuality } from '@/lib/search/match-quality';
 import HighlightedText from '@/components/search/HighlightedText';
+import SearchWebMCP from '@/components/search/SearchWebMCP';
 import { SEARCH_TYPE_STYLES, type SearchIndexType } from '@/lib/style-constants';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { LIBRARY_PARTNERS } from '@/lib/library-partners';
@@ -989,6 +990,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false, lang
 
   return (
     <div className="bg-cream" lang={lang}>
+      {/* WebMCP only on the main site: tool results emit /book/… URLs whose
+          shape is wrong on tenant reading rooms, and embedded iframes would
+          need an explicit allow="tools" grant from the partner page anyway. */}
+      {!embed && <SearchWebMCP />}
       {!embed && <SiteHeader variant="light" />}
 
       {/* Search Bar */}

--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -10,6 +10,7 @@ import Logo from '@/components/layout/Logo';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import DownloadButton from '@/components/ui/DownloadButton';
 import { FeedbackPanel } from './FeedbackPanel';
+import ReaderWebMCP from './ReaderWebMCP';
 import PageDeepZoomButton from '@/components/reader/PageDeepZoomButton';
 import type { DeepZoomManifest } from '@/lib/types/book';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
@@ -3165,6 +3166,10 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
 
   return (
     <div data-reader-v2 data-reader-theme={themeAttr(r.settings.theme)} className="flex flex-col h-[100dvh]">
+      {/* WebMCP only on the main site: get_citation emits /book/… URLs whose
+          shape is wrong on tenant reading rooms, and embedded iframes would
+          need an explicit allow="tools" grant from the partner page anyway. */}
+      {!isEmbedded && <ReaderWebMCP r={r} />}
       {/* Never in an embed or on a tenant subdomain. A partner reading room
           exists to hold one collection; a menu offering Explore, Works and
           Support sends the reader to URLs the tenant host 404s, and out of the

--- a/src/components/reader-v2/ReaderWebMCP.tsx
+++ b/src/components/reader-v2/ReaderWebMCP.tsx
@@ -2,6 +2,7 @@
 
 import { useWebMCPTools } from '@/hooks/useWebMCPTools';
 import { textResult, type WebMCPTool } from '@/lib/webmcp';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import type { useReaderV2 } from './useReaderV2';
 
 type ReaderState = ReturnType<typeof useReaderV2>;
@@ -58,8 +59,16 @@ export default function ReaderWebMCP({ r }: { r: ReaderState }) {
         inputSchema: { type: 'object', properties: {} },
         annotations: { readOnlyHint: true },
         execute: () => {
-          const ocr = currentPage.ocr?.data?.trim();
-          const translation = currentPage.translation?.data?.trim();
+          // A tool result is a quotable text surface: route it through
+          // stripEditorialWrappers like every other one (quote/search/text/
+          // IIIF), or the AI-written <meta>/<warning>/… page descriptions get
+          // served to the agent as if they were words on the page.
+          const ocr = currentPage.ocr?.data
+            ? stripEditorialWrappers(currentPage.ocr.data).trim()
+            : '';
+          const translation = currentPage.translation?.data
+            ? stripEditorialWrappers(currentPage.translation.data).trim()
+            : '';
           const parts = [
             `${bookLabel}, page ${currentPage.page_number} of ${totalPages}.`,
           ];

--- a/src/components/reader-v2/ReaderWebMCP.tsx
+++ b/src/components/reader-v2/ReaderWebMCP.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useWebMCPTools } from '@/hooks/useWebMCPTools';
+import { textResult, type WebMCPTool } from '@/lib/webmcp';
+import type { useReaderV2 } from './useReaderV2';
+
+type ReaderState = ReturnType<typeof useReaderV2>;
+
+const stripTags = (s: string) => s.replace(/<[^>]*>/g, '');
+
+/**
+ * Registers WebMCP tools scoped to the open book, so in-browser agents
+ * (Gemini in Chrome, ChatGPT Desktop, …) can page through the reader, read
+ * the current page's text, mint a citation, and search within the book —
+ * instead of scraping the DOM. Renders nothing; no-ops in browsers without
+ * WebMCP. All tools are read-only (issue #4594): they call the same
+ * same-origin APIs the reader UI already calls, in the user's own session,
+ * so auth, metering and rate limits apply unchanged.
+ */
+export default function ReaderWebMCP({ r }: { r: ReaderState }) {
+  useWebMCPTools((): WebMCPTool[] => {
+    const { book, currentPage, pageList, totalPages } = r;
+    const bookLabel = `"${book.display_title || book.title}"${book.author ? ` by ${book.author}` : ''}`;
+
+    return [
+      {
+        name: 'go_to_page',
+        description:
+          `Turn the reader to a printed page number of the open book, ${bookLabel} ` +
+          `(${totalPages} pages). Use get_current_page_text afterwards to read it.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            page_number: {
+              type: 'number',
+              description: 'The printed page number to open, starting at 1.',
+            },
+          },
+          required: ['page_number'],
+        },
+        execute: (params) => {
+          const n = Number(params.page_number);
+          const target = pageList.find((p) => p.page_number === n);
+          if (!target) {
+            return textResult(
+              `No page ${n} in this book — printed page numbers run 1 to ${totalPages}.`
+            );
+          }
+          r.goToPage(target.id);
+          return textResult(`Opened page ${n} of ${bookLabel}.`);
+        },
+      },
+      {
+        name: 'get_current_page_text',
+        description:
+          `Read the page the reader is currently showing in ${bookLabel}: ` +
+          'the original transcription (OCR) and the English translation, when available.',
+        inputSchema: { type: 'object', properties: {} },
+        annotations: { readOnlyHint: true },
+        execute: () => {
+          const ocr = currentPage.ocr?.data?.trim();
+          const translation = currentPage.translation?.data?.trim();
+          const parts = [
+            `${bookLabel}, page ${currentPage.page_number} of ${totalPages}.`,
+          ];
+          if (translation) parts.push(`--- English translation ---\n${translation}`);
+          if (ocr) parts.push(`--- Original text (${book.language || 'source language'}) ---\n${ocr}`);
+          if (!ocr && !translation) {
+            parts.push(
+              'No text is available on this client for this page (it may be untranscribed, an image plate, or gated pending sign-in).'
+            );
+          }
+          return textResult(parts.join('\n\n'));
+        },
+      },
+      {
+        name: 'get_citation',
+        description:
+          `Get a stable, shareable citation URL and a formatted reference for the page ` +
+          `currently open in ${bookLabel}.`,
+        inputSchema: { type: 'object', properties: {} },
+        annotations: { readOnlyHint: true },
+        execute: () => {
+          // Built from the canonical /book/<slug>/page/<id> shape, not
+          // window.location — the reader can be mounted on an /embed/… or
+          // /es/… or design-preview path, none of which is the citable URL.
+          const url = `${window.location.origin}/book/${r.bookPath}/page/${r.currentPageId}`;
+          const line = [
+            book.author,
+            `"${book.display_title || book.title}"`,
+            book.published ? `(${book.published})` : null,
+            `p. ${currentPage.page_number}`,
+            `Source Library, ${url}`,
+          ]
+            .filter(Boolean)
+            .join(', ');
+          return textResult(`${line}\n\nCitable URL: ${url}`);
+        },
+      },
+      {
+        name: 'search_this_book',
+        description:
+          `Full-text search within ${bookLabel} — matches both the original text and ` +
+          'the English translation, returning page numbers you can open with go_to_page.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Words or a phrase to find in this book.' },
+          },
+          required: ['query'],
+        },
+        annotations: { readOnlyHint: true },
+        execute: async (params) => {
+          const query = String(params.query || '').trim();
+          if (!query) return textResult('Provide a non-empty query.');
+          const res = await fetch(
+            `/api/books/${encodeURIComponent(book.id)}/search?q=${encodeURIComponent(query)}`
+          );
+          if (!res.ok) {
+            return textResult(`Search failed (HTTP ${res.status}). Try again shortly.`);
+          }
+          const data = (await res.json()) as {
+            total?: number;
+            results?: Array<{
+              pageNumber?: number;
+              matches?: Array<{ field?: string; snippet?: string }>;
+            }>;
+          };
+          const results = data.results || [];
+          if (!results.length) {
+            return textResult(`No matches for "${query}" in ${bookLabel}.`);
+          }
+          const lines = results.slice(0, 8).map((hit) => {
+            const snippet = stripTags(hit.matches?.[0]?.snippet || '').trim();
+            return `p. ${hit.pageNumber}: ${snippet}`;
+          });
+          const shown = Math.min(results.length, 8);
+          return textResult(
+            `${data.total ?? results.length} matching page(s) for "${query}" in ${bookLabel}` +
+              ` — showing ${shown}:\n\n${lines.join('\n')}\n\nUse go_to_page to open one.`
+          );
+        },
+      },
+    ];
+  }, [r.book.id]);
+
+  return null;
+}

--- a/src/components/search/SearchWebMCP.tsx
+++ b/src/components/search/SearchWebMCP.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useWebMCPTools } from '@/hooks/useWebMCPTools';
+import { textResult, type WebMCPTool } from '@/lib/webmcp';
+
+/**
+ * Registers a WebMCP `search_library` tool on the search page, so in-browser
+ * agents can query the catalogue directly instead of driving the search box.
+ * Renders nothing; no-ops in browsers without WebMCP. Read-only (issue
+ * #4594) — same same-origin API the page itself calls, in the user's own
+ * session, so metering and rate limits apply unchanged.
+ */
+export default function SearchWebMCP() {
+  useWebMCPTools((): WebMCPTool[] => [
+    {
+      name: 'search_library',
+      description:
+        'Search the Source Library catalogue of historical primary sources ' +
+        '(alchemy, Hermetica, Kabbalah, early modern science, and more) by ' +
+        'title, author, or full-text content. Returns the top-ranked matches ' +
+        'with links — not an exhaustive list, so it cannot answer "how many" ' +
+        'or "show me all" questions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'What to search for — a title, author, topic, or phrase.',
+          },
+        },
+        required: ['query'],
+      },
+      annotations: { readOnlyHint: true },
+      execute: async (params) => {
+        const query = String(params.query || '').trim();
+        if (!query) return textResult('Provide a non-empty query.');
+        const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&limit=10`);
+        if (!res.ok) {
+          return textResult(`Search failed (HTTP ${res.status}). Try again shortly.`);
+        }
+        const data = (await res.json()) as {
+          total?: number;
+          results?: Array<{
+            id?: string;
+            slug?: string;
+            title?: string;
+            display_title?: string;
+            author?: string;
+            book_title?: string;
+            book_author?: string;
+            published?: string;
+            snippet?: string;
+          }>;
+        };
+        const results = data.results || [];
+        if (!results.length) return textResult(`No results for "${query}".`);
+        const origin = window.location.origin;
+        const lines = results.slice(0, 10).map((r) => {
+          const title = r.display_title || r.title || r.book_title || 'Untitled';
+          const author = r.author || r.book_author;
+          const path = r.slug || r.id;
+          const url = path ? ` — ${origin}/book/${path}` : '';
+          const meta = [author, r.published].filter(Boolean).join(', ');
+          return `- ${title}${meta ? ` (${meta})` : ''}${url}`;
+        });
+        return textResult(
+          `${data.total ?? results.length} result(s) for "${query}":\n${lines.join('\n')}`
+        );
+      },
+    },
+  ]);
+
+  return null;
+}

--- a/src/hooks/useWebMCPTools.ts
+++ b/src/hooks/useWebMCPTools.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { registerWebMCPTools, type WebMCPTool } from '@/lib/webmcp';
+
+/**
+ * Register WebMCP tools for the lifetime of the calling component.
+ *
+ * Tools are (re)registered only when `deps` change (e.g. the book id), but
+ * each registered tool delegates `execute` to the latest `getTools()` result
+ * at call time — so callbacks always see current component state (current
+ * page number, etc.) without re-registering on every render, which would
+ * churn the agent-visible tool list.
+ */
+export function useWebMCPTools(
+  getTools: () => WebMCPTool[],
+  deps: React.DependencyList = []
+): void {
+  const getToolsRef = useRef(getTools);
+  getToolsRef.current = getTools;
+
+  useEffect(() => {
+    const registered = getToolsRef.current().map((tool) => ({
+      ...tool,
+      execute: (params: Record<string, unknown>) => {
+        const live =
+          getToolsRef.current().find((t) => t.name === tool.name) ?? tool;
+        return live.execute(params);
+      },
+    }));
+    return registerWebMCPTools(registered);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -1,0 +1,107 @@
+/**
+ * WebMCP (Web Model Context Protocol) adapter.
+ *
+ * WebMCP is a draft W3C standard (webmachinelearning/webmcp) that lets a page
+ * register typed tools that in-browser AI agents (Gemini in Chrome, ChatGPT
+ * Desktop, Brave Leo, Edge/Copilot) can discover and call. Chrome ships it in
+ * an origin trial (149–156); the API host has moved between revisions
+ * (`window.agent` → `navigator.modelContext` → `document.modelContext`), so we
+ * feature-detect both current hosts and treat the whole thing as progressive
+ * enhancement: no API, no-op.
+ *
+ * Registered tools run in the page with the user's own session, so existing
+ * auth/rate limits apply unchanged. v1 policy (issue #4594): read-only tools
+ * only — no writes without requestUserInteraction(), which is not yet stable.
+ */
+
+export interface WebMCPToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+}
+
+export interface WebMCPTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean };
+  execute: (
+    params: Record<string, unknown>
+  ) => WebMCPToolResult | Promise<WebMCPToolResult>;
+}
+
+interface ModelContext {
+  registerTool?: (
+    tool: WebMCPTool,
+    options?: { signal?: AbortSignal }
+  ) => Promise<void> | void;
+  unregisterTool?: (name: string) => void;
+  provideContext?: (context: { tools: WebMCPTool[] }) => void;
+}
+
+/** Wrap plain text in the MCP result shape agents expect. */
+export function textResult(text: string): WebMCPToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function getModelContext(): ModelContext | null {
+  if (typeof document === 'undefined') return null;
+  const doc = document as Document & { modelContext?: ModelContext };
+  const nav = navigator as Navigator & { modelContext?: ModelContext };
+  return doc.modelContext ?? nav.modelContext ?? null;
+}
+
+/** True when the current browser exposes a WebMCP registration surface. */
+export function isWebMCPAvailable(): boolean {
+  return getModelContext() !== null;
+}
+
+/**
+ * Register a set of tools; returns a cleanup function that unregisters them.
+ * Safe to call unconditionally — silently no-ops when WebMCP is unavailable.
+ */
+export function registerWebMCPTools(tools: WebMCPTool[]): () => void {
+  const ctx = getModelContext();
+  if (!ctx) return () => {};
+
+  if (typeof ctx.registerTool === 'function') {
+    const controller = new AbortController();
+    for (const tool of tools) {
+      try {
+        void ctx.registerTool(tool, { signal: controller.signal });
+      } catch {
+        // An experimental API rejecting one tool must never break the page.
+      }
+    }
+    return () => {
+      controller.abort();
+      // Older revisions ignore the abort signal but expose unregisterTool.
+      if (typeof ctx.unregisterTool === 'function') {
+        for (const tool of tools) {
+          try {
+            ctx.unregisterTool(tool.name);
+          } catch {
+            /* already gone */
+          }
+        }
+      }
+    };
+  }
+
+  if (typeof ctx.provideContext === 'function') {
+    // provideContext replaces the full tool set; clearing on cleanup keeps
+    // stale page-scoped tools from outliving their page.
+    try {
+      ctx.provideContext({ tools });
+    } catch {
+      return () => {};
+    }
+    return () => {
+      try {
+        ctx.provideContext?.({ tools: [] });
+      } catch {
+        /* best effort */
+      }
+    };
+  }
+
+  return () => {};
+}


### PR DESCRIPTION
Implements the v1 plan in #4594.

## What

Registers **WebMCP** tools (draft W3C standard; Chrome 149–156 origin trial, also consumed by ChatGPT Desktop and Brave Leo) so in-browser AI agents can drive the reader through typed tools instead of DOM-scraping:

**Book reader** (`Reader2C`, main site only):
- `go_to_page` — turn to a printed page number (validates against `pageList`, reports the valid range on a miss)
- `get_current_page_text` — current page's OCR + English translation; states absence explicitly instead of returning silence
- `get_citation` — formatted reference + canonical `/book/<slug>/page/<id>` URL, built from `bookPath`/`currentPageId`, never `window.location` (which may be an `/embed/…`, `/es/…`, or design-preview path)
- `search_this_book` — same `/api/books/[id]/search` the in-reader panel calls; returns page numbers that feed `go_to_page`

**Search page**:
- `search_library` — `/api/search?q=…&limit=10`, returning top-ranked matches with full book URLs. The description states it cannot answer "how many / show me all" (per `.claude/docs/invariants/agent-tool-results.md` — a ranker cannot answer a cardinality question).

## How

- `src/lib/webmcp.ts` — feature-detected adapter over `document.modelContext` (current spec) with `navigator.modelContext` fallback (earlier revision); `registerTool`+AbortSignal, `provideContext` fallback; returns a cleanup fn; silent no-op when the API is absent.
- `src/hooks/useWebMCPTools.ts` — registers per-component; `execute` delegates to the latest closure at call time, so page turns update tool behavior **without** re-registering (re-registration would churn the agent-visible tool list).
- Mounted behind `!isEmbedded` / `!embed` — tenant reading rooms and embeds have different URL shapes, and cross-origin iframes need an explicit `allow="tools"` grant regardless.

## Safety posture

- **Read-only tools only** (v1 policy from #4594). No writes; `submit_feedback` etc. deferred until `requestUserInteraction()` stabilizes.
- Tools call the same same-origin APIs the UI already calls, **in the user's own session** — auth, anon-gate, page budgets, and rate limits apply unchanged. No new server surface; zero backend changes.
- No behavior change for any browser without WebMCP (that's all stable browsers today — the API is behind Chrome's origin trial / flags).

## Out of scope

- Chrome/Edge **origin-trial token registration** (needs a Google/Microsoft dev account action — follow-up steps in a comment on #4594). Until a token ships, this code is live only for users who enable `chrome://flags/#enable-webmcp-testing`, which is also how to test it.
- Declarative form annotation, write tools, tenant-scoped variants.

`npx tsc --noEmit` and eslint pass locally.

Closes #4594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHsmfFyqVcewXHJSqSWEFg