### PR TITLE
fix(gallery): the download buttons never worked — our image host is cross-origin (#4630)

### DIFF
--- a/.claude/docs/invariants/image-host-allowlists.md
+++ b/.claude/docs/invariants/image-host-allowlists.md
@@ -1,6 +1,6 @@
 # Two allowlists decide whether an image appears — and every resolver must consult them
 
-**Read this when:** adding or editing an image-URL resolver; adding a provider host; storing a new `image_*` / `*_photo` / `thumbnail*` field; or triaging "the images are broken" when the URLs return 200 to curl.
+**Read this when:** adding or editing an image-URL resolver; adding a provider host; storing a new `image_*` / `*_photo` / `thumbnail*` field; or triaging "the images are broken" — or "the download button does nothing" — when the URLs return 200 to curl.
 
 *Written 2026-08-21 after #4163: every page thumbnail on 2,506 Florentine Codex pages was refused by every browser for months, while each of those URLs returned a clean `200 image/jpeg` to curl.*
 
@@ -73,5 +73,42 @@ curl -sI https://sourcelibrary.org/book/<slug> | grep -o "img-src[^;]*"
 ## Server-side consumers must sign their /api/image fetches (#4356)
 
 `/api/image` and `/api/crop-image` budget anonymous non-browser traffic (`src/lib/image-gate.ts`). A server-side consumer of the proxy — an export, a pipeline step, anything handing a proxy URL to a worker — is exactly "anonymous non-browser" unless it carries the internal HMAC token (`itk`, `src/lib/image-proxy-auth.ts`). The `images.fetchBuffer/fetchBase64/fetchBufferWithMimeType` helpers sign automatically; a new consumer using bare `fetch()` against the proxy will work in testing (under 500/day) and then starve mid-batch. Fetch through the helpers, or call `signImageProxyUrl()` yourself.
+
+## A DOWNLOAD is not a render — it needs a third and fourth permission (#4630)
+
+*Added 2026-09-03, after both gallery download buttons were found dead for every reader.*
+
+`img-src` governs whether the browser will **paint** an image. Saving one to disk means
+reading its **bytes** with `fetch()`, and that crosses two more boundaries our own image
+host did not permit:
+
+| permission | where it lives | miss looks like |
+|---|---|---|
+| CSP `connect-src` | `next.config.ts` (guarded by `tests/unit/csp-image-hosts.test.ts`) | `fetch()` throws; button does nothing |
+| CORS `Access-Control-Allow-Origin` | the **R2 bucket's** CORS rules — infrastructure, not this repo | `fetch()` throws; button does nothing |
+
+`images.sourcelibrary.org` is a **different origin** from `sourcelibrary.org`, so both
+apply to our own files. Neither was set until 2026-09-03: every click on the gallery's
+*Download* / *Download High-Res* threw, and the `window.open` fallback ran after an
+`await` — no longer a user gesture, so the popup blocker swallowed it and the page did
+nothing at all, with no console error a reader would ever see.
+
+The bucket CORS rule allows `GET`/`HEAD` from `sourcelibrary.org`, `*.sourcelibrary.org`
+(tenants), `*.vercel.app` (previews) and `localhost:3000` — deliberately **not** `*`, so
+this does not widen #4373 (unmarked `/archived/` originals) to arbitrary websites.
+Verified cache-safe: Cloudflare returns `Vary: Origin` and MISSes an Origin request
+against a primed no-Origin entry, so an ACAO-less body is never served to the site.
+
+Read it back with `GetBucketCorsCommand` against the R2 S3 endpoint using
+`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`; the fastest check is the served header:
+
+```
+curl -sI -H "Origin: https://sourcelibrary.org" <image-url> | grep -i access-control
+```
+
+**Rule:** a browser-side download of one of our own images fetches it directly (clean
+bytes) and falls back to the same-origin `/api/image` proxy, which always works but
+re-encodes and stamps the visible provenance mark. Keep the fallback — it is what makes
+the button survive a CDN or CORS regression instead of dying silently again.
 
 Related: `content-urls-and-libraries.md` (provider prefixes), `image-quality-and-bboxes.md` (crops and bboxes), `text-helpers-and-exports.md` (the export surfaces that consume these URLs), `crawler-access-gate.md` (the image-proxy budget ladder).

--- a/next.config.ts
+++ b/next.config.ts
@@ -124,7 +124,11 @@ const nextConfig: NextConfig = {
               // Host list lives in src/lib/csp-img-hosts.ts (shared with getBookThumbnailUrl's
               // renderability screen — edit it there, never inline here).
               CSP_IMG_SRC,
-              "connect-src 'self' https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co https://api.elevenlabs.io wss://*.elevenlabs.io https://www.google-analytics.com https://region1.google-analytics.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://analytics.ahrefs.com",
+              // images.sourcelibrary.org is in img-src for rendering, but a
+              // DOWNLOAD reads the bytes with fetch() — that is connect-src, and
+              // its absence here silently killed both gallery download buttons
+              // (with the R2 bucket's missing CORS header, #4630).
+              "connect-src 'self' https://images.sourcelibrary.org https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co https://api.elevenlabs.io wss://*.elevenlabs.io https://www.google-analytics.com https://region1.google-analytics.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://analytics.ahrefs.com",
               "media-src 'self' blob: https://api.elevenlabs.io https://images.sourcelibrary.org",
               "frame-src 'self' https://translate.google.com",
               "worker-src 'self' blob: data:",

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -45,6 +45,7 @@ const DeepZoomOverlay = lazy(() => import('@/components/artwork/DeepZoomOverlay'
 import { useSession } from 'next-auth/react';
 import { sendGAEvent } from '@/lib/ga';
 import { trackEvent } from '@/lib/track-event';
+import { toast } from 'sonner';
 
 /** In-memory cache for prefetched gallery image API responses */
 const prefetchCache = new Map<string, Promise<GalleryImageDetail>>();
@@ -636,15 +637,69 @@ export default function ImageDetailPage({
 
   const [downloading, setDownloading] = useState(false);
 
-  const triggerDownload = async (fetchUrl: string, suffix?: string) => {
-    const res = await fetch(fetchUrl);
-    const blob = await res.blob();
+  /**
+   * Save a blob under a real filename.
+   *
+   * The anchor goes into the document and the object URL is revoked on a later
+   * tick: a detached anchor plus an immediate revoke is a race the browser
+   * sometimes loses, and losing it looks exactly like a dead button.
+   */
+  const saveBlob = (blob: Blob, suffix?: string) => {
+    const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
+    a.href = url;
     const bookSlug = data!.book.title.replace(/[^a-z0-9]+/gi, '-').toLowerCase().slice(0, 40);
     a.download = `source-library-${bookSlug}-p${data!.pageNumber}${suffix || ''}.jpg`;
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(a.href);
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  };
+
+  /**
+   * Fetch an image for download, cross-origin included.
+   *
+   * Our own images live on images.sourcelibrary.org, which is a DIFFERENT
+   * ORIGIN from the page. That fetch needs two permissions and had neither
+   * until 2026-09-03: the bucket must send `Access-Control-Allow-Origin` (now
+   * set on R2) and our CSP must list the host in `connect-src` (now in
+   * next.config.ts). Both buttons therefore threw on every click, and the
+   * `window.open` fallback ran after an `await` — no longer a user gesture, so
+   * the popup blocker ate it and nothing at all happened (#4630, Corey, 2026-09-03).
+   *
+   * The /api/image proxy is the belt-and-braces path: same-origin, so it works
+   * whatever the CDN is sending today. It re-encodes and stamps the visible
+   * provenance mark, so it is a fallback, not the default.
+   */
+  const fetchImageBlob = async (sourceUrl: string, proxyWidth: number): Promise<Blob> => {
+    const sameOrigin = (() => {
+      try {
+        return new URL(sourceUrl, window.location.href).origin === window.location.origin;
+      } catch {
+        return false;
+      }
+    })();
+
+    if (sameOrigin) {
+      const res = await fetch(sourceUrl);
+      if (!res.ok) throw new Error(`Download failed (${res.status})`);
+      return res.blob();
+    }
+
+    try {
+      const direct = await fetch(sourceUrl, { mode: 'cors' });
+      // An error body must never be saved as a .jpg — that is how a download
+      // becomes a file that "won't open" (DownloadButton, 2026-07-02).
+      if (direct.ok) return await direct.blob();
+    } catch {
+      // CORS or CSP refused it; fall through to the same-origin proxy.
+    }
+
+    const proxied = await fetch(
+      `/api/image?url=${encodeURIComponent(sourceUrl)}&w=${proxyWidth}&q=90`,
+    );
+    if (!proxied.ok) throw new Error(`Download failed (${proxied.status})`);
+    return proxied.blob();
   };
 
   const downloadImage = async () => {
@@ -653,16 +708,12 @@ export default function ImageDetailPage({
 
     // Quick download: use existing extracted image
     const sourceUrl = data.extractedUrl || data.highResUrl || data.imageUrl;
-    const isExternal = sourceUrl.startsWith('http') && !sourceUrl.includes('vercel-storage.com') && !sourceUrl.includes('sourcelibrary.org');
-    const fetchUrl = isExternal
-      ? `/api/image?url=${encodeURIComponent(sourceUrl)}&w=2000&q=90`
-      : sourceUrl;
 
     try {
-      await triggerDownload(fetchUrl);
+      saveBlob(await fetchImageBlob(sourceUrl, 2000));
       sendGAEvent({ action: 'gallery_download', label: imageId || undefined });
     } catch {
-      window.open(sourceUrl, '_blank');
+      toast.error('Download failed — please try again.');
     }
   };
 
@@ -675,10 +726,10 @@ export default function ImageDetailPage({
       const hiresRes = await fetch(`/api/gallery/image/${imageId}/hires`);
       if (!hiresRes.ok) throw new Error('High-res generation failed');
       const { url } = await hiresRes.json();
-      await triggerDownload(url, '-hires');
+      saveBlob(await fetchImageBlob(url, 4000), '-hires');
       sendGAEvent({ action: 'gallery_download_hires', label: imageId || undefined });
     } catch {
-      // Fall back to standard download
+      // Fall back to standard download, which reports its own failure.
       await downloadImage();
     } finally {
       setDownloading(false);

--- a/tests/unit/csp-image-hosts.test.ts
+++ b/tests/unit/csp-image-hosts.test.ts
@@ -162,3 +162,29 @@ describe('CSP_IMG_SRC', () => {
     }
   });
 });
+
+/**
+ * img-src governs RENDERING. A download reads the bytes with `fetch()`, which
+ * CSP governs under `connect-src` — a different directive, and one that listed
+ * only 'self' until 2026-09-03. Both gallery download buttons therefore threw
+ * on every click and failed silently (#4630).
+ *
+ * Our own image host is the only one that needs this: it is the only
+ * cross-origin host whose bytes the browser reads rather than renders.
+ */
+describe('CSP connect-src covers the image host we fetch bytes from (#4630)', () => {
+  const connectSrc = NEXT_CONFIG.match(/"connect-src [^"]+"/)?.[0] ?? '';
+
+  it('finds the connect-src directive', () => {
+    expect(connectSrc).toContain("'self'");
+  });
+
+  it('allows fetching from images.sourcelibrary.org', () => {
+    expect(
+      connectSrc,
+      'A gallery/page-image download fetch()es its bytes from images.sourcelibrary.org. ' +
+        'Without the host in connect-src the browser blocks the fetch and the download ' +
+        'button does nothing at all. Keep it listed.',
+    ).toContain('https://images.sourcelibrary.org');
+  });
+});


### PR DESCRIPTION
Fixes #4630. Reported by Corey on Telegram at 02:00 today: "this download high res button doesn't seem to work… the download button doesn't either."

## What was wrong

`images.sourcelibrary.org` is a **different origin** from `sourcelibrary.org`. Both gallery download buttons read the bytes with `fetch()`, and that needed two permissions our own host did not have:

- **CSP `connect-src`** listed only `'self'` (plus analytics/Supabase/ElevenLabs). `img-src` has the host — that is why pictures *render* — but `img-src` governs painting, not fetching.
- **CORS.** The R2 bucket had no CORS configuration at all: `GetBucketCors` returned `NoSuchCORSConfiguration`, so `Access-Control-Allow-Origin` was never sent.

Either one alone kills the fetch. The `catch` then called `window.open()` **after an `await`** — no longer a user gesture, so the popup blocker ate that too. Net effect: a button that does absolutely nothing, with nothing in the console a reader would ever see.

The APIs were healthy the whole time — `/api/gallery/image/<id>/hires` returns 200 and a real, freshly generated R2 object. This was only ever the browser refusing to read it.

## In this PR

- `connect-src` now lists the image host, **guarded by a test** that fails when it is removed (negative-controlled: removing the host fails 1 of 44).
- Same-origin is decided by comparing **origins**, not `String.includes('sourcelibrary.org')` — which classified our own cross-origin CDN as internal and skipped the proxy that would have worked.
- Direct fetch first (clean bytes, no re-encode), same-origin `/api/image` proxy as fallback — so the button survives a CORS or CDN regression instead of dying silently again.
- `res.ok` is checked before saving. An error body must never land on disk as a `.jpg` (`DownloadButton` learned that on 2026-07-02).
- The anchor goes into the document and the object URL is revoked a minute later. A detached anchor plus an immediate revoke is a race that looks exactly like a dead button.
- Failures now say so, with a toast.
- `.claude/docs/invariants/image-host-allowlists.md` gains the section: a download is not a render, and needs two more permissions than one.

## Infrastructure, already applied (out of band)

R2 bucket CORS: `GET`/`HEAD` from `sourcelibrary.org`, `www.`, `*.sourcelibrary.org` (tenants), `*.vercel.app` (previews), `localhost:3000`. Deliberately **not** `*`, so this does not widen #4373 (unmarked `/archived/` originals) to arbitrary websites. Verified: correct per-origin `ACAO`; **no** `ACAO` for a third-party origin; and the edge honours `Vary: Origin` (an Origin request MISSes against a primed no-Origin cache entry, so an ACAO-less body is never served to the site).

This half is live now and is inert without the PR — the CSP still blocks the fetch until this merges.

## Out of scope

- The reader's per-page scan link (`Reader2C.tsx`) is a cross-origin `<a download>`, and browsers **ignore** the `download` attribute cross-origin — it navigates to the JPEG rather than saving it. Same root cause, different surface, its own PR.
- Corey also reports the page scan he downloads is a badly split half (the left edge of the text is cut off). That is a spread-split data problem in that specific book, not this bug.

## Verification

`npx tsc --noEmit` clean. `tests/unit/csp-image-hosts.test.ts` 44/44, and 43/44 with the host removed from `connect-src`. The R2 CORS behaviour was verified against production with `curl` per origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAy5NktSck7J7dAfvoJLxs