### PR TITLE
feat(analytics): log shortlink_visit to light up the quote-share funnel (#2047)

### DIFF
--- a/scripts/analytics/usage-deepdive.mjs
+++ b/scripts/analytics/usage-deepdive.mjs
@@ -428,11 +428,40 @@ async function main() {
   // SECTION 5 — Notable gaps
   // -----------------------------------------------------------------
   print(`## 5. Instrumentation gaps surfaced by this run`);
+
+  // Shortlink arrivals come from the server-side `shortlink_visit` event
+  // (#2047), not from pageviews: /q/<code> answers 302 before any page renders,
+  // so the client-side /api/track call never fires and the pageview count below
+  // only ever caught the handful of crawlers that log the redirect itself.
+  const shortlinkVisits = await db.collection('analytics_events').aggregate([
+    { $match: { event: 'shortlink_visit', timestamp: { $gte: SINCE } } },
+    { $group: { _id: { $ifNull: ['$traffic_class', 'unclassified'] }, n: { $sum: 1 } } },
+  ]).toArray();
+  const visitsBy = new Map(shortlinkVisits.map((r) => [r._id, r.n]));
+  const humanVisits = visitsBy.get('human') || 0;
+  const totalVisits = shortlinkVisits.reduce((a, r) => a + r.n, 0);
+  if (totalVisits === 0) {
+    print(`- shortlink_visit events: 0 — either nobody opened a /q/ link in this window, or the route logging regressed (src/lib/shortlink-visit-log.ts)`);
+  } else {
+    const breakdown = [...visitsBy.entries()].sort((a, b) => b[1] - a[1]).map(([k, n]) => `${k}=${n}`).join(', ');
+    print(`- shortlink_visit events: ${totalVisits.toLocaleString()} total, ${humanVisits.toLocaleString()} human (${breakdown})`);
+    const topLinks = await db.collection('analytics_events').aggregate([
+      { $match: { event: 'shortlink_visit', traffic_class: 'human', timestamp: { $gte: SINCE } } },
+      { $group: { _id: { book: '$book_id', page: '$page_number' }, n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 10 },
+    ]).toArray();
+    if (topLinks.length) {
+      print(``);
+      print(table(topLinks.map((r) => [r._id.book || '(unknown)', r._id.page ?? '-', r.n]), ['book_id', 'page', 'visits']));
+      print(``);
+    }
+  }
   const shortlinkHits = kindHits.get('shortlink') || 0;
-  print(`- /q/<code> shortlink hits captured in pageviews: ${shortlinkHits} (likely undercount — shortlinks may redirect before pageview fires)`);
+  print(`- /q/<code> hits that also produced a pageview row: ${shortlinkHits} (expected to be ~0; the redirect fires first)`);
   const apiHits = kindHits.get('api') || 0;
   print(`- /api/* pageview hits: ${apiHits} (API endpoints are not the source of truth for usage)`);
-  print(`- No client-side "quote copied", "citation exported", or "shortlink opened" events`);
+  print(`- No client-side "quote copied" or "citation exported" events`);
   print(`- search_queries has its own ip_hash separate from analytics_events.ip — can't trivially join`);
   print(``);
 

--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -3,6 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { decodeShortlink } from '@/lib/shortlinks';
 import { mintCitationToken } from '@/lib/citation-token';
 import { meteredReaderEnabled } from '@/lib/free-preview';
+import { logShortlinkVisit } from '@/lib/shortlink-visit-log';
 import { Page } from '@/lib/types';
 
 interface RouteContext {
@@ -49,6 +50,18 @@ export async function GET(request: NextRequest, context: RouteContext) {
     ]);
     const bookPath = (book?.slug as string) || bookId;
     const prefix = lang && Number(book?.[`pages_translated_${lang}`] || 0) > 0 ? `/${lang}` : '';
+
+    // Record the arrival (#2047). Deferred and timeout-bounded inside the
+    // logger, so the 302 below never waits on it. Both branches log: a
+    // shortlink whose page has vanished is still a share that was clicked, and
+    // the null target_page_id is how we find those.
+    logShortlinkVisit({
+      request,
+      code,
+      bookId,
+      pageNumber: pageNumber ?? null,
+      targetPageId: page?.id ?? null,
+    });
 
     if (!page) {
       // Redirect to book page if specific page not found

--- a/src/lib/shortlink-visit-log.ts
+++ b/src/lib/shortlink-visit-log.ts
@@ -1,0 +1,140 @@
+import { after, type NextRequest } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { classifyRequest } from '@/lib/analytics-ingest';
+
+/**
+ * The single writer for `analytics_events` `shortlink_visit` documents (#2047).
+ *
+ * `/q/<code>` is the canonical share format — the reader copies it, pastes it
+ * into Slack or a footnote, and somebody else clicks it. Until this existed the
+ * arrival was invisible: the route answers 302 before any page renders, so no
+ * client-side `/api/track` pageview ever fires, and `search → book → quote →
+ * share → arrive` had its last step permanently dark (0 events out of ~136K in
+ * the 30-day deep dive). The destination pageview is recorded, but it is
+ * byte-identical to a Google click on the same page, so it cannot answer "which
+ * books get shared" or "which channels send readers".
+ *
+ * Two things this module is careful about:
+ *
+ * 1. **The redirect must never wait on Mongo.** The write is deferred with
+ *    `after()` and raced against a short timeout, the same shape as
+ *    `/api/track`. A slow Atlas costs us the row, never the reader's hop.
+ * 2. **Traffic is classified at WRITE time**, via the shared
+ *    `classifyRequest()`. Non-human hits are STORED and tagged rather than
+ *    dropped — the same choice as `/api/analytics/event`, and for the same
+ *    reason: shortlinks are click-driven and low-volume, and the unfurl bots
+ *    (Slack, Twitter, mail scanners) ARE part of the finding when a share
+ *    "gets clicks" that were never people. Read paths filter on
+ *    `traffic_class: 'human'`. See CLAUDE.md, "The measurement layer fails
+ *    silently, and always toward good news", and #3405.
+ */
+
+const DEDUP_WINDOW_MS = 60_000;
+const DB_TIMEOUT_MS = 3000;
+const SITE_HOST = 'sourcelibrary.org';
+
+// Per-instance dedup on ip + code, mirroring the pageview dedup in /api/track:
+// a reader who reloads the shared link, or a client that prefetches it before
+// following it, is one visit and not three.
+const recentHits = new Map<string, number>();
+let lastCleanup = Date.now();
+
+function isDuplicate(key: string): boolean {
+  const now = Date.now();
+  if (now - lastCleanup >= DEDUP_WINDOW_MS) {
+    lastCleanup = now;
+    for (const [k, ts] of recentHits) if (now - ts > DEDUP_WINDOW_MS) recentHits.delete(k);
+  }
+  const last = recentHits.get(key);
+  if (last && now - last < DEDUP_WINDOW_MS) return true;
+  recentHits.set(key, now);
+  return false;
+}
+
+/** Referring domain, with self-referrals collapsed the way /api/track does. */
+function referrerDomain(request: NextRequest): string {
+  const raw = request.headers.get('referer') || request.headers.get('referrer');
+  if (!raw) return 'direct';
+  try {
+    const hostname = new URL(raw).hostname.replace(/^www\./, '');
+    // A tenant subdomain is still us — collapse anything under the site host.
+    if (hostname === SITE_HOST || hostname.endsWith(`.${SITE_HOST}`)) return 'direct';
+    return hostname.slice(0, 200);
+  } catch {
+    return (raw.split('/')[2] || 'unknown').slice(0, 200);
+  }
+}
+
+export interface ShortlinkVisitInput {
+  request: NextRequest;
+  /** The base62 code as it appeared in the URL. */
+  code: string;
+  /** Decoded book id. */
+  bookId: string;
+  /** Decoded page number — the shortlink always carries one, but keep it nullable. */
+  pageNumber: number | null;
+  /** Resolved page id, or null when the page was not found and we fell back to the book. */
+  targetPageId: string | null;
+}
+
+/**
+ * Record one shortlink arrival. Never throws, never awaited by the caller.
+ *
+ * Call it only once the code has DECODED — an invalid shortlink is a 404-shaped
+ * event about a bad URL, not a share arriving, and logging it would put junk
+ * codes in the "most shared" ranking.
+ */
+export function logShortlinkVisit(input: ShortlinkVisitInput): void {
+  try {
+    const { cls, userAgent, ip, host } = classifyRequest(input.request);
+    if (isDuplicate(`${ip}:${input.code}`)) return;
+
+    const now = new Date();
+    const doc = {
+      event: 'shortlink_visit',
+      code: input.code.slice(0, 64),
+      book_id: input.bookId,
+      page_number: input.pageNumber,
+      target_page_id: input.targetPageId,
+      // The tenant the link was opened ON (bph.sourcelibrary.org/q/…), stamped
+      // by the proxy. Null on the canonical host. Note this is the reading room
+      // the reader arrived through, not the book's owning tenant.
+      tenant: input.request.headers.get('x-tenant-slug') || null,
+      tenantId: input.request.headers.get('x-tenant-id') || null,
+      referrer: referrerDomain(input.request),
+      country:
+        input.request.headers.get('x-vercel-ip-country') ||
+        input.request.headers.get('cf-ipcountry') ||
+        'Unknown',
+      ip,
+      user_agent: userAgent,
+      traffic_class: cls,
+      host,
+      timestamp: now,
+      created_at: now,
+    };
+
+    const write = async () => {
+      try {
+        await Promise.race([
+          (async () => {
+            const db = await getDb();
+            await db.collection('analytics_events').insertOne(doc);
+          })(),
+          new Promise<void>((resolve) => setTimeout(resolve, DB_TIMEOUT_MS)),
+        ]);
+      } catch {
+        // Analytics must never affect the redirect.
+      }
+    };
+
+    try {
+      after(write);
+    } catch {
+      // Tests / contexts without an after() scope — still attempt the write.
+      void write();
+    }
+  } catch {
+    // Classification or header access failed; drop the row, keep the redirect.
+  }
+}

--- a/tests/unit/shortlink-visit-instrumentation.test.ts
+++ b/tests/unit/shortlink-visit-instrumentation.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// The last step of the share funnel was dark (#2047).
+//
+// `/q/<code>` answers 302 before anything renders, so no client-side pageview
+// ever fires for a shortlink arrival: out of ~136K analytics events in the
+// 30-day deep dive, shortlink visits contributed exactly zero. Nothing could
+// say which books get shared, or whether a link pasted into Slack was ever
+// opened — the destination pageview is byte-identical to a Google click.
+//
+// Two kinds of test, same split as the search-event instrumentation test:
+//
+//   1. BEHAVIOUR — drive `logShortlinkVisit` and assert on the document it
+//      really writes (classification at write time, tenant, dedup, referrer).
+//   2. ABSENCE — assert the route still calls the logger. A route that quietly
+//      stops logging looks exactly like a shortlink nobody clicked, which is
+//      the failure this whole issue was about.
+
+const inserted: Record<string, unknown>[] = [];
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      insertOne: async (doc: Record<string, unknown>) => {
+        inserted.push(doc);
+        return { insertedId: 'test' };
+      },
+    }),
+  })),
+}));
+
+import { logShortlinkVisit } from '@/lib/shortlink-visit-log';
+
+type Req = Parameters<typeof logShortlinkVisit>[0]['request'];
+
+function req(headers: Record<string, string> = {}): Req {
+  return {
+    headers: new Headers({
+      'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
+      host: 'sourcelibrary.org',
+      'cf-connecting-ip': '203.0.113.45',
+      'cf-ipcountry': 'NL',
+      ...headers,
+    }),
+  } as unknown as Req;
+}
+
+/** The write is deferred; let its microtask chain settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+let ipCounter = 0;
+/** A fresh /24 per test so the 60s ip+code dedup cache never crosses tests. */
+function freshIp(): string {
+  ipCounter += 1;
+  return `198.51.${ipCounter}.7`;
+}
+
+beforeEach(() => {
+  inserted.length = 0;
+});
+
+describe('logShortlinkVisit — the document it writes', () => {
+  it('records the decoded target and classifies the request at write time', async () => {
+    logShortlinkVisit({
+      request: req({ 'cf-connecting-ip': freshIp(), referer: 'https://twitter.com/someone/status/1' }),
+      code: 'aB3xQ',
+      bookId: 'book-123',
+      pageNumber: 42,
+      targetPageId: 'page-abc',
+    });
+    await settle();
+
+    expect(inserted).toHaveLength(1);
+    const doc = inserted[0];
+    expect(doc.event).toBe('shortlink_visit');
+    expect(doc.code).toBe('aB3xQ');
+    expect(doc.book_id).toBe('book-123');
+    expect(doc.page_number).toBe(42);
+    expect(doc.target_page_id).toBe('page-abc');
+    expect(doc.referrer).toBe('twitter.com');
+    expect(doc.country).toBe('NL');
+    // Classified at ingest — the only moment the evidence exists (#3405).
+    expect(doc.traffic_class).toBe('human');
+    expect(doc.user_agent).toContain('Macintosh');
+    expect(doc.host).toBe('sourcelibrary.org');
+    // IP is anonymized to a /24 by the shared classifier.
+    expect(String(doc.ip).endsWith('.0')).toBe(true);
+  });
+
+  it('carries the tenant when the link was opened in a partner reading room', async () => {
+    logShortlinkVisit({
+      request: req({
+        'cf-connecting-ip': freshIp(),
+        host: 'bph.sourcelibrary.org',
+        'x-tenant-slug': 'bph',
+        'x-tenant-id': 'bce03f71-c18d-4460-b8ad-224c817f9aa0',
+      }),
+      code: 'tenantCode',
+      bookId: 'book-1',
+      pageNumber: 3,
+      targetPageId: 'page-3',
+    });
+    await settle();
+
+    expect(inserted[0].tenant).toBe('bph');
+    expect(inserted[0].tenantId).toBe('bce03f71-c18d-4460-b8ad-224c817f9aa0');
+    expect(inserted[0].host).toBe('bph.sourcelibrary.org');
+  });
+
+  it('leaves tenant null on the canonical host', async () => {
+    logShortlinkVisit({
+      request: req({ 'cf-connecting-ip': freshIp() }),
+      code: 'globalCode',
+      bookId: 'book-1',
+      pageNumber: 1,
+      targetPageId: 'page-1',
+    });
+    await settle();
+    expect(inserted[0].tenant).toBeNull();
+  });
+
+  it('collapses self-referrals (including tenant subdomains) to direct', async () => {
+    logShortlinkVisit({
+      request: req({ 'cf-connecting-ip': freshIp(), referer: 'https://bph.sourcelibrary.org/book/x' }),
+      code: 'selfRef',
+      bookId: 'book-1',
+      pageNumber: 1,
+      targetPageId: 'page-1',
+    });
+    await settle();
+    expect(inserted[0].referrer).toBe('direct');
+  });
+
+  it('records a null target_page_id when the page is gone but the link was still clicked', async () => {
+    logShortlinkVisit({
+      request: req({ 'cf-connecting-ip': freshIp() }),
+      code: 'missingPage',
+      bookId: 'book-1',
+      pageNumber: 999,
+      targetPageId: null,
+    });
+    await settle();
+    expect(inserted[0].target_page_id).toBeNull();
+    expect(inserted[0].book_id).toBe('book-1');
+  });
+
+  it('stores bot traffic tagged rather than dropping it — an unfurl is not a reader', async () => {
+    logShortlinkVisit({
+      request: req({ 'cf-connecting-ip': freshIp(), 'user-agent': 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)' }),
+      code: 'botCode',
+      bookId: 'book-1',
+      pageNumber: 1,
+      targetPageId: 'page-1',
+    });
+    await settle();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].traffic_class).not.toBe('human');
+  });
+
+  it('dedups the same ip+code inside the window but not a different code', async () => {
+    const ip = freshIp();
+    const base = { bookId: 'book-1', pageNumber: 1, targetPageId: 'page-1' };
+    logShortlinkVisit({ request: req({ 'cf-connecting-ip': ip }), code: 'dupCode', ...base });
+    logShortlinkVisit({ request: req({ 'cf-connecting-ip': ip }), code: 'dupCode', ...base });
+    await settle();
+    expect(inserted).toHaveLength(1);
+
+    logShortlinkVisit({ request: req({ 'cf-connecting-ip': ip }), code: 'otherCode', ...base });
+    await settle();
+    expect(inserted).toHaveLength(2);
+  });
+});
+
+describe('the /q/[code] route still logs', () => {
+  const routeSrc = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/q/[code]/route.ts'),
+    'utf8'
+  );
+
+  it('calls the shared logger', () => {
+    expect(routeSrc).toContain("from '@/lib/shortlink-visit-log'");
+    expect(routeSrc).toMatch(/logShortlinkVisit\(/);
+  });
+
+  it('logs only after the code has decoded, never from the invalid-shortlink catch', () => {
+    const decodeAt = routeSrc.indexOf('decodeShortlink(code)');
+    const logAt = routeSrc.indexOf('logShortlinkVisit({');
+    const catchAt = routeSrc.indexOf('} catch');
+    expect(decodeAt).toBeGreaterThan(-1);
+    expect(logAt).toBeGreaterThan(decodeAt);
+    expect(logAt).toBeLessThan(catchAt);
+  });
+
+  it('does not hand-roll its own analytics_events insert', () => {
+    expect(routeSrc).not.toContain('analytics_events');
+  });
+});


### PR DESCRIPTION
Closes #2047.

## Why

`/q/<code>` is the canonical share format and the system mints a shortlink for every page-level quote — but the route answers a 302 before anything renders, so no client-side pageview ever fires. Shortlink visits contributed **exactly zero** of the ~136K events in the 30-day deep dive, and the destination pageview is byte-identical to a Google click on the same page. "Which books get shared", "did that Slack paste get opened", and the last step of `search → book → quote → share → arrive` were all unanswerable.

## What

- **`src/lib/shortlink-visit-log.ts`** — one writer for `analytics_events` `shortlink_visit` rows, modelled on `search-event-log.ts`.
  - Deferred with `after()` and raced against a 3s timeout: the redirect never waits on Mongo (same shape as `/api/track`).
  - Classified at **write** time via the shared `classifyRequest()` → `traffic_class`, `user_agent`, `host`, anonymized `ip`. Non-human hits are **stored tagged, not dropped**, matching `/api/analytics/event`: shortlink traffic is click-driven and low-volume, and the unfurl bots *are* the finding when a share "gets clicks" that were never people. Read paths filter `traffic_class: 'human'`.
  - 60s per-instance dedup on `ip + code`.
  - Referrer normalized to a domain, self-referrals (including tenant subdomains) collapsed to `direct`.
- **`src/app/q/[code]/route.ts`** — one call, placed after `decodeShortlink()` and before both redirects. The page-not-found branch logs too, with `target_page_id: null` — a link whose page has vanished was still clicked, and that null is how we find those.
- **`scripts/analytics/usage-deepdive.mjs`** — Section 5 now reads the event stream (human/bot split + top shared book/page) instead of inferring from pageview paths, which by construction saw ~0.
- **`tests/unit/shortlink-visit-instrumentation.test.ts`** — 10 tests: document shape, tenant header, dedup, referrer collapse, bot tagging, plus absence-style assertions that the route still calls the logger and never hand-rolls its own insert.

## Notes on scope

- **There is no `src/app/[tenant]/q/[code]/route.ts`** as the issue assumed. After the tenant-as-filter migration a tenant subdomain flows through the global route with `x-tenant-*` headers stamped by the proxy, so one call site covers `bph.sourcelibrary.org/q/…` as well; `tenant` and `tenantId` come off those headers.
- The issue's pattern list (`BOT_PATTERNS`, `isCloudflareBot`, direct `anonymizeIp`) predates `src/lib/analytics-ingest.ts`; `classifyRequest()` is the current shared entry point and folds in all three.
- Invalid shortlinks write nothing — the existing catch/redirect-to-`/` branch is untouched.

## Out of scope (per the issue)

Client-side "citation copied" / "quote exported" events; like/favorite events; any dashboard surfacing the new data; backfill (not possible).

## Verification

- `npx tsc --noEmit` clean; eslint clean on changed files.
- `npx vitest run tests/unit/shortlink-visit-instrumentation.test.ts` → 10 passed.
- Post-merge: hit a real `/q/<code>` (canonical and `bph.`), confirm the 302 is still immediate, then `db.analytics_events.find({event:'shortlink_visit'}).sort({timestamp:-1}).limit(5)`; repeat within 60s to see the dedup. After 7 days, `node scripts/analytics/usage-deepdive.mjs --days 7` Section 5 should show a non-zero human count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
