### PR TITLE
feat(review): point the page-check queue at live defects (#4580)

### DIFF
--- a/scripts/maintenance/build-page-check-candidates.mjs
+++ b/scripts/maintenance/build-page-check-candidates.mjs
@@ -34,6 +34,74 @@ const named = args.find(a => !a.startsWith('--') && a !== FILE);
  * Campaigns. Each returns rows; keep them small and specific — "check this
  * blog post for errors" is answerable, "review the site" is not.
  */
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0 Safari/537.36';
+
+/**
+ * Turn a defect MARKER into a campaign.
+ *
+ * Most live OCR defects have a fingerprint that the public search index can
+ * already find — the text a reader sees is indexed, so a bug that reaches the
+ * reader is searchable by definition. This walks a set of probes, collects the
+ * page hits, and hands each one to a volunteer as "go and look".
+ *
+ * Why the public search API and not Mongo or Supabase: an `ilike '%marker%'`
+ * over `page_translations` has no index to use and times out, and a regex over
+ * `pages` (19.1M docs) is a full collection scan. The search index is the one
+ * place this lookup is cheap — and it is also, by construction, exactly the set
+ * of pages a reader could stumble on.
+ *
+ * `perBook` keeps one bad book from filling the queue: three pages is enough to
+ * confirm a pattern, and the volunteer is asked to note whether the rest of the
+ * book looks the same.
+ */
+async function markerCampaign({
+  probes, prompt, label, campaign, idPrefix, perBook = 3,
+  confirm = () => true,
+}) {
+  const byPage = new Map();
+  const perBookCount = new Map();
+  let rejected = 0;
+
+  for (const probe of probes) {
+    const res = await fetch(
+      `${SITE}/api/search?q=${encodeURIComponent(probe)}&limit=50`,
+      { headers: { 'User-Agent': UA } },
+    );
+    if (!res.ok) {
+      console.warn(`  probe "${probe}" → HTTP ${res.status} (skipped)`);
+      continue;
+    }
+    const data = await res.json();
+    const hits = (data.results ?? []).filter(r => r.type === 'page' && r.page_id && r.slug);
+    console.warn(`  probe "${probe}" → ${data.total} total, ${hits.length} page hits`);
+    for (const h of hits) {
+      if (byPage.has(h.page_id)) continue;
+      // A search hit is a candidate, not a confirmation: a probe word can match
+      // an ordinary sentence. `confirm` looks at the indexed snippet — the text
+      // a reader actually sees — so a volunteer is never sent to a page where
+      // there is nothing to find. Sending someone to look at a false positive
+      // spends the one thing this system is short of.
+      if (!confirm(h)) { rejected++; continue; }
+      const n = perBookCount.get(h.book_id) ?? 0;
+      if (n >= perBook) continue;
+      perBookCount.set(h.book_id, n + 1);
+      byPage.set(h.page_id, {
+        item_id: `${idPrefix}:${h.page_id}`,
+        url: `${SITE}/book/${h.slug}/page/${h.page_id}`,
+        label,
+        campaign,
+        prompt: `${prompt}\n\nThis is page ${h.page_number} of “${h.title}”.`,
+      });
+    }
+    // The edge bot-limiter allows ~10 requests a minute; probes are few, so a
+    // short pause is cheaper than being throttled halfway through a build.
+    await new Promise(r => setTimeout(r, 3000));
+  }
+  if (rejected) console.warn(`  ${rejected} hit(s) rejected: the snippet showed no defect`);
+  return [...byPage.values()];
+}
+
 const CAMPAIGNS = {
   blog: {
     describe: 'Every blog post, read for factual and typographic errors',
@@ -71,6 +139,33 @@ const CAMPAIGNS = {
       }));
     },
   },
+
+  // ── Campaigns pointed at live, open defects ──────────────────────────────
+  // These exist so volunteer minutes land on something the tracker is actually
+  // trying to close, rather than on a generic "is this scan blurry". Each names
+  // its issue in the campaign label, so an answer can be carried back to it.
+  'tex-greek': {
+    describe: 'Greek printed as LaTeX code in the text readers see (#4580)',
+    build: () =>
+      markerCampaign({
+        idPrefix: 'tex',
+        label: 'the page',
+        campaign: 'Greek rendered as LaTeX (#4580)',
+        // Six fingerprints of the same failure: the model draws the SHAPE of a
+        // Greek word as maths notation instead of transcribing it as Greek.
+        probes: ['varsigma', 'mathrm', 'overline', 'varepsilon', 'lambda\\', 'begin{aligned}'],
+        // A literal backslash in running prose is essentially always TeX. This
+        // is what separates a page that PRINTS \varsigma from a translation that
+        // happens to discuss the word "overline".
+        confirm: h => typeof h.snippet === 'string' && h.snippet.includes('\\'),
+        prompt:
+          'The transcription on this page may show LaTeX code — things like \\alpha, ' +
+          '$\\varsigma$ or \\overline{} — where the book actually prints Greek letters. ' +
+          'Compare the text with the scan beside it. Is code standing in for Greek? ' +
+          'If you read Greek, the useful extra is what the word should say. And please ' +
+          'note whether the rest of the book does the same thing, or only this page.',
+      }),
+  },
 };
 
 if (args.includes('--list') || (!named && !FILE)) {
@@ -97,7 +192,7 @@ if (FILE) {
 } else {
   const c = CAMPAIGNS[named];
   if (!c) { console.error(`Unknown campaign "${named}". Try --list.`); process.exit(1); }
-  rows = c.build();
+  rows = await c.build();
 }
 
 console.log(`${rows.length} task(s)`);


### PR DESCRIPTION
The page-check pool held 67 tasks — "read this blog post", "read this Spanish page". Worth doing, but unconnected to anything the tracker is trying to close. This adds a way to turn an **open defect** into volunteer work, and uses it for the first one.

## The mechanism

`markerCampaign()` walks probe terms through the **public search API** and hands each page hit to a volunteer as "go and look".

The search index is the right instrument here for two reasons:
- It is the only place this lookup is cheap. An `ilike '%varsigma%'` over `page_translations` has no index to use and **times out** (measured); a regex over `pages` is a 19.1M-doc collection scan.
- It is, by construction, the set of pages **a reader could actually stumble on**. A defect that reaches the reader is searchable; one that isn't indexed isn't hurting anyone yet.

**`confirm` is the part that matters.** A search hit is a candidate, not a confirmation — a probe word matches ordinary prose too. For #4580 the test is a literal backslash in the indexed snippet, which separates a page that prints `$\varsigma$` from a translation that happens to discuss the word "overline". **It rejected 67 of 136 hits.** Without it half of every volunteer session would go to pages with nothing wrong — which spends the one resource this system is short of.

## The first campaign: #4580, Greek printed as LaTeX

Six fingerprints of one failure — the model draws the *shape* of a Greek word as maths notation instead of transcribing it as Greek:

| probe | total | page hits |
|---|---|---|
| `varsigma` | 29 | 29 |
| `mathrm` | 50 | 26 |
| `overline` | 22 | 22 |
| `varepsilon` | 16 | 16 |
| `lambda\` | 33 | 33 |
| `begin{aligned}` | 33 | 10 |

After confirmation and a 3-page-per-book cap: **69 tasks queued, pool 67 → 136.** Already applied to production (`inserted 69, updated 0`) — additive rows in `review_candidates`, read only by volunteers at `/review/page-check`, no cron consumes them. Re-running updates prompts in place rather than duplicating; `(queue, item_id)` is uniquely indexed.

The issue estimated "at least 19 books". The confirmed set is larger than that, and spans exactly the books where it hurts most — *Erotemata*, Lascaris' Greek grammar, Ficino's *Epistolae*, the Bodmer Alexandria codex.

The prompt asks for the one thing a script cannot get: whether code is standing in for Greek on the page in front of them, what the word should say if they read Greek, and **whether the rest of the book does the same** — which is what turns 69 spot-checks into a blast radius.

## Notes

- Requests are spaced 3s: the edge bot-limiter allows ~10/minute.
- A zero-hit or erroring probe is logged and skipped, never fatal.
- Adding the next campaign is a probe list, a prompt, and a `confirm` predicate.
- Reader pages 403 to a script (bot gate), so confirmation reads the indexed snippet rather than the rendered page. That is the reader-visible text either way.

Stacks alongside #4573 (consensus-preferring selection + the `not-a-page` button); no file overlap.

Refs #4580, #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)