### PR TITLE
feat(audit): verify what the Lambdas are actually running (#4600)

### DIFF
--- a/scripts/audit/lambda-drift.mjs
+++ b/scripts/audit/lambda-drift.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: none — searched scripts/audit/ (no lambda/aws/worker-drift script),
+ * scripts/aws-lambda/ (build/package/deploy only — they SHIP code, none READ BACK what is
+ * running), and scripts/lib/. The closest neighbour is scripts/audit/spend-perimeter.mjs,
+ * which classifies our own spenders from source and never asks the vendor what is deployed.
+ *
+ * lambda-drift — is the deployed Lambda actually running the commit we think it is?
+ *
+ * WHY THIS EXISTS (#4600)
+ * -----------------------
+ * The four workers are hand-deployed. Merging a PR does NOT deploy them — it ships the Vercel
+ * side only. So the deployed code and `main` drift silently, and every diagnosis made by reading
+ * `src/workers/` is then wrong in a way that reads exactly like being right.
+ *
+ * On 2026-09-04 this check found `db-write` one commit stale, missing #4523's
+ * `{ $ne: ["$ocr.unreadable", true] }` — so it was counting attempted-but-unreadable pages as
+ * OCR'd. Nothing was failing. Nothing would have failed. The number was just wrong.
+ *
+ * HOW IT WORKS
+ * ------------
+ * `aws lambda get-function` returns a presigned URL to the deployed zip. Unzip it, and compare
+ * its `index.js` byte-for-byte against a fresh esbuild of the same worker entry point from the
+ * current checkout. Identical bytes mean the deployed artifact IS this tree's build. This works
+ * because the build is deterministic — same esbuild invocation, same input, same output.
+ *
+ * TRAPS (both cost time on 2026-09-04)
+ * ------------------------------------
+ * A. Run this from the MAIN CHECKOUT. esbuild embeds each module's resolved path in a comment,
+ *    and a worktree has no local `node_modules` — so it resolves `../../../node_modules/...` and
+ *    every byte comparison fails on a difference that means nothing. This script refuses to run
+ *    from a worktree rather than report false drift.
+ * B. "Deployed" is a claim about bytes, not about a timestamp. LastModified tells you when
+ *    someone last uploaded, never what they uploaded.
+ *
+ * REQUIRES: lambda:GetFunction (granted, scoped to the four sourcelibrary-*-processor functions).
+ *
+ * USAGE
+ *   node --env-file=.env.production.local scripts/audit/lambda-drift.mjs [--json]
+ *
+ * EXIT CODES: 0 all current · 1 drift found · 2 could not check (missing creds/permission)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const JSON_OUT = process.argv.includes('--json');
+
+/** worker entry point -> deployed function name. The mapping is NOT uniform: write -> db-write. */
+const WORKERS = [
+  { entry: 'ocr-processor', fn: 'sourcelibrary-ocr-processor' },
+  { entry: 'translation-processor', fn: 'sourcelibrary-translation-processor' },
+  { entry: 'image-extraction-processor', fn: 'sourcelibrary-image-extraction-processor' },
+  { entry: 'write-processor', fn: 'sourcelibrary-db-write-processor' },
+];
+
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const sh = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, ...opts });
+
+// ── Trap A: refuse to produce false drift from a worktree build.
+const gitDir = sh('git', ['rev-parse', '--git-dir']).trim();
+if (gitDir.includes('.git/worktrees') || !existsSync('node_modules')) {
+  console.error('Run this from the MAIN checkout (~/sourcelibrary), not a worktree.');
+  console.error('A worktree has no local node_modules, so esbuild embeds different module paths');
+  console.error('and every comparison reports drift that is not there.');
+  process.exit(2);
+}
+
+const head = sh('git', ['rev-parse', '--short', 'HEAD']).trim();
+const dirty = sh('git', ['status', '--porcelain', '--', 'src/']).trim();
+
+const tmp = mkdtempSync(join(tmpdir(), 'lambda-drift-'));
+const results = [];
+let failed = false;
+
+try {
+  for (const w of WORKERS) {
+    const localPath = join(tmp, `${w.entry}.js`);
+    sh('npx', ['esbuild', `src/workers/${w.entry}.ts`, '--bundle', '--platform=node',
+      '--target=node24', '--external:@aws-sdk/*', `--outfile=${localPath}`]);
+    const localSha = createHash('sha256').update(readFileSync(localPath)).digest('hex');
+
+    let deployedSha = null, lastModified = null, error = null;
+    try {
+      const cfg = JSON.parse(sh('aws', ['lambda', 'get-function', '--function-name', w.fn,
+        '--region', REGION, '--query', '{loc:Code.Location,mod:Configuration.LastModified}',
+        '--output', 'json']));
+      lastModified = cfg.mod;
+      const zipPath = join(tmp, `${w.entry}.zip`);
+      sh('curl', ['-sS', '-o', zipPath, cfg.loc]);
+      sh('unzip', ['-oq', zipPath, 'index.js', '-d', join(tmp, w.entry)]);
+      deployedSha = createHash('sha256').update(readFileSync(join(tmp, w.entry, 'index.js'))).digest('hex');
+    } catch (e) {
+      error = String(e.stderr || e.message).trim().split('\n').pop().slice(0, 160);
+    }
+
+    const current = deployedSha !== null && deployedSha === localSha;
+    if (error || !current) failed = true;
+    results.push({ fn: w.fn, current, error, lastModified,
+      localSha: localSha.slice(0, 12), deployedSha: deployedSha?.slice(0, 12) ?? null });
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ head, dirty: Boolean(dirty), results }, null, 2));
+} else {
+  console.log(`\nLambda drift vs local build @ ${head}${dirty ? ' (WORKING TREE DIRTY — comparing against uncommitted code)' : ''}\n`);
+  for (const r of results) {
+    const status = r.error ? `COULD NOT CHECK — ${r.error}` : r.current ? 'current' : 'DRIFTED';
+    console.log(`  ${r.fn.padEnd(45)} ${status}`);
+    if (!r.error && !r.current) console.log(`      deployed ${r.deployedSha}  local ${r.localSha}  (uploaded ${r.lastModified})`);
+  }
+  console.log(failed
+    ? '\nDrift or an unchecked function is NOT a failure of the pipeline — it is a failure of\nknowledge. Redeploy with `npm run lambda:prepare && npm run lambda:deploy -- <entry>`,\nthen re-run this. See scripts/aws-lambda/BUILD-AND-DEPLOY.md.'
+    : '\nAll four workers are running this commit.');
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/aws-lambda/BUILD-AND-DEPLOY.md
+++ b/scripts/aws-lambda/BUILD-AND-DEPLOY.md
@@ -1,12 +1,23 @@
 # Building and Deploying Lambda Functions
 
+> **Merging a PR does NOT deploy these functions.** A merge ships the Vercel side only. The
+> Lambdas are hand-deployed, so deployed code and `main` drift silently — and a diagnosis made by
+> reading `src/workers/` is then wrong in a way that reads exactly like being right. Before
+> trusting worker source, run `node --env-file=.env.production.local scripts/audit/lambda-drift.mjs`
+> (see [Verifying what is actually deployed](#verifying-what-is-actually-deployed)).
+
 ## Quick Start
 
 1. In terminal run: `npm run lambda:prepare`
-2. Three packages are built:
-    - `dist/packages/ocr-processor.zip`
-    - `dist/packages/translation-processor.zip`
-    - `dist/packages/image-extraction-processor.zip`
+2. **Four** packages are built — one per worker:
+    - `dist/packages/ocr-processor.zip` → `sourcelibrary-ocr-processor`
+    - `dist/packages/translation-processor.zip` → `sourcelibrary-translation-processor`
+    - `dist/packages/image-extraction-processor.zip` → `sourcelibrary-image-extraction-processor`
+    - `dist/packages/write-processor.zip` → **`sourcelibrary-db-write-processor`**
+
+**The last mapping is not uniform** — the entry point is `write-processor`, the deployed function
+is `db-write-processor`. `--all` covers all four; a doc that said "three" is how the write
+processor gets forgotten.
 
 ## Deployment Options
 
@@ -144,12 +155,55 @@ The deployment script will:
 4. Select the zip file from `dist/packages/`
 5. Repeat for other processors as needed
 
+## Verifying what is actually deployed
+
+`LastModified` tells you when someone last uploaded. It never tells you **what** they uploaded.
+The only honest check is comparing bytes:
+
+```bash
+# from the MAIN checkout, not a worktree
+node --env-file=.env.production.local scripts/audit/lambda-drift.mjs
+```
+
+It rebuilds each worker with the same esbuild invocation the deploy uses, downloads the deployed
+zip via `aws lambda get-function`, and compares `index.js` byte-for-byte. Exit 0 = all current,
+1 = drift, 2 = could not check.
+
+**Run it from the main checkout.** esbuild embeds each module's resolved path in a comment, and a
+worktree has no local `node_modules` — so it resolves `../../../node_modules/...` and every
+comparison reports drift that is not real. The script refuses to run from a worktree for this
+reason.
+
+Found this way on 2026-09-04: `db-write` was one commit stale, missing #4523's
+`{ $ne: ["$ocr.unreadable", true] }`, so it counted attempted-but-unreadable pages as OCR'd.
+Nothing was failing — the number was just wrong. That is the failure mode this check exists for.
+
+### What the IAM user can and cannot do
+
+The `sourcelibrary` IAM user (credentials in the app environment) has `lambda:GetFunction`,
+`lambda:GetFunctionConfiguration` and `lambda:UpdateFunctionCode`, all **scoped to the four
+`sourcelibrary-*-processor` functions**. It does **not** have `lambda:ListFunctions` or
+`lambda:UpdateFunctionConfiguration` — so you can replace a worker's **code** but cannot change an
+**environment variable**. Env changes need the AWS console or an admin.
+
+**Two traps when deploying:**
+
+- **A "timed out" upload may have succeeded.** The CLI can exceed a 2-minute foreground timeout
+  after the upload has landed. Always re-read `aws lambda get-function-configuration` and check
+  `CodeSha256` before retrying — never assume the failure meant nothing shipped.
+- **`get-function` and `get-function-configuration` print `Environment.Variables` in plaintext** —
+  `MONGODB_URI` and `GEMINI_API_KEY` among them. Do not redirect those responses into a file you
+  leave lying around, and do not paste them into an issue. (This also means the AWS key can read
+  Gemini keys that Vercel's `sensitive` flag withholds.)
+
 ## Architecture
 
 Each Lambda function processes **one page** per invocation:
 - **OCR Processor**: Reads page image, performs OCR, saves to MongoDB
 - **Translation Processor**: Translates OCR text with context from previous page
 - **Image Extraction Processor**: Detects and extracts illustrations
+- **Write Processor** (`db-write`): consumes the write-results SQS queue and applies the results
+  to MongoDB. It holds no Gemini key — it is the only one of the four that spends nothing.
 
 All processors:
 - Update job progress directly in MongoDB


### PR DESCRIPTION
## Why

**Merging a PR does not deploy the four Lambda workers.** A merge ships the Vercel side only; the workers are hand-deployed. So deployed code and `main` drift silently — and a diagnosis made by reading `src/workers/` is then wrong *in a way that reads exactly like being right*.

Found by hand this way on 2026-09-04: `db-write` was one commit stale, missing #4523's `{ $ne: ["$ocr.unreadable", true] }`, so it was counting attempted-but-unreadable pages as OCR'd. Nothing was failing. Nothing would have failed. The number was just wrong.

## What

`scripts/audit/lambda-drift.mjs` — rebuilds each worker with the same esbuild invocation the deploy uses, pulls the deployed zip via `aws lambda get-function`, and compares `index.js` **byte-for-byte**.

`LastModified` tells you when someone last uploaded. It never tells you *what* they uploaded. Bytes do.

```
Lambda drift vs local build @ d9f47edb

  sourcelibrary-ocr-processor                   current
  sourcelibrary-translation-processor           current
  sourcelibrary-image-extraction-processor      current
  sourcelibrary-db-write-processor              current

All four workers are running this commit.
```

Exit 0 = current, 1 = drift, 2 = could not check. Needs `lambda:GetFunction`, which is granted and scoped to these four functions. Suitable for wiring into CI later — that's the rest of #4600.

## Doc fixes in `BUILD-AND-DEPLOY.md`

- It said **three** packages. There are **four** — and the mapping is not uniform: entry point `write-processor` deploys to `sourcelibrary-db-write-processor`. A doc that says "three" is precisely how that worker gets forgotten.
- Added the IAM reality: the account can replace worker **code** but cannot change an **environment variable** (`UpdateFunctionConfiguration` is not granted), so env changes need the console.
- Added two traps hit today: a **"timed out" upload may have succeeded** — re-read `CodeSha256` before retrying; and **reading Lambda config prints `MONGODB_URI` and `GEMINI_API_KEY` in plaintext**, so don't redirect it to a file or paste it into an issue.

## Verification

- Positive control: run from the main checkout at `d9f47edb` → all four `current`, exit 0.
- Negative control: run from a worktree → refuses, exit 2. esbuild embeds resolved module paths and a worktree has no local `node_modules`, so every comparison would report drift that isn't real. The script guards against reporting that.
- The `DRIFTED` path itself was verified **by hand** on `db-write` earlier today using the same byte comparison — not by this script. Stated plainly rather than implied.

## Scope

Read-only, no writes, no repo state. Out of scope: wiring it into CI, and `lambda:UpdateFunctionConfiguration` (a permission decision, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQkkHNnZ3en3UDYtuicykT