### PR TITLE
feat(review): translation-check — do readers of the original find our translations any good? (#2107)

### DIFF
--- a/scripts/maintenance/build-page-check-candidates.mjs
+++ b/scripts/maintenance/build-page-check-candidates.mjs
@@ -26,6 +26,7 @@ const QUEUE = 'page-check';
 const SITE = 'https://sourcelibrary.org';
 const args = process.argv.slice(2);
 const APPLY = args.includes('--apply');
+const argOf = (n, d) => args.find(a => a.startsWith(`--${n}=`))?.split('=')[1] ?? d;
 const fileIdx = args.indexOf('--file');
 const FILE = fileIdx >= 0 ? args[fileIdx + 1] : null;
 const named = args.find(a => !a.startsWith('--') && a !== FILE);
@@ -165,6 +166,104 @@ const CAMPAIGNS = {
           'If you read Greek, the useful extra is what the word should say. And please ' +
           'note whether the rest of the book does the same thing, or only this page.',
       }),
+  },
+
+  /**
+   * The one task no machine can do for us.
+   *
+   * Everything else in this file is a defect a script could in principle find:
+   * a marker in the text, a script that does not match the folio. Translation
+   * FIDELITY is different in kind. Asking a model whether a translation is
+   * faithful, when the same model family produced the transcription AND the
+   * translation, measures agreement with itself — it is circular, and it is
+   * exactly how 529 Tibetan books came to carry invented scripture that read
+   * fluently all the way through. A person who reads Latin is not replaceable
+   * here by a better prompt.
+   *
+   * SAMPLING. Stratified RANDOM within a language, never self-selected. This is
+   * the "panel" lane of .claude/docs/community-quality-review-design.md and its
+   * whole purpose is a number that generalises: "how good is our Latin on the
+   * books enthusiasts happen to like" is not a corpus statistic. Volunteers who
+   * want to pick their own text are welcome to — through the feedback widget on
+   * any page — but those answers belong to the other lane and must not be mixed
+   * into this pool.
+   *
+   * WHY ~35 PAGES PER LANGUAGE. Every corpus-wide quality claim we publish
+   * currently rests on 32 human-verified anchor pages, and the calibration
+   * scorecard refuses to fit a stratum below five. About 35 judgments buys ±10%
+   * for a language at 95% confidence; ~140 buys ±5%. Say the small number out
+   * loud — everyone assumes this work is unbounded, and it is the boundedness
+   * that makes people start.
+   *
+   *   node scripts/maintenance/build-page-check-candidates.mjs translations \
+   *     --language=Latin --n=40 [--apply]
+   */
+  translations: {
+    describe: 'Spot-check a translation against its original (--language=, --n=)',
+    async build() {
+      const language = argOf('language', 'Latin');
+      const n = parseInt(argOf('n', '40'), 10);
+      if (!process.env.MONGODB_URI) {
+        console.error('MONGODB_URI required to build this campaign');
+        process.exit(1);
+      }
+      const client = new MongoClient(process.env.MONGODB_URI);
+      await client.connect();
+      const db = client.db('bookstore');
+
+      // `language` is the EDITION's language — the script actually on the page,
+      // which is what a reader will be comparing against. See
+      // .claude/docs/invariants/language-fields.md.
+      const books = await db.collection('books')
+        .find(
+          { language, visible: true, pages_count: { $gt: 0 }, pages_ocr: { $gt: 0 } },
+          { projection: { id: 1, title: 1, slug: 1, published: 1, author: 1 } },
+        )
+        .limit(600)
+        .toArray();
+      console.warn(`  ${books.length} live ${language} books with transcription`);
+
+      const rows = [];
+      const shuffled = books.sort(() => Math.random() - 0.5);
+      for (const b of shuffled) {
+        if (rows.length >= n) break;
+        const bookId = b.id ?? String(b._id);
+        // One page per book: pages within a book are one observation, not many
+        // (memory: lesson_sample_one_page_per_book). A book that reads well on
+        // page 40 tells you little extra about page 41.
+        const [page] = await db.collection('pages')
+          .aggregate([
+            {
+              $match: {
+                book_id: bookId,
+                'ocr.data': { $type: 'string', $ne: '' },
+                'translation.data': { $type: 'string', $ne: '' },
+              },
+            },
+            { $sample: { size: 1 } },
+            { $project: { page_number: 1 } },
+          ])
+          .toArray();
+        if (!page) continue;
+        rows.push({
+          item_id: `trans:${language}:${page._id}`,
+          url: `${SITE}/book/${b.slug ?? bookId}/page/${page._id}`,
+          label: 'the page',
+          campaign: `Translation spot-check — ${language}`,
+          prompt:
+            `You read ${language}. This page shows the original beside our English. ` +
+            'Does the English say what the original says? We are not asking whether it ' +
+            'reads nicely — we are asking whether it is TRUE to the page: dropped ' +
+            'clauses, invented sentences, a negation lost, a name or number changed. ' +
+            'If it is sound, say so and press "looks right" — knowing which pages are ' +
+            'fine is exactly as valuable to us as knowing which are wrong. If something ' +
+            'is off, quote the phrase and what it should say.' +
+            (b.title ? `\n\nThis is “${b.title}”${b.published ? `, ${b.published}` : ''}.` : ''),
+        });
+      }
+      await client.close();
+      return rows;
+    },
   },
 };
 

--- a/scripts/maintenance/build-page-check-candidates.mjs
+++ b/scripts/maintenance/build-page-check-candidates.mjs
@@ -246,18 +246,17 @@ const CAMPAIGNS = {
           .toArray();
         if (!page) continue;
         rows.push({
+          queue: 'translation-check',
           item_id: `trans:${language}:${page._id}`,
           url: `${SITE}/book/${b.slug ?? bookId}/page/${page._id}`,
           label: 'the page',
-          campaign: `Translation spot-check — ${language}`,
+          language,
+          campaign: `Translation check — ${language}`,
           prompt:
-            `You read ${language}. This page shows the original beside our English. ` +
-            'Does the English say what the original says? We are not asking whether it ' +
-            'reads nicely — we are asking whether it is TRUE to the page: dropped ' +
-            'clauses, invented sentences, a negation lost, a name or number changed. ' +
-            'If it is sound, say so and press "looks right" — knowing which pages are ' +
-            'fine is exactly as valuable to us as knowing which are wrong. If something ' +
-            'is off, quote the phrase and what it should say.' +
+            `You read ${language}. This page shows the scan, our transcription of it, ` +
+            'and our English. Two separate questions, in this order: does the ' +
+            'transcription match what is actually on the page, and does the English ' +
+            'match the original?' +
             (b.title ? `\n\nThis is “${b.title}”${b.published ? `, ${b.published}` : ''}.` : ''),
         });
       }
@@ -305,18 +304,27 @@ const client = new MongoClient(process.env.MONGODB_URI);
 await client.connect();
 const col = client.db('bookstore').collection('review_candidates');
 let inserted = 0, updated = 0;
+const queuesTouched = new Set();
 for (const r of rows) {
+  // A campaign may target a queue other than page-check — `translations` goes to
+  // `translation-check`, whose verdicts separate the transcription layer from
+  // the translation layer. Default stays page-check so every existing campaign
+  // and every --file run behaves exactly as before.
+  const queue = r.queue ?? QUEUE;
+  queuesTouched.add(queue);
   // (queue, item_id) is uniquely indexed — re-running must refresh the prompt,
   // not duplicate the task or throw.
   const res = await col.updateOne(
-    { queue: QUEUE, item_id: r.item_id },
+    { queue, item_id: r.item_id },
     {
-      $set: { payload: r, stratum: { campaign: r.campaign } },
-      $setOnInsert: { queue: QUEUE, item_id: r.item_id, is_gold: false, created_at: new Date() },
+      $set: { payload: r, stratum: { campaign: r.campaign, language: r.language } },
+      $setOnInsert: { queue, item_id: r.item_id, is_gold: false, created_at: new Date() },
     },
     { upsert: true },
   );
   if (res.upsertedCount) inserted++; else if (res.modifiedCount) updated++;
 }
-console.log(`\ninserted ${inserted}, updated ${updated}, pool now ${await col.countDocuments({ queue: QUEUE })}`);
+for (const q of queuesTouched) {
+  console.log(`\ninserted ${inserted}, updated ${updated}, ${q} pool now ${await col.countDocuments({ queue: q })}`);
+}
 await client.close();

--- a/src/app/api/review/translation-check/next/route.ts
+++ b/src/app/api/review/translation-check/next/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { nextCandidate } from '@/lib/review-candidates';
+
+export const maxDuration = 15;
+
+/**
+ * GET /api/review/translation-check/next?volunteer_id=<uuid>
+ *
+ * One page for a reader of the original language to judge. Same generic pool as
+ * page-check, different queue and a different set of verdicts: this one asks
+ * about the transcription and the translation SEPARATELY, because a faithful
+ * English rendering of an invented Latin line is not a good translation, and a
+ * single verdict cannot tell those apart.
+ *
+ * Pool: scripts/maintenance/build-page-check-candidates.mjs translations
+ *       --language=Latin --n=40 --apply
+ */
+export async function GET(request: NextRequest) {
+  const volunteerId = request.nextUrl.searchParams.get('volunteer_id');
+  if (!volunteerId) {
+    return NextResponse.json({ error: 'volunteer_id required' }, { status: 400 });
+  }
+
+  const result = await nextCandidate('translation-check', volunteerId);
+  if (!result.item) {
+    return NextResponse.json({ item: null, message: result.message });
+  }
+
+  const p = (result.item.payload ?? {}) as {
+    url?: string;
+    prompt?: string;
+    label?: string;
+    campaign?: string;
+    language?: string;
+  };
+
+  return NextResponse.json({
+    item: {
+      item_id: result.item.item_id,
+      url: p.url ?? '',
+      prompt: p.prompt ?? '',
+      label: p.label ?? 'the page',
+      campaign: p.campaign ?? '',
+      language: p.language ?? '',
+    },
+  });
+}

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -9,6 +9,17 @@ export const metadata: Metadata = {
 
 const QUEUES = [
   {
+    slug: 'translation-check',
+    title: 'Translation check',
+    blurb:
+      'Do you read Latin, Greek or Arabic? Almost every translation here was made by a machine ' +
+      'and almost none has been read by someone who knows the language. Tell us whether our ' +
+      'English says what the original says — and whether we transcribed the page correctly ' +
+      'in the first place.',
+    status: 'live',
+    timePerItem: '~5 minutes',
+  },
+  {
     slug: 'page-check',
     title: 'Page check',
     blurb:

--- a/src/app/review/translation-check/page.tsx
+++ b/src/app/review/translation-check/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import TranslationCheckReview from '@/components/review/TranslationCheckReview';
+
+export const metadata: Metadata = {
+  title: 'Translation check — Source Library',
+  description:
+    'Read the original? Tell us whether our English says what it says — and whether our transcription got the page right in the first place.',
+};
+
+export default function TranslationCheckPage() {
+  return <TranslationCheckReview />;
+}

--- a/src/components/review/TranslationCheckReview.tsx
+++ b/src/components/review/TranslationCheckReview.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useReviewQueue } from './useReviewQueue';
+import { QueueShell } from './QueueShell';
+
+/**
+ * Translation fidelity, judged by someone who reads the original.
+ *
+ * Modelled on PageCheckReview: the thing being judged is a whole reader page —
+ * scan, transcription and English together — so the volunteer opens it, reads
+ * it properly, and comes back. Rendering an excerpt here would be worse than
+ * useless, because judging a translation means seeing the original beside it at
+ * full size, and the scan beside both.
+ *
+ * The two-layer question is the point (see QUEUE_RATINGS['translation-check']).
+ * The instructions say it in the order the layers actually fail: check the
+ * transcription against the scan FIRST, because if that is wrong the English
+ * cannot be judged at all and the honest verdict is "transcription wrong"
+ * rather than "bad translation".
+ */
+type Item = {
+  item_id: string;
+  url: string;
+  prompt: string;
+  label: string;
+  campaign: string;
+  language: string;
+};
+
+export default function TranslationCheckReview() {
+  const q = useReviewQueue<Item>({
+    queue: 'translation-check',
+    fetchUrl: '/api/review/translation-check/next',
+    itemToDetail: it => ({ url: it.url, campaign: it.campaign, language: it.language }),
+  });
+
+  const body = q.item ? (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {q.item.campaign && (
+        <div className="text-xs uppercase tracking-wider text-stone-500">{q.item.campaign}</div>
+      )}
+
+      <div className="bg-white border border-stone-200 rounded-lg p-6 space-y-4">
+        <p
+          className="text-xl leading-snug text-stone-900"
+          style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+        >
+          {q.item.prompt}
+        </p>
+
+        <a
+          href={q.item.url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-block px-4 py-2 rounded-md bg-accent-rust text-white text-sm font-medium hover:opacity-90"
+        >
+          Open the page &rarr;
+        </a>
+
+        <div className="text-xs text-stone-500 break-all">{q.item.url}</div>
+      </div>
+
+      <ol className="text-sm text-stone-600 space-y-2 list-decimal pl-5">
+        <li>
+          <b>Look at the scan first.</b> Does our transcription actually say what is printed or
+          written on the page?
+        </li>
+        <li>
+          <b>Then the English.</b> Does it say what the original says — no dropped clauses, no
+          invented sentences, no lost negation, no changed name or number?
+        </li>
+        <li>
+          If the transcription is wrong, the English cannot be judged: choose{' '}
+          <i>transcription wrong</i> rather than blaming the translation for it.
+        </li>
+      </ol>
+
+      <p className="text-xs text-stone-500">
+        Telling us a page is <i>sound</i> is worth exactly as much as telling us it is broken.
+        Without it we only ever hear about failures and never learn how much of the library has
+        been checked at all.
+      </p>
+    </div>
+  ) : null;
+
+  return (
+    <QueueShell
+      queueTitle={q.item?.language ? `Translation check — ${q.item.language}` : 'Translation check'}
+      question="Does our English say what the original says?"
+      ratings={q.ratings}
+      sessionCount={q.sessionCount}
+      loading={q.loading}
+      error={q.error}
+      onRate={q.submit}
+      onSkip={q.skipItem}
+      onRetry={() => q.fetchNext(q.volunteerId)}
+      body={body}
+      submitting={q.submitting}
+      canSubmit={q.canSubmit}
+      authStatus={q.authStatus}
+      note={q.note}
+      notePlaceholder="e.g. line 4 renders 'nisi' as 'if' — it should be 'unless', which reverses the sense"
+      onNoteChange={q.setNote}
+      onNoteSubmit={q.submitNote}
+      noteSaved={q.noteSaved}
+    />
+  );
+}

--- a/src/lib/review-queue.ts
+++ b/src/lib/review-queue.ts
@@ -62,6 +62,24 @@ export const QUEUE_RATINGS: Record<string, RatingOption[]> = {
     { key: 'j', rating: 'problem', label: '\u2717 found something', color: '#ef4444', hint: 'Something is off \u2014 please say what in the box' },
     { key: 'u', rating: 'unclear', label: '? unclear', color: '#6b7280', hint: "Couldn't tell, or the page wouldn't load" },
   ],
+  // Translation fidelity, judged by someone who reads the original language.
+  //
+  // THE VERDICTS SEPARATE TWO LAYERS ON PURPOSE. A page has to pass through
+  // transcription before it can be translated, and the two fail differently:
+  // where the OCR invented the original, the English can be perfectly faithful
+  // TO THAT INVENTION and still tell the reader something the book never said.
+  // One "is this translation any good?" button would fold those together and
+  // the resulting number would be uninterpretable — we could not tell a
+  // translation problem from an OCR problem, and they have different fixes.
+  // This is the failure that produced 529 books of invented Tibetan scripture
+  // (#4523): the translation layer did its job faithfully on a fabricated text.
+  'translation-check': [
+    { key: 'k', rating: 'both_sound',        label: '✓ both sound',           color: '#10b981', hint: 'The transcription matches the page, and the English matches the original' },
+    { key: 'j', rating: 'translation_drift', label: '✗ translation drifts',   color: '#ef4444', hint: 'The transcription is right, but the English departs from it' },
+    { key: 'x', rating: 'transcription_off', label: '✗ transcription wrong',  color: '#f59e0b', hint: "The text doesn't match the page — so the English can't be judged" },
+    { key: 'b', rating: 'both_off',          label: '✗✗ both wrong',          color: '#b91c1c', hint: 'Neither the transcription nor the English can be trusted here' },
+    { key: 'u', rating: 'unclear',           label: '? unclear',              color: '#6b7280', hint: "Can't tell — say why in the box if you can" },
+  ],
   // Wikipedia contribution events. Not a rating queue — used as an event log
   // for the /contribute/wikipedia playbook (claim → post → response → merged).
   // No keyboard shortcuts; events come from explicit button clicks.
@@ -100,7 +118,7 @@ export function getRatingOptions(queue: string): RatingOption[] {
   return QUEUE_RATINGS[queue] ?? [];
 }
 
-export const QUEUE_KEYS = ['hallucination', 'gallery-quality', 'scan-quality', 'spanish-copy', 'page-check', 'wikipedia'] as const;
+export const QUEUE_KEYS = ['hallucination', 'gallery-quality', 'scan-quality', 'spanish-copy', 'page-check', 'translation-check', 'wikipedia'] as const;
 export type QueueKey = (typeof QUEUE_KEYS)[number];
 
 // Wikipedia event ordering: defines what's a "later" status. Used to roll up


### PR DESCRIPTION
**The question a reader actually wants answered: do people who read the original languages think our translations are any good?** We cannot answer that today. This builds the instrument that can.

120 pages queued — 40 each in Latin, Greek and Arabic — in a new `translation-check` queue.

## The verdicts separate two layers, deliberately

Folding this into one "is the translation good?" button would produce a number nobody could interpret. A page passes through transcription before it is translated, and the layers fail differently: **where the OCR invented the original, the English can be perfectly faithful to that invention** and still tell the reader something the book never said. That is not a translation defect and it has no translation fix.

It is also not hypothetical. It is exactly what produced 529 books of invented Tibetan scripture (#4523) — the translation layer did its job faithfully on a fabricated text.

| verdict | meaning |
|---|---|
| **✓ both sound** | transcription matches the page, English matches the original |
| **✗ translation drifts** | transcription is right, the English departs from it |
| **✗ transcription wrong** | the text doesn't match the page — the English can't be judged |
| **✗✗ both wrong** | neither can be trusted here |
| **? unclear** | can't tell |

The instructions put the questions in the order the layers actually fail: **check the transcription against the scan first**, because if that is wrong the honest answer is "transcription wrong" rather than blaming the translation for it.

This split is what makes the eventual result publishable. *"94% of sampled Latin pages read faithfully"* means nothing if OCR failures are folded into the same bucket.

## Why a person, not a model

Asking a model whether a translation is faithful — when the same model family produced both the transcription and the translation — measures agreement with itself.

I tested the boundary rather than asserting it. I took four pages the `ocr-script-fidelity` screen flagged as Devanagari-on-Tibetan and looked at the folios: **4/4 confirmed in about two minutes**, and the fourth turned out to be clean *printed* uchen with a Chinese editor's header that our OCR called handwritten Nepalese Prachalit Sanskrit (written up on #4523). So script checking is a vision pass and needs no volunteer. Translation fidelity is the one that genuinely needs a person who knows the language.

## Sampling

- **Stratified random within a language, never self-selected.** "How good is our Latin on books enthusiasts happen to like" is not a corpus statistic. Self-chosen review is still welcome via the feedback widget — it belongs to the improvement lane, not this pool.
- **One page per book** — pages within a book are one observation.
- **~35 pages per language** buys ±10% at 95% confidence. Every corpus-wide quality claim we publish today rests on **32 anchor pages**; Tibetan and Chinese have **zero**.
- `stratum.language` is recorded, so the sample reads per language.

## Also here

- `/review/translation-check` and its route, modelled on page-check — the thing judged is a whole reader page (scan + transcription + English), so the volunteer opens it rather than reading an excerpt in the queue.
- Listed **first** on `/review`, with the ask stated plainly.
- The builder can now target a queue per campaign; **page-check stays the default**, so every existing campaign and every `--file` run is unchanged.
- The 120 rows queued earlier under `page-check` were removed — after verifying zero ratings against them — and re-queued here.

Matches what volunteers actually offered: of 780 who wrote about themselves, 106 mentioned translation, 15 Latin, 9 Greek.

## Still missing

Nothing yet reads these verdicts. A per-language rollup — *checked N, sound N%* — is the piece that turns this into the public answer, and it is deliberately not in this PR.

Refs #2107, #4523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
