### PR TITLE
fix(estimates): four scripts each hardcoded the same stale July per-page rate

### DIFF
--- a/scripts/audit/nearly-finished-translations.mjs
+++ b/scripts/audit/nearly-finished-translations.mjs
@@ -68,6 +68,7 @@
  */
 import { MongoClient } from 'mongodb';
 import { translatablePageFilter, isTranslatablePage } from '../lib/translate-core.mjs';
+import { PAGE_RATE_USD, PAGE_RATES_MEASURED_ON } from '../lib/model-pricing.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (n, d) => {
@@ -83,7 +84,8 @@ const SAMPLE = parseInt(getArg('sample', '80'), 10);
 const JSON_OUT = getArg('json', null);
 
 /** Measured 2026-08-31 over 55 pages of realtime translation. */
-const COST_PER_PAGE = 0.00079;
+// Translation runs on the realtime lane, not batch — price it as such.
+const COST_PER_PAGE = PAGE_RATE_USD.translationRealtime;
 
 const client = new MongoClient(process.env.MONGODB_URI);
 await client.connect();
@@ -269,7 +271,7 @@ for (const c of candidates.slice(0, LIMIT)) {
 
 console.log(`\n--- Summary ---`);
 console.log(`Books: ${candidates.length}  (${requested.length} with an open reader request)`);
-console.log(`Pages to finish: ${totalPages}  ≈ $${(totalPages * COST_PER_PAGE).toFixed(2)} at $${COST_PER_PAGE}/page`);
+console.log(`Pages to finish: ${totalPages}  ≈ $${(totalPages * COST_PER_PAGE).toFixed(2)} at $${COST_PER_PAGE}/page (measured ${PAGE_RATES_MEASURED_ON})`);
 console.log(`Counter drift among verified books: ${drifted.length} of ${candidates.length}, worst ${maxDrift} page(s)`);
 if (candidates.length > LIMIT) console.log(`(showing ${LIMIT} of ${candidates.length} — raise --limit or use --json)`);
 

--- a/scripts/audit/scope-progress.mjs
+++ b/scripts/audit/scope-progress.mjs
@@ -37,12 +37,12 @@
 
 import { withMongo } from '../lib/mongo.mjs';
 import { getTodaySpendUsd, readDailyBudgetUsd, readScopeEnvelopes, getScopeSpendUsd } from '../lib/spend-guard.mjs';
+import { PAGE_RATE_USD, PAGE_RATES_MEASURED_ON, estimatePagesCost } from '../lib/model-pricing.mjs';
 
 const args = process.argv.slice(2);
 const flag = (n) => args.includes(`--${n}`);
 const val = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : null; };
 
-const BATCH_RATE_USD_PER_PAGE = 0.00079; // measured 2026-07-16, gemini_usage
 
 // Status rank: where the state machine THINKS the book is. Used only for the
 // images stage (no output predicate) and for the ahead-of-output drift check.
@@ -232,7 +232,13 @@ await withMongo(async (db) => {
     translate_pages_remaining: reports.reduce((s, r) => s + r.remaining.translate_pages, 0),
     drift_books: reports.filter((r) => r.drift.length).length,
   };
-  totals.est_batch_cost_usd = Number(((totals.ocr_pages_remaining + totals.translate_pages_remaining) * BATCH_RATE_USD_PER_PAGE).toFixed(2));
+  // OCR and translation are priced SEPARATELY — they run on different lanes
+  // (batch vs realtime) at different rates, and the old single-rate estimate
+  // understated a translation-heavy remainder by ~3x.
+  totals.est_cost_usd = Number(estimatePagesCost({
+    ocrPages: totals.ocr_pages_remaining,
+    translationPages: totals.translate_pages_remaining,
+  }).toFixed(2));
 
   if (flag('json')) {
     console.log(JSON.stringify({ source, gates, totals, missing, artworks: artworks.map((b) => b.id), books: reports }, null, 2));
@@ -262,6 +268,6 @@ await withMongo(async (db) => {
   }
 
   console.log(`\nTotals: ${totals.done}/${totals.books} complete · OCR remaining ${totals.ocr_pages_remaining} pages · translation remaining ${totals.translate_pages_remaining} pages`);
-  console.log(`Estimated batch cost to finish OCR+translation: ~$${totals.est_batch_cost_usd} (at $${BATCH_RATE_USD_PER_PAGE}/page)`);
+  console.log(`Estimated cost to finish: ~$${totals.est_cost_usd}  (OCR $${PAGE_RATE_USD.ocrBatch}/pg batch + translation $${PAGE_RATE_USD.translationRealtime}/pg realtime, measured ${PAGE_RATES_MEASURED_ON})`);
   if (totals.drift_books) console.log(`⚠ ${totals.drift_books} book(s) have status ahead of output (#3740 shape) — status claims a stage with no output and no recorded skip.`);
 });

--- a/scripts/batch/bulk-reocr-opened-books.mjs
+++ b/scripts/batch/bulk-reocr-opened-books.mjs
@@ -18,6 +18,7 @@
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { PAGE_RATE_USD, PAGE_RATES_MEASURED_ON } from '../lib/model-pricing.mjs';
 
 // --- Config ---
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -335,8 +336,8 @@ async function run() {
   console.log(`Books skipped: ${booksSkipped}`);
   console.log(`Pages submitted: ${totalQueued.toLocaleString()}`);
   if (totalSkipped > 0) console.log(`Pages skipped (active job): ${totalSkipped.toLocaleString()}`);
-  const costPerPage = 0.00079; // batch API = 50% of $0.00158
-  console.log(`Est. cost @ $${costPerPage}/page (batch): $${(totalQueued * costPerPage).toFixed(2)}`);
+  const costPerPage = PAGE_RATE_USD.ocrBatch;
+  console.log(`Est. cost @ $${costPerPage}/page (batch, measured ${PAGE_RATES_MEASURED_ON}): $${(totalQueued * costPerPage).toFixed(2)}`);
   if (!DRY_RUN) {
     console.log(`\nResults will be collected by /api/cron/process-batches (every 2h)`);
   }

--- a/scripts/eval/reocr-pairing-check.mjs
+++ b/scripts/eval/reocr-pairing-check.mjs
@@ -54,6 +54,7 @@ import fs from 'fs';
 import path from 'path';
 import { agreementPrimary, scriptClassOf } from './lib/metrics.mjs';
 import { getPageSource } from '../lib/page-image-url.mjs';
+import { PAGE_RATE_USD, PAGE_RATES_MEASURED_ON } from '../lib/model-pricing.mjs';
 
 const args = Object.fromEntries(process.argv.slice(2).filter(a => a.startsWith('--')).map(a => {
   const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true];
@@ -62,7 +63,7 @@ const N = parseInt(args.n || '500');              // total across BOTH arms
 const APPLY = !!args.apply;
 const CONC = parseInt(args.concurrency || '4');
 const MODEL = args.model || 'gemini-3.1-flash-lite';
-const COST_PER_PAGE = 0.00079;
+const COST_PER_PAGE = PAGE_RATE_USD.ocrBatch;
 const OUT = args.out || `scripts/eval/results/reocr-pairing-${new Date().toISOString().slice(0, 10)}.json`;
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY_2 || process.env.GEMINI_API_KEY;
@@ -160,7 +161,7 @@ async function main() {
   console.log(`  control languages: ${dist(arms.control)}`);
   const targets = [...arms.suspect, ...arms.control];
   console.log(`arms: suspect=${arms.suspect.length}  control=${arms.control.length}  total=${targets.length}`);
-  console.log(`ESTIMATED COST: ${targets.length} pages x $${COST_PER_PAGE} = $${(targets.length * COST_PER_PAGE).toFixed(2)}`);
+  console.log(`ESTIMATED COST: ${targets.length} pages x $${COST_PER_PAGE} = $${(targets.length * COST_PER_PAGE).toFixed(2)}  (rate measured ${PAGE_RATES_MEASURED_ON})`);
   if (!APPLY) {
     console.log('\nDRY RUN — nothing spent, nothing called. Re-run with --apply to execute.');
     await client.close();

--- a/scripts/lib/model-pricing.mjs
+++ b/scripts/lib/model-pricing.mjs
@@ -78,6 +78,57 @@ export const SUPERSEDED_PRICING_BEFORE_2026_09_03 = {
   'gemini-3.6-flash': { input: 1.50, output: 7.50 },
 };
 
+/**
+ * PER-PAGE rates — what a page of work actually COSTS US, as opposed to the
+ * per-token vendor prices above.
+ *
+ * These are OBSERVATIONS, not prices. They are the ratio of `gemini_usage`
+ * cost to pages over a recent window, so they move whenever prompt length,
+ * model routing, or page density moves. They exist because four separate
+ * scripts had each hardcoded their own copy of a 2026-07-16 measurement
+ * ($0.00079/page) and were still printing it in September, understating every
+ * estimate by ~2.8x. A stale constant is invisible; that is the whole failure.
+ *
+ * Two rules, both learned the hard way:
+ *   1. NEVER print a rate without its measurement date. Use `describePageRate`.
+ *      The old constant survived 7 weeks because the output said "$3.18" and
+ *      never said "at a rate measured in July".
+ *   2. RE-MEASURE before quoting these anywhere that matters. One query:
+ *
+ *        select type, mode, model, sum(cost_usd), sum(page_count)
+ *        from gemini_usage where timestamp >= <recent> group by 1,2,3
+ *
+ * Measured 2026-09-04 over rows since 2026-09-03 (i.e. priced with the
+ * corrected constants from #4601 — do not mix with older rows):
+ *   translation realtime lite  $0.00241/pg  (9,971 pages, n=2,737)
+ *   ocr batch lite             $0.00222/pg  (8,656 pages, n=352)
+ *   extract_images flash       $0.00285/pg  (1,622 pages, n=30)
+ *   index/summary/chapters     ~$0.0001/pg combined — negligible
+ *
+ * DELIBERATELY ABSENT: batch OCR on flash-preview. It measures $0.00106/pg,
+ * which is below the lite rate and cannot be right — the flash batch rows are
+ * contaminated by uncollected $0 placeholders (#4567). An obviously-wrong
+ * number is safer missing than published.
+ */
+export const PAGE_RATES_MEASURED_ON = '2026-09-04';
+
+export const PAGE_RATE_USD = {
+  ocrBatch: 0.00222,
+  translationRealtime: 0.00241,
+  imageExtraction: 0.00285,
+  enrichmentTail: 0.0001,
+};
+
+/** A rate never travels without its vintage. */
+export function describePageRate(rate) {
+  return `$${rate}/page (measured ${PAGE_RATES_MEASURED_ON})`;
+}
+
+/** Estimate for a mixed OCR + translation remainder, the common case. */
+export function estimatePagesCost({ ocrPages = 0, translationPages = 0 }) {
+  return ocrPages * PAGE_RATE_USD.ocrBatch + translationPages * PAGE_RATE_USD.translationRealtime;
+}
+
 export function priceFor(model) {
   return MODEL_PRICING[model] || DEFAULT_PRICING;
 }


### PR DESCRIPTION
`$0.00079/page` was measured on 2026-07-16 and copy-pasted into four scripts. All four were still printing it in September, understating every estimate by **~2.8x**.

Caught on the Forum of Conscience run (#4541): `scope-progress` reported "~$3.18 to finish" against a real remainder near $10 — and nothing in that line said the rate was seven weeks old.

## Two errors, not one

The rate was stale, **and** a single rate was applied to both OCR and translation. Those run on different lanes at different prices, so a translation-heavy remainder was understated twice over.

## Re-measured 2026-09-04

Over `gemini_usage` rows since 09-03 — i.e. priced with the corrected constants from #4601, never mixed with older rows:

| lane | rate | sample |
|---|---|---|
| translation realtime lite | **$0.00241/pg** | 9,971 pages, n=2,737 |
| ocr batch lite | **$0.00222/pg** | 8,656 pages, n=352 |
| extract_images flash | $0.00285/pg | 1,622 pages, n=30 |
| index / summary / chapters | ~$0.0001/pg combined | negligible |

## What changed

- `PAGE_RATE_USD`, `PAGE_RATES_MEASURED_ON` and `estimatePagesCost()` in `scripts/lib/model-pricing.mjs` — one definition, sitting next to the per-token prices they are derived from. The four call sites import it.
- OCR and translation priced separately wherever both appear.
- **Every printed estimate now carries its measurement date.** This is the real fix. The old constant survived seven weeks because the output said "$3.18" and never said "at a July rate" — a stale number that announces its vintage gets questioned; one that doesn't, doesn't.

The doc comment also records the query to re-measure, so the next person re-derives rather than inherits.

## One number deliberately NOT published

Batch OCR on flash-preview measures **$0.00106/pg** — below the lite rate, which cannot be right. Those rows are contaminated by uncollected $0 placeholders (#4567). An obviously-wrong number is safer missing than published, so the table omits it and says why.

## Verification

`scope-progress --scope forum-conscience-finish` now reports **~$9.59** for the same remainder it previously called $3.18 — against ~$11 of measured spend actually needed to finish. All five touched files parse; the import-resolution hook passes.

Out of scope: #4567 ($0 placeholders) and #4566 (pooled batch attribution). Neither changes these rates; both would make them measurable at book grain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116Jc7Z7ZzYmAhCPKQNLJpC
