### PR TITLE
fix(reader): say plainly that Tibetan transcriptions cannot be trusted (#4523)

### DIFF
--- a/src/components/reader-v2/Reader2C.tsx
+++ b/src/components/reader-v2/Reader2C.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { localeHref, useLocale } from '@/lib/i18n';
 import { getReaderStrings, type ReaderStrings } from '@/lib/reader-strings';
+import { transcriptionReliability } from '@/lib/transcription-reliability';
 import { useSession, signOut } from 'next-auth/react';
 import Logo from '@/components/layout/Logo';
 import { AuthCheck } from '@/components/auth/AuthCheck';
@@ -1018,6 +1019,45 @@ function TranslitProgress({ ocrLength }: { ocrLength: number }) {
         </span>
       </span>
     </div>
+  );
+}
+
+/**
+ * Says plainly that a transcription cannot be trusted, above the transcription
+ * itself (#4523).
+ *
+ * Placed INSIDE the scrolling pane rather than in the pane header, because the
+ * header is sticky chrome a reader learns to skip, and this needs to sit with
+ * the text it is about. It is deliberately not dismissible: it is a property of
+ * the text, not a notification.
+ *
+ * Suppressed when a paired critical edition is showing, because that surface
+ * already carries its own, more specific version of the same warning and two
+ * stacked disclaimers read as boilerplate.
+ */
+function UnreliableTranscriptionNotice({
+  book,
+  paired,
+}: {
+  book: { language?: string | null };
+  paired: boolean;
+}) {
+  const flag = transcriptionReliability(book);
+  if (!flag || paired) return null;
+  return (
+    <aside
+      className="mb-5 rounded-md px-4 py-3 text-[13.5px] leading-snug"
+      style={{
+        background: 'var(--accent-rust-soft, rgba(158,74,58,0.06))',
+        border: '1px solid rgba(158,74,58,0.28)',
+        color: 'var(--text-primary, #2b2622)',
+      }}
+    >
+      <p className="m-0">{flag.message}</p>
+      <p className="m-0 mt-1.5 text-[12px]" style={{ color: 'var(--text-secondary, #6b6560)' }}>
+        {flag.evidence}
+      </p>
+    </aside>
   );
 }
 
@@ -3500,6 +3540,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
                   style={{ overscrollBehavior: 'contain' }}
                 >
                   <div key={r.currentPageId} className="rv2-page-in">
+                    <UnreliableTranscriptionNotice book={r.book} paired={!!paired} />
                     {paired
                       ? <PairedTranscriptionProse paired={paired} page={r.currentPage} settings={r.settings} baseSize={17.5} />
                       : <ReaderProse suppressBlockquote={quotesDisagree} page={r.currentPage} book={r.book} kind="ocr" settings={r.settings} baseSize={17.5} />}
@@ -3584,6 +3625,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
                   style={{ overscrollBehavior: 'contain' }}
                 >
                   <div key={r.currentPageId} className="rv2-page-in">
+                    {!r.views.ocr && <UnreliableTranscriptionNotice book={r.book} paired={!!paired} />}
                     {paired
                       ? <PairedTranslationProse paired={paired} page={r.currentPage} settings={r.settings} baseSize={18.5} />
                       : showingSpanish
@@ -3864,6 +3906,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
                 </div>
               </div>
               <div data-reader-panel className="px-[22px] pt-4 pb-8">
+                <UnreliableTranscriptionNotice book={r.book} paired={!!paired} />
                 {paired
                       ? <PairedTranscriptionProse paired={paired} page={r.currentPage} settings={r.settings} baseSize={16} />
                       : <ReaderProse suppressBlockquote={quotesDisagree} page={r.currentPage} book={r.book} kind="ocr" settings={r.settings} baseSize={16} />}
@@ -3910,6 +3953,7 @@ export default function Reader2C({ initialBook, initialPage, initialPageList }: 
                 </div>
               </div>
               <div data-reader-panel className="px-[22px] pt-4 pb-6">
+                {!r.views.ocr && <UnreliableTranscriptionNotice book={r.book} paired={!!paired} />}
                 {paired
                   ? <PairedTranslationProse paired={paired} page={r.currentPage} settings={r.settings} baseSize={16} />
                   : showingSpanish

--- a/src/lib/transcription-reliability.ts
+++ b/src/lib/transcription-reliability.ts
@@ -1,0 +1,84 @@
+/**
+ * Scripts our OCR cannot reliably read, and what to tell the reader.
+ *
+ * PRIOR ART: src/components/reader-v2/PairedEdition.tsx — the Marcianus paired
+ * edition already demotes an unreliable transcription and tells the reader why.
+ * It does not fit here because it is built for ONE manuscript around a
+ * hand-aligned critical edition: it needs a text of record to promote in place
+ * of the OCR. There is no critical edition to promote for 1,467 Tibetan pecha,
+ * so the honest move is a warning rather than a substitution. The argument is
+ * the same one, and it is already written down at Reader2C.tsx:3050 — showing
+ * an OCR that self-agrees at 0.62 with documented hallucinations "is not a
+ * missing feature, it is the reader asserting something false."
+ *
+ * WHY THIS EXISTS (#4523)
+ * ----------------------
+ * Measured 2026-09-01 against real ground truth — 63 intact Derge Kangyur
+ * folios scored by syllable alignment against the OpenPecha etext, both arms
+ * seeing identical images:
+ *
+ *   positive control (etext + 5% noise)   0.968
+ *   BDRC Woodblock (specialist ONNX)      0.880
+ *   Gemini 3.1 flash-lite (ours)          0.412
+ *   chance floor (wrong pages)            0.103
+ *
+ * Ours sits closer to the chance floor than to the specialist. And the failure
+ * is not noise: it invents fluent text in the wrong script and religion — one
+ * confirmed Bhutanese Nyingma folio was transcribed as a Devanagari Rāma
+ * invocation and then faithfully translated into English. The folios in that
+ * test were INTACT, so this is not confined to the damaged-master cohort of
+ * #4534: the model cannot read cursive dbu-med at all.
+ *
+ * SCOPE. Tibetan only, because Tibetan is the only script where we hold a
+ * ground-truth measurement. The same audit found an unexplained-substitution
+ * residue in Syriac (19.5%), Persian (19.3%) and Hebrew (13.2%) — milder, and
+ * the substitute is Latin rather than a foreign script. Do not add them here on
+ * the strength of that number alone; measure first. Korean's apparently terrible
+ * own-script rate is an ARTIFACT (classical Korean is written in hanmun) and is
+ * not a candidate.
+ *
+ * WHAT THIS IS NOT. It does not hide, delete or alter any text. Derek's
+ * decision of 2026-09-01 was "we can't claim those are translations, I agree.
+ * we don't need to withdraw the text yet though" — the first-translation claims
+ * were duly retracted (795 Tibetan verdicts set to not_applicable; zero books
+ * still carry the public boolean) and this is the reader-facing warning that
+ * was scoped to ship alongside it. Withdrawing the text remains a separate,
+ * unmade decision.
+ */
+
+export type TranscriptionReliability = {
+  /** Machine-readable so a caller can decide how loudly to render it. */
+  level: 'unreliable';
+  /** One sentence, addressed to a reader rather than to us. */
+  message: string;
+  /** Where the claim comes from, for anyone who wants to check it. */
+  evidence: string;
+};
+
+/** Lowercased edition languages whose transcription we cannot vouch for. */
+const UNREADABLE_LANGUAGES = new Set(['tibetan']);
+
+/**
+ * `language` is the EDITION's language, not the source work's — see
+ * `.claude/docs/invariants/language-fields.md`. That is the right field here:
+ * what matters is the script actually photographed on the folio, which is what
+ * the OCR had to read.
+ */
+export function transcriptionReliability(
+  book: { language?: string | null } | null | undefined,
+): TranscriptionReliability | null {
+  const lang = (book?.language ?? '').trim().toLowerCase();
+  if (!UNREADABLE_LANGUAGES.has(lang)) return null;
+  return {
+    level: 'unreliable',
+    message:
+      'This transcription is machine-made and unreliable. Our OCR cannot read ' +
+      'cursive Tibetan, and where it fails it does not stop — it invents ' +
+      'plausible text, sometimes in another script entirely. Read the scan as ' +
+      'the source, and please do not quote the transcription or the English ' +
+      'without checking the folio.',
+    evidence:
+      'Measured against the Derge Kangyur etext on intact folios: 0.41 where a ' +
+      'specialist Tibetan model scores 0.88 and chance is 0.10.',
+  };
+}


### PR DESCRIPTION
**1,467 live Tibetan books** serve a machine transcription and an English translation of it, with nothing on the page telling the reader what that text is worth.

## The measurement

2026-09-01, against real ground truth — 63 intact Derge Kangyur folios scored by syllable alignment against the OpenPecha etext, both arms seeing identical images:

| arm | median identity |
|---|---|
| positive control (etext + 5% noise) | 0.968 |
| BDRC Woodblock (specialist ONNX) | **0.880** |
| Gemini 3.1 flash-lite (ours) | **0.412** |
| chance floor (wrong pages) | 0.103 |

Ours sits closer to the chance floor than to the specialist. And the failure mode is not noise — it invents fluent text in the wrong script and religion. One confirmed Bhutanese Nyingma folio is transcribed as a Devanagari Rāma invocation (`॥ श्रीरामचन्द्राय नमः ॥`) and then *faithfully translated* into English.

**The folios in that test were intact.** So this is not confined to the damaged-master cohort of #4534: the model cannot read cursive dbu-med at all, and the exposure is the whole Tibetan holding rather than the 529-book suspect set.

## The argument is already in this codebase

`Reader2C.tsx:3050` demotes the Marcianus OCR in favour of a critical edition because showing a transcription that self-agrees at 0.62 with documented hallucinations *"is not a missing feature, it is the reader asserting something false."*

Tibetan measures far worse and says nothing at all. This applies the same principle to the cohort where it matters more.

## What this is, and is not

This is the **reader-facing half** of Derek's decision of 2026-09-01 — *"we can't claim those are translations, I agree. we don't need to withdraw the text yet though"* — recorded in `scripts/maintenance/retract-tibetan-ft-claims.mjs`.

Verified today: the first half **shipped** — 795 Tibetan books carry `first_translation.verdict: not_applicable`, and **zero** still carry the public boolean. The second half, the warning that was scoped to ship alongside it, **did not**.

- Changes **no data**. Hides **no text**. Withdrawing the transcriptions remains a separate decision that is still Derek's.
- Renders above the transcription, and above the translation **when the transcription pane is closed** — so a reader in single-pane view is not left unwarned.
- Suppressed where a paired critical edition already carries its own, more specific warning; two stacked disclaimers read as boilerplate.
- Not dismissible: it is a property of the text, not a notification.
- Placed inside the scrolling pane rather than the sticky header, which readers learn to skip.

## Scope

Tibetan only — the one script where we hold a ground-truth measurement. The module documents the Syriac (19.5%), Persian (19.3%) and Hebrew (13.2%) substitution residue and deliberately **excludes** them pending measurement, and records that Korean's apparently terrible own-script rate is an artifact of hanmun, not a defect.

## Testing

`npx tsc --noEmit` clean on the rebased tree. Worth eyeballing on a preview against any Tibetan book before merge — e.g. one of the Gangtey or Ogyen Choling pecha named in #4523.

Refs #4523, #4534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
