### PR TITLE
fix(book): list every earlier English translation, oldest first

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -79,7 +79,7 @@ import { buildSeoTitle, buildSeoDescription } from '@/lib/book-seo';
 import { getPageImageUrl } from '@/lib/page-image-url';
 import { galleryFilter, galleryHref, type GalleryScope } from '@/lib/gallery-scope';
 import { cleanOriginalTitle, isNonLatinScript } from '@/lib/original-title';
-import { hasPublishablePriorTranslation, priorTranslationSentence, priorLinkLabel } from '@/lib/prior-translation';
+import { hasPublishablePriorTranslation, priorTranslationSentence, priorLinkLabel, collectPriorTranslations } from '@/lib/prior-translation';
 import type { PriorTranslationCredit, TranslationVerification } from '@/lib/types/book';
 import { getEffectiveByline } from '@/lib/byline';
 import AuthorName from '@/components/AuthorName';
@@ -1307,49 +1307,61 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       const m = s.match(/(\d{3,4})/);
       return m ? Date.UTC(Number(m[1]), 0, 1) : -0.5;
     };
+    // EVERY earlier English translation we hold evidence for, each on its own year.
+    //
+    // This used to render exactly one: `prior_translation`, else `picks[0]` of the
+    // verification array. Two things were wrong with that. It hid 2,212 recorded
+    // translations across 1,339 books (measured 2026-09-04). Worse, the array is
+    // unordered, so `[0]` is not the earliest — in 35% of books with two or more
+    // dated picks it is a LATER one, and the entry then sits on a date axis under a
+    // heading that says "Earlier". Pico's Opera Omnia credited Copenhaver (2022)
+    // while hiding Sir Thomas More (1510); the Hypnerotomachia credited Godwin
+    // (1999) over Dallington (1592). On a timeline, showing an arbitrary member of
+    // a set is not merely incomplete — it is chronologically false.
     const timelinePrior = hasPublishablePriorTranslation(book as unknown as { prior_translation?: PriorTranslationCredit })
       ? (book as unknown as { prior_translation: PriorTranslationCredit }).prior_translation
       : null;
     const timelineVerification = (book as unknown as { translation_verification?: TranslationVerification }).translation_verification;
-    const timelineExistingEvidence = !timelinePrior && timelineVerification?.disposition === 'translation_found'
-      ? (timelineVerification.validated_translations?.[0] || timelineVerification.translations_found?.[0] || timelineVerification.translations?.[0])
-      : undefined;
-    if (timelinePrior) {
-      rawTimeline.push({
-        ts: yearTs(timelinePrior.year),
-        key: 'prior-translation',
-        dateText: timelinePrior.year ? String(timelinePrior.year) : t.tlEarlier,
-        label: t.tlEarlierEnglishTranslation,
-        detail: (
+    const verificationPicks = timelineVerification?.disposition === 'translation_found'
+      ? (timelineVerification.validated_translations ?? timelineVerification.translations_found ?? timelineVerification.translations ?? [])
+      : [];
+
+    collectPriorTranslations(timelinePrior, verificationPicks).forEach((row, i) => {
+      let detail: React.ReactNode;
+      if (row.credit) {
+        detail = (
           <>
-            {priorTranslationSentence(timelinePrior)}
+            {priorTranslationSentence(row.credit)}
             {embedPolicy.showExternalLinks && (
-              <>{' '}<a href={timelinePrior.url} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>{priorLinkLabel(timelinePrior)} →</a></>
+              <>{' '}<a href={row.credit.url} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>{priorLinkLabel(row.credit)} →</a></>
             )}
           </>
-        ),
-      });
-    } else if (timelineExistingEvidence) {
-      const ev = timelineExistingEvidence;
-      const bits = [ev.translator ? `trans. ${ev.translator}` : null, ev.publisher || null].filter(Boolean).join(', ');
-      const summary = ev.english_title
-        ? `${ev.english_title}${bits ? ` — ${bits}` : ''}`
-        : (bits || t.tlEarlierTranslationExists);
-      rawTimeline.push({
-        ts: yearTs(ev.pub_year),
-        key: 'existing-translation',
-        dateText: ev.pub_year ? String(ev.pub_year) : t.tlEarlier,
-        label: t.tlEarlierEnglishTranslation,
-        detail: (
+        );
+      } else {
+        const ev = row.pick!;
+        const bits = [ev.translator ? `trans. ${ev.translator}` : null, ev.publisher || null].filter(Boolean).join(', ');
+        const summary = ev.english_title
+          ? `${ev.english_title}${bits ? ` — ${bits}` : ''}`
+          : (bits || t.tlEarlierTranslationExists);
+        detail = (
           <>
             {summary}
             {ev.url && embedPolicy.showExternalLinks && (
               <>{' '}<a href={ev.url} target="_blank" rel="noopener noreferrer" className="hover:underline whitespace-nowrap" style={{ color: '#a5503d' }}>{t.view}</a></>
             )}
           </>
-        ),
+        );
+      }
+      rawTimeline.push({
+        // Undated priors carry +Infinity from the collector; the timeline sorts on
+        // a finite axis, so map that back to the "unknown year" sentinel here.
+        ts: Number.isFinite(row.ts) ? row.ts : -0.5,
+        key: `prior-translation-${i}`,
+        dateText: row.year ?? t.tlEarlier,
+        label: t.tlEarlierEnglishTranslation,
+        detail,
       });
-    }
+    });
     // English editions / translations published on Source Library.
     const publishedEditions = ((book.editions as TranslationEdition[] | undefined) || [])
       .filter((e) => e.status === 'published' && e.published_at)

--- a/src/lib/prior-translation.ts
+++ b/src/lib/prior-translation.ts
@@ -40,6 +40,71 @@ export function priorLinkLabel(p: PriorTranslationCredit): string {
   }
 }
 
+/** One earlier English translation, ready to place on the book timeline. */
+export interface PriorTimelineRow {
+  /** Sort key: the publication year as ms, or +Infinity when undated. */
+  ts: number;
+  /** Year as shown, or null when we have none. */
+  year: string | null;
+  /** The curated, verified credit — renders with its "find it" link. */
+  credit?: PriorTranslationCredit;
+  /** A verification-array pick — renders as a plain summary line. */
+  pick?: { english_title?: string | null; translator?: string | null; publisher?: string | null; pub_year?: string | number | null; url?: string | null };
+}
+
+const priorYearTs = (y?: string | number | null): number => {
+  const m = String(y ?? '').match(/(\d{3,4})/);
+  return m ? Date.UTC(Number(m[1]), 0, 1) : Number.POSITIVE_INFINITY;
+};
+
+/**
+ * Every earlier English translation we hold, oldest first, deduped.
+ *
+ * Why this is a function and not an inline `[0]`: the verification array is
+ * UNORDERED. Taking its first element hid 2,212 recorded translations across
+ * 1,339 books, and in 35% of the books with two or more dated picks the one
+ * shown was not the earliest — so a timeline entry headed "Earlier English
+ * translation" credited a LATER translation and buried the earlier one, by up
+ * to five centuries (Pico's Opera Omnia showed Copenhaver 2022 over Sir Thomas
+ * More 1510). On a date axis, an arbitrary member of a set is not just
+ * incomplete; it is false.
+ *
+ * The curated `prior_translation` credit is emitted first so it wins the dedupe
+ * against any verification pick naming the same translator and year — it is the
+ * verified one, and it carries the outbound link.
+ */
+export function collectPriorTranslations(
+  credit: PriorTranslationCredit | null | undefined,
+  picks: ReadonlyArray<NonNullable<PriorTimelineRow['pick']>> = [],
+): PriorTimelineRow[] {
+  const rows: PriorTimelineRow[] = [];
+  const seen = new Set<string>();
+  const take = (key: string, row: PriorTimelineRow) => {
+    const k = key.trim().toLowerCase();
+    // A row with no translator AND no year cannot be deduped meaningfully; keep it.
+    if (k !== '|infinity' && seen.has(k)) return;
+    seen.add(k);
+    rows.push(row);
+  };
+  if (credit) {
+    take(`${formatTranslators(credit.translators)}|${priorYearTs(credit.year)}`, {
+      ts: priorYearTs(credit.year),
+      year: credit.year ? String(credit.year) : null,
+      credit,
+    });
+  }
+  for (const p of picks) {
+    take(`${p.translator ?? ''}|${priorYearTs(p.pub_year)}`, {
+      ts: priorYearTs(p.pub_year),
+      year: p.pub_year ? String(p.pub_year) : null,
+      pick: p,
+    });
+  }
+  // Oldest first; undated sort last among priors rather than drifting to the top
+  // of the whole timeline on a sentinel year.
+  return rows.sort((a, b) => a.ts - b.ts);
+}
+
 /** "trans. A, B and C" — Oxford-free join of translator names. */
 export function formatTranslators(translators: string[]): string {
   const names = (translators || []).filter(Boolean);

--- a/tests/unit/prior-translation-timeline.test.ts
+++ b/tests/unit/prior-translation-timeline.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { collectPriorTranslations } from '@/lib/prior-translation';
+import type { PriorTranslationCredit } from '@/lib/types/book';
+
+const credit = (over: Partial<PriorTranslationCredit> = {}): PriorTranslationCredit => ({
+  work_title: 'The Work', translators: ['A Translator'], scope: 'complete',
+  url: 'https://example.org/x', verification_method: 'worldcat', year: 1900,
+  publisher: 'A Press', ...over,
+} as PriorTranslationCredit);
+
+const pick = (translator: string | null, pub_year: string | number | null, over = {}) =>
+  ({ english_title: 'T', translator, pub_year, publisher: null, url: null, ...over });
+
+describe('collectPriorTranslations — the timeline shows EVERY prior, oldest first', () => {
+  it('returns every pick, not just the first', () => {
+    const rows = collectPriorTranslations(null, [
+      pick('Copenhaver', 2022), pick('More', 1510), pick('Someone', 1789),
+    ]);
+    expect(rows).toHaveLength(3);
+  });
+
+  // The regression this function exists for: the array is unordered, so [0] was
+  // often a LATER translation shown under a heading reading "Earlier".
+  it('orders oldest first even when the array leads with the latest', () => {
+    const rows = collectPriorTranslations(null, [pick('Copenhaver', 2022), pick('More', 1510)]);
+    expect(rows.map((r) => r.year)).toEqual(['1510', '2022']);
+    expect(rows[0].pick?.translator).toBe('More');
+  });
+
+  it('a single pick still renders (no regression for the common case)', () => {
+    const rows = collectPriorTranslations(null, [pick('Solo', 1850)]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].year).toBe('1850');
+  });
+
+  it('the curated credit is included alongside verification picks', () => {
+    const rows = collectPriorTranslations(credit({ year: 1651 }), [pick('Later', 1990)]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].credit).toBeDefined();
+    expect(rows[0].year).toBe('1651');
+  });
+
+  it('a pick duplicating the curated credit is dropped, and the CREDIT survives', () => {
+    // The credit is the verified one and carries the outbound link, so it must win.
+    const rows = collectPriorTranslations(
+      credit({ translators: ['Jane Doe'], year: 1900 }),
+      [pick('Jane Doe', 1900), pick('Other', 1975)],
+    );
+    expect(rows).toHaveLength(2);
+    const nineteenHundred = rows.find((r) => r.year === '1900');
+    expect(nineteenHundred?.credit).toBeDefined();
+    expect(nineteenHundred?.pick).toBeUndefined();
+  });
+
+  it('duplicate picks collapse', () => {
+    const rows = collectPriorTranslations(null, [pick('Same', 1800), pick('Same', 1800)]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('undated priors sort last, never to the front of the timeline', () => {
+    const rows = collectPriorTranslations(null, [pick('Undated', null), pick('Dated', 1600)]);
+    expect(rows.map((r) => r.pick?.translator)).toEqual(['Dated', 'Undated']);
+    expect(rows[1].ts).toBe(Number.POSITIVE_INFINITY);
+    expect(rows[1].year).toBeNull();
+  });
+
+  it('several undated priors are all kept — they cannot be deduped by year', () => {
+    const rows = collectPriorTranslations(null, [pick(null, null), pick(null, null)]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('no evidence at all yields nothing (silence stays the fail direction)', () => {
+    expect(collectPriorTranslations(null, [])).toEqual([]);
+    expect(collectPriorTranslations(undefined, undefined)).toEqual([]);
+  });
+
+  it('a year embedded in prose still sorts correctly', () => {
+    const rows = collectPriorTranslations(null, [pick('B', 'c. 1998'), pick('A', 'first printed 1592')]);
+    expect(rows.map((r) => r.pick?.translator)).toEqual(['A', 'B']);
+  });
+});


### PR DESCRIPTION
## The bug

You asked whether the timeline should list *all* previous translations rather than one. It should — and the single-pick behaviour turned out to be worse than incomplete.

`src/app/book/[id]/page.tsx` rendered exactly one prior: the curated `prior_translation` credit, else `picks[0]` of `translation_verification`.

**1. It hid evidence we already hold.** 2,212 recorded translations across 1,339 books (1,117 live) never rendered anywhere. Some books carry six or more.

**2. The one it showed was often the wrong one.** The verification array is unordered, so `[0]` is not the earliest. In **35% of books with two or more dated picks — 457 books, 364 live — the rendered entry is a LATER translation**, sitting on a date axis under a heading that reads *"Earlier English translation"*:

| book | shown | earlier one hidden | gap |
|---|---|---|---|
| Pico, *Opera Omnia* | Copenhaver 2022 | **Sir Thomas More 1510** | 512y |
| *Hypnerotomachia Poliphili* | Godwin 1999 | Robert Dallington 1592 | 407y |
| *Sphaera Mundi* | Thorndike 1949 | Anthony Ascham 1527 | 422y |
| Erasmus, *De octo orationis partium* | McGregor 1978 | William Lily 1533 | 445y |

On a timeline, an arbitrary member of a set is not merely incomplete — it is chronologically false. Sir Thomas More translating Pico is exactly the kind of fact this panel exists to surface, and it was being buried under a 2022 edition.

## The change

- Every prior renders, each on its own year, **oldest first**, deduped.
- Ordering and dedupe move into `collectPriorTranslations()` in `src/lib/prior-translation.ts`, so the logic is testable away from JSX.
- The curated `prior_translation` credit is emitted first and **wins any dedupe tie** against a pick naming the same translator and year — it is the verified one and it carries the outbound "find it" link, which the raw picks usually lack.
- Undated priors sort last among the priors instead of drifting to the top of the whole timeline on a sentinel year.

No change to what counts as publishable evidence: `hasPublishablePriorTranslation` still gates the credit, and silence is still the fail direction.

## Tests

`tests/unit/prior-translation-timeline.test.ts` — 10 cases covering completeness, ordering, credit-vs-pick precedence, dedupe, undated handling, and years embedded in prose.

**Negative-controlled**: I simulated the previous `[0]` behaviour against these assertions and it violates 4 of the 10, so the test genuinely catches the regression rather than merely passing. Local `npx tsc --noEmit` clean; related suites (`translation-card-label`, `first-translation-render`, `ft-prior-guard`) pass — 58 tests.

## Out of scope, deliberately

- **Whether the prior credits are TRUE.** #4634 covers 1,351 books whose `translation_verification` says `translation_found` while its own `reasoning` says nothing was found, and the 194 likely-fabricated "grounding audit alternative" picks. This PR renders the data faithfully; that issue is about the data being wrong. Rendering all of a bad set makes bad data *more* visible, which I think is the right direction while #4634 is open, but it is a real consequence worth naming.
- **No cap on the number of rows.** 44 books have 6+ priors. Each is a genuine dated event and the timeline is already scrollable; a "+N more" affordance can follow if it reads long in practice.
- The card (`Bibliographic information`) already lists all its entries and is untouched.

## Provenance

Found while draining the translation-card queue (#4617) — from looking at a book page as a reader, not from the data. Same review pass produced the 74-card false-first-claim repair (comment on #4617), #4634, and #4635.

Refs #4617

🤖 Generated with [Claude Code](https://claude.com/claude-code)