### PR TITLE
fix(ai): disable Gemini thinking on the image-extraction path (#4599)

### DIFF
--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -216,6 +216,12 @@ export async function extractWithGemini(
         generationConfig: {
           temperature: 0.1,
           maxOutputTokens: 2048,
+          // Gemini 3.x thinks by default and bills thought tokens at the output
+          // rate, while candidatesTokenCount excludes them — so an unconfigured
+          // call spends money the meter cannot see (#4581, 17x in Aug 2026).
+          // ai.ts's six entry points were fixed in #4591; this REST call was not,
+          // and it is the busiest unattended Gemini path we run (#4599).
+          thinkingConfig: { thinkingBudget: 0 },
         }
       })
     }
@@ -233,7 +239,10 @@ export async function extractWithGemini(
   const usageMetadata = data.usageMetadata;
   const usage = {
     inputTokens: usageMetadata?.promptTokenCount || 0,
-    outputTokens: usageMetadata?.candidatesTokenCount || 0,
+    // Count thought tokens too: if thinking is ever re-enabled here, the meter
+    // sees it instead of going blind again (#4581).
+    outputTokens: (usageMetadata?.candidatesTokenCount || 0) +
+      (usageMetadata?.thoughtsTokenCount || 0),
   };
 
   // Parse JSON from response


### PR DESCRIPTION
## What

`extractWithGemini` in `src/lib/image-extraction.ts` is a raw REST `generateContent`. Its `generationConfig` set `temperature` and `maxOutputTokens` but **no `thinkingConfig`** — so Gemini 3.x thought by default and billed thought tokens at the output rate, while the usage row counted `candidatesTokenCount` only. That is exactly the August blindness of #4581, still live.

#4591 fixed the six `ai.ts` entry points (OCR ×2, translation, summary, modernization, transliteration). This call site was not among them.

## Why it matters now, not eventually

This is not a dormant path — it is currently **the only one running**. From `gemini_usage`, since the Lambda deploy on 2026-09-03 06:04Z:

| endpoint | last row | calls since deploy | metered |
|---|---|---|---|
| `worker/image-extraction` | 2026-09-04 00:23Z | 7,166 | $13.83 |
| `worker/ocr` | 2026-08-31 11:04Z | 0 | — |
| `worker/translation` | 2026-08-29 01:11Z | 0 | — |

So #4591's fix is deployed but has had no production traffic through it, and the busiest unattended Gemini path we run is the one it did not reach. The spend is authorized (dial closed at $16.6/$5; burn is under the `forum-conscience-finish` envelope, $2.60/$35 open) — the problem is that the metered figure under-reports it by whatever thinking costs.

## Change

- `generationConfig` gains `thinkingConfig: { thinkingBudget: 0 }` — the AI Models rule in `CLAUDE.md` already specifies budget 0 for OCR/translation/**extraction**, so this is bringing the code to stated doctrine.
- `usage.outputTokens` now adds `thoughtsTokenCount`, mirroring #4591, so the meter cannot go blind again if thinking is re-enabled here.

## Verification

- `npx tsc --noEmit` clean.
- Rebuilt `image-extraction-processor` with the repo's own esbuild invocation: `thinkingBudget` is present in the Lambda artifact.
- Discovered by comparing the **deployed** Lambda bundles against a build of `main` @ 5838c77a — the deployed image-extraction bundle contains zero occurrences of `thinkingBudget`, while ocr and translation contain one each.

## ⚠️ Merging does not take effect

The image-extraction worker runs on Lambda. This PR ships the Vercel side only — the fix reaches production when `sourcelibrary-image-extraction-processor` is redeployed. Related: #4600 (no Lambda CI). Separately noted: `db-write` is currently one commit stale on Lambda, missing #4523's `ocr.unreadable` exclusion.

## Out of scope

`src/lib/identify-rerank.ts` and the traffic-driven `chat` / `ask` / `explain` routes — the rest of #4599's inventory. Those want a per-route quality decision, not a blanket zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQkkHNnZ3en3UDYtuicykT