### PR TITLE
fix(collections): publishing a collection did not publish its page

### DIFF
--- a/scripts/audit/collection-page-live.mjs
+++ b/scripts/audit/collection-page-live.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: `scripts/audit/gallery-visibility-leak.mjs` checks visibility only
+ * INSIDE the database (frozen id lists vs `books.visible`) and never fetches a
+ * page; `scripts/maintenance/prewarm-browse.mjs` fetches pages but to warm them,
+ * asserting nothing about what came back. Neither can answer the question here:
+ * does the page a READER gets agree with the database? Also checked
+ * `scripts/audit/` for any *-live / *-render probe — none exists.
+ *
+ * collection-page-live — every visible collection must actually render.
+ *
+ * THE FAILURE THIS CATCHES
+ * ------------------------
+ * `/collections/<slug>` is ISR- and CDN-cached. Before the collection exists the
+ * page renders as missing, and THAT gets cached; creating the document and
+ * flipping `visible` changes Mongo and nothing else. The reader keeps getting
+ * the cached miss, and the database looks perfectly correct the whole time.
+ * Nobody notices until someone opens the page by hand — which is exactly how
+ * this was found (Derek, 2026-09-04, on `forum-of-conscience`).
+ *
+ * A write-side helper (`scripts/lib/revalidate.mjs`) fixes the scripts we know
+ * about. It cannot fix the next script someone writes, which is why this exists:
+ * the check belongs on the READ side, where the truth is observable.
+ *
+ * WHAT "RENDERS" MEANS HERE
+ * -------------------------
+ * Not HTTP 200. A hidden or missing page returns **200 with a soft-404 body**,
+ * so status is worthless as a signal (see `lesson_soft404_wears_real_metadata`).
+ * A page passes only if all three hold:
+ *   1. HTTP 200
+ *   2. no `NEXT_HTTP_ERROR_FALLBACK;404` marker in the body
+ *   3. the collection's own NAME appears in the body — the check that catches a
+ *      page that renders but renders something else
+ *
+ * PACING: the edge rate-limits non-browser clients (10 req/60s), so this sends a
+ * browser UA and sleeps between requests. A full sweep is minutes, not seconds;
+ * that is fine for a nightly cron and the reason `--limit` exists.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/audit/collection-page-live.mjs
+ *   ... --slug forum-of-conscience      # one collection
+ *   ... --limit 20                      # first N (by most recently updated)
+ *   ... --fix                           # revalidate the ones that fail
+ *
+ * Exit 0 = every checked collection renders. Exit 1 = at least one does not.
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+import { revalidateCollection } from '../lib/revalidate.mjs';
+
+const args = process.argv.slice(2);
+const flag = (n) => args.includes(`--${n}`);
+const val = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : null; };
+
+const BASE = process.env.SITE_URL || 'https://sourcelibrary.org';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0 Safari/537.36';
+const PACE_MS = Number(val('pace') || 7000);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Three checks, because HTTP status alone cannot tell a real page from a soft-404. */
+async function probe(slug, name) {
+  const url = `${BASE}/collections/${slug}`;
+  let res;
+  try {
+    res = await fetch(url, { headers: { 'User-Agent': UA } });
+  } catch (err) {
+    return { ok: false, reason: `fetch failed: ${err.message}`, url };
+  }
+  if (res.status === 429) return { ok: null, reason: 'rate-limited — slow down (--pace)', url };
+  if (!res.ok) return { ok: false, reason: `HTTP ${res.status}`, url };
+
+  const body = await res.text();
+  if (body.includes('NEXT_HTTP_ERROR_FALLBACK;404')) return { ok: false, reason: 'soft-404 (200 with a not-found body)', url };
+  // The name is HTML-escaped in the markup; compare on a conservative subset.
+  const needle = String(name || '').replace(/&/g, '&amp;').replace(/'/g, '&#x27;');
+  if (needle && !body.includes(needle)) return { ok: false, reason: `renders, but the collection name is absent`, url };
+  return { ok: true, url };
+}
+
+await withMongo(async (db) => {
+  const slug = val('slug');
+  const limit = Number(val('limit') || 0);
+
+  const query = slug ? { slug } : { visible: true };
+  let cursor = db.collection('collections').find(query, { projection: { slug: 1, name: 1, visible: 1, updated_at: 1, _id: 0 } })
+    .sort({ updated_at: -1 });
+  if (limit) cursor = cursor.limit(limit);
+  const collections = await cursor.toArray();
+
+  if (!collections.length) {
+    console.log(slug ? `No collection with slug '${slug}'.` : 'No visible collections.');
+    process.exit(slug ? 1 : 0);
+  }
+
+  console.log(`Checking ${collections.length} collection page(s) at ${PACE_MS}ms intervals — ~${Math.ceil(collections.length * PACE_MS / 60000)} min.\n`);
+
+  const broken = [];
+  let skipped = 0;
+
+  for (let i = 0; i < collections.length; i++) {
+    const c = collections[i];
+    const r = await probe(c.slug, c.name);
+    if (r.ok === null) { skipped++; console.log(`  ?  ${c.slug} — ${r.reason}`); }
+    else if (r.ok) { if (flag('verbose')) console.log(`  ok ${c.slug}`); }
+    else { broken.push({ ...c, ...r }); console.log(`  ✘  ${c.slug} — ${r.reason}`); }
+    if (i < collections.length - 1) await sleep(PACE_MS);
+  }
+
+  console.log('');
+  if (skipped) console.log(`${skipped} skipped (rate-limited) — NOT counted as passing. Re-run with a longer --pace.`);
+
+  if (!broken.length) {
+    console.log(`✔ all ${collections.length - skipped} checked collection pages render.`);
+    process.exit(skipped ? 1 : 0);
+  }
+
+  console.log(`✘ ${broken.length} collection page(s) do not render what the database says they should:\n`);
+  for (const b of broken) console.log(`   ${b.url}\n     ${b.reason}`);
+
+  if (flag('fix')) {
+    console.log('\nRevalidating…');
+    for (const b of broken) {
+      try {
+        await revalidateCollection(b.slug);
+      } catch (err) {
+        console.log(`  ${b.slug}: revalidate FAILED — ${err.message}`);
+      }
+      await sleep(PACE_MS);
+    }
+    console.log('\nRe-run without --fix to confirm. A purge is only a fix if the origin can refill it.');
+  } else {
+    console.log('\nRun again with --fix to revalidate these, or purge by hand.');
+  }
+  process.exit(1);
+});

--- a/scripts/lib/revalidate.mjs
+++ b/scripts/lib/revalidate.mjs
@@ -1,0 +1,82 @@
+/**
+ * PRIOR ART: none — checked `scripts/lib/` (no cache/purge/revalidate helper) and
+ * the five scripts that already do this: `create-proposed-collections-2026-08.mjs`,
+ * `import/create-slime-moulds-collection.mjs`, `import/publish-slime-moulds.mjs`,
+ * `import/rewrite-book-summaries.mjs`, `maintenance/cleanup-orphan-gallery-images.mjs`.
+ * Each hand-rolls the same fetch with its own auth header and error handling, and
+ * most of them ignore the response. That copy-paste IS the bug this file fixes;
+ * `src/lib/cloudflare-cache.ts` is server-side TS and not importable from a script.
+ *
+ * Revalidate public pages after a script writes to Mongo.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A collection page is ISR-cached and CDN-cached. Before a collection exists,
+ * `/collections/<slug>` renders as missing — and THAT is what gets cached. A
+ * script then writes the document and flips `visible`, which changes the
+ * database and nothing else, so the reader keeps getting the cached miss. There
+ * is no API write path to hook: collections are created by scripts writing
+ * straight to Mongo, so the purge has to be something the script calls.
+ *
+ * Corollary worth stating, because it is the trap: **a write that changes what a
+ * page should show is not finished until the cache is told.** The write
+ * succeeding is not evidence the page changed.
+ *
+ * READ THE RESPONSE. `/api/admin/revalidate` returns `{ revalidated: N }`; a 200
+ * with `revalidated: 0` means the paths were rejected (they must start with "/")
+ * and the page is still stale. Every caller here checks it, because a discarded
+ * purge response is how a dead Cloudflare token hid for weeks.
+ */
+
+const BASE = process.env.SITE_URL || 'https://sourcelibrary.org';
+
+function authHeader() {
+  const secret = process.env.REVALIDATE_SECRET || process.env.CRON_SECRET;
+  if (!secret) {
+    throw new Error(
+      'revalidate: no REVALIDATE_SECRET or CRON_SECRET in env — refusing to call silently. ' +
+      'Run with --env-file=.env.production.local.',
+    );
+  }
+  return { 'x-revalidate-secret': secret, 'Content-Type': 'application/json' };
+}
+
+/**
+ * Revalidate explicit paths (and purge them at the edge — the route does both).
+ * Returns the parsed result; throws on a non-200 or on an empty revalidation,
+ * so a caller cannot mistake "nothing happened" for success.
+ */
+export async function revalidatePaths(paths, { quiet = false } = {}) {
+  const list = (Array.isArray(paths) ? paths : [paths]).filter(Boolean);
+  if (!list.length) return { revalidated: 0, paths: [] };
+
+  const bad = list.filter((p) => !String(p).startsWith('/'));
+  if (bad.length) throw new Error(`revalidate: paths must start with "/" — got ${bad.join(', ')}`);
+
+  const res = await fetch(`${BASE}/api/admin/revalidate`, {
+    method: 'POST',
+    headers: authHeader(),
+    body: JSON.stringify({ paths: list }),
+  });
+
+  const body = await res.text();
+  if (!res.ok) throw new Error(`revalidate: HTTP ${res.status} — ${body.slice(0, 200)}`);
+
+  let json;
+  try { json = JSON.parse(body); } catch { throw new Error(`revalidate: non-JSON response — ${body.slice(0, 200)}`); }
+  if (!json.revalidated) throw new Error(`revalidate: server revalidated 0 paths for ${list.join(', ')}`);
+
+  if (!quiet) console.log(`  revalidated ${json.revalidated} path(s): ${list.join(', ')}`);
+  return json;
+}
+
+/**
+ * Publish-time purge for one collection: its own page, plus the two listings a
+ * new collection has to appear in. Call this after creating a collection, after
+ * flipping `visible`, and after editing authored prose — all three change what
+ * the cached page should say.
+ */
+export async function revalidateCollection(slug, opts = {}) {
+  if (!slug) throw new Error('revalidateCollection: slug is required');
+  return revalidatePaths([`/collections/${slug}`, '/collections', '/collections/all'], opts);
+}


### PR DESCRIPTION
Derek: *"the collection page isn't rendering. that often happens when I make new collections. make sure it doesn't happen again."*

## The mechanism

`/collections/<slug>` is ISR- and CDN-cached. **Before the collection exists, that path renders as missing — and that is what gets cached.** A script then writes the document and flips `visible`, which changes Mongo and nothing else. Readers keep getting the cached miss while the database looks perfectly correct, so nothing looks broken from the inside. It stays wrong until something unrelated evicts it.

There is no API write path to hook: `/api/admin/book-collections` is GET-only, and collections are created by scripts writing straight to Mongo. So the purge has to be something a script calls — and **five scripts already hand-roll that fetch**, each with its own auth header and error handling, most ignoring the response. That copy-paste is the bug.

## Two halves, write side and read side

**`scripts/lib/revalidate.mjs`** — `revalidatePaths()` / `revalidateCollection()`, one definition. It **reads the response** and throws on `revalidated: 0`, because the route answers 200 while silently rejecting paths that don't start with `/`. A discarded purge response is how a dead Cloudflare token hid for weeks. It also refuses to run with no secret rather than calling anonymously.

**`scripts/audit/collection-page-live.mjs`** — the standing check, deliberately on the **read** side. A write-side helper fixes the scripts we know about; it cannot fix the next script someone writes. This asserts what a reader actually gets.

"Renders" is deliberately **not** "HTTP 200" — a missing page returns *200 with a soft-404 body*. A page passes only if it is 200, carries no `NEXT_HTTP_ERROR_FALLBACK;404` marker, **and** contains the collection's own name. That third check catches a page that renders, but renders something else. Rate-limited probes are reported and counted as **not** passing, never silently skipped.

## Verified in both directions

The part that matters for a detector — it can return "broken", not just "fine":

| probe | result | exit |
|---|---|---|
| `daoism` (hidden in Mongo) | ✘ HTTP 404 | 1 |
| `forum-of-conscience` (live) | ✔ renders | 0 |

## Scope

**Left alone deliberately:** the five existing hand-rolled callers. They are one-shot historical scripts; rewriting them risks breaking a rerun and gains nothing, and the read-side check covers them regardless.

**Follow-up, not in this PR:** schedule the audit on Hetzner — it needs DB access, so CI can't run it. Suggested nightly at `--pace 7000` (the edge rate-limits non-browser clients, so a full sweep is minutes, not seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116Jc7Z7ZzYmAhCPKQNLJpC
