### PR TITLE
Fix the mobile hero on the fungi and slime mould collection pages

### DIFF
--- a/src/app/api/collections/[id]/hero-collage/route.ts
+++ b/src/app/api/collections/[id]/hero-collage/route.ts
@@ -14,25 +14,39 @@ export const revalidate = 86400;
 // tiles so the dark ground shows through as a grid, and the same #14100c the
 // book hero uses, so the two heroes read as one system rather than two.
 const GAP = 6;
-const COLS = 7, COLW = 200, H = 900;
-const W = COLS * COLW + (COLS + 1) * GAP;
+const COLW = 200;
+// Two shapes. The landscape default fills a wide desktop hero. `?shape=portrait`
+// exists because a phone hero is a PORTRAIT box: object-cover on the 1448x900
+// landscape sheet scaled it up and showed only ~40% of its width (under three of
+// seven columns), so plates read as slabs of texture rather than specimens. The
+// portrait sheet is narrow and tall, so a phone sees every column at full width.
+const SHAPES = {
+  landscape: { cols: 7, h: 900 },
+  portrait: { cols: 3, h: 1100 },
+} as const;
+type ShapeName = keyof typeof SHAPES;
+const canvasWidth = (cols: number) => cols * COLW + (cols + 1) * GAP;
 const BG = '#14100c';
 const FETCH_LIMIT = 48;
 // Below this many matches a filtered collage looks broken, so we fall back.
 const MIN_COLLAGE = 14;
 
-async function solid(maxAge: number): Promise<Response> {
-  const out = await sharp({ create: { width: W, height: H, channels: 3, background: BG } }).webp({ quality: 60 }).toBuffer();
+async function solid(maxAge: number, cols: number = SHAPES.landscape.cols, h: number = SHAPES.landscape.h): Promise<Response> {
+  const out = await sharp({ create: { width: canvasWidth(cols), height: h, channels: 3, background: BG } }).webp({ quality: 60 }).toBuffer();
   return new Response(new Uint8Array(out), { headers: { 'Content-Type': 'image/webp', 'Cache-Control': `public, max-age=${maxAge}` } });
 }
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const shapeParam = req.nextUrl.searchParams.get('shape');
+  const shape = SHAPES[(shapeParam as ShapeName) in SHAPES ? (shapeParam as ShapeName) : 'landscape'];
+  const { cols: COLS, h: H } = shape;
+  const W = canvasWidth(COLS);
   try {
     const db = await getReadDb();
     const bookDocs = await db.collection('books').find({ collections: id, visible: true }, { projection: { id: 1 }, maxTimeMS: 5000 }).toArray();
     const bookIds = bookDocs.map((d) => d.id as string);
-    if (!bookIds.length) return solid(3600);
+    if (!bookIds.length) return solid(3600, COLS, H);
 
     // Optional ?match=<regex> narrows the collage to plates whose description
     // matches — a collection about one subject inside broader books (slime
@@ -59,7 +73,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         .sort({ gallery_quality: -1 }).limit(FETCH_LIMIT).toArray();
     }
     const urls = imgs.map((g) => (g.thumbnail_url || g.extracted_url || g.image_url) as string | undefined).filter((u): u is string => Boolean(u));
-    if (!urls.length) return solid(3600);
+    if (!urls.length) return solid(3600, COLS, H);
 
     // Fetch + resize to column width in parallel (natural height preserved).
     const resized = (await Promise.all(urls.map(async (u) => {
@@ -70,7 +84,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         return { data, height: info.height };
       } catch { return null; }
     }))).filter((r) => r !== null);
-    if (!resized.length) return solid(3600);
+    if (!resized.length) return solid(3600, COLS, H);
 
     // Masonry pack: each image goes to the currently-shortest column; the bottom
     // overflowing tile in a column is cropped so nothing exceeds the canvas.
@@ -87,11 +101,11 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       tiles.push({ input, left: GAP + c * (COLW + GAP), top: colH[c] });
       colH[c] += r.height + GAP;
     }
-    if (!tiles.length) return solid(3600);
+    if (!tiles.length) return solid(3600, COLS, H);
 
     const out = await sharp({ create: { width: W, height: H, channels: 3, background: BG } }).composite(tiles).webp({ quality: 68 }).toBuffer();
     return new Response(new Uint8Array(out), { headers: { 'Content-Type': 'image/webp', 'Cache-Control': 'public, max-age=31536000, immutable' } });
   } catch {
-    return solid(600);
+    return solid(600, COLS, H);
   }
 }

--- a/src/app/collections/mycology/page.tsx
+++ b/src/app/collections/mycology/page.tsx
@@ -275,11 +275,19 @@ export default async function MycologyCollectionPage() {
       {/* Dark navbar variant of the global header. Breadcrumbs live in the hero. */}
       <ConditionalSiteHeader variant="dark" />
       {/* ===== Hero ===== */}
-      <section className="relative overflow-hidden min-h-[66vh] flex items-end" style={{ background: '#14100c' }}>
+      <section className="relative overflow-hidden min-h-[56svh] md:min-h-[75vh] flex items-end" style={{ background: '#14100c' }}>
         {/* One composited collage image (2:3 tiles) — single optimized load, subtle parallax. */}
-        <ParallaxImage src={`/api/collections/${SLUG}/hero-collage`} loading="eager" strength={0.08} oversize={0.1} />
-        {/* Mobile: vertical tint — strongest at the bottom (text), light at top. */}
-        <div className="absolute inset-0 md:hidden bg-gradient-to-t from-dark/85 via-dark/45 to-dark/5" />
+        <ParallaxImage
+          src={`/api/collections/${SLUG}/hero-collage`}
+          srcMobile={`/api/collections/${SLUG}/hero-collage?shape=portrait`}
+          loading="eager" strength={0.08} oversize={0.1}
+        />
+        {/* Mobile: the shared scrim's bottom-weighted variant, so the phone hero
+            is darkened to the same 72% base as the desktop one instead of the 45%
+            it used to hand-roll. */}
+        <div className="absolute inset-0 md:hidden">
+          <HeroScrim variant="bottom" />
+        </div>
         {/* Desktop: the book hero's tint, so the two read as one system —
             see src/components/HeroScrim.tsx. The previous stack was a
             left-weighted gradient plus a bottom fade with no flat base scrim,
@@ -289,31 +297,35 @@ export default async function MycologyCollectionPage() {
           <HeroScrim />
         </div>
 
-        <div className="relative z-10 w-full max-w-[1500px] mx-auto px-6 md:px-12 pt-12 pb-10">
-          <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-white/60 mb-6">
-            <Link href="/collections" className="hover:text-white/90 transition-colors">Collections</Link>
+        <div className="relative z-10 w-full max-w-[1500px] mx-auto px-6 md:px-12 pt-12 pb-10" style={{ textShadow: '0 1px 16px rgba(0,0,0,0.72)' }}>
+          {/* Breadcrumb as the book hero's rust author-eyebrow, matching
+              /collections/slime-moulds. The two were one click apart and used two
+              different systems (white/60 sentence case here, rust caps there). */}
+          <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 uppercase text-[10.5px] md:text-[13px] tracking-[0.1em] font-medium mb-3 md:mb-4" style={{ color: '#d98a72' }}>
+            <Link href="/collections" className="hover:opacity-80 transition-opacity">Collections</Link>
             {parent && (
               <>
-                <span className="text-white/30">/</span>
-                <Link href={parentHref} className="hover:text-white/90 transition-colors">{parent.name}</Link>
+                <span style={{ opacity: 0.5 }}>/</span>
+                <Link href={parentHref} className="hover:opacity-80 transition-opacity">{parent.name}</Link>
               </>
             )}
           </nav>
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-3 font-display">Fungi &amp; Mycology</h1>
           <p className="text-lg sm:text-xl text-white/75 max-w-3xl leading-relaxed mb-5">Fungi built the soil that built our world. These are the books that first studied them.</p>
-          <div className="flex flex-wrap items-center gap-2">
-            {/* Stat chips borrow the book hero's colour language so the two read as
-                one system: soft blue for scope, green for language coverage, gold
-                for the first-translation claim. Same tones as book/[id] page.tsx. */}
-            <span className="text-xs sm:text-sm px-3 py-1 border" style={{ color: '#e8e2d6', borderColor: 'rgba(232,226,214,0.3)' }}>{total.toLocaleString('en-US')} works</span>
-            {ftCount > 0 && (
-              <span className="text-xs sm:text-sm px-3 py-1 border" style={{ color: '#e0b46a', borderColor: 'rgba(224,180,106,0.42)' }}>{ftCount} first translation{ftCount === 1 ? '' : 's'}</span>
-            )}
+          {/* Stats set as the book hero's status row (size, weight, colours blue /
+              green / gold in that order), no boxes — identical to
+              /collections/slime-moulds. The bordered chips this replaces fought a
+              busy collage and wrapped to two ragged rows at 360px. */}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] md:text-[13.5px] font-medium">
+            <span style={{ color: '#8fbfe6' }}>{total.toLocaleString('en-US')} works</span>
             {dateRange && (
-              <span className="text-xs sm:text-sm px-3 py-1 border" style={{ color: '#8fbfe6', borderColor: 'rgba(143,191,230,0.4)' }}>{dateRange.min} – {dateRange.max}</span>
+              <span style={{ color: '#86c98f' }}>{dateRange.min} – {dateRange.max}</span>
+            )}
+            {ftCount > 0 && (
+              <span style={{ color: '#e0b46a' }}>{ftCount} first translation{ftCount === 1 ? '' : 's'}</span>
             )}
             {languages.length > 0 && (
-              <span className="text-xs sm:text-sm px-3 py-1 border" style={{ color: '#86c98f', borderColor: 'rgba(134,201,143,0.4)' }}>{languages.join(' · ')}</span>
+              <span className="hidden sm:inline" style={{ color: '#e8e2d6' }}>{languages.join(' · ')}</span>
             )}
           </div>
         </div>

--- a/src/app/collections/slime-moulds/page.tsx
+++ b/src/app/collections/slime-moulds/page.tsx
@@ -381,13 +381,21 @@ export default async function SlimeMouldsCollectionPage() {
       {/* Dark navbar variant of the global header. Breadcrumbs live in the hero. */}
       <ConditionalSiteHeader variant="dark" />
       {/* ===== Hero ===== */}
-      <section className="relative overflow-hidden min-h-[60vh] md:min-h-[75vh] flex items-center" style={{ background: '#14100c' }}>
+      <section className="relative overflow-hidden min-h-[56svh] md:min-h-[75vh] flex items-end md:items-center" style={{ background: '#14100c' }}>
         {/* One composited collage image (2:3 tiles) — single optimized load, subtle parallax. */}
         {/* The collage is filtered to actual slime mould plates; the route falls
             back to the collection's full plate set while too few are extracted. */}
-        <ParallaxImage src={`/api/collections/${SLUG}/hero-collage?match=${encodeURIComponent(MYXO_DESC_RX)}`} loading="eager" strength={0.08} oversize={0.1} />
-        {/* Mobile: vertical tint — strongest at the bottom (text), light at top. */}
-        <div className="absolute inset-0 md:hidden bg-gradient-to-t from-dark/85 via-dark/45 to-dark/5" />
+        <ParallaxImage
+          src={`/api/collections/${SLUG}/hero-collage?match=${encodeURIComponent(MYXO_DESC_RX)}`}
+          srcMobile={`/api/collections/${SLUG}/hero-collage?shape=portrait&match=${encodeURIComponent(MYXO_DESC_RX)}`}
+          loading="eager" strength={0.08} oversize={0.1}
+        />
+        {/* Mobile: the shared scrim's bottom-weighted variant, so the phone hero
+            is darkened to the same 72% base as the desktop one instead of the 45%
+            it used to hand-roll. */}
+        <div className="absolute inset-0 md:hidden">
+          <HeroScrim variant="bottom" />
+        </div>
         {/* Desktop: the book hero's tint, so the two read as one system —
             see src/components/HeroScrim.tsx. The previous stack was a
             left-weighted gradient plus a bottom fade with no flat base scrim,
@@ -412,7 +420,13 @@ export default async function SlimeMouldsCollectionPage() {
             )}
           </nav>
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-3 font-display">Slime Moulds</h1>
-          <p className="text-lg sm:text-xl text-white/75 max-w-3xl leading-relaxed mb-5">One cell, big enough to see, that creeps across rotting wood and then stands up as a crop of tiny stalked spore-heads. These are the books that first drew, named and puzzled over it, from a seventeenth-century herbal to the first monograph of 1875.</p>
+          {/* Phones get the first sentence only. The full deck ran six lines and
+              205px, 40% of the hero, and the herbal-to-monograph clause is
+              repeated in the introduction directly below. */}
+          <p className="text-lg sm:text-xl text-white/75 max-w-3xl leading-relaxed mb-5">
+            One cell, big enough to see, that creeps across rotting wood and then stands up as a crop of tiny stalked spore-heads.
+            <span className="hidden sm:inline"> These are the books that first drew, named and puzzled over it, from a seventeenth-century herbal to the first monograph of 1875.</span>
+          </p>
           {/* Stats set exactly as the book hero's status row (size, weight,
               colours blue / green / gold in that order), no boxes. Same hex
               values as book/[id] page.tsx. Order: works, years, then first

--- a/src/components/HeroScrim.tsx
+++ b/src/components/HeroScrim.tsx
@@ -1,7 +1,7 @@
 /**
  * The tint that sits between a hero's background imagery and its text.
  *
- * Three layers, in order:
+ * Desktop (`variant="side"`, the default) — three layers:
  *   1. a flat warm near-black at 72% — does most of the darkening, and is what
  *      makes white text legible over arbitrary page scans;
  *   2. a left-weighted gradient, so the side carrying the title is darker than
@@ -9,20 +9,41 @@
  *   3. a faint rust glow up and to the right, which keeps the whole thing from
  *      reading as neutral grey.
  *
- * Shared by the book hero (`HeroVariants`) and the collection hero so the two
- * genuinely match rather than happening to hold the same numbers — changing the
- * tint in one place changes it in both, which is the point.
+ * Mobile (`variant="bottom"`) — the same flat 72% base and the same rust glow,
+ * but the directional gradient runs bottom-to-top instead of left-to-right,
+ * because a phone hero stacks its text along the bottom rather than down one
+ * side. A short top fade closes the hard seam where the dark navbar meets a
+ * bright plate.
+ *
+ * The mobile variant exists because the collection heroes were hand-rolling a
+ * single `from-dark/85 via-dark/45 to-dark/5` gradient whose flat middle was 45%
+ * against desktop's 72%. Text sitting in that middle band measured 1.7:1 against
+ * the collage. Both variants live here so the two collection pages and the book
+ * hero cannot drift apart again.
  *
  * Expects a positioned ancestor; render it directly over the background layer.
  */
-export default function HeroScrim() {
+export default function HeroScrim({ variant = 'side' }: { variant?: 'side' | 'bottom' }) {
   return (
     <>
       <div className="absolute inset-0" style={{ background: 'rgba(16,12,8,0.72)' }} />
-      <div
-        className="absolute inset-0"
-        style={{ background: 'linear-gradient(90deg, rgba(14,10,7,0.5) 0%, rgba(14,10,7,0.12) 60%, transparent 100%)' }}
-      />
+      {variant === 'side' ? (
+        <div
+          className="absolute inset-0"
+          style={{ background: 'linear-gradient(90deg, rgba(14,10,7,0.5) 0%, rgba(14,10,7,0.12) 60%, transparent 100%)' }}
+        />
+      ) : (
+        <>
+          <div
+            className="absolute inset-0"
+            style={{ background: 'linear-gradient(0deg, rgba(14,10,7,0.72) 0%, rgba(14,10,7,0.6) 42%, rgba(14,10,7,0.22) 68%, transparent 100%)' }}
+          />
+          <div
+            className="absolute inset-x-0 top-0 h-20"
+            style={{ background: 'linear-gradient(180deg, rgba(14,10,7,0.55) 0%, transparent 100%)' }}
+          />
+        </>
+      )}
       <div
         className="absolute inset-0"
         style={{ background: 'radial-gradient(120% 90% at 82% 18%, rgba(165,80,61,0.2) 0%, transparent 55%)' }}

--- a/src/components/ParallaxImage.tsx
+++ b/src/components/ParallaxImage.tsx
@@ -19,10 +19,17 @@ export const framingEvent = (slot: string) => `framing:${slot}`;
  * to make the <img> targetable by the editor.
  */
 export default function ParallaxImage({
-  src, alt = '', className = '', strength = 0.12, loading = 'lazy',
+  src, srcMobile, mobileBreakpoint = 768,
+  alt = '', className = '', strength = 0.12, loading = 'lazy',
   oversize = 0.15, objectPosition = 'center', framing, frameSlot,
 }: {
   src: string;
+  /** Narrow-viewport variant, served below `mobileBreakpoint` via <picture>.
+   *  A phone hero is a portrait box, so a landscape source is cover-cropped to a
+   *  sliver of its width; pass a portrait sheet here instead. */
+  srcMobile?: string;
+  /** Width (px) below which `srcMobile` is used. */
+  mobileBreakpoint?: number;
   alt?: string;
   className?: string;
   strength?: number;
@@ -54,6 +61,12 @@ export default function ParallaxImage({
     const parent = el?.parentElement;
     if (!el || !parent) return;
     if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+    // No parallax on phones: a ~470px hero shifts by a few pixels, which nobody
+    // sees, while the oversized box and the rAF cost are paid in full.
+    if (typeof window !== 'undefined' && window.matchMedia?.(`(max-width: ${mobileBreakpoint - 1}px)`).matches) {
+      el.style.transform = 'none';
+      return;
+    }
 
     let raf = 0;
     let visible = false;
@@ -80,22 +93,24 @@ export default function ParallaxImage({
       window.removeEventListener('resize', onScroll);
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [strength]);
+  }, [strength, mobileBreakpoint]);
 
   const op = frame ? `${frame.x}% ${frame.y}%` : objectPosition;
   const scale = frame?.scale ?? 1;
 
   return (
     <div ref={wrapRef} className="absolute inset-x-0" style={{ willChange: 'transform', top: `${-oversize * 100}%`, height: `${100 + oversize * 200}%` }}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        data-frame-slot={frameSlot}
-        src={src}
-        alt={alt}
-        loading={loading}
-        className={`w-full h-full object-cover ${className}`}
-        style={{ objectPosition: op, transformOrigin: op, transform: `scale(${scale})` }}
-      />
+      <picture className="block w-full h-full">
+        {srcMobile && <source media={`(max-width: ${mobileBreakpoint - 1}px)`} srcSet={srcMobile} />}
+        <img
+          data-frame-slot={frameSlot}
+          src={src}
+          alt={alt}
+          loading={loading}
+          className={`w-full h-full object-cover ${className}`}
+          style={{ objectPosition: op, transformOrigin: op, transform: `scale(${scale})` }}
+        />
+      </picture>
     </div>
   );
 }


### PR DESCRIPTION
The mobile hero on both bespoke collection pages, measured on a 390px viewport against production.

## What was wrong

| | |
|---|---|
| **Contrast** | Each page hand-rolled a mobile scrim, `from-dark/85 via-dark/45 to-dark/5`. Text landing in the flat middle sat over a 45% tint where the desktop scrim uses 72%. The slime moulds hero is centred, so its rust breadcrumb sat in the 5% band over a bright plate and measured **1.7:1**. |
| **Collage crop** | `hero-collage` only built a 7-column 1448×900 landscape sheet. `object-cover` fitted that into a 390×608 portrait box by scaling it *up*, so a phone saw ~40% of its width, under three of seven columns. Plates read as slabs of texture, not specimens. |
| **Deck length** | The slime moulds deck ran 248 characters, six lines, 205px — 40% of the hero. |
| **Viewport units** | `min-h-[60vh]` / `[66vh]` measure against iOS Safari's large viewport, so the hero ran taller than the visible area with the URL bar down. |
| **Divergence** | Two pages one click apart, two hero systems: bordered chips vs status row, white/60 breadcrumb vs rust caps, `items-end` vs `items-center`, 66vh vs 60vh. |

## What changed

- **`HeroScrim` gains `variant="bottom"`.** Same 72% base and rust glow as desktop, but the directional gradient runs bottom-to-top, because a phone stacks its text along the bottom rather than down one side. Plus a short top fade closing the seam where the navbar meets a bright plate. Both variants live in the one component so the pages can't drift again. The `side` default is byte-identical, so the book hero is untouched.
- **`?shape=portrait` on `hero-collage`** (3 columns, 1100 tall) and a `srcMobile` prop on `ParallaxImage` serving it below 768px via `<picture>`. A phone now sees every column at full width.
- **Slime moulds deck** shows its first sentence on phones, the rest returns at `sm:`. The clause it drops is repeated in the introduction directly below.
- **`56svh`** on both, which also puts the anchor bar above the fold.
- **Mycology adopts the slime moulds treatment** (the newer deliberate one): rust author-eyebrow breadcrumb, and the book hero's status row instead of bordered chips, which fought the collage and wrapped to two ragged rows at 360px. Its desktop min-height goes 66vh → 75vh to match.
- **Parallax off below 768px**, where a ~470px hero shifts a few pixels nobody sees while the oversized box and the rAF are paid in full.

No CTA added — one was tried and removed from the slime moulds hero already.

## Measured

Composited backdrop luminance behind each element, 390×844, text hidden:

| | before | after |
|---|---|---|
| breadcrumb (mean / worst) | 1.72 / 1.12 | **5.34 / 4.42** |
| h1 | 4.93 / 3.18 | 15.57 / 13.21 |
| deck | 7.35 / 4.37 | 16.52 / 14.81 |
| stats | 11.58 / 9.16 | 17.14 / 16.01 |

`tsc --noEmit` clean; eslint clean apart from a pre-existing `set-state-in-effect` in `ParallaxImage`; `collections-utils`, `retired-collections` and `dynamic-routes-not-edge-cached` pass.

## Known follow-up

`CollectionAnchorBar` is `tone="dark"` on slime moulds but light on mycology, so the bar directly under the hero is a bright band on one page and dark on the other. One prop, but it changes desktop too, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXEianWK2DFQv22fKgST65