### PR TITLE
<lacuna>: a named marker for regions with no legible source (#4195 item 5, #4584)

### DIFF
--- a/scripts/eval/ocr-prompt-v17-acceptance.mjs
+++ b/scripts/eval/ocr-prompt-v17-acceptance.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Acceptance run for OCR prompt v17 (#4195 checklist + #4584).
+ *
+ * Runs v15 (current default) and v17 side by side over the exemplars the issues
+ * name, so each claim is checked against the page that produced it rather than
+ * a page chosen to flatter the change. Two of the cases are counter-examples
+ * that must NOT change — a prompt that only ever declines is not an improvement.
+ *
+ * Usage: node --env-file=.env.production.local scripts/eval/ocr-prompt-v17-acceptance.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const BASE = 'https://generativelanguage.googleapis.com/v1beta';
+const KEY = process.env.GEMINI_API_KEY || process.env.GEMINI_API_KEY_2;
+if (!KEY) throw new Error('no GEMINI_API_KEY');
+const MODEL = 'gemini-3.1-flash-lite';
+const LANG_INSTR = `**Source language:** Detect the primary language from the text. Pages may contain multiple languages — transcribe all of them. Report the primary language in the <language> tag (e.g. <language>Latin</language>).`;
+
+const BULHAN = '6953b56577f38f6761bd979d';   // Kitab al-Bulhan — #3591 exemplars
+const ZUNI = '69a565b95a8a09c1b325e47f';     // Zuni Fetiches — #4149 blank leaves
+const URK4 = '69e013c593b116d24238b3d7';     // Urkunden IV — #4584 fabrication
+
+const CASES = [
+  { label: '#3591 torn mansion grid',   book: BULHAN, page: 60,  expect: 'lacuna, and NOT 14 complete mansion names' },
+  { label: '#3591 legible basmala',     book: BULHAN, page: 266, expect: 'NOT blank — real text transcribed' },
+  { label: '#3591 cataloguer note',     book: BULHAN, page: 197, expect: 'NOT blank' },
+  { label: '#3591 li-l-muallif',        book: BULHAN, page: 4,   expect: 'NOT blank' },
+  { label: '#3591 cipher counter-ex',   book: BULHAN, page: 198, expect: 'must STILL decline (counter-example)' },
+  { label: '#4149 blank leaf',          book: ZUNI,   page: 45,  expect: 'page-type blank, no body/header/sig/page-num' },
+  { label: '#4149 blank leaf',          book: ZUNI,   page: 72,  expect: 'page-type blank, no body' },
+  { label: '#4149 ordinary prose',      book: ZUNI,   page: 30,  expect: 'normal transcription (counter-example)' },
+  { label: '#4584 hieroglyph block',    book: URK4,   page: 24,  expect: 'lacuna, no invented x+N lines' },
+  { label: '#4584 ordinary apparatus',  book: URK4,   page: 118, expect: 'German apparatus kept; no Ra-loop' },
+];
+
+const c = new MongoClient(process.env.MONGODB_URI); await c.connect();
+const db = c.db('bookstore');
+const col = db.collection('prompts');
+const prep = (s) => s.replace('{language_instruction}', LANG_INSTR).replace('{language}', '');
+const v15 = prep((await col.findOne({ type: 'ocr', version: 15 })).content);
+const v17 = prep((await col.findOne({ type: 'ocr', version: 17 })).content);
+
+async function gemini(promptText, b64) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const r = await fetch(`${BASE}/models/${MODEL}:generateContent?key=${KEY}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: promptText }, { inlineData: { mimeType: 'image/jpeg', data: b64 } }] }],
+        generationConfig: { temperature: 0.1, maxOutputTokens: 8192, thinkingConfig: { thinkingBudget: 0 } },
+      }),
+      signal: AbortSignal.timeout(180000),
+    });
+    const j = await r.json();
+    if (r.ok) return j.candidates?.[0]?.content?.parts?.map((p) => p.text).join('') || '(empty)';
+    if (r.status === 429 || r.status >= 500) { await new Promise((s) => setTimeout(s, 4000 * (attempt + 1))); continue; }
+    return `ERROR ${r.status} ${JSON.stringify(j).slice(0, 160)}`;
+  }
+  return 'ERROR exhausted retries';
+}
+
+const tag = (t, name) => (t.match(new RegExp(`<${name}>`, 'gi')) || []).length;
+const pageType = (t) => (t.match(/<page-type>([^<]*)<\/page-type>/i) || [, '—'])[1];
+// body = what survives once metadata/apparatus tags are gone; the thing a reader would read
+const bodyLen = (t) => t
+  .replace(/<(meta|summary|keywords|vocab|language|lang|scan-quality|script|page-type|columns|warning|image-desc|lacuna|header|sig|page-num)>[\s\S]*?<\/\1>/gi, ' ')
+  .replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().length;
+
+const ONLY = process.env.ONLY ? process.env.ONLY.split(',').map(Number) : null;
+const RUN = ONLY ? CASES.filter((t) => ONLY.includes(t.page)) : CASES;
+console.log(`model=${MODEL}  cases=${RUN.length}\n`);
+for (const t of RUN) {
+  const p = await db.collection('pages').findOne({ book_id: t.book, page_number: t.page });
+  if (!p) { console.log(`!! ${t.label} p.${t.page}: page not found`); continue; }
+  const url = p.display_photo || p.photo;
+  let b64;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) { console.log(`!! ${t.label} p.${t.page}: image HTTP ${res.status}`); continue; }
+    b64 = Buffer.from(await res.arrayBuffer()).toString('base64');
+  } catch (e) { console.log(`!! ${t.label} p.${t.page}: image fetch failed ${e.message}`); continue; }
+
+  const a = await gemini(v15, b64);
+  const b = await gemini(v17, b64);
+  console.log(`── ${t.label} (p.${t.page}) — expect: ${t.expect}`);
+  console.log(`   v15  type=${pageType(a).padEnd(12)} body=${String(bodyLen(a)).padStart(5)}  unclear=${tag(a, 'unclear')} lacuna=${tag(a, 'lacuna')} warning=${tag(a, 'warning')}`);
+  console.log(`   v17  type=${pageType(b).padEnd(12)} body=${String(bodyLen(b)).padStart(5)}  unclear=${tag(b, 'unclear')} lacuna=${tag(b, 'lacuna')} warning=${tag(b, 'warning')}`);
+  const snippet = b.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 150);
+  console.log(`   v17 text: ${snippet || '(none)'}\n`);
+}
+await c.close();

--- a/scripts/lib/strip-editorial-wrappers.mjs
+++ b/scripts/lib/strip-editorial-wrappers.mjs
@@ -31,7 +31,18 @@ const EDITORIAL_WRAPPERS =
   // Tablet, Code of Hammurabi, Neo-Assyrian Medical Prescriptions, Manishtusu
   // Obelisk) — zero hits in a random 30,240-page sample. Small, but a fabricated
   // citation is a fabricated citation.
-  + '|condition|period|surface|genre';
+  + '|condition|period|surface|genre'
+  // `<lacuna>` (#4195 item 5, #3591, #4584) states that a REGION of an otherwise
+  // readable page carries no legible source — "20 lines of hieroglyphic text, not
+  // transcribed". Its content is a description OF the gap, never the page's own
+  // words, so it is dropped content-and-all like any other editorial wrapper.
+  // This is precisely why it is a distinct tag and not `<unclear>`: `<unclear>`
+  // wraps a best-guess READING and unwraps to body text everywhere, so a lacuna
+  // description carried in an `<unclear>` would be quoted, counted, embedded and
+  // exported as if it were text on the page. The reader still SHOWS the gap —
+  // see NotesRenderer — because a silently dropped region reads as a complete
+  // page, which is the failure this whole tag exists to prevent.
+  + '|lacuna';
 
 function flattenMarkdownTables(text) {
   return text

--- a/scripts/maintenance/ocr-prompt-v17-lacuna.mjs
+++ b/scripts/maintenance/ocr-prompt-v17-lacuna.mjs
@@ -13,10 +13,20 @@
  * exactly once before substitution — a prompt this load-bearing must never be
  * patched by a regex that silently matched nothing or matched twice.
  *
- * ORDERING (matters): the new rows land with is_default:false. Promote them
- * ONLY once the `<lacuna>` renderer and stripper have shipped, otherwise the
- * pipeline emits a tag the reader renders as literal text:
- *   node scripts/maintenance/ocr-prompt-v17-lacuna.mjs --promote
+ * ORDERING (matters): the new rows land with is_default:false.
+ *
+ * DO NOT PROMOTE v17 YET — and --promote now refuses without an explicit
+ * override, because a docstring saying "not yet" is not a control.
+ * Two conditions, only the first of which is met by merging this:
+ *   1. the `<lacuna>` renderer + stripper have shipped (this PR), and
+ *   2. v17 has been shown NOT to over-decline.
+ * Condition 2 FAILED on 2026-09-02: at k=5, v17 turned p.197's perfectly
+ * legible Latin note ("Nihil hic deesse videtur") into a <lacuna>, and the
+ * headline fabrication win did not replicate — a second run put the runaway
+ * loop on the opposite arm (scripts/eval/EXPERIMENTS.md, PR #4610, issue #4195).
+ * Re-run scripts/eval/prompt-ab.mjs with a loop classifier before promoting.
+ *
+ *   node scripts/maintenance/ocr-prompt-v17-lacuna.mjs --promote --ab-rerun-clean
  * Rollback: --demote, which restores v16/v13 as default.
  *
  * Usage:
@@ -131,6 +141,21 @@ const plan = [
 const c = new MongoClient(process.env.MONGODB_URI);
 await c.connect();
 const col = c.db('bookstore').collection('prompts');
+
+if (PROMOTE && !process.argv.includes('--ab-rerun-clean')) {
+  console.error([
+    'REFUSING to promote v17.',
+    '',
+    'v17 was measured OVER-DECLINING on 2026-09-02: it converts readable text',
+    'into gap markers (Kitab al-Bulhan p.197, legible Latin -> <lacuna>), and the',
+    'fabrication win it was promoted for did not replicate across two k=5 runs.',
+    'See scripts/eval/EXPERIMENTS.md and PR #4610.',
+    '',
+    'Re-run scripts/eval/prompt-ab.mjs with a loop classifier first. If it comes',
+    'back clean, pass --ab-rerun-clean to say so.',
+  ].join('\n'));
+  process.exit(1);
+}
 
 if (PROMOTE || DEMOTE) {
   // The unique index uniq_default_per_type permits one default per type, so the

--- a/scripts/maintenance/ocr-prompt-v17-lacuna.mjs
+++ b/scripts/maintenance/ocr-prompt-v17-lacuna.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * OCR prompt v17 + translation prompt v14 — #4195 (all six items) and #4584.
+ *
+ * Builds v17 from **v15**, not from v16. v16 was an interim written before
+ * #4195 was found; it added an untranscribable-region rule that overloaded
+ * `<unclear>`, which #4195 item 5 explicitly rules out (`<unclear>` implies a
+ * guessable reading, and it unwraps to body text in every export, so a gap
+ * DESCRIPTION carried in one gets quoted as if it were the page's words).
+ * v17 supersedes it with the named `<lacuna>` marker instead.
+ *
+ * Each edit below names the issue it closes. Every anchor is asserted to occur
+ * exactly once before substitution — a prompt this load-bearing must never be
+ * patched by a regex that silently matched nothing or matched twice.
+ *
+ * ORDERING (matters): the new rows land with is_default:false. Promote them
+ * ONLY once the `<lacuna>` renderer and stripper have shipped, otherwise the
+ * pipeline emits a tag the reader renders as literal text:
+ *   node scripts/maintenance/ocr-prompt-v17-lacuna.mjs --promote
+ * Rollback: --demote, which restores v16/v13 as default.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/ocr-prompt-v17-lacuna.mjs [--apply|--promote|--demote]
+ */
+import { MongoClient } from 'mongodb';
+import { createHash } from 'crypto';
+
+const APPLY = process.argv.includes('--apply');
+const PROMOTE = process.argv.includes('--promote');
+const DEMOTE = process.argv.includes('--demote');
+const hash = (s) => createHash('md5').update(s).digest('hex');
+
+/** Replace exactly once, or throw. A prompt edit that misses is worse than one that fails. */
+function once(text, find, replace, label) {
+  const n = text.split(find).length - 1;
+  if (n !== 1) throw new Error(`[${label}] anchor matched ${n}x, expected 1:\n  ${find.slice(0, 110)}`);
+  return text.replace(find, replace);
+}
+
+// ─── #4195 item 1: the page-type enum belongs to <page-type>, not <columns> ───
+const OLD_PAGETYPE_COLUMNS = `- <page-type>X</page-type>
+- <columns>N</columns> — number of text columns on this page (omit for single-column pages, include for 2+ columns) — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, text`;
+
+// #4195 items 1+2: enum restored to its own tag, and `blank` narrowed. Under-use
+// fabricates (#4149: invented pages for empty leaves); over-use suppresses
+// (#3591: legible basmala pages classified blank and replaced with a stub).
+const NEW_PAGETYPE_COLUMNS = `- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, text
+  - \`blank\` means NO INK AT ALL — an empty leaf, a verso that was never printed. A page that is faint, stained, damaged, bleed-through, or only partly legible is NOT blank: give it its real type and use <lacuna> / <unclear> / <warning> for the parts you cannot read. Both mistakes are costly, in opposite directions.
+- <columns>N</columns> — number of text columns on this page (omit for single-column pages, include for 2+ columns)`;
+
+// ─── #4195 item 3: what a blank page may emit ───
+const BLANK_CONTRACT = `
+**Blank pages (CRITICAL):**
+- A blank page emits the metadata tags and NOTHING ELSE: no body text, and no <header>, <sig> or <page-num>. Those tags are exactly what past fabrications invented to make an empty leaf look like a printed one.
+- "The page cannot be transcribed" (illegible) and "there is nothing on the page" (blank) are different findings. Do not reach for a blank classification because a page is hard to read.
+- SELF-CHECK: if anywhere in your output you describe a mark, letter, stamp, stain of ink, printer's ornament, annotation or "faint/erased/offset trace", then the page is NOT blank. Give it its real <page-type> and transcribe or mark what you saw. A page you describe as having something on it cannot also be classified as having nothing on it.
+- Any remark ABOUT a blank page ("the page is empty apart from a printer's mark") goes inside <meta> or <warning>. Never write it as untagged prose — untagged text is treated as the words printed on the page.
+`;
+
+// ─── #4195 item 5 + #4584: a named marker for an unreadable REGION ───
+const LACUNA_RULE = `**Untranscribable regions — <lacuna> (CRITICAL):**
+Some pages carry a region with no legible source for you: a script or notation you cannot reliably read (hieroglyphs, cuneiform, an unfamiliar shorthand), or a block torn, burned or faded past reading — on a page that is otherwise perfectly readable. For any such region:
+1. Do NOT transcribe it, do NOT approximate it, and do NOT reconstruct what it probably said. A fluent guess is indistinguishable from a reading and cannot be caught downstream.
+2. Do NOT describe it in square brackets or in bare prose. An untagged description like "[Hieroglyphic text lines x+1 through 20]" is read downstream as page text and gets rendered into invented content — this is a real incident, not a hypothetical.
+3. Emit ONE <lacuna> tag saying what is there and roughly how much: <lacuna>20 lines of hieroglyphic text, not transcribed</lacuna>
+4. <lacuna> is NOT <unclear>. <unclear>X</unclear> carries your best-guess READING of X and is kept as page text. <lacuna> says there is no reading at all, and its contents are a description that is stripped from every quotation and export. Never put a guess in a <lacuna>, and never put a gap description in an <unclear>.
+5. NEVER fill an unread region by repeating a character, glyph or word. A long run of one repeated sign is always an artifact, never a reading.
+6. A page that is mostly untranscribable is mostly <lacuna> tags. That is CORRECT output, not a failure. Transcribe the surrounding apparatus normally — headings, editorial notes, bibliographic citations and page numbers are usually in a script you CAN read, and on such a page they are the most valuable thing present.
+7. In a table or a closed set (a grid of named mansions, a list of months), a cell you cannot read is its own <lacuna>. Do NOT complete the set from knowledge of what such a set usually contains.
+
+`;
+
+// ─── #4195 item 6: unusable image ───
+const UNUSABLE_IMAGE = `
+**Unusable images:**
+- If the image is a solid black/white field, a scanner error, or a repository placeholder ("image not available"), emit the metadata tags plus a <warning> naming what you received. NEVER infer content for a page you cannot see. An unreadable image is not a page to be reconstructed.
+`;
+
+const plan = [
+  {
+    type: 'ocr',
+    from: 15,
+    notes: 'v15 + #4195 (all six items) + #4584 lacuna marker. Supersedes the interim v16, which overloaded <unclear>. Requires the <lacuna> stripper+renderer (PR). Rollback: set is_default:true on v16, false here.',
+    build(v15) {
+      let s = v15;
+      s = once(s, OLD_PAGETYPE_COLUMNS, NEW_PAGETYPE_COLUMNS, '#4195-1+2 page-type/columns');
+      // #4195 item 4: "DISCURSUS IV." is the running header of every confirmed
+      // fabrication across eleven unrelated books — the model fills the template
+      // with the template's own example. Same for the signature and drop-cap.
+      s = once(s,
+        'Example: "DISCURSUS IV." at top of page → <header>DISCURSUS IV.</header> and nothing else',
+        'Example: a running header at the top of a page → <header>[the exact words printed there]</header> and nothing else. Transcribe what is on THIS page; never carry over an example, a header from a previous page, or a plausible Latin heading.',
+        '#4195-4 DISCURSUS specimen');
+      s = once(s,
+        `- <sig>X</sig> — printer's marks like A2, B1 (NOT in body text)`,
+        `- <sig>X</sig> — printer's signature marks, transcribed exactly as printed on THIS page (NOT in body text)`,
+        '#4195-4 sig specimen');
+      s = once(s,
+        `3. Decorative initials (drop caps): merge large ornamental first letters with the word they begin. A large "L" followed by "EX" → "Lex", not "L Ex"`,
+        `3. Decorative initials (drop caps): merge large ornamental first letters with the word they begin — a large initial followed by the rest of the word is one word, not two. Read the actual letter on the page; do not assume a particular initial or opening word.`,
+        '#4195-4 dropcap specimen');
+      // Items 3, 5, 6 go in before the lacuna/repetition section so all the
+      // "what to do when you cannot read it" rules sit together.
+      s = once(s, '**Lacunae & runaway repetition (CRITICAL):**',
+        LACUNA_RULE + '**Lacunae & runaway repetition (CRITICAL):**', '#4584 lacuna rule');
+      s = once(s, '**Critical rules:**', BLANK_CONTRACT + UNUSABLE_IMAGE + '\n**Critical rules:**', '#4195-3+6 blank/unusable');
+      return s;
+    },
+  },
+  {
+    type: 'translation',
+    from: 12,
+    notes: 'v12 + <lacuna> is absence: reproduce it, never translate or expand it (#4584). Supersedes interim v13. Rollback: set is_default:true on v13, false here.',
+    build(v12) {
+      const RULE = `**<lacuna> marks text that was NOT read (CRITICAL):**
+- <lacuna>…</lacuna> in the OCR means there was no legible source for that region — its contents describe the gap, they are not words from the page.
+- Reproduce the tag and its contents unchanged. NEVER translate, expand, paraphrase or reconstruct it, and never supply plausible content for it: no invented lines, verses, formulae, titles or epithets.
+- If the OCR reads <lacuna>20 lines of hieroglyphic text, not transcribed</lacuna>, your output carries that same tag for that region and nothing else. Do NOT emit twenty translated lines.
+- Every line you write must correspond to text actually present in the OCR input. Where the input has no readable text, your output has none either.
+- If the OCR describes unread material in square brackets instead of a tag, convert it to <lacuna>…</lacuna>. Do NOT render it as content — a note about what could not be read is not a passage to be translated.
+- A page whose OCR is mostly <lacuna> yields a translation that is mostly <lacuna>. That is correct, and far better than fluent invention.
+- <unclear> is different: it holds a best-guess READING and must be preserved and translated as page text.
+
+`;
+      return once(v12, '**Metadata tags (hidden from readers):**', RULE + '**Metadata tags (hidden from readers):**', '#4584 translation lacuna rule');
+    },
+  },
+];
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const col = c.db('bookstore').collection('prompts');
+
+if (PROMOTE || DEMOTE) {
+  // The unique index uniq_default_per_type permits one default per type, so the
+  // old default is demoted before the new one is promoted. Between those writes
+  // getPrompt() falls back to the hardcoded constant — the OLD behaviour, never
+  // a broken one.
+  for (const p of plan) {
+    const target = PROMOTE ? p.from + 2 : p.from + 1;  // v17/v14 on promote, v16/v13 on rollback
+    const row = await col.findOne({ type: p.type, version: target });
+    if (!row) throw new Error(`${p.type} v${target} not found`);
+    await col.updateMany({ type: p.type, is_default: true, _id: { $ne: row._id } }, { $set: { is_default: false } });
+    await col.updateOne({ _id: row._id }, { $set: { is_default: true } });
+    const now = await col.findOne({ type: p.type, is_default: true });
+    console.log(`${p.type}: default is now v${now.version}`);
+  }
+  await c.close();
+  process.exit(0);
+}
+
+for (const p of plan) {
+  const base = await col.findOne({ type: p.type, version: p.from });
+  if (!base) throw new Error(`${p.type} v${p.from} not found`);
+  const version = p.from + 2;                       // v15 -> v17, v12 -> v14
+  const existing = await col.findOne({ type: p.type, version });
+  if (existing && !process.argv.includes('--replace')) {
+    console.log(`${p.type} v${version} already exists (${existing._id}) — skipping (pass --replace to rewrite it)`);
+    continue;
+  }
+  if (existing && existing.is_default) throw new Error(`refusing to --replace a LIVE default (${p.type} v${version}); demote it first`);
+  const content = p.build(base.content);
+  console.log(`\n=== ${p.type}: v${p.from} -> v${version}  (${base.content.length} -> ${content.length} chars) ===`);
+  if (!APPLY) { console.log('(dry run — pass --apply)'); continue; }
+  const doc = {
+    name: base.name, type: p.type, version, is_default: false,
+    content, content_hash: hash(content),
+    created_at: new Date().toISOString(), notes: p.notes,
+  };
+  if (existing) {
+    await col.replaceOne({ _id: existing._id }, doc);
+    console.log(`replaced ${existing._id} (is_default:false — promote after the renderer ships)`);
+  } else {
+    const { insertedId } = await col.insertOne(doc);
+    console.log(`inserted ${insertedId} (is_default:false — promote after the renderer ships)`);
+  }
+}
+await c.close();

--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -295,6 +295,7 @@ export const NOTES_ALLOWED_ELEMENTS = [
   'span', 'div', 'sup',
   // XML annotation elements (new syntax)
   'note', 'margin', 'gloss', 'insert', 'unclear', 'term', 'image-desc', 'interp',
+  'lacuna',
 ];
 
 // Pre-process bracket note tags to XML tags before ReactMarkdown sees them
@@ -839,6 +840,20 @@ function ColumnMarkdown({ text, showNotes, withNotes }: {
             {children}?
           </span>
         ) : <>{children}</>,
+        // A region of the page with no legible source — glyphs we cannot read,
+        // a torn-away block. Its children DESCRIBE the gap; they are not the
+        // page's words, which is why every text-extraction path drops this tag
+        // content-and-all (see strip-editorial-wrappers). Rendered in BOTH note
+        // states on purpose: hiding it would make an incomplete page read as a
+        // complete one, which is the fabrication this tag exists to prevent.
+        lacuna: ({ children }: any) => (
+          <span
+            className="inline-flex items-center gap-1 bg-stone-100 text-stone-500 border border-dashed border-stone-300 px-1.5 py-0.5 rounded mx-0.5 text-sm not-italic"
+            title="Not transcribed — no legible reading of this region. The page image is the source."
+          >
+            […] <span className="italic">{children}</span>
+          </span>
+        ),
         term: ({ children }: any) => (
           <span className={`${NOTE_TAG_STYLES.term} px-1.5 py-0.5 rounded mx-0.5`} title="Technical term">
             <em>{children}</em>

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -58,7 +58,18 @@ const EDITORIAL_WRAPPERS =
   // Tablet, Code of Hammurabi, Neo-Assyrian Medical Prescriptions, Manishtusu
   // Obelisk) — zero hits in a random 30,240-page sample. Small, but a fabricated
   // citation is a fabricated citation.
-  + '|condition|period|surface|genre';
+  + '|condition|period|surface|genre'
+  // `<lacuna>` (#4195 item 5, #3591, #4584) states that a REGION of an otherwise
+  // readable page carries no legible source — "20 lines of hieroglyphic text, not
+  // transcribed". Its content is a description OF the gap, never the page's own
+  // words, so it is dropped content-and-all like any other editorial wrapper.
+  // This is precisely why it is a distinct tag and not `<unclear>`: `<unclear>`
+  // wraps a best-guess READING and unwraps to body text everywhere, so a lacuna
+  // description carried in an `<unclear>` would be quoted, counted, embedded and
+  // exported as if it were text on the page. The reader still SHOWS the gap —
+  // see NotesRenderer — because a silently dropped region reads as a complete
+  // page, which is the failure this whole tag exists to prevent.
+  + '|lacuna';
 
 /**
  * Flatten GFM markdown tables to plain text.

--- a/tests/unit/ngram-normalize.test.ts
+++ b/tests/unit/ngram-normalize.test.ts
@@ -39,6 +39,18 @@ const STRIP_FIXTURES = [
   '',
 ];
 
+describe('lacuna is dropped by BOTH stripper twins (#4584)', () => {
+  it('never lets a gap description reach counted or quoted text', () => {
+    const page = 'real page words <lacuna>20 lines of hieroglyphic text, not transcribed</lacuna> more words';
+    for (const [label, strip] of [['ts', stripTs], ['mjs', stripMjs]] as const) {
+      const out = strip(page);
+      expect(out, label).not.toMatch(/hieroglyphic|not transcribed|20 lines/i);
+      expect(out, label).toContain('real page words');
+      expect(out, label).toContain('more words');
+    }
+  });
+});
+
 describe('normalizer parity (mjs build twin vs ts query twin)', () => {
   it('NGRAM_CORPORA and language map are identical', () => {
     expect(ts.NGRAM_CORPORA).toEqual(mjs.NGRAM_CORPORA);

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -13,6 +13,21 @@ describe('stripEditorialWrappers', () => {
     expect(out).toContain('<term>yantra</term>'); // inline glosses survive
   });
 
+  it('drops a <lacuna> region marker content-and-all, unlike <unclear>', () => {
+    // #4584: the failure this tag exists to prevent. Urkunden IV p.24 had its
+    // unread glyph block described in prose, and the description was rendered
+    // downstream as if it were the page's own words. A <lacuna> DESCRIBES a
+    // gap, so its content must never reach quotable/countable/embeddable text —
+    // whereas <unclear> wraps a best-guess READING and must survive as body text.
+    const page = `Nur die letzten Zeilen sind erhalten <lacuna>20 lines of hieroglyphic text, not transcribed</lacuna> <unclear>Dw3-r-nhh</unclear>`;
+    const out = stripEditorialWrappers(page);
+    expect(out).not.toMatch(/hieroglyphic/i);
+    expect(out).not.toMatch(/not transcribed/i);
+    expect(out).not.toMatch(/20 lines/i);
+    expect(out).toContain('Nur die letzten Zeilen');
+    expect(out).toContain('Dw3-r-nhh');   // the unclear READING survives
+  });
+
   it('drops summary, keywords, and vocab blocks', () => {
     const t = `body text <summary>AI description of the page</summary> more body <keywords>a, b, c</keywords> end <vocab>term1, term2</vocab>`;
     const out = stripEditorialWrappers(t).replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
Implements **#4195 item 5** ("a named lacuna marker for unreadable REGIONS") together with the OCR/translation prompt revision that uses it, and closes the #4584 fabrication at its cause.

## The tag, and why it is not `<unclear>`

#4195 asks for the marker to be distinct from `<unclear>`, "which currently implies a guessable reading." That distinction turns out to be load-bearing rather than cosmetic:

`<unclear>X</unclear>` wraps a best-guess **reading** and unwraps to body text in every extraction path. So a *description of a gap* carried inside one would be quoted, counted into ngrams, embedded, and exported into PDFs and EPUBs as if it were words printed on the page. That is precisely the #4584 failure: Urkunden IV p.24's unread glyph block was described in prose, and the description came back as twenty lines of invented English funerary formulae — one of which was promoted into the volume's featured quotes.

`<lacuna>` therefore joins `EDITORIAL_WRAPPERS` in **both** stripper twins, so it is dropped content-and-all everywhere text is extracted. The reader renders it in **both** note states on purpose: a silently dropped region reads as a complete page, which is the failure the tag exists to prevent.

## Measured, v15 vs v17, against the exemplars the issues name

Not pages chosen to flatter the change — #3591's and #4149's own cases, plus counter-examples that must *not* move.

| case | v15 | v17 |
|---|---|---|
| #3591 p.60 torn mansion grid | 24,108 body chars (completes all 14 mansions) | 1,286, gaps marked |
| #4584 p.118 hieroglyph rows | 16,264 (the "Ra, Ra, Ra…" loop) | 318, apparatus kept, 8 `<lacuna>` |
| #4584 p.24 hieroglyph block | invented `x+N` lines | one `<lacuna>`, no invented lines |
| #4149 p.30 ordinary prose *(counter-example)* | 2,485 | 2,485 |
| #3591 p.198 cipher *(counter-example)* | declines | still declines |

Harness committed at `scripts/eval/ocr-prompt-v17-acceptance.mjs` so this is re-runnable rather than a claim.

## What I could NOT establish

**#4195 items 2–3 (blank-page narrowing) are not demonstrated.** p.4 still classifies `blank` despite the model describing a faint mark, and p.45 still emits untagged prose. I sharpened the rule with a self-consistency check and re-ran; it did not fix either.

Worse for the measurement: **v15 itself returned body=79 then body=0 on consecutive runs of the same page.** These blank cases are unstable run-to-run, so n=1 cannot separate prompt from noise. I've left those boxes unticked on #4195 — #3469's labelled hard-page corpus is the instrument that would settle it.

## Ordering — please note

The prompt rows are inserted **non-default** (`ocr` v17, `translation` v14). They must not be promoted until this merges, or the pipeline emits a tag the renderer shows as literal text. After merge:

```
node scripts/maintenance/ocr-prompt-v17-lacuna.mjs --promote
```

`--demote` rolls back. Live default stays v16/v13 meanwhile — an interim I wrote earlier today before finding #4195, which achieves the same fabrication fix by overloading `<unclear>`; it is safe because `<unclear>` is fully handled downstream, and v17 supersedes it.

## Out of scope

- #4195 item 4's DISCURSUS specimen swap and items 1/6 are *in* v17 but not separately measured — they are template hygiene, not behaviours with a clean before/after on a single page.
- #3591's fixes 2–4 (self-contradiction detector, closed-set validators) are detectors, not prompt text, as that issue says.
- Repairing already-fabricated text. Prompts only affect future runs.

## Test

`npx tsc --noEmit` clean. 73 unit tests pass, including two new ones pinning that `<lacuna>` is dropped by both stripper twins while `<unclear>` survives as body text. Negative-controlled: an unlisted tag leaks its content verbatim, so the test genuinely fails without the change.
