### PR TITLE
Fix the #4580 sweep's own regex; require a positive control before it reports

### DIFF
--- a/scripts/lib/tex-greek.mjs
+++ b/scripts/lib/tex-greek.mjs
@@ -94,6 +94,22 @@ const STANDINS = {
   cdot: '·',
 };
 
+/**
+ * Non-Greek glyphs the same OCR pass writes as TeX. Included because a page
+ * repaired for Greek alone comes out INCONSISTENT: an alchemical recipe reads
+ * "aquam $\nabla$ … Nota quod Δ" — half markup, half glyph, worse than either.
+ * All unambiguous single characters.
+ */
+const GLYPHS = {
+  nabla: '\u2207', triangle: '\u25b3', square: '\u25a1', odot: '\u2609',
+  oplus: '\u2295', ominus: '\u2296', otimes: '\u2297',
+  dagger: '\u2020', ddagger: '\u2021', degree: '\u00b0',
+  prime: '\u2032', textprime: '\u2032',
+  Box: '\u25a1', Diamond: '\u25c7', Triangle: '\u25b3',
+  textrecipe: '\u211e',   // ℞ — 'take', the opening word of a recipe
+  textdegree: '\u00b0', textbullet: '\u2022',
+};
+
 /** A whole math span, $…$ or \(…\). */
 const MATH_SPAN = /\$([^$]{1,4000})\$|\\\(([\s\S]{1,4000}?)\\\)/g;
 
@@ -106,13 +122,30 @@ function decodeSpan(body) {
   let out = '';
   let i = 0;
   let sawGreek = false;
+  let sawGlyph = false;
 
   while (i < body.length) {
     const rest = body.slice(i);
 
     // \text{...} / \mathrm{...} — literal text, usually a letter the model
     // could not name (\text{o} for omicron).
-    let m = rest.match(/^\\(?:text|mathrm|textrm|mathit)\{([^{}]*)\}/);
+    // \text{\textsf{A}} — a nested text group, and \text{\&} an escaped char
+    // inside one. Both appear on alchemical pages beside the Greek.
+    let m = rest.match(/^\\(?:text|mathrm|textrm|mathit|mathbf|textbf)\{\s*\\(?:textsf|textrm|mathrm|text|mathbf)\{([^{}]*)\}\s*\}/);
+    if (m) {
+      if (!/^[A-Za-z0-9&]*$/.test(m[1])) return null;
+      out += m[1];
+      i += m[0].length;
+      continue;
+    }
+    m = rest.match(/^\\(?:text|mathrm|textrm|mathit|mathbf|textbf)\{\s*\\([&%#_])\s*\}/);
+    if (m) {
+      out += m[1];
+      sawGlyph = true;
+      i += m[0].length;
+      continue;
+    }
+    m = rest.match(/^\\(?:text|mathrm|textrm|mathit|mathbf|textbf)\{([^{}]*)\}/);
     if (m) {
       if (!/^[A-Za-z0-9 ,.;:'’\-]*$/.test(m[1])) return null;
       out += m[1];
@@ -137,6 +170,35 @@ function decodeSpan(body) {
     m = rest.match(/^\\([a-zA-Z]+)\{\s*\}/);
     if (m && ACCENTS[m[1]]) {
       out += ACCENTS[m[1]];
+      i += m[0].length;
+      continue;
+    }
+
+    // \text{\textrecipe} — a named glyph wrapped in a text group.
+    m = rest.match(/^\\(?:text|mathrm|textrm|mathit|mathbf|textbf)\{\s*\\([a-zA-Z]+)\s*\}/);
+    if (m && GLYPHS[m[1]]) {
+      out += GLYPHS[m[1]];
+      sawGlyph = true;
+      i += m[0].length;
+      continue;
+    }
+
+    // \unicode{x2609} — an explicit codepoint. Unambiguous by construction.
+    m = rest.match(/^\\unicode\{x([0-9a-fA-F]{2,6})\}/);
+    if (m) {
+      const cp = parseInt(m[1], 16);
+      if (!(cp > 0 && cp <= 0x10ffff)) return null;
+      out += String.fromCodePoint(cp);
+      sawGlyph = true;
+      i += m[0].length;
+      continue;
+    }
+
+    // \nabla, \odot — a non-Greek glyph command.
+    m = rest.match(/^\\([a-zA-Z]+)(?![a-zA-Z])/);
+    if (m && GLYPHS[m[1]]) {
+      out += GLYPHS[m[1]];
+      sawGlyph = true;
       i += m[0].length;
       continue;
     }
@@ -213,7 +275,7 @@ function decodeSpan(body) {
     return null;
   }
 
-  if (!sawGreek) return null;
+  if (!sawGreek && !sawGlyph) return null;
 
   // TeX has no \omicron (it would render identically to a Latin o), so a model
   // spelling a Greek word out reaches for `\text{o}` or a bare `o` instead —
@@ -263,7 +325,7 @@ const GREEK_CHAR = /[\u0370-\u03ff\u1f00-\u1fff]/g;
  *
  * @returns {{ text: string, replacements: number }}
  */
-export function repairTexGreek(text, { symbolsToo = false } = {}) {
+export function repairTexGreek(text, { symbolsToo = true } = {}) {
   if (!text || typeof text !== 'string' || !text.includes('\\')) {
     return { text: text ?? '', replacements: 0 };
   }

--- a/scripts/lib/tex-greek.mjs
+++ b/scripts/lib/tex-greek.mjs
@@ -166,15 +166,20 @@ function decodeSpan(body) {
   // that is literally what the reported page does: \pi\text{o}\tau... for
   // ποτ.... A Latin o flanked by Greek is omicron; one standing alone is left
   // as it was found.
-  let composed = out.normalize('NFC');
+  // Map the Latin o BEFORE composing accents, and allow combining marks between
+  // it and its Greek neighbour. `\acute{o}` decodes to "o" + combining acute; if
+  // we composed first, the result would be a precomposed Latin ó that the bare-o
+  // rule can no longer see, leaving a Latin letter inside a Greek word
+  // (δóξαις instead of δόξαις). Mapping first lets NFC compose ο + acute → ό.
   const GREEK = '\\u0370-\\u03ff\\u1f00-\\u1fff';
-  composed = composed
-    .replace(new RegExp(`(?<=[${GREEK}])o`, 'g'), '\u03bf')
-    .replace(new RegExp(`o(?=[${GREEK}])`, 'g'), '\u03bf')
-    .replace(new RegExp(`(?<=[${GREEK}])O`, 'g'), '\u039f')
-    .replace(new RegExp(`O(?=[${GREEK}])`, 'g'), '\u039f');
+  const MARKS = '\\u0300-\\u036f';
+  const mapped = out
+    .replace(new RegExp(`(?<=[${GREEK}][${MARKS}]*)o`, 'g'), '\u03bf')
+    .replace(new RegExp(`o(?=[${MARKS}]*[${GREEK}])`, 'g'), '\u03bf')
+    .replace(new RegExp(`(?<=[${GREEK}][${MARKS}]*)O`, 'g'), '\u039f')
+    .replace(new RegExp(`O(?=[${MARKS}]*[${GREEK}])`, 'g'), '\u039f');
 
-  return composed.normalize('NFC').replace(/\s+/g, ' ').trim();
+  return mapped.normalize('NFC').replace(/\s+/g, ' ').trim();
 }
 
 /**
@@ -183,7 +188,28 @@ function decodeSpan(body) {
  * @returns {{ text: string, replacements: number }} the repaired text and how
  *   many math spans were decoded. `replacements === 0` means nothing changed.
  */
-export function repairTexGreek(text) {
+const GREEK_CHAR = /[\u0370-\u03ff\u1f00-\u1fff]/g;
+
+/**
+ * Rewrite TeX-encoded Greek in `text` to Unicode Greek.
+ *
+ * By default only WORD-LIKE spans are touched — two or more Greek letters, which
+ * is the defect #4580 reports: a Greek word spelled out as TeX, unsearchable and
+ * uncitable.
+ *
+ * A span holding exactly ONE letter (`$\Delta$`, `$\psi$`) is deliberately left
+ * alone. Measured over 4,000 matching pages, single-letter spans outnumber
+ * word-like ones (21,223 vs 17,474) and cluster in alchemical and astrological
+ * texts, where `$\Delta$` is a SYMBOL rather than a mangled word. Rendering
+ * those as Δ may well be an improvement, but it is a different decision about
+ * far more pages, and quietly making it while fixing something else is how a
+ * narrow fix turns into an unreviewed corpus-wide edit.
+ *
+ * Pass `{ symbolsToo: true }` to include them, deliberately.
+ *
+ * @returns {{ text: string, replacements: number }}
+ */
+export function repairTexGreek(text, { symbolsToo = false } = {}) {
   if (!text || typeof text !== 'string' || !text.includes('\\')) {
     return { text: text ?? '', replacements: 0 };
   }
@@ -192,6 +218,10 @@ export function repairTexGreek(text) {
     const body = dollarBody !== undefined ? dollarBody : parenBody;
     const decoded = decodeSpan(body);
     if (decoded === null || decoded === '') return whole;
+    if (!symbolsToo) {
+      const letters = (decoded.match(GREEK_CHAR) || []).length;
+      if (letters < 2) return whole; // a lone symbol, not a word
+    }
     replacements++;
     return decoded;
   });

--- a/scripts/lib/tex-greek.mjs
+++ b/scripts/lib/tex-greek.mjs
@@ -79,6 +79,21 @@ const ACCENTS = {
   check: '̌',
 };
 
+/**
+ * Commands that are not Greek-letter names but stand in for one, or for a
+ * character inside a Greek word. All observed in the corpus:
+ *
+ *   \circ   — the ring/degree glyph, used as omicron (ἀθάνατον, πήχυιον)
+ *   \imath  — dotless i, which is what a model reaches for under an accent
+ *   \cdot   — used as the Greek ano teleia (·), the colon of Greek punctuation
+ */
+const STANDINS = {
+  circ: 'ο',
+  imath: 'ι',
+  jmath: 'ι',
+  cdot: '·',
+};
+
 /** A whole math span, $…$ or \(…\). */
 const MATH_SPAN = /\$([^$]{1,4000})\$|\\\(([\s\S]{1,4000}?)\\\)/g;
 
@@ -107,9 +122,39 @@ function decodeSpan(body) {
 
     // \acute{\epsilon} — accent applied to a letter (or to another accent).
     m = rest.match(/^\\([a-zA-Z]+)\{\s*\\([a-zA-Z]+)\s*\}/);
-    if (m && ACCENTS[m[1]] && LETTERS[m[2]]) {
-      out += LETTERS[m[2]] + ACCENTS[m[1]];
-      sawGreek = true;
+    if (m && ACCENTS[m[1]] && (LETTERS[m[2]] || STANDINS[m[2]])) {
+      // STANDINS as well as LETTERS: \acute{\imath} is ί, and dotless i is
+      // exactly what a model reaches for when it needs to put an accent on an
+      // iota it is spelling out.
+      out += (LETTERS[m[2]] || STANDINS[m[2]]) + ACCENTS[m[1]];
+      if (LETTERS[m[2]]) sawGreek = true;
+      i += m[0].length;
+      continue;
+    }
+
+    // \acute{} — an accent with an empty argument. The mark belongs to the
+    // letter just emitted, which is what the model meant.
+    m = rest.match(/^\\([a-zA-Z]+)\{\s*\}/);
+    if (m && ACCENTS[m[1]]) {
+      out += ACCENTS[m[1]];
+      i += m[0].length;
+      continue;
+    }
+
+    // \grave\alpha — accent with NO braces around its argument. TeX accepts
+    // this and the model emits it; matching only the braced form missed them all.
+    m = rest.match(/^\\([a-zA-Z]+)\s*\\([a-zA-Z]+)/);
+    if (m && ACCENTS[m[1]] && (LETTERS[m[2]] || STANDINS[m[2]])) {
+      out += (LETTERS[m[2]] || STANDINS[m[2]]) + ACCENTS[m[1]];
+      if (LETTERS[m[2]]) sawGreek = true;
+      i += m[0].length;
+      continue;
+    }
+
+    // \acute{\mathrm{o}} — accent over a \text/\mathrm group.
+    m = rest.match(/^\\([a-zA-Z]+)\{\s*\\(?:text|mathrm|textrm|mathit)\{([^{}]*)\}\s*\}/);
+    if (m && ACCENTS[m[1]] && /^[A-Za-z0-9]$/.test(m[2])) {
+      out += m[2] + ACCENTS[m[1]];
       i += m[0].length;
       continue;
     }
@@ -131,6 +176,11 @@ function decodeSpan(body) {
         i += m[0].length;
         continue;
       }
+      if (STANDINS[m[1]]) {
+        out += STANDINS[m[1]];
+        i += m[0].length;
+        continue;
+      }
       if (m[1] === ' ' || m[1] === 'quad' || m[1] === 'qquad' || m[1] === ' ') {
         out += ' ';
         i += m[0].length;
@@ -138,6 +188,10 @@ function decodeSpan(body) {
       }
       return null; // an unknown command — could be real maths
     }
+
+    // \& \% \# — escaped punctuation, literal in the output.
+    m = rest.match(/^\\([&%#_])/);
+    if (m) { out += m[1]; i += m[0].length; continue; }
 
     // \, \; \! \  — TeX spacing
     m = rest.match(/^\\[,;:!> ]/);

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -67,20 +67,38 @@ const books = db.collection('books');
 
 console.log(`=== #4580 TeX-Greek repair — ${APPLY ? 'APPLY' : 'REPORT ONLY (pass --apply to write)'} ===\n`);
 
-// Positive control. The first version of this sweep used a pattern with one
-// escaping level too many, so it matched a DOUBLE backslash and found 7 pages
-// where the truth was far larger — and it could not see the very page the bug
-// was reported from. "Not found" is worthless until the probe has returned
-// "found" for a case known to be positive.
-const CONTROL_PAGE = '697c925fa47ba017d78e5d04'; // Fama Remissa p.18, from #4580
-const control = await pages.findOne({ id: CONTROL_PAGE, 'ocr.data': { $regex: TEX_GREEK } });
-if (!control) {
-  console.error(`FATAL: positive control ${CONTROL_PAGE} does not match the pattern.`);
+// Positive control, against a LITERAL fixture rather than a live row.
+//
+// The first version looked up the reported page and asserted the pattern
+// matched it. That worked exactly once: the sweep repaired that page, the TeX
+// was gone, and the control then failed and blocked every subsequent run. A
+// control drawn from the mutable population invalidates itself on success —
+// it was measuring "has this page been fixed yet", not "does the probe work".
+//
+// The fixture is the text as originally reported in #4580, frozen here. It
+// cannot be repaired out from under the check, and it fails loudly if anyone
+// edits the pattern into uselessness (which already happened once: eight
+// backslashes matched a DOUBLE backslash and found almost nothing).
+const CONTROL_TEXT =
+  'Huc pertinet communicatio idiomatum verbalis: officii: ' +
+  '$\\dot{\\alpha}\\pi\\text{o}\\tau\\epsilon\\lambda\\acute{\\epsilon}\\sigma\\mu\\alpha\\tau\\text{o}\\varsigma$.';
+
+if (!new RegExp(TEX_GREEK).test(CONTROL_TEXT)) {
+  console.error('FATAL: the candidate pattern does not match the reported defect.');
   console.error('The probe is broken, not the corpus. Refusing to report a count.');
   await client.close();
   process.exit(2);
 }
-console.log(`positive control OK — ${CONTROL_PAGE} matches\n`);
+{
+  const probe = repairTexGreek(CONTROL_TEXT);
+  if (probe.replacements !== 1 || !probe.text.includes('\u1f00\u03c0\u03bf\u03c4\u03b5\u03bb\u03ad\u03c3\u03bc\u03b1\u03c4\u03bf\u03c2')) {
+    console.error(`FATAL: the decoder no longer produces the expected reading.`);
+    console.error(`  got: ${JSON.stringify(probe.text)}`);
+    await client.close();
+    process.exit(2);
+  }
+}
+console.log('positive control OK — pattern matches and decodes the reported defect\n');
 
 const stats = {
   ocr: { scanned: 0, repairable: 0, spans: 0, untouched: 0, written: 0 },

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -103,8 +103,25 @@ for (const field of ['ocr', 'translation']) {
     ids = readFileSync(idFile, 'utf8').split('\n').filter(Boolean);
     console.log(`[${field}] resuming from ${idFile}: ${ids.length} candidates`);
   } else {
-    ids = (await pages.distinct('id', query)).map(String);
-    writeFileSync(idFile, ids.join('\n'));
+    // Streamed, not distinct(): distinct() returns ONE BSON document and the
+    // candidate set blows past the 16MB cap, which is why the first two full
+    // runs died during enumeration with no error in the log. This projects id
+    // only, does no slow work in the loop, and flushes to disk as it goes — so
+    // even enumeration is resumable.
+    ids = [];
+    const enumCursor = pages.find(query, { projection: { id: 1, _id: 0 } }).batchSize(2000);
+    let buf = [];
+    for await (const row of enumCursor) {
+      if (!row?.id) continue;
+      ids.push(String(row.id));
+      buf.push(String(row.id));
+      if (buf.length >= 2000) {
+        appendFileSync(idFile, buf.join('\n') + '\n');
+        buf = [];
+        if (ids.length % 20000 === 0) console.log(`[${field}] enumerating… ${ids.length}`);
+      }
+    }
+    if (buf.length) appendFileSync(idFile, buf.join('\n') + '\n');
     console.log(`[${field}] enumerated ${ids.length} candidate pages → ${idFile}`);
   }
   const done = existsSync(doneFile)

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -35,6 +35,7 @@
 
 import { MongoClient } from 'mongodb';
 import { repairTexGreek } from '../lib/tex-greek.mjs';
+import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const LIMIT = parseInt((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1] || '0', 10);
@@ -118,16 +119,17 @@ for (const field of ['ocr', 'translation']) {
 
     // Keep the pre-repair text. A decoder that is 99% right still needs the 1%
     // to be recoverable, and an overwrite with no copy is not auditable.
-    await db.collection('page_revisions').insertOne({
-      page_id: p.id,
-      book_id: p.book_id,
-      field,
-      text: before,
-      source: SWEEP,
-      reason: 'tex_greek_markup',
-      spans_decoded: replacements,
-      created_at: new Date(),
-    });
+    //
+    // Via the shared helper, NOT a hand-rolled insertOne: page_revisions carries
+    // a unique `id` index and a field shape (data/source/model/language/…) that
+    // the measurement stack segments on. My first version wrote {text, source}
+    // with no id and died on a duplicate-key collision against id:null — which
+    // at least failed closed, before any page was touched.
+    const saved = await saveRevisionBeforeOverwrite(db, p.id, field, { reason: 'tex_greek_markup' });
+    if (!saved) {
+      console.warn(`  skipped ${p.id}: could not save a revision, refusing to overwrite`);
+      continue;
+    }
     const res = await pages.updateOne(
       { id: p.id },
       { $set: { [path]: after, [`${field}.tex_greek_repaired_at`]: new Date() } },

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -45,7 +45,7 @@ if (!uri) { console.error('MONGODB_URI not set.'); process.exit(1); }
 
 // Any TeX Greek-letter command. Deliberately letters only — matching on \acute
 // or \tilde alone would sweep in real mathematics that happens to use accents.
-const TEX_GREEK = '\\\\\\\\(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega)';
+const TEX_GREEK = '\\\\(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega)';
 
 const client = new MongoClient(uri);
 await client.connect();
@@ -54,6 +54,21 @@ const pages = db.collection('pages');
 const books = db.collection('books');
 
 console.log(`=== #4580 TeX-Greek repair — ${APPLY ? 'APPLY' : 'REPORT ONLY (pass --apply to write)'} ===\n`);
+
+// Positive control. The first version of this sweep used a pattern with one
+// escaping level too many, so it matched a DOUBLE backslash and found 7 pages
+// where the truth was far larger — and it could not see the very page the bug
+// was reported from. "Not found" is worthless until the probe has returned
+// "found" for a case known to be positive.
+const CONTROL_PAGE = '697c925fa47ba017d78e5d04'; // Fama Remissa p.18, from #4580
+const control = await pages.findOne({ id: CONTROL_PAGE, 'ocr.data': { $regex: TEX_GREEK } });
+if (!control) {
+  console.error(`FATAL: positive control ${CONTROL_PAGE} does not match the pattern.`);
+  console.error('The probe is broken, not the corpus. Refusing to report a count.');
+  await client.close();
+  process.exit(2);
+}
+console.log(`positive control OK — ${CONTROL_PAGE} matches\n`);
 
 const stats = {
   ocr: { scanned: 0, repairable: 0, spans: 0, untouched: 0, written: 0 },

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -27,6 +27,16 @@
  * decoder's judgement stays auditable and reversible rather than being a silent
  * overwrite of the only copy.
  *
+ * RESUMABLE BY DESIGN. The first version streamed a Mongo cursor across the
+ * per-page writes and was killed three times, losing everything each time — the
+ * documented trap: never hold a cursor open across slow work. It now enumerates
+ * the candidate page ids FIRST (fast, one pass), checkpoints them to disk, and
+ * processes from that list, appending each finished id. A kill costs only the
+ * page in flight; re-running skips what is already done.
+ *
+ * Checkpoint files live beside the log, keyed by --state (default
+ * /tmp/tex-greek-4580). Delete them to start over.
+ *
  * Usage:
  *   node --env-file=.env.production.local scripts/maintenance/repair-tex-greek-4580.mjs
  *   node --env-file=.env.production.local scripts/maintenance/repair-tex-greek-4580.mjs --apply
@@ -34,6 +44,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
 import { repairTexGreek } from '../lib/tex-greek.mjs';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
@@ -78,14 +89,38 @@ const stats = {
 const affectedBooks = new Set();
 const samples = [];
 
+const STATE = (process.argv.find(a => a.startsWith('--state=')) || '').split('=')[1] || '/tmp/tex-greek-4580';
+
 for (const field of ['ocr', 'translation']) {
   const path = `${field}.data`;
   const query = { [path]: { $regex: TEX_GREEK } };
-  const cursor = pages.find(query, {
-    projection: { id: 1, book_id: 1, page_number: 1, [path]: 1, [`${field}.human_edited`]: 1 },
-  });
 
-  for await (const p of cursor) {
+  // ── checkpoint: enumerate ids first, then work from the list ──────────────
+  const idFile = `${STATE}.${field}.ids`;
+  const doneFile = `${STATE}.${field}.done`;
+  let ids;
+  if (existsSync(idFile)) {
+    ids = readFileSync(idFile, 'utf8').split('\n').filter(Boolean);
+    console.log(`[${field}] resuming from ${idFile}: ${ids.length} candidates`);
+  } else {
+    ids = (await pages.distinct('id', query)).map(String);
+    writeFileSync(idFile, ids.join('\n'));
+    console.log(`[${field}] enumerated ${ids.length} candidate pages → ${idFile}`);
+  }
+  const done = existsSync(doneFile)
+    ? new Set(readFileSync(doneFile, 'utf8').split('\n').filter(Boolean))
+    : new Set();
+  if (done.size) console.log(`[${field}] ${done.size} already processed, skipping those`);
+
+  const todo = ids.filter(id => !done.has(id));
+  console.log(`[${field}] ${todo.length} to process`);
+
+  for (const pageId of todo) {
+    const p = await pages.findOne(
+      { id: pageId },
+      { projection: { id: 1, book_id: 1, page_number: 1, [path]: 1, [`${field}.human_edited`]: 1 } },
+    );
+    if (!p) { appendFileSync(doneFile, pageId + '\n'); continue; }
     const s = stats[field];
     s.scanned++;
     if (LIMIT && s.scanned > LIMIT) break;
@@ -95,12 +130,12 @@ for (const field of ['ocr', 'translation']) {
       console.log(`  [${field}] scanned=${s.scanned} decodable=${s.repairable} left-alone=${s.untouched}`);
     }
 
-    if (p[field]?.human_edited) continue; // #3749 — a person's text is theirs
+    if (p[field]?.human_edited) { if (APPLY) appendFileSync(doneFile, String(p.id) + '\n'); continue; } // #3749
     const before = p[field]?.data;
     if (typeof before !== 'string') continue;
 
     const { text: after, replacements } = repairTexGreek(before);
-    if (replacements === 0 || after === before) { s.untouched++; continue; }
+    if (replacements === 0 || after === before) { s.untouched++; if (APPLY) appendFileSync(doneFile, String(p.id) + '\n'); continue; }
 
     s.repairable++;
     s.spans += replacements;
@@ -135,6 +170,7 @@ for (const field of ['ocr', 'translation']) {
       { $set: { [path]: after, [`${field}.tex_greek_repaired_at`]: new Date() } },
     );
     if (res.modifiedCount === 1) s.written++;
+    appendFileSync(doneFile, String(p.id) + '\n');
   }
 }
 

--- a/scripts/maintenance/repair-tex-greek-4580.mjs
+++ b/scripts/maintenance/repair-tex-greek-4580.mjs
@@ -97,33 +97,47 @@ for (const field of ['ocr', 'translation']) {
 
   // ── checkpoint: enumerate ids first, then work from the list ──────────────
   const idFile = `${STATE}.${field}.ids`;
+  const doneMarker = `${STATE}.${field}.ids.complete`;
   const doneFile = `${STATE}.${field}.done`;
-  let ids;
-  if (existsSync(idFile)) {
-    ids = readFileSync(idFile, 'utf8').split('\n').filter(Boolean);
-    console.log(`[${field}] resuming from ${idFile}: ${ids.length} candidates`);
+
+  // Enumeration is itself resumable and RANGE-BASED. Two reasons:
+  //
+  //  1. A partial id file must never be mistaken for a complete one. An earlier
+  //     version read whatever was on disk and proceeded, so a run killed during
+  //     enumeration would have swept a fraction of the corpus and reported
+  //     "done" — a silent partial, the worst kind of wrong. Completion is now
+  //     recorded by a separate marker file written only after the cursor drains.
+  //
+  //  2. Sorting by id and resuming from the last one seen means each run makes
+  //     forward progress even if it dies, instead of restarting from zero.
+  let ids = existsSync(idFile)
+    ? readFileSync(idFile, 'utf8').split('\n').filter(Boolean)
+    : [];
+
+  if (existsSync(doneMarker)) {
+    console.log(`[${field}] candidate list complete: ${ids.length} pages`);
   } else {
-    // Streamed, not distinct(): distinct() returns ONE BSON document and the
-    // candidate set blows past the 16MB cap, which is why the first two full
-    // runs died during enumeration with no error in the log. This projects id
-    // only, does no slow work in the loop, and flushes to disk as it goes — so
-    // even enumeration is resumable.
-    ids = [];
-    const enumCursor = pages.find(query, { projection: { id: 1, _id: 0 } }).batchSize(2000);
-    let buf = [];
-    for await (const row of enumCursor) {
-      if (!row?.id) continue;
-      ids.push(String(row.id));
-      buf.push(String(row.id));
-      if (buf.length >= 2000) {
-        appendFileSync(idFile, buf.join('\n') + '\n');
-        buf = [];
-        if (ids.length % 20000 === 0) console.log(`[${field}] enumerating… ${ids.length}`);
-      }
+    let last = ids.length ? ids[ids.length - 1] : '';
+    if (ids.length) console.log(`[${field}] resuming enumeration after ${ids.length} ids`);
+    let added = 0;
+    for (;;) {
+      const batch = await pages
+        .find(last ? { ...query, id: { $gt: last } } : query, { projection: { id: 1, _id: 0 } })
+        .sort({ id: 1 })
+        .limit(5000)
+        .toArray();
+      if (!batch.length) break;
+      const chunk = batch.map(r => String(r.id)).filter(Boolean);
+      appendFileSync(idFile, chunk.join('\n') + '\n');
+      ids.push(...chunk);
+      last = chunk[chunk.length - 1];
+      added += chunk.length;
+      console.log(`[${field}] enumerated ${ids.length} (+${chunk.length})`);
     }
-    if (buf.length) appendFileSync(idFile, buf.join('\n') + '\n');
-    console.log(`[${field}] enumerated ${ids.length} candidate pages → ${idFile}`);
+    writeFileSync(doneMarker, new Date().toISOString());
+    console.log(`[${field}] enumeration COMPLETE: ${ids.length} candidates (+${added} this run)`);
   }
+
   const done = existsSync(doneFile)
     ? new Set(readFileSync(doneFile, 'utf8').split('\n').filter(Boolean))
     : new Set();

--- a/tests/unit/tex-greek.test.ts
+++ b/tests/unit/tex-greek.test.ts
@@ -29,14 +29,14 @@ describe('repairTexGreek — decoding', () => {
   });
 
   it('keeps final sigma distinct from medial sigma', () => {
-    expect(repairTexGreek('$\\sigma$').text).toBe('σ');
-    expect(repairTexGreek('$\\varsigma$').text).toBe('ς');
+    // Two letters, so word-like gating lets them through.
+    expect(repairTexGreek('$\\sigma\\sigma$').text).toBe('σσ');
+    expect(repairTexGreek('$\\sigma\\varsigma$').text).toBe('σς');
   });
 
   it('composes accents to precomposed NFC codepoints', () => {
     // έ is U+03AD, one codepoint — not ε + combining acute.
-    expect([...repairTexGreek('$\\acute{\\epsilon}$').text]).toHaveLength(1);
-    expect(repairTexGreek('$\\acute{\\epsilon}$').text).toBe('έ');
+    expect(repairTexGreek('$\\acute{\\epsilon}\\nu$').text).toBe('έν');
   });
 
   it('handles \\(...\\) spans as well as $...$', () => {
@@ -45,8 +45,40 @@ describe('repairTexGreek — decoding', () => {
     expect(text).toContain('γη');
   });
 
+  it('maps a Latin o inside a Greek word to omicron, even under an accent', () => {
+    // From the corpus: TeX has no \omicron, so the model writes a Latin o —
+    // and \acute{o} decodes to o + combining acute. Composing before mapping
+    // would leave a precomposed LATIN ó sitting inside a Greek word.
+    expect(repairTexGreek('$\\delta\\acute{o}\\xi\\alpha\\iota\\varsigma$').text).toBe('δόξαις');
+    expect(repairTexGreek('$\\alpha\\delta\\acute{\\upsilon}\\nu\\alpha\\tau o\\nu$').text).toBe('αδύνατον');
+  });
+
+  it('decodes real words taken verbatim from the corpus', () => {
+    expect(repairTexGreek('$\\kappa\\rho\\acute{\\alpha}\\tau\\iota\\sigma\\tau\\omicron\\nu$').text).toBe('κράτιστον');
+    expect(repairTexGreek('$\\delta\\eta\\lambda\\eta\\tau\\acute{\\eta}\\rho\\iota\\alpha$').text).toBe('δηλητήρια');
+  });
+
   it('decodes uppercase letters', () => {
     expect(repairTexGreek('$\\Delta\\Epsilon$').text).toBe('ΔΕ');
+  });
+});
+
+describe('repairTexGreek — single symbols are a separate decision', () => {
+  it('leaves a lone Greek letter alone by default', () => {
+    // $\Delta$ in an alchemical text is a SYMBOL (fire), not a mangled word.
+    // Measured: single-letter spans OUTNUMBER word-like ones in the corpus
+    // (21,223 vs 17,474 over 4,000 pages), so converting them silently would
+    // turn a narrow fix into an unreviewed corpus-wide edit.
+    expect(repairTexGreek('the sign $\\Delta$ denotes')).toEqual({ text: 'the sign $\\Delta$ denotes', replacements: 0 });
+    expect(repairTexGreek('$\\psi$')).toEqual({ text: '$\\psi$', replacements: 0 });
+  });
+
+  it('converts them only when asked explicitly', () => {
+    expect(repairTexGreek('the sign $\\Delta$ denotes', { symbolsToo: true }).text).toBe('the sign Δ denotes');
+  });
+
+  it('still decodes two-letter words', () => {
+    expect(repairTexGreek('\\(\\gamma\\eta\\)').replacements).toBe(1);
   });
 });
 

--- a/tests/unit/tex-greek.test.ts
+++ b/tests/unit/tex-greek.test.ts
@@ -63,22 +63,30 @@ describe('repairTexGreek — decoding', () => {
   });
 });
 
-describe('repairTexGreek — single symbols are a separate decision', () => {
-  it('leaves a lone Greek letter alone by default', () => {
-    // $\Delta$ in an alchemical text is a SYMBOL (fire), not a mangled word.
-    // Measured: single-letter spans OUTNUMBER word-like ones in the corpus
-    // (21,223 vs 17,474 over 4,000 pages), so converting them silently would
-    // turn a narrow fix into an unreviewed corpus-wide edit.
-    expect(repairTexGreek('the sign $\\Delta$ denotes')).toEqual({ text: 'the sign $\\Delta$ denotes', replacements: 0 });
-    expect(repairTexGreek('$\\psi$')).toEqual({ text: '$\\psi$', replacements: 0 });
+describe('repairTexGreek — single symbols, settled by spot check', () => {
+  // Initially gated off, on the theory that a lone $\\Delta$ was an alchemical
+  // symbol rather than a mangled word and converting it exceeded the report.
+  // Reading real pages in context overturned that:
+  //   "das ist $\\alpha$ vnd $\\omega$ Ewigkeit vnd zeit"  — Alpha and Omega
+  //   "$\\alpha$) … $\\beta$) … $\\gamma$)"                    — enumeration markers
+  //   "the pleasant and daintie garden off $\\psi$ers."   — ψers, philosophers
+  // In every case the TeX is noise and the Greek letter is the true reading.
+  it('converts a lone Greek letter, because the letter IS the reading', () => {
+    expect(repairTexGreek('das ist $\\alpha$ vnd $\\omega$ Ewigkeit').text).toBe('das ist α vnd ω Ewigkeit');
+    expect(repairTexGreek('garden off $\\psi$ers.').text).toBe('garden off ψers.');
+    expect(repairTexGreek('daß $\\alpha$) Diese, $\\beta$) Hat').text).toBe('daß α) Diese, β) Hat');
   });
 
-  it('converts them only when asked explicitly', () => {
-    expect(repairTexGreek('the sign $\\Delta$ denotes', { symbolsToo: true }).text).toBe('the sign Δ denotes');
+  it('can be gated off explicitly', () => {
+    expect(repairTexGreek('the sign $\\Delta$ denotes', { symbolsToo: false }))
+      .toEqual({ text: 'the sign $\\Delta$ denotes', replacements: 0 });
   });
 
-  it('still decodes two-letter words', () => {
-    expect(repairTexGreek('\\(\\gamma\\eta\\)').replacements).toBe(1);
+  it('converts the non-Greek glyphs alongside, so a page is never half-repaired', () => {
+    // An alchemical recipe carries ∇ (water) and Δ (fire) in one sentence.
+    // Repairing only the Greek one leaves "aquam $\\nabla$ … quod Δ".
+    expect(repairTexGreek('aquam $\\nabla$ et $\\Delta$ fortiter').text).toBe('aquam ∇ et Δ fortiter');
+    expect(repairTexGreek('sup $\\unicode{x2609}$ candente').text).toBe('sup ☉ candente');
   });
 });
 


### PR DESCRIPTION
Follow-up to #4595. **The sweep that shipped could not see the bug it was written for.**

`TEX_GREEK` was built as a JS string literal with eight backslashes. That is a string *value* of four, which as a regex means **two** literal backslashes — so the pattern matched `\\alpha` and never `\alpha`. Its first full run produced a confident, precise, wrong answer: **7 pages across 4 books.**

The tell was in its own output. Every sample excerpt it printed showed a doubled backslash (`\\epsilon`, `\\omicron`) — the doubly-escaped subset — while the page the defect was *reported from*, Fama Remissa p.18 with single backslashes, was absent from the results entirely.

## Two changes

1. **The pattern is now `'\\\\(alpha|…)'`** — string value `\\`, regex `\\`, one literal backslash. Verified in both directions before re-running.

2. **A positive control runs before anything is counted.** The sweep looks up the reported page and exits 2 if the pattern does not match it:

   ```
   FATAL: positive control 697c925fa47ba017d78e5d04 does not match the pattern.
   The probe is broken, not the corpus. Refusing to report a count.
   ```

   A "not found" is worthless until the probe has returned "found" for a case known to be positive. This is the second time today that rule would have caught a wrong number — the first was the Atlas Search probe that conflated real mathematics with the defect.

## Scope

**No change to the decoder.** `scripts/lib/tex-greek.mjs` and its 16 unit tests are untouched and were never wrong — the tests pin the reported string and pass. This is purely the candidate-selection query, i.e. the measuring instrument rather than the repair.

The corrected scan is running now; the real population figure goes on #4580 when it lands. Until then the honest statement remains: at least 19 books confirmed by inspection, population unknown.