### PR TITLE
docs: Gemini thinking-by-default rule in CLAUDE.md AI Models (#4581)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ the principle outlives it.) Related: `.claude/docs/invariants/first-translation-
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
 - OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
+- **Gemini 3.x thinks by default and bills it at the output rate, invisibly** — every `generateContent` call site MUST set an explicit `thinkingConfig` (`thinkingBudget: 0` for OCR/translation/extraction — measured no quality loss) and count `thoughtsTokenCount` when metering. Six unconfigured call sites cost ~$2K/mo for months (#4581, 17× meter gap); sweep of remaining sites: #4599.
 - **Grounded search: flash-lite does NOT ground** (0/189 measured 2026-08-10 — empty `groundingMetadata` while the prose claims "extensive searches"). Use `gemini-3-flash-preview` with an explicit positive `thinkingBudget` (512 → 6/6 grounded, ~$0.003/book; unbounded ≈ $0.19/book; `-1` silently suppresses grounding). Verify groundedness from `queries[]` on written rows, never from response prose.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 


### PR DESCRIPTION
One added bullet in **AI Models — IMPORTANT**: Gemini 3.x runs thinking by default, bills it at the output rate, and `candidatesTokenCount` hides it — so every `generateContent` call site must set an explicit `thinkingConfig` and meter `thoughtsTokenCount`. Points at #4581 (the incident), #4599 (the call-site sweep).

The real guards are in code (merged `getThinkingOffModel()` in `src/lib/ai.ts`, the meter counting thought tokens, `spend-reconcile.mjs`); this line is the doctrine pointer for anyone writing a NEW call site.

**Budget note:** `wc -w CLAUDE.md` was already 5,627 (vs the ~5,500 cap) before this +55-word change — the breach predates this PR. Next CLAUDE.md edit should demote a section to `invariants/`; candidates: the grounded-search bullet (subsystem-conditional) could move into a gemini-call-sites invariant doc together with this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)