### PR TITLE
feat(audit): weekly watch for provider keys unmapped in LIBRARY_PARTNERS (#4627)

### DIFF
--- a/.github/workflows/library-coverage-watch.yml
+++ b/.github/workflows/library-coverage-watch.yml
@@ -1,0 +1,58 @@
+name: Library registry coverage watch
+
+# Standing detector for issue #4627: every image_source.provider with visible
+# books must be mapped by a LIBRARY_PARTNERS entry, or those books are silently
+# absent from /libraries (the crediting surface) — the absence reads as "we
+# hold nothing from that institution". The 2026-09-03 audit found 16 unmapped
+# keys / ~1,050 invisible books (fixed in #4615); a new importer minting a new
+# provider key recreates the gap without failing anything, and the key usually
+# starts existing when the import RUNS, not when code merges — hence a
+# schedule, not a PR gate.
+#
+# Read-only. Findings go to an issue, not a red X on someone's PR (same
+# reasoning as field-sprawl-watch.yml, whose exit-code convention this
+# follows: 1 = findings, 2 = could not measure).
+
+on:
+  schedule:
+    # Weekly, Tuesdays 08:00 UTC (after field-sprawl's 07:30).
+    - cron: '0 8 * * 2'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  library-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci --ignore-scripts
+      - name: Audit provider-key coverage of LIBRARY_PARTNERS
+        id: run
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          set +e
+          node scripts/audit/library-registry-coverage.mjs --threshold 10 > report.txt 2>&1
+          echo "fired=$?" >> "$GITHUB_OUTPUT"
+          cat report.txt
+      - name: File findings
+        if: steps.run.outputs.fired == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Unmapped library providers on /libraries — $(date -u +'%Y-%m-%d')"
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "Provider keys with visible books but no LIBRARY_PARTNERS entry — those books are invisible on /libraries. Add a registry entry, or fold the key into an existing partner via aliasProviderKeys (see PR #4615 for both patterns). Playbook: issue #4627." \
+            "$(tail -40 report.txt)")
+          gh issue create --title "$TITLE" --body "$BODY" --label pipeline
+      - name: Fail if the audit could not run
+        if: steps.run.outputs.fired != '0' && steps.run.outputs.fired != '1'
+        run: |
+          echo "::error::library-registry-coverage could not measure (exit ${{ steps.run.outputs.fired }}) — DB unreachable or registry parser broken. Nothing was checked."
+          exit 1

--- a/scripts/audit/library-registry-coverage.mjs
+++ b/scripts/audit/library-registry-coverage.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: scripts/audit/holding-library-coverage.mjs — adjacent but measures
+ * the citation copy-clause (how many books can name a physical holder), not
+ * registry coverage. The one-off version of THIS check ran in-session on
+ * 2026-09-03 (scratchpad audit.mjs, issue #4627) and found 16 unmapped keys /
+ * ~1,050 invisible books, fixed in #4615. This ports it as a standing watch.
+ *
+ * Registry coverage: every image_source.provider that has visible books must
+ * be mapped by a LIBRARY_PARTNERS entry (providerKey or aliasProviderKeys) —
+ * otherwise those books are silently absent from /libraries, and the absence
+ * reads as "we hold nothing from that institution". A new importer minting a
+ * new provider key recreates the gap without failing anything, which is why
+ * this is a scheduled watch (library-coverage-watch.yml) and not a PR gate:
+ * the key usually starts existing when the import RUNS, not when code merges.
+ *
+ * The registry is a static TS literal, so we parse it textually rather than
+ * import TS from .mjs. A positive control guards the parser: if it stops
+ * finding well-known entries, we exit 2 (instrument broken), never 0.
+ *
+ * Exit codes (same convention as field-sprawl.mjs — the workflow depends on
+ * distinguishing these):
+ *   0 = ran, no findings
+ *   1 = ran, unmapped provider(s) at/above threshold — report on stdout
+ *   2 = could not measure (DB unreachable, registry unparseable)
+ *
+ *   node --env-file=.env.production.local scripts/audit/library-registry-coverage.mjs [--threshold 10]
+ */
+import { readFileSync } from 'node:fs';
+import { MongoClient } from 'mongodb';
+
+const thresholdArg = process.argv.indexOf('--threshold');
+const THRESHOLD = thresholdArg > -1 ? parseInt(process.argv[thresholdArg + 1], 10) : 10;
+
+// Infrastructure buckets, not institutions — mirrored from /libraries and
+// /api/libraries (EXCLUDE_PROVIDERS there).
+const INFRA_KEYS = new Set(['user_upload', 'other', 'library', 'iiif']);
+
+// ---------- Parse the registry (with a positive control) ----------
+let known;
+try {
+  const src = readFileSync(new URL('../../src/lib/library-partners.ts', import.meta.url), 'utf8');
+  const providerKeys = [...src.matchAll(/providerKey: '([^']+)'/g)].map(m => m[1]);
+  const aliasKeys = [...src.matchAll(/aliasProviderKeys: \[([^\]]+)\]/g)]
+    .flatMap(m => [...m[1].matchAll(/'([^']+)'/g)].map(x => x[1]));
+  known = new Set([...providerKeys, ...aliasKeys]);
+  // Positive control: the parser must see entries we know exist. A refactor of
+  // the registry's shape must break THIS loudly, not silently return an empty
+  // set that makes every provider look unmapped (or, worse, a partial set).
+  const mustContain = ['internet_archive', 'bph', 'mdz', 'bsb', 'gallica'];
+  const missing = mustContain.filter(k => !known.has(k));
+  if (missing.length || known.size < 40) {
+    console.error(`Registry parse failed positive control (size=${known.size}, missing=${missing.join(',') || 'none'}) — library-partners.ts shape changed; update this parser.`);
+    process.exit(2);
+  }
+} catch (err) {
+  console.error('Could not read/parse src/lib/library-partners.ts:', err.message);
+  process.exit(2);
+}
+
+// ---------- Census visible books per provider ----------
+let rows;
+const client = new MongoClient(process.env.MONGODB_URI ?? '');
+try {
+  await client.connect();
+  rows = await client.db('bookstore').collection('books').aggregate([
+    { $match: { visible: true, pages_count: { $gt: 0 }, 'image_source.provider': { $type: 'string', $ne: '' } } },
+    { $group: { _id: '$image_source.provider', n: { $sum: 1 } } },
+    { $sort: { n: -1 } },
+  ], { maxTimeMS: 60_000 }).toArray();
+} catch (err) {
+  console.error('Could not census books by provider:', err.message);
+  process.exit(2);
+} finally {
+  await client.close().catch(() => {});
+}
+
+// ---------- Compare ----------
+const unmapped = rows.filter(r => !known.has(r._id) && !INFRA_KEYS.has(r._id));
+const overThreshold = unmapped.filter(r => r.n >= THRESHOLD);
+const invisible = unmapped.reduce((s, r) => s + r.n, 0);
+
+console.log(`Registry: ${known.size} provider keys | census: ${rows.length} provider keys with visible books`);
+console.log(`Unmapped: ${unmapped.length} keys / ${invisible} books invisible on /libraries (threshold for firing: >=${THRESHOLD} books)`);
+for (const r of unmapped) {
+  console.log(`  ${r.n >= THRESHOLD ? 'FIRE' : 'note'}\t${r._id}\t${r.n} books`);
+}
+
+if (overThreshold.length) {
+  console.log(`\n${overThreshold.length} provider key(s) need a LIBRARY_PARTNERS entry (or an aliasProviderKeys fold into an existing partner). See #4615 for the pattern; singletons can stay unregistered deliberately.`);
+  process.exit(1);
+}
+console.log('OK — every provider key at/above threshold is mapped.');
+process.exit(0);


### PR DESCRIPTION
Closes #4627 — the standing-detector follow-up to the /libraries arc.

## What it does
`scripts/audit/library-registry-coverage.mjs` censuses `image_source.provider` over visible books (Mongo) and diffs against the partner registry (providerKey + aliasProviderKeys, infra keys excluded). `library-coverage-watch.yml` runs it weekly (Tue 08:00 UTC) and files a `pipeline`-labeled issue when an unmapped key holds ≥10 visible books.

## Why a schedule, not a PR gate
A new importer minting a provider key creates the gap when the import **runs**, not when code merges — there's nothing for a PR check to see.

## Guards on the instrument itself
- Registry is parsed textually (static TS literal); a **positive control** (must find 5 known keys, ≥40 total) exits 2 if the file's shape drifts, so a refactor breaks the instrument loudly rather than making every provider look unmapped.
- Exit-code convention copied from `field-sprawl.mjs` (0 clean / 1 findings / 2 cannot-measure), and the workflow distinguishes them — learned from the three weeks field-sprawl spent filing 'breach' issues that were its own missing secret.
- **Negative-controlled before commit:** exit 1 verified at `--threshold 1`, exit 2 verified with unreachable Mongo.

## Live evidence it's needed
Today's clean run already shows a new `jstage` key (4 books) that did not exist in yesterday's audit — below threshold, but exactly the drift this watches for.

## Out of scope
- Registering jstage/singleton keys (deliberate, per #4615).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjAU6kQKngdU3X5JJEsSGg