### PR TITLE
fix(audit): lambda-drift — retries and a real deadline for the zip download

### DIFF
--- a/scripts/audit/lambda-drift.mjs
+++ b/scripts/audit/lambda-drift.mjs
@@ -91,7 +91,13 @@ try {
         '--output', 'json']));
       lastModified = cfg.mod;
       const zipPath = join(tmp, `${w.entry}.zip`);
-      sh('curl', ['-sS', '-o', zipPath, cfg.loc]);
+      // The deployed zips are ~2.3 MB and the presigned host is occasionally slow. Both layers
+      // need headroom: curl retries transient failures, and execFileSync gets its own longer
+      // deadline — the generic 120s killed a real run with `spawnSync curl ETIMEDOUT`, which
+      // reports as COULD NOT CHECK and teaches people to ignore the tool.
+      sh('curl', ['-sS', '--fail', '--connect-timeout', '20', '--max-time', '180',
+        '--retry', '3', '--retry-delay', '2', '--retry-all-errors', '-o', zipPath, cfg.loc],
+        { timeout: 600000 });
       sh('unzip', ['-oq', zipPath, 'index.js', '-d', join(tmp, w.entry)]);
       deployedSha = createHash('sha256').update(readFileSync(join(tmp, w.entry, 'index.js'))).digest('hex');
     } catch (e) {


### PR DESCRIPTION
## Why

First run of the just-merged `lambda-drift.mjs` from its canonical path (#4640) reported:

```
sourcelibrary-image-extraction-processor      COULD NOT CHECK — spawnSync curl ETIMEDOUT
```

That is **Node's** generic 120 s `execFileSync` timeout firing, not curl's. The deployed zips are ~2.3 MB and the presigned S3 host is occasionally slow, so the download was sharing a deadline sized for fast local commands.

A verification tool that reports `COULD NOT CHECK` on a transient network hiccup is one people learn to ignore — which defeats the entire purpose of having it.

## Fix

- `curl` gets `--fail --connect-timeout 20 --max-time 180 --retry 3 --retry-delay 2 --retry-all-errors`
- the download step gets its own **600 s** `execFileSync` deadline instead of the generic 120 s

## Verification

Re-ran unpiped after the failure: all four workers `current` at `2ebff17b`, real exit code 0.

Incidental note worth recording: my first reading of that failing run showed "exit code 0" because I'd piped it through `tail` — **a pipe reports the last stage's status, not the script's**. The failure path's exit-1 behaviour is therefore still unobserved, only read from the source. Said plainly rather than claimed as tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQkkHNnZ3en3UDYtuicykT