### PR TITLE
fix(meter): the worker stack bills thinking tokens but never counted them (#4581)

### DIFF
--- a/scripts/audit/gemini-thinking-and-meter.baseline.txt
+++ b/scripts/audit/gemini-thinking-and-meter.baseline.txt
@@ -1,0 +1,30 @@
+# Known #4581-class call sites outside the worker-stack fix. Tracked by #4599.
+# One `<path>:<kind>` per line. Delete a line when you fix that file; never add one
+# by hand — declare a deliberate exception with `// thinking-ok: <reason>` instead.
+scripts/batch/batch-extract-chapters.mjs:meter
+scripts/batch/batch-extract-chapters.mjs:thinking
+scripts/batch/batch-generate-indexes.mjs:meter
+scripts/batch/batch-generate-indexes.mjs:thinking
+scripts/batch/batch-mint-doi.mjs:thinking
+scripts/batch/batch-transliterate.mjs:meter
+scripts/batch/realtime-ocr.mjs:meter
+scripts/batch/realtime-reocr-efm.mjs:meter
+scripts/batch/realtime-translate.mjs:meter
+scripts/lib/batch-mint-doi.mjs:thinking
+src/lib/chapter-extraction.ts:meter
+src/lib/chapter-extraction.ts:thinking
+src/lib/collection-relevance.ts:thinking
+src/lib/cover-selection.ts:meter
+src/lib/cover-selection.ts:thinking
+src/lib/email-digest-generator.ts:meter
+src/lib/email-digest-generator.ts:thinking
+src/lib/image-extraction.ts:meter
+src/lib/metadata-enrichment.ts:meter
+src/lib/metadata-enrichment.ts:thinking
+src/lib/page-split/splitDetectionML.ts:thinking
+src/lib/quality-scoring.ts:meter
+src/lib/quality-scoring.ts:thinking
+src/lib/tweet-generator.ts:thinking
+src/lib/ustc-matcher.ts:meter
+src/lib/verify-first-translation.ts:meter
+src/lib/word-alignment.ts:thinking

--- a/scripts/audit/gemini-thinking-and-meter.mjs
+++ b/scripts/audit/gemini-thinking-and-meter.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: scripts/audit/spend-reconcile.mjs — reconciles metered vs billed totals
+ * after the fact; it cannot say WHICH call site under-reports, and it needs a bill to
+ * run. This is the static counterpart: it fails on the two code shapes that produce the
+ * gap, before any money is spent. Also checked: scripts/audit/r2-key-book-scope.mjs
+ * (same "standing detector for a known-recurring bug" pattern, different subsystem).
+ *
+ * gemini-thinking-and-meter — guard the two halves of #4581.
+ *
+ * The defect recurs because it is INVISIBLE: nothing errors, nothing looks wrong, the
+ * pages come out fine. It has now shipped three times — `src/lib/ai.ts` (Dec 2025 →
+ * fixed #4591), and the whole Hetzner `.mjs` worker stack (fixed alongside this file).
+ * August metered $499.74 against $8,389.32 billed.
+ *
+ * Two checks, matching the two halves:
+ *
+ *   1. THINKING — every `getGenerativeModel({...})` must reach an explicit
+ *      `thinkingConfig`. Gemini 3.x thinks by default and bills reasoning at the
+ *      output rate. Measured 2026-09-04: `gemini-3-flash-preview` emits ~1.5 thought
+ *      tokens per visible output token with no config; `gemini-3.1-flash-lite` emits
+ *      none on realistic prompts — so the exposure depends on which model a call
+ *      happens to route to, which is exactly why it must be explicit.
+ *
+ *   2. METER — anywhere `candidatesTokenCount` is summed into an output-token figure,
+ *      `thoughtsTokenCount` must be summed too (in practice: call `outputTokensFrom`).
+ *      Google bills both.
+ *
+ * A deliberate exception (grounded search needs a POSITIVE budget — flash-lite does not
+ * ground at all, and `-1` silently suppresses grounding) is declared with a waiver
+ * comment on the line above:  // thinking-ok: <reason>
+ *
+ * Usage: node scripts/audit/gemini-thinking-and-meter.mjs
+ * Exit 0 = clean, 1 = findings. Cheap and offline — safe in CI or a pre-push hook.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync, writeFileSync } from 'fs';
+import { join, relative } from 'path';
+
+const ROOT = process.cwd();
+const SCAN_DIRS = ['scripts/workers', 'scripts/lib', 'scripts/batch', 'src/lib'];
+const EXTS = ['.mjs', '.ts', '.js'];
+const WAIVER = /\/\/\s*thinking-ok:/;
+
+function walk(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e);
+    let st;
+    try { st = statSync(p); } catch { continue; }
+    if (st.isDirectory()) {
+      if (e === 'node_modules' || e === '_archived' || e.startsWith('.')) continue;
+      walk(p, out);
+    } else if (EXTS.some((x) => e.endsWith(x))) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Extract the balanced `{...}` object literal that starts at `open`. */
+function objectAt(src, open) {
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  return src.slice(open); // unbalanced — treat as the rest of the file
+}
+
+const lineOf = (src, idx) => src.slice(0, idx).split('\n').length;
+// Look back a few lines, not one: the waiver is as likely to sit above the enclosing
+// function as above the call itself, and a one-line window silently ignores it — the
+// failure mode being that a DECLARED exception reads as an undeclared one.
+const priorLines = (src, idx, n = 4) => {
+  const lines = src.slice(0, idx).split('\n');
+  return lines.slice(Math.max(0, lines.length - 1 - n), lines.length - 1).join('\n');
+};
+
+const files = SCAN_DIRS.flatMap((d) => walk(join(ROOT, d)));
+
+// ── Baseline ──
+// The same defect exists at call sites outside this fix's scope (`src/lib/*` TS paths
+// and the `scripts/batch/*` one-shots) — inventoried under #4599, whose sweep is a
+// separate decision because turning thinking off changes OUTPUT on the creative paths
+// (tweet copy, email digests), not just cost. They are recorded here so this guard can
+// go green and start failing on NEW violations today, which is the whole point of a
+// standing detector; a guard that has always been red teaches nothing.
+//
+// Removing a line from the baseline as you fix it is the intended workflow. Do NOT add
+// to it: `// thinking-ok: <reason>` at the call site is how a DELIBERATE exception is
+// declared, and it says why. --update-baseline rewrites the file from current findings.
+const BASELINE_PATH = join(ROOT, 'scripts/audit/gemini-thinking-and-meter.baseline.txt');
+const baseline = new Set(
+  existsSync(BASELINE_PATH)
+    ? readFileSync(BASELINE_PATH, 'utf8').split('\n').map((l) => l.replace(/#.*$/, '').trim()).filter(Boolean)
+    : [],
+);
+
+// Resolve `generationConfig: SOME_CONST` — the config may be hoisted into a shared
+// constant in another file (SUMMARY_GEN_CONFIG was, and a fixed-width window would
+// have missed it: a guard's coverage must not track code style).
+const constDefs = new Map();
+for (const f of files) {
+  const src = readFileSync(f, 'utf8');
+  for (const m of src.matchAll(/(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{/g)) {
+    constDefs.set(m[1], objectAt(src, src.indexOf('{', m.index)));
+  }
+}
+
+const findings = [];
+
+for (const f of files) {
+  const src = readFileSync(f, 'utf8');
+  const rel = relative(ROOT, f);
+
+  // ── 1. thinking ──
+  for (const m of src.matchAll(/getGenerativeModel\s*\(\s*\{/g)) {
+    const open = src.indexOf('{', m.index + 'getGenerativeModel('.length - 1);
+    const obj = objectAt(src, open);
+    if (WAIVER.test(priorLines(src, m.index))) continue;
+    // Embedding models have no reasoning stage — `getGenerativeModel` is merely how the
+    // SDK hands back an embedding handle. Not a thinking site.
+    if (/embedding/i.test(obj)) continue;
+    let hasThinking = /thinkingConfig/.test(obj);
+    if (!hasThinking) {
+      const ref = obj.match(/generationConfig\s*:\s*([A-Za-z_$][\w$]*)/);
+      if (ref && constDefs.has(ref[1])) hasThinking = /thinkingConfig/.test(constDefs.get(ref[1]));
+    }
+    if (!hasThinking) {
+      findings.push({ file: rel, line: lineOf(src, m.index), kind: 'thinking', detail: 'getGenerativeModel with no explicit thinkingConfig' });
+    }
+  }
+
+  // ── 2. meter ──
+  const srcLines = src.split('\n');
+  for (const m of src.matchAll(/^.*candidatesTokenCount.*$/gm)) {
+    const line = m[0];
+    // The sum is frequently spread over two lines (`... || 0) +` then the thoughts term).
+    // Judge the window, not the line — a line-scoped test would flag the FIXED shape in
+    // src/lib/ai.ts, which is exactly the style-sensitivity this guard is meant to avoid.
+    const ln = lineOf(src, m.index);
+    const window = [line, srcLines[ln] || ''].join('\n');
+    if (/thoughtsTokenCount|outputTokensFrom/.test(window)) continue;
+    if (WAIVER.test(line)) continue;
+    // Only flag lines that FEED a token/cost figure — a console.log or a comment is fine.
+    if (!/(output|tokens|cost|usage)\s*[:+=]/i.test(line)) continue;
+    findings.push({ file: rel, line: lineOf(src, m.index), kind: 'meter', detail: line.trim().slice(0, 100) });
+  }
+}
+
+const key = (f) => `${f.file}:${f.kind}`;
+
+if (process.argv.includes('--update-baseline')) {
+  const lines = [
+    '# Known #4581-class call sites outside the worker-stack fix. Tracked by #4599.',
+    '# One `<path>:<kind>` per line. Delete a line when you fix that file; never add one',
+    '# by hand — declare a deliberate exception with `// thinking-ok: <reason>` instead.',
+    ...[...new Set(findings.map(key))].sort(),
+  ];
+  writeFileSync(BASELINE_PATH, lines.join('\n') + '\n');
+  console.log(`Baseline written: ${new Set(findings.map(key)).size} entr(ies) from ${findings.length} finding(s).`);
+  process.exit(0);
+}
+
+const fresh = findings.filter((f) => !baseline.has(key(f)));
+const known = findings.length - fresh.length;
+
+if (!fresh.length) {
+  console.log(`✔ ${files.length} files scanned — no new findings.`);
+  if (known) console.log(`  (${known} baselined finding(s) still open — see #4599 and the baseline file.)`);
+  process.exit(0);
+}
+
+console.log(`✘ ${fresh.length} NEW finding(s) — see #4581.${known ? ` (${known} baselined, not shown.)` : ''}\n`);
+findings.length = 0;
+findings.push(...fresh);
+for (const kind of ['thinking', 'meter']) {
+  const rows = findings.filter((x) => x.kind === kind);
+  if (!rows.length) continue;
+  console.log(kind === 'thinking'
+    ? 'THINKING — Gemini 3.x thinks by default and bills it at the output rate:'
+    : 'METER — candidatesTokenCount excludes thoughtsTokenCount; Google bills both:');
+  for (const r of rows) console.log(`  ${r.file}:${r.line}  ${r.detail}`);
+  console.log('');
+}
+console.log('Fix: add `thinkingConfig: { thinkingBudget: 0 }`, or call `outputTokensFrom(usage)`');
+console.log('from scripts/workers/lib/supabase-usage-logger.mjs. Deliberate exception:');
+console.log('put `// thinking-ok: <reason>` on the line above.');
+process.exit(1);

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -19,7 +19,7 @@
 import { MongoClient } from 'mongodb';
 
 import { GoogleGenAI } from '@google/genai';
-import { completeBatchUsage, sumBatchResponseUsage } from './lib/supabase-usage-logger.mjs';
+import { completeBatchUsage, sumBatchResponseUsage, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import { syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { hasScope } from './lib/selective-unpause.mjs';
 import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
@@ -343,7 +343,7 @@ async function processOneJob(db, job) {
         const share = parsed.length || 1;
         const pageUsage = usage ? {
           promptTokenCount: Math.round((usage.promptTokenCount || 0) / share),
-          candidatesTokenCount: Math.round((usage.candidatesTokenCount || 0) / share),
+          candidatesTokenCount: Math.round(outputTokensFrom(usage) / share),
         } : undefined;
         for (const [pageId, ocrText] of parsed) {
           pageResults.push({ pageId, text: ocrText, usage: pageUsage });
@@ -516,7 +516,7 @@ async function processOneJob(db, job) {
 
       // Per-page stamp only — the job totals are summed per response above.
       const inputTokens = usage?.promptTokenCount || 0;
-      const outputTokens = usage?.candidatesTokenCount || 0;
+      const outputTokens = outputTokensFrom(usage);
 
       if (job.type === 'ocr') {
         // Refused by the blank-page guard: keep the evidence, write no OCR.

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -36,7 +36,7 @@
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { logUsage as logUsageToSupabase } from './lib/supabase-usage-logger.mjs';
+import { logUsage as logUsageToSupabase, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import { createBookRevisions } from './lib/book-revisions.mjs';
 import { buildSummaryPrompt, SUMMARY_GEN_CONFIG } from './lib/summary-prompt.mjs';
 import { createClient } from '@supabase/supabase-js';
@@ -354,7 +354,7 @@ async function researchBook(title, author) {
 async function processBatch(pages, bookTitle, bookAuthor, bookLanguage) {
   const model = getClient().getGenerativeModel({
     model: LITE_MODEL,
-    generationConfig: { temperature: 0.2, maxOutputTokens: 2000 },
+    generationConfig: { temperature: 0.2, maxOutputTokens: 2000, thinkingConfig: { thinkingBudget: 0 } },
   });
 
   const pageRange = {
@@ -423,7 +423,7 @@ CRITICAL for quotes:
       const usageMetadata = result.response.usageMetadata;
       const usage = {
         input_tokens: usageMetadata?.promptTokenCount || 0,
-        output_tokens: usageMetadata?.candidatesTokenCount || 0,
+        output_tokens: outputTokensFrom(usageMetadata),
       };
 
       const jsonMatch = responseText.match(/\{[\s\S]*\}/);
@@ -712,7 +712,7 @@ async function generateBookSummary(batchExtractions, bookTitle, bookAuthor, book
   const usageMetadata = result.response.usageMetadata;
   const usage = {
     input_tokens: usageMetadata?.promptTokenCount || 0,
-    output_tokens: usageMetadata?.candidatesTokenCount || 0,
+    output_tokens: outputTokensFrom(usageMetadata),
   };
 
   const jsonMatch = responseText.match(/\{[\s\S]*\}/);
@@ -1363,7 +1363,10 @@ async function extractChaptersForBook(db, bookId) {
 
   // Call Gemini — flash-lite is sufficient for structured chapter extraction
   const modelId = LITE_MODEL;
-  const model = getClient().getGenerativeModel({ model: modelId });
+  const model = getClient().getGenerativeModel({
+    model: modelId,
+    generationConfig: { thinkingConfig: { thinkingBudget: 0 } },
+  });
   const prompt = buildExtractionPrompt(
     book.display_title || book.title,
     book.author || 'Unknown',
@@ -1379,7 +1382,7 @@ async function extractChaptersForBook(db, bookId) {
   const responseText = response.text();
   const usageMetadata = response.usageMetadata;
   const inputTokens = usageMetadata?.promptTokenCount || 0;
-  const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+  const outputTokens = outputTokensFrom(usageMetadata);
 
   // Parse AI response
   let aiChapters;
@@ -1749,7 +1752,7 @@ Guidelines:
 
         const model = getClient().getGenerativeModel({
           model: LITE_MODEL,
-          generationConfig: { temperature: 0.1, maxOutputTokens: 2048, responseMimeType: 'application/json' },
+          generationConfig: { temperature: 0.1, maxOutputTokens: 2048, responseMimeType: 'application/json', thinkingConfig: { thinkingBudget: 0 } },
         });
 
         const result = await Promise.race([
@@ -1802,7 +1805,7 @@ Guidelines:
             type: 'quality-scoring', mode: 'realtime', model: LITE_MODEL,
             book_id: book.id, book_title: title,
             input_tokens: usageMeta?.promptTokenCount || 0,
-            output_tokens: usageMeta?.candidatesTokenCount || 0,
+            output_tokens: outputTokensFrom(usageMeta),
             status: 'success', endpoint: 'worker/hetzner-enrich',
           });
         }
@@ -1936,6 +1939,7 @@ NO explanation, just the JSON array.`;
                 generationConfig: {
                   temperature: 0.1,
                   responseMimeType: 'application/json',
+                  thinkingConfig: { thinkingBudget: 0 },
                 },
                 systemInstruction: collectionSystemPrompt,
               });
@@ -1953,7 +1957,7 @@ NO explanation, just the JSON array.`;
               await logUsage(db, {
                 type: 'collection-assignment', mode: 'realtime', model: COLLECTION_MODEL,
                 input_tokens: usageMeta?.promptTokenCount || 0,
-                output_tokens: usageMeta?.candidatesTokenCount || 0,
+                output_tokens: outputTokensFrom(usageMeta),
                 status: 'success', endpoint: 'worker/hetzner-enrich',
               });
               break;

--- a/scripts/workers/es-translate-worker.mjs
+++ b/scripts/workers/es-translate-worker.mjs
@@ -37,7 +37,7 @@
 import { MongoClient } from 'mongodb';
 import pg from 'pg';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { logUsage } from './lib/supabase-usage-logger.mjs';
+import { logUsage, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import { embedBookPageTexts } from '../lib/embed-book-page-texts.mjs';
 
 const args = process.argv.slice(2);
@@ -75,6 +75,7 @@ let keyIdx = 0;
 const nextModel = () => new GoogleGenerativeAI(API_KEYS[keyIdx++ % API_KEYS.length]).getGenerativeModel({
   model: MODEL,
   safetySettings: ['HARM_CATEGORY_HARASSMENT', 'HARM_CATEGORY_HATE_SPEECH', 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'HARM_CATEGORY_DANGEROUS_CONTENT'].map(category => ({ category, threshold: 'BLOCK_NONE' })),
+  generationConfig: { thinkingConfig: { thinkingBudget: 0 } },
 });
 
 const WRAP = /<(meta|image-desc|vocab|summary|keywords|warning|scan-quality|language|page-type|page-num|columns|script)\b[^>]*>[\s\S]*?<\/\1>/gi;
@@ -122,12 +123,12 @@ async function translatePage(eng) {
       continue;
     }
     const meta = res.usageMetadata || {};
-    usage.input += meta.promptTokenCount || 0; usage.output += meta.candidatesTokenCount || 0; usage.calls++;
+    usage.input += meta.promptTokenCount || 0; usage.output += outputTokensFrom(meta); usage.calls++;
     let text;
     try { text = res.text(); } catch { continue; } // empty candidate / blocked
     if (sane(text)) {
       const dist = enLen < 200 ? 0 : Math.abs(clean(text).length / enLen - 1);
-      if (dist < bestDist) { best = { text, inputTokens: meta.promptTokenCount || 0, outputTokens: meta.candidatesTokenCount || 0 }; bestDist = dist; }
+      if (dist < bestDist) { best = { text, inputTokens: meta.promptTokenCount || 0, outputTokens: outputTokensFrom(meta) }; bestDist = dist; }
       if (bestDist < 0.3) break;
     }
   }

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -21,7 +21,7 @@ import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { nanoid } from 'nanoid';
 import sharp from 'sharp';
-import { logUsage } from './lib/supabase-usage-logger.mjs';
+import { logUsage, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 
@@ -732,6 +732,7 @@ async function extractImagesFromPage(page, prompt, groundingCtx) {
       maxOutputTokens: 4096,
       responseMimeType: 'application/json',
       responseSchema: RESPONSE_SCHEMA,
+      thinkingConfig: { thinkingBudget: 0 },
     },
   });
 
@@ -760,7 +761,7 @@ async function extractImagesFromPage(page, prompt, groundingCtx) {
     text,
     characteristics,
     inputTokens: usage.promptTokenCount || 0,
-    outputTokens: usage.candidatesTokenCount || 0,
+    outputTokens: outputTokensFrom(usage),
   };
 }
 

--- a/scripts/workers/lib/summary-prompt.mjs
+++ b/scripts/workers/lib/summary-prompt.mjs
@@ -18,7 +18,7 @@ export const SUMMARY_PROMPT_VERSION = '2026-05-29-plain-encyclopedic';
 // Low temperature keeps the prose factual. At the default (~1.0) flash-lite
 // reaches for grand register ("seminal", "delineates the trajectory of...")
 // and slips into copywriter mode ("Readers will discover...").
-export const SUMMARY_GEN_CONFIG = { temperature: 0.2 };
+export const SUMMARY_GEN_CONFIG = { temperature: 0.2, thinkingConfig: { thinkingBudget: 0 } };
 
 /**
  * Build the synthesis prompt from already-assembled inputs.

--- a/scripts/workers/lib/supabase-usage-logger.mjs
+++ b/scripts/workers/lib/supabase-usage-logger.mjs
@@ -61,13 +61,31 @@ export function calculateUsageCost(model, inputTokens, outputTokens, isBatch) {
  * $0.00. And in multi-page mode one response covers N pages but carries ONE
  * usageMetadata, so per-page attribution multiplied the same tokens by N.
  */
+/**
+ * Output tokens as GOOGLE BILLS THEM: visible text plus reasoning.
+ *
+ * Gemini 3.x charges `thoughtsTokenCount` at the output rate, and on models
+ * that think by default (measured 2026-09-04: `gemini-3-flash-preview` emits
+ * ~1.5 thought tokens per visible output token with no `thinkingConfig`) a
+ * meter reading `candidatesTokenCount` alone under-reports the bill without
+ * ever erroring. That is how August metered $499.74 against $8,389.32 billed
+ * (#4581). `src/lib/ai.ts` was fixed in #4591; the Hetzner `.mjs` stack — which
+ * runs nearly all current work — was not, until now.
+ *
+ * Use this at every site that records what a call cost. Fix the definition,
+ * not the call site.
+ */
+export function outputTokensFrom(usageMetadata) {
+  return (usageMetadata?.candidatesTokenCount || 0) + (usageMetadata?.thoughtsTokenCount || 0);
+}
+
 export function sumBatchResponseUsage(responses) {
   let input = 0;
   let output = 0;
   for (const r of responses || []) {
     const usage = r?.response?.usageMetadata;
     input += usage?.promptTokenCount || 0;
-    output += usage?.candidatesTokenCount || 0;
+    output += outputTokensFrom(usage);
   }
   return { inputTokens: input, outputTokens: output };
 }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -37,7 +37,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { logUsage, logUsageAsync } from './lib/supabase-usage-logger.mjs';
+import { logUsage, logUsageAsync, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import { findTrailingDupes, applyHide } from './lib/trailing-dedup.mjs';
 import { getScopeConfig, shouldBypassPause } from './lib/selective-unpause.mjs';
 const execFileAsync = promisify(execFile);
@@ -586,7 +586,7 @@ async function transliteratePage(db, page, sourceScript) {
   const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
   const usage = data.usageMetadata || {};
   const inputTokens = usage.promptTokenCount || 0;
-  const outputTokens = usage.candidatesTokenCount || 0;
+  const outputTokens = outputTokensFrom(usage);
 
   if (!text) return null;
 
@@ -3498,7 +3498,7 @@ Rules:
           const rawText = (data.candidates?.[0]?.content?.parts?.[0]?.text || '').trim();
           const usage = data.usageMetadata || {};
           const inputTokens = usage.promptTokenCount || 0;
-          const outputTokens = usage.candidatesTokenCount || 0;
+          const outputTokens = outputTokensFrom(usage);
 
           let parsed;
           try {

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -25,7 +25,7 @@ import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { createHash, randomBytes } from 'crypto';
 import { nanoid } from 'nanoid';
-import { logUsage } from './lib/supabase-usage-logger.mjs';
+import { logUsage, outputTokensFrom } from './lib/supabase-usage-logger.mjs';
 import {
   getTranslateModelForBook as getModelForBook,
   sanitizeTranslationTags,
@@ -273,7 +273,7 @@ async function translatePage(db, page, book, prevTranslation) {
   const model = ai.getGenerativeModel({
     model: selectedModel,
     safetySettings: SAFETY_SETTINGS,
-    generationConfig: { maxOutputTokens: maxOutputTokensFor([page]) },
+    generationConfig: { maxOutputTokens: maxOutputTokensFor([page]), thinkingConfig: { thinkingBudget: 0 } },
   });
   const start = Date.now();
   const result = await model.generateContent(prompt);
@@ -285,7 +285,7 @@ async function translatePage(db, page, book, prevTranslation) {
   return {
     text,
     inputTokens: usage.promptTokenCount || 0,
-    outputTokens: usage.candidatesTokenCount || 0,
+    outputTokens: outputTokensFrom(usage),
     durationMs,
     promptRef,
   };
@@ -349,7 +349,7 @@ async function translateBatch(db, pages, book, prevTranslation) {
   const model = ai.getGenerativeModel({
     model: selectedModel,
     safetySettings: SAFETY_SETTINGS,
-    generationConfig: { maxOutputTokens: maxOutputTokensFor(pages) },
+    generationConfig: { maxOutputTokens: maxOutputTokensFor(pages), thinkingConfig: { thinkingBudget: 0 } },
   });
   const start = Date.now();
   const result = await model.generateContent(prompt);
@@ -400,7 +400,7 @@ async function translateBatch(db, pages, book, prevTranslation) {
   return {
     translations, // Map<pageNumber, translatedText>
     inputTokens: usage.promptTokenCount || 0,
-    outputTokens: usage.candidatesTokenCount || 0,
+    outputTokens: outputTokensFrom(usage),
     durationMs,
     promptRef,
   };


### PR DESCRIPTION
Closes the Hetzner half of #4581. PR #4591 fixed the six `src/lib/ai.ts` paths; the fix never travelled to the `.mjs` worker stack, which runs nearly all current work.

Found while auditing what the `forum-of-conscience` scope envelope (#4541) actually meters — the envelope is a ceiling on a meter, so a blind meter is not a ceiling.

## The two defects

1. **`supabase-usage-logger.mjs` summed `candidatesTokenCount` only.** Gemini bills `thoughtsTokenCount` at the output rate too. Its consumers are the whole live pipeline: translate, image-extract, enrich, batch-collector, es-translate, orchestrator.
2. **No worker declared a thinking budget.** `translate-worker`, `image-extract-worker` and `enrich-worker` had zero `thinkingConfig`; only the orchestrator carried the guard.

## Measured, with a positive control

| call shape | visible | thinking |
|---|---|---|
| flash-preview, no config | 443 | **652** |
| flash-preview, `thinkingBudget: 0` | 475 | 0 |
| flash-lite, real Latin page, no config | 1,655 | 0 |
| **control** — flash-lite, `thinkingBudget: 512` | 305 | **154** |

`gemini-3-flash-preview` thinks by default at ~1.5x its visible output; `gemini-3.1-flash-lite` does not think at all on realistic prompts. The control fires, so the null is a real null and not a blind probe.

The consequence worth reading twice: **exposure depends on which model a call happens to route to.** `translate-worker` was safe only by luck — a BPH-routed book sends that same bare call site to flash-preview. Thinking off also produced slightly *more* visible text (475 vs 443), matching the earlier 20-page A/B.

## What changed

- `outputTokensFrom(usageMetadata)` — candidates + thoughts, one definition, applied at all 15 recording sites. Fix the definition, not the call site.
- `thinkingConfig: { thinkingBudget: 0 }` at every worker call site, including three with no `generationConfig` at all (enrich index generation, es-translate) and the hoisted `SUMMARY_GEN_CONFIG`.
- **`scripts/audit/gemini-thinking-and-meter.mjs`** — a standing detector, because this has now shipped twice and a doc is the weakest layer. Offline, ~1s, safe for CI.

## The guard was negative-controlled, and it needed it

The first cut was style-sensitive **twice**, which is the exact failure this file exists to prevent:
- it flagged the multi-line *fixed* shape in `ai.ts` (the sum spans two lines) — now judged on a two-line window;
- it ignored a waiver sitting above the enclosing function rather than the call — now a four-line look-back.

Verified in both directions against both idioms (inline config, hoisted const): violating fixture exits 1 on all three checks, correct fixture exits 0. Fixtures deleted before commit.

## Scope

Deliberate exceptions declare themselves at the call site: `// thinking-ok: <reason>` (grounded search needs a *positive* budget — flash-lite does not ground, and `-1` suppresses grounding).

**Out of scope, deliberately:** 31 findings in `src/lib/*` and `scripts/batch/*` are recorded in a baseline file so the guard is green now and fails on NEW violations. Their sweep is #4599 and is a separate decision — turning thinking off changes *output* on the creative paths (tweet copy, email digests), not just cost, and that is a judgment call per site rather than a mechanical edit. Deleting a baseline line as you fix that file is the intended workflow.

Also out of scope: pooled batch attribution (#4566), dateless Mongo usage rows (#4593), generation parameters as provenance (#4613).

## Verification

- `node --check` on all 9 touched files; `outputTokensFrom` unit cases 4/4.
- No `src/` changes, no dependency changes.
- **This changes what the meter reports, so expect recorded cost to RISE on any lane where thinking was firing** — that is the meter getting less wrong, not a new expense. The falsifiable check from the spend audit still stands: the ~Oct 1 Google payment for September should be in the low hundreds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116Jc7Z7ZzYmAhCPKQNLJpC
