### PR TITLE
fix(archive): the archiver was blocked, not slow — and one blocked host stalled all of it (#4588)

### DIFF
--- a/.claude/docs/invariants/archive-fetch-failures.md
+++ b/.claude/docs/invariants/archive-fetch-failures.md
@@ -53,3 +53,76 @@ the direction that looks like success*.
   long-running script reads as a hang (two full scans were killed before
   emitting a line). The fix is a heartbeat, not an index: indexing
   `archived_photo` would add ~1.5 GB to a hot collection to serve a rare sweep.
+
+---
+
+## A fast failure is the expensive one (2026-09-04, #4588)
+
+Three rounds of diagnosis went into "the archiver completes ~0 books per run:
+0.08 pages/s, ~58% page failures, 12,433 books parked at `archiving`", and the
+first two were wrong. The measurements that settled it took four minutes. What
+they found:
+
+| host | what it answered | verdict |
+|---|---|---|
+| `iiif.archive.org` | **400 "Invalid size" in 0.2s**, some 504 after 60s | our URL is invalid; it can never work |
+| `gallica.bnf.fr` | **429 in 0.08s, to every request** | serves 200s in ~1s when the archiver is idle |
+| `api.digitale-sammlungen.de` | **200 in 0.3s, 8 of 8** | perfectly healthy |
+
+Three different failures, one number. And **60% of the parked backlog was on the
+healthy host** (bsb 4,623 + mdz 2,936 books) — it was starved behind the other
+two, not slow.
+
+### The rules that follow
+
+- **The IIIF size keyword belongs to the API VERSION, not the host.** Image API
+  3.0 removed `full`; the v3 spelling is `max`, and a v3 service answers
+  `/full/full/` with `400 Bad Request — Invalid size`. 223,328 unarchived pages
+  sat on `iiif.archive.org/image/iiif/3/`, and the corpus held *both* spellings
+  against the same host — so the endpoint read as intermittently flaky rather
+  than as systematically misaddressed. `upgradeToFullRes` now keys on `/iiif/3/`
+  in the path. Counter-example that keeps the rule honest: `dl.ndl.go.jp` is
+  excluded, because it 500s on `max` and wants `full`.
+- **A 400 and a timeout are not the same fact, and a run that records neither
+  is not measuring anything.** `noteFailure` counted only 401/403/429 and
+  dropped every other error, so the log said `617 failed` for a week without
+  once naming a status. Archivers now print a per-host table of ok/fail/status
+  every run. This is the general rule in `measurement-instruments.md`, and the
+  cost of not having it here was three wrong diagnoses.
+- **A cumulative average cannot report a cliff.** The heartbeat's `pages/s` was
+  computed over the whole run, so a collapse from 53 pages/min to 5 rendered as
+  a smooth drift from 0.86 to 0.15 — which reads as gradual decay. Rate
+  counters on a long run must be windowed.
+- **A rate that does not vary with the counterparty is a fact about US.** The
+  flat 0.08 pages/s across different hosts was the tell that the limiter was
+  innocent; a per-host rate limiter cannot produce a number that ignores which
+  host it is talking to.
+
+### The scheduling rule, which is the actual fix
+
+**A barrier turns one blocked source into a global stall.** Both loops in
+`archive-acquired.ts` were `for (i += N) { await Promise.all(slice) }`. A slice
+does not advance until its slowest member finishes, and the members that
+finished early sit idle — so a slice holding one book on a refusing host runs at
+that book's speed with most of its capacity parked. Measured: a run archived 53
+pages/min for four minutes, completed its one healthy book at minute 5, then
+held seven of eight slots for 45 minutes on books that could not fetch a single
+page. **Use a worker pool with a shared cursor, never a sliced `Promise.all`,
+for any sweep whose items have wildly unequal cost** — and pair it with a
+per-host circuit breaker (`scripts/lib/host-breaker.mjs`), or the pool refills
+its freed slots and hands them straight back to the host that emptied them.
+
+Corollary, and the reason the breaker is half-open: **a breaker that never
+re-tests is the same half-a-control-loop mistake as a backoff with no recovery**
+(#4396 → #4559). It just fails in the safe direction, so nobody notices. Writing
+the recovery test found that a failed probe left the original trip timestamp in
+place, which turned the breaker back into no breaker after one cooldown.
+
+### And the write that would have become destructive
+
+A book that archived **zero** pages was marked `archived: true` and dropped from
+the queue for good, with the truth demoted to a note (`partial:0/424`) that
+nothing reads. That line had been unreachable only because the run was always
+killed at the 50-minute ceiling first. **Fixing a throughput bug makes the code
+after it reachable — audit that code in the same PR**, or the fix ships the
+latent one.

--- a/.claude/docs/pipeline.md
+++ b/.claude/docs/pipeline.md
@@ -207,7 +207,7 @@ The Hetzner `pipeline-orchestrator.mjs` (~2,900 lines) runs all phases. Individu
 | Phase | Transition | Notes |
 |-------|-----------|-------|
 | Phase 0: Auto-enroll | new → `queued` | Books imported within 14 days without `pipeline_auto`. |
-| Phase 1: Archive check | `queued` → `archiving` → `archive_complete` | DB checks only; Hetzner copies images to Cloudflare R2. 24h timeout — advances anyway since OCR works on original IIIF URLs. |
+| Phase 1: Archive check | `queued` → `archiving` → `archive_complete` | DB checks only; Hetzner copies images to Cloudflare R2. **There is NO timeout — a book advances only when every page is covered.** |
 | Phase 1.25: BPH split | `archive_complete` (BPH only) | Detects two-page spreads, crops into left/right pages. |
 | Phase 1.5: Preview OCR | `archive_complete` → (no status change) | First 25 pages sent to Lambda via SQS for fast preview. Triggers preview translation on completion. |
 | Phase 2: Submit OCR | `archive_complete` → `ocr_submitted` | Gemini Batch API (Hetzner direct). See "OCR Routing" below. |

--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -27,15 +27,46 @@ import {
 } from '../lib/iiif-utils.mjs';
 import { createHostBreaker, classifyFetchError } from '../lib/host-breaker.mjs';
 const execFileP = promisify(execFile);
-const CONCURRENCY = parseInt(process.argv[process.argv.indexOf('--concurrency') + 1] || '6');
+/**
+ * Read `--name <int>`, falling back to `dflt` when it is absent or unusable.
+ *
+ * The idiom this replaces — `parseInt(argv[argv.indexOf('--x') + 1] || 'N')` —
+ * is wrong when the flag is ABSENT: `indexOf` returns -1, so it reads
+ * `argv[0]`, which is the node binary path, and `parseInt('/usr/bin/node')` is
+ * NaN. The `|| 'N'` default never fires because `argv[0]` is a non-empty
+ * string.
+ *
+ * Measured 2026-09-04, and the reason this helper exists: run without
+ * `--page-concurrency`, PAGE_CONCURRENCY was NaN, `Array.from({length: NaN})`
+ * produced ZERO page workers, and the archiver processed 24 books in one second
+ * fetching nothing — while reporting `complete 2, partial 22`. It failed
+ * silently in the direction that looks like success, which is this file's
+ * signature failure mode.
+ */
+const intArg = (name: string, dflt: number): number => {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i < 0) return dflt;
+  const v = parseInt(process.argv[i + 1] ?? '', 10);
+  return Number.isInteger(v) && v > 0 ? v : dflt;
+};
+
+const CONCURRENCY = intArg('concurrency', 6);
 // Pages in flight per book. Unchanged from the chunk width it replaces —
 // CONCURRENCY × PAGE_CONCURRENCY is the memory budget, and PR #4527 measured
 // that budget against `opj_decompress` (~1.0 GB per JP2 decode, 687 OOM events,
 // one of which killed cron.service itself). This PR is about scheduling, not
 // about buying throughput with memory, so the width stays where it was.
-const PAGE_CONCURRENCY = parseInt(process.argv[process.argv.indexOf('--page-concurrency') + 1] || '6');
+const PAGE_CONCURRENCY = intArg('page-concurrency', 6);
+const BATCH = intArg('batch', 60);
 
-const BATCH = parseInt(process.argv[process.argv.indexOf('--batch') + 1] || '60');
+// A pool width is load-bearing: at 0 or NaN this script archives nothing and
+// says it succeeded. Fail at startup instead — a constructor that throws beats
+// a comment asking the next person to be careful.
+for (const [flag, v] of [['concurrency', CONCURRENCY], ['page-concurrency', PAGE_CONCURRENCY], ['batch', BATCH]] as const) {
+  if (!Number.isInteger(v) || v < 1) {
+    throw new Error(`--${flag} resolved to ${v}. A width of ${v} archives nothing while reporting success; refusing to start.`);
+  }
+}
 const log = (...a: any[]) => console.log(new Date().toISOString().slice(11, 19), ...a);
 
 async function main() {
@@ -364,19 +395,46 @@ async function main() {
       }
     }
   };
+  // ── The summary must survive the kill ────────────────────────────────────
+  //
+  // The cron wrapper ALWAYS ends this run with SIGTERM at its 50-minute
+  // ceiling — that is its designed behaviour, not an error path. So until now
+  // the final summary and the per-host table were printed only on the rare run
+  // that finished its whole batch, which in practice meant never: the very
+  // instrument this PR adds would have been unreachable in production. Print it
+  // on the way out instead.
+  //
+  // Deliberately does no I/O: a handler that awaits a Mongo count during
+  // shutdown is a handler that races the 60s SIGKILL and prints nothing.
+  const printSummary = (reason: string) => {
+    const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
+    const runMins = (Date.now() - runStart) / 60000;
+    const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
+    log(`archive-acquired (${reason}): complete ${ok}, partial ${partial}, stalled ${stalled} | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed, ${pagesSkipped} skipped${localFailures ? `, ${localFailures} local (store/encode)` : ''} in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s)${throttled ? ` | throttled ${throttled}` : ''}`);
+    // Per-host triage. A failure count without the source's own answer beside
+    // it is not a measurement — it is what made #4588 take three rounds of
+    // diagnosis to reach a cause this table states outright.
+    if (breaker.size()) log(`per-host outcomes this run:\n${breaker.report()}`);
+  };
+  let signalled = false;
+  for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(sig, () => {
+      if (signalled) return;   // a second signal must not interleave two reports
+      signalled = true;
+      clearInterval(hb);
+      log(`${sig} received — stopping. In-flight pages are abandoned; the next run resumes from the pages that still lack archived_photo.`);
+      printSummary(`stopped by ${sig}`);
+      process.exit(143);
+    });
+  }
+
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, todo.length) }, () => bookWorker()));
   clearInterval(hb);
   const remaining = PROVIDER
     ? await books.countDocuments({ 'image_source.provider': PROVIDER, pages_count: { $gt: 0 }, archive_status: { $ne: 'archive_complete' } })
     : await queue.countDocuments({ status: 'acquired', archived: { $ne: true } });
-  const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
-  const runMins = (Date.now() - runStart) / 60000;
-  const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
-  log(`archive-acquired: complete ${ok}, partial ${partial}, stalled ${stalled} | pages ${pagesDone} ok, ${pagesFailed} failed, ${pagesSkipped} skipped${localFailures ? `, ${localFailures} local (store/encode)` : ''} in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s) | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
-  // Per-host triage, printed every run. A failure count without the source's
-  // own answer next to it is not a measurement — it is what made #4588 take
-  // three wrong diagnoses to reach a cause that this table states outright.
-  if (breaker.size()) log(`per-host outcomes this run:\n${breaker.report()}`);
+  printSummary('finished');
+  log(`un-archived acquired remaining ${remaining}`);
   if (blocked) {
     // Exit non-zero so a wrapper loop stops instead of re-running into the block.
     log(`ABORTED — SOURCE BLOCKED: ${(blocked as Error).message}`);

--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -25,8 +25,15 @@ import {
   upgradeToFullRes, rateLimitedFetch,
   fetchIiifInfo, fetchIiifNativeRes, shouldTileStitch, SILENT_CAP_HOSTS,
 } from '../lib/iiif-utils.mjs';
+import { createHostBreaker, classifyFetchError } from '../lib/host-breaker.mjs';
 const execFileP = promisify(execFile);
 const CONCURRENCY = parseInt(process.argv[process.argv.indexOf('--concurrency') + 1] || '6');
+// Pages in flight per book. Unchanged from the chunk width it replaces —
+// CONCURRENCY × PAGE_CONCURRENCY is the memory budget, and PR #4527 measured
+// that budget against `opj_decompress` (~1.0 GB per JP2 decode, 687 OOM events,
+// one of which killed cron.service itself). This PR is about scheduling, not
+// about buying throughput with memory, so the width stays where it was.
+const PAGE_CONCURRENCY = parseInt(process.argv[process.argv.indexOf('--page-concurrency') + 1] || '6');
 
 const BATCH = parseInt(process.argv[process.argv.indexOf('--batch') + 1] || '60');
 const log = (...a: any[]) => console.log(new Date().toISOString().slice(11, 19), ...a);
@@ -57,10 +64,28 @@ async function main() {
   const hostThrottles = new Map<string, number>();
   const FAIL_ABORT = 25;
   class HostBlocked extends Error {}
+
+  // ── Per-host outcome ledger + circuit breaker ────────────────────────────
+  //
+  // Until now a page failure was recorded only if it carried 401, 403 or 429;
+  // every other error was dropped on the floor. So the log could report "617
+  // failed" and say nothing whatever about why, and #4588 spent three rounds of
+  // diagnosis guessing at a cause that a status histogram would have handed
+  // over in one line. Measured on the box 2026-09-04 the answer was three
+  // different things at once — iiif.archive.org 400 "Invalid size", gallica 429
+  // on every request, MDZ 100% healthy at 0.3s — and the run's own instrument
+  // could not tell them apart.
+  //
+  // The breaker itself lives in scripts/lib/host-breaker.mjs, lifted from
+  // archive-ocr.mjs rather than re-invented here; see that file's header for
+  // the rules and why a fourth hand-rolled copy was the wrong move.
+  const breaker = createHostBreaker({ log: (m: string) => log(m) });
+  const hostOf = (url: string) => { try { return new URL(url).hostname; } catch { return 'unknown'; } };
+
   const noteFailure = (url: string, err: unknown) => {
-    let host = 'unknown';
-    try { host = new URL(url).hostname; } catch { /* keep 'unknown' */ }
+    const host = hostOf(url);
     const msg = String((err as Error)?.message ?? err);
+    breaker.failure(host, classifyFetchError(err));
     if (/\b429\b/.test(msg)) {
       // Throttling is not a block. Count it for visibility only — the backoff
       // itself already happened inside rateLimitedFetch.
@@ -88,27 +113,64 @@ async function main() {
   // index (invariants/archive-fetch-failures.md). Counters are PAGE-grain
   // because book-grain moves too slowly to separate "working" from "stuck": a
   // 250-page book is minutes of apparent silence on its own.
+  //
+  // The rate shown is now the rate over the LAST MINUTE, not since the run
+  // started. A cumulative average cannot report a stall: on 2026-09-04 the
+  // archiver did 53 pages in minute 4 and 5 pages in every minute after, and
+  // the heartbeat drifted smoothly from 0.86 to 0.15 pages/s — a shape that
+  // reads as gradual decay when it was in fact a cliff. `since` is what the
+  // archiver is doing now; the run summary still reports the whole-run figure.
   const runStart = Date.now();
   let pagesDone = 0;
   let pagesFailed = 0;
+  let pagesSkipped = 0;
+  let localFailures = 0;   // failed AFTER the bytes arrived: sharp, R2 or Mongo, never the source
   let booksDone = 0;
   let workTotal = 0;
   let currentHost = '-';
+  let lastTick = Date.now();
+  let lastPages = 0;
   const hb = setInterval(() => {
     const mins = (Date.now() - runStart) / 60000;
-    const rate = mins > 0 ? pagesDone / (mins * 60) : 0;
+    const now = Date.now();
+    const since = (now - lastTick) / 1000;
+    const recent = since > 0 ? (pagesDone - lastPages) / since : 0;
+    lastTick = now; lastPages = pagesDone;
     const thr = [...hostThrottles.entries()].map(([h, n]) => `${h.split('.')[0]}:${n}`).join(' ');
-    log(`heartbeat ${mins.toFixed(1)}m | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed | ${rate.toFixed(2)} pages/s | host ${currentHost}${thr ? ` | throttled ${thr}` : ''}`);
+    const paused = breaker.openHosts().map(h => h.split('.')[0]).join(' ');
+    log(`heartbeat ${mins.toFixed(1)}m | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed${pagesSkipped ? `, ${pagesSkipped} skipped` : ''} | ${recent.toFixed(2)} pages/s now | host ${currentHost}${thr ? ` | throttled ${thr}` : ''}${paused ? ` | PAUSED ${paused}` : ''}`);
   }, 60_000);
   // Never let the heartbeat hold the process open past the work.
   if (typeof hb.unref === 'function') hb.unref();
 
   async function archiveIiif(bookId: string) {
     const ps = await pages.find({ book_id: bookId, archived_photo: { $exists: false }, $or: [{ photo: /^https?:/ }, { photo_original: /^https?:/ }] }, { projection: { _id: 1, page_number: 1, photo: 1, photo_original: 1 } }).toArray();
-    for (let i = 0; i < ps.length; i += 6) {
-      await Promise.all(ps.slice(i, i + 6).map(async (p: any) => {
+    // Pages ran in chunks of 6 behind `await Promise.all(chunk)`. That barrier
+    // paces the whole chunk at its slowest member, and the slowest member of a
+    // chunk is routinely a page burning 4 attempts × 30s of timeout — so five
+    // healthy pages waited two minutes on one doomed one. A pool of the same
+    // width keeps 6 requests genuinely in flight instead.
+    let next = 0;
+    let pageBlocked: Error | null = null;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        if (pageBlocked) return;
+        const p: any = ps[next++];
+        if (!p) return;
         const url = upgradeToFullRes(p.photo_original || p.photo);
-        try { currentHost = new URL(url).hostname; } catch { /* keep previous */ }
+        const host = hostOf(url);
+        currentHost = host;
+        // A paused host is skipped without a request, and cheaply: the point is
+        // to hand this worker back to the pool, not to fail faster.
+        if (!breaker.allow(host)) { breaker.skipped(host); pagesSkipped++; continue; }
+        // Did the bytes arrive? Everything after that point is OUR machinery —
+        // sharp, R2, Mongo — and a failure there says nothing about the source.
+        // Charging an R2 outage to the institution's breaker would pause every
+        // healthy host at once and stall the run for the same reason a bad
+        // `archived_photo` write hides a readable page: an error we did not
+        // attribute became a fact about someone else
+        // (invariants/archive-fetch-failures.md).
+        let fetched = false;
         try {
           // `/full/full/` is a REQUEST, not a guarantee. Seven hosts silently
           // cap the response below native — measured losses up to 8.69x (Kyoto),
@@ -136,6 +198,11 @@ async function main() {
           } else {
             buf = await rateLimitedFetch(url);
           }
+          fetched = true;
+          // The host served us: that is the breaker's whole question, and
+          // settling it here (rather than after the write) is also what releases
+          // a half-open probe slot on every path out of this block.
+          breaker.success(host);
 
           // Archive at source fidelity: no resolution cap (#3897, matches archive-ia-bulk).
           const jpg = await sharp(buf).rotate().jpeg({ quality: 90, mozjpeg: true }).toBuffer();
@@ -162,12 +229,27 @@ async function main() {
           pagesDone++;
           hostFailures.clear(); // a success clears the streak
         } catch (e) {
-          if (e instanceof HostBlocked) throw e;
+          if (e instanceof HostBlocked) { pageBlocked = e; return; }
           pagesFailed++;
-          noteFailure(url, e); // rethrows HostBlocked once the host looks blocked
+          if (!fetched) {
+            try {
+              noteFailure(url, e); // rethrows HostBlocked once the host looks blocked
+            } catch (h) {
+              if (h instanceof HostBlocked) { pageBlocked = h; return; }
+              throw h;
+            }
+          } else {
+            // The source did its part. Count it so the run still reports the
+            // loss, but never against the host — pausing an institution because
+            // our own bucket is down is precisely backwards.
+            localFailures++;
+            if (localFailures <= 5) log(`local failure after a good fetch (${classifyFetchError(e)}): ${String((e as Error)?.message ?? e).slice(0, 140)}`);
+          }
         }
-      }));
-    }
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(PAGE_CONCURRENCY, ps.length) }, () => worker()));
+    if (pageBlocked) throw pageBlocked;
   }
 
   // Work list: acquisition_queue rows by default, or hidden imports of one
@@ -188,9 +270,23 @@ async function main() {
     todo = cand.map((b: any) => ({ sn: null, book_id: b.id, source: 'iiif' }));
     log(`provider mode: ${PROVIDER} — ${todo.length} book(s) not yet archive_complete`);
   } else {
-    todo = await queue.find({ status: 'acquired', book_id: { $exists: true }, archived: { $ne: true } }).limit(BATCH).toArray();
+    // Least-attempted first. The selection had no sort, so it returned the same
+    // head of the queue every hour — and once that head was a set of books on a
+    // host that was refusing us, every run for days re-attempted exactly those
+    // books and never reached the healthy ones behind them. Ordering by attempt
+    // count makes the queue rotate: a book that could not be archived this hour
+    // goes to the back rather than to the front. Rows written before this field
+    // existed sort first (missing < 0 in BSON), which is what we want — an
+    // untried book outranks one we have already failed on.
+    todo = await queue.find({ status: 'acquired', book_id: { $exists: true }, archived: { $ne: true } })
+      .sort({ archive_attempts: 1, _id: 1 })
+      .limit(BATCH).toArray();
   }
-  let ok = 0, partial = 0;
+  let ok = 0, partial = 0, stalled = 0;
+  // How many runs a book may make zero progress on before it is parked out of
+  // the queue. Eight hours of hourly runs is long enough to ride out a source
+  // outage and short enough that a permanently-dead book stops taking a slot.
+  const MAX_ATTEMPTS = 8;
   // Provider-mode rows have no queue row. `{ sn: null }` would MATCH queue docs
   // whose sn is null/missing, so every queue write goes through this guard.
   const markQueue = async (w: any, set: Record<string, unknown>) => {
@@ -214,24 +310,61 @@ async function main() {
       // Record partial progress on the book too, so provider-mode runs are
       // resumable and a later run can see how far it got.
       await books.updateOne({ id: w.book_id }, { $set: { pages_archived: r2, updated_at: new Date() } });
-      await markQueue(w, { archived: true, archive_note: `partial:${r2}/${b.pages_count}` });
+      // A book that archived NOTHING was being marked `archived: true` and
+      // dropped from the queue for good, with the truth demoted to a note
+      // ("partial:0/424") that nothing reads. That is the shape CLAUDE.md's
+      // Data Protection rule names: a write that erases its own repair path.
+      // It was invisible only because the run was killed at the 50-minute
+      // ceiling before it ever reached this line — fixing the throughput above
+      // is precisely what makes it reachable, so it has to be fixed here too.
+      //
+      // A book stays in the queue while it is still making progress, or until
+      // it has been tried MAX_ATTEMPTS times without any. Then it is parked
+      // with a note that SAYS it was parked, so the archiving watchdog and a
+      // human can both find it.
+      const attempts = (w.archive_attempts ?? 0) + 1;
+      const progressed = r2 > have0;
+      if (!progressed && attempts >= MAX_ATTEMPTS) {
+        await markQueue(w, { archived: true, archive_stalled: true, archive_attempts: attempts, archive_note: `stalled:${r2}/${b.pages_count} after ${attempts} attempts` });
+        stalled++;
+      } else {
+        await markQueue(w, { archive_attempts: attempts, archive_note: `partial:${r2}/${b.pages_count}` });
+      }
       partial++;
     }
   }
   let blocked: Error | null = null;
   workTotal = todo.length;
-  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} — heartbeat every 60s`);
-  for (let i = 0; i < todo.length && !blocked; i += CONCURRENCY) {
-    await Promise.all(todo.slice(i, i + CONCURRENCY).map(w => processBook(w)
-      .then(() => { booksDone++; })
-      .catch((e) => {
-        booksDone++;
+  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} × ${PAGE_CONCURRENCY} pages — heartbeat every 60s`);
+  // Books ran in fixed slices of CONCURRENCY behind `await Promise.all(slice)`.
+  // A slice does not advance until its SLOWEST book finishes, and its finished
+  // workers sit idle in the meantime — so a slice containing one book on a
+  // blocked host runs at that book's speed with most of its capacity parked.
+  // Measured 2026-09-04: a run completed its first book at minute 5 and then
+  // held the remaining seven slots on gallica and Internet Archive books that
+  // could not fetch a single page, for 45 more minutes, while 7,559 healthy
+  // MDZ/BSB books waited in the same 240-row batch and were never reached.
+  //
+  // A pool keeps CONCURRENCY books genuinely in flight: a finished book is
+  // replaced immediately by the next one in the queue.
+  let nextBook = 0;
+  const bookWorker = async (): Promise<void> => {
+    while (!blocked) {
+      const w = todo[nextBook++];
+      if (!w) return;
+      try {
+        await processBook(w);
+      } catch (e) {
         // Per-book failures stay swallowed (one bad book must not stop a sweep),
         // but a blocked HOST is a verdict about the source: stop the whole run
         // and say so, rather than grinding out thousands of doomed requests.
-        if (e instanceof HostBlocked) blocked = e;
-      })));
-  }
+        if (e instanceof HostBlocked) blocked = e as Error;
+      } finally {
+        booksDone++;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, todo.length) }, () => bookWorker()));
   clearInterval(hb);
   const remaining = PROVIDER
     ? await books.countDocuments({ 'image_source.provider': PROVIDER, pages_count: { $gt: 0 }, archive_status: { $ne: 'archive_complete' } })
@@ -239,7 +372,11 @@ async function main() {
   const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
   const runMins = (Date.now() - runStart) / 60000;
   const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
-  log(`archive-acquired: complete ${ok}, partial ${partial} | pages ${pagesDone} ok, ${pagesFailed} failed in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s) | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
+  log(`archive-acquired: complete ${ok}, partial ${partial}, stalled ${stalled} | pages ${pagesDone} ok, ${pagesFailed} failed, ${pagesSkipped} skipped${localFailures ? `, ${localFailures} local (store/encode)` : ''} in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s) | un-archived acquired remaining ${remaining}${throttled ? ` | throttled ${throttled}` : ''}`);
+  // Per-host triage, printed every run. A failure count without the source's
+  // own answer next to it is not a measurement — it is what made #4588 take
+  // three wrong diagnoses to reach a cause that this table states outright.
+  if (breaker.size()) log(`per-host outcomes this run:\n${breaker.report()}`);
   if (blocked) {
     // Exit non-zero so a wrapper loop stops instead of re-running into the block.
     log(`ABORTED — SOURCE BLOCKED: ${(blocked as Error).message}`);

--- a/scripts/lib/host-breaker.mjs
+++ b/scripts/lib/host-breaker.mjs
@@ -1,0 +1,191 @@
+/**
+ * Per-host circuit breaker for archivers.
+ *
+ * PRIOR ART: scripts/workers/archive-ocr.mjs (lines ~455-515) — the same three
+ * rules, inlined there since #1909/#1914, and the only tested version of this
+ * logic in the repo. archive-acquired.ts was about to become the FOURTH
+ * hand-rolled copy (archive-ocr, archive-gallica, archive-harvard are the
+ * others), and the version being written was worse than the one already
+ * shipped: it had only the sustained-failure rule, missing both the cold-start
+ * and ratio rules that catch the two failure shapes measured in #4588. So the
+ * logic moves here instead. archive-ocr.mjs deliberately still carries its own
+ * copy — swapping a load-bearing worker over belongs in its own PR, tracked
+ * separately; this file is the one new callers must use.
+ *
+ * ── What this is for ──────────────────────────────────────────────────────
+ *
+ * NOT politeness — the rate limiter in iiif-utils.mjs already does that. This
+ * is about SCHEDULING: a worker pool has a fixed number of slots, and a host
+ * that is refusing us can occupy every one of them with requests that cannot
+ * succeed, while healthy work waits in the same queue.
+ *
+ * Measured on the pipeline box 2026-09-04 (#4588): a 50-minute archiver run
+ * did 53 pages/min for four minutes off a healthy host, then its remaining
+ * seven book slots landed on gallica (429 to every request) and Internet
+ * Archive (400 to every request). Throughput sat at exactly 5 pages/min for
+ * the next 45 minutes — every worker burning 4 attempts x 30s of timeout
+ * against hosts that had answered hundreds of consecutive failures — while
+ * 7,559 healthy MDZ/BSB books sat unreached in the same batch.
+ *
+ * ── Recovery ──────────────────────────────────────────────────────────────
+ *
+ * The inlined copies trip permanently for the life of the process. This one is
+ * half-open: after `cooldownMs` it lets exactly ONE request through to find out
+ * whether the host came back, and re-opens on failure. A breaker that never
+ * re-tests is the same half-a-control-loop mistake as a backoff with no
+ * recovery (#4396 -> #4559) — it just fails in the safe direction, so nobody
+ * notices it never recovers.
+ *
+ * Everything here is per-process and in memory. Nothing a breaker decides is
+ * ever written to a page or a book: an error we have not attributed must not
+ * become a durable fact (invariants/archive-fetch-failures.md).
+ */
+
+/** Thresholds, matching archive-ocr.mjs so operators see one behaviour. */
+export const BREAKER_DEFAULTS = {
+  // Cold start: the host has never served us in this run. Five is low because
+  // "unreachable from the first request" needs no patience.
+  coldStartFails: 5,
+  // Sustained: N back-to-back failures after earlier successes. Catches the
+  // rate-limit-kicks-in-mid-run case that a cumulative ratio misses — once a
+  // host has thousands of early successes the ratio stays healthy right
+  // through a 429 storm. Any success resets the streak, so a blip is free.
+  consecutiveFails: 20,
+  // Noisy host: mostly-bad pages, measured only once there is enough to judge.
+  ratioMinSamples: 50,
+  ratioFailFraction: 0.9,
+  // How long a tripped host is left alone before one probe is allowed through.
+  cooldownMs: 10 * 60_000,
+};
+
+/**
+ * @param {object} [opts] overrides for BREAKER_DEFAULTS, plus:
+ * @param {() => number} [opts.now] clock seam, so tests need not sleep.
+ * @param {(msg: string) => void} [opts.log] where trip notices go.
+ */
+export function createHostBreaker(opts = {}) {
+  const cfg = { ...BREAKER_DEFAULTS, ...opts };
+  const now = opts.now ?? (() => Date.now());
+  const log = opts.log ?? (() => {});
+  /** @type {Map<string, {ok:number,fail:number,skipped:number,consecutiveFails:number,statuses:Map<string,number>,openedAt:number,probing:boolean,reason:string}>} */
+  const hosts = new Map();
+
+  const stateFor = (host) => {
+    let s = hosts.get(host);
+    if (!s) {
+      s = { ok: 0, fail: 0, skipped: 0, consecutiveFails: 0, statuses: new Map(), openedAt: 0, probing: false, reason: '' };
+      hosts.set(host, s);
+    }
+    return s;
+  };
+
+  const trip = (host, s, reason) => {
+    if (s.openedAt) return;
+    s.openedAt = now();
+    s.reason = reason;
+    log(`host ${host}: ${reason} — pausing it for ${Math.round(cfg.cooldownMs / 60000)}m so the pool can work elsewhere`);
+  };
+
+  return {
+    /**
+     * May we send to `host` right now?
+     *
+     * Consumes the half-open probe slot when it returns true for a host whose
+     * cooldown has elapsed, so only one caller tests a recovering host at a
+     * time. Call `success` or `failure` for every `allow` that returned true,
+     * or the probe slot stays held.
+     */
+    allow(host) {
+      const s = stateFor(host);
+      if (!s.openedAt) return true;
+      if (now() - s.openedAt < cfg.cooldownMs) return false;
+      if (s.probing) return false;
+      s.probing = true;
+      return true;
+    },
+
+    success(host) {
+      const s = stateFor(host);
+      s.ok++;
+      s.consecutiveFails = 0;
+      s.openedAt = 0;
+      s.probing = false;
+      s.reason = '';
+    },
+
+    /** @param {string} [code] status or class to count, e.g. '400', 'timeout'. */
+    failure(host, code = 'other') {
+      const s = stateFor(host);
+      s.fail++;
+      s.consecutiveFails++;
+      s.probing = false;
+      s.statuses.set(code, (s.statuses.get(code) ?? 0) + 1);
+      // A failed half-open probe re-arms the cooldown FROM NOW. Without this the
+      // breaker quietly stops being a breaker after its first cooldown: the trip
+      // timestamp stays in the past, so `allow` hands every caller a probe slot
+      // against a host that is still down. Caught by the negative control in
+      // tests/unit/host-breaker.test.ts, not by reading the code — the bug is an
+      // absence, and it fails in the direction that looks like normal operation.
+      if (s.openedAt) { s.openedAt = now(); return; }
+      const codes = [...s.statuses.entries()].sort((a, b) => b[1] - a[1]).slice(0, 4).map(([c, n]) => `${c}:${n}`).join(' ');
+      if (s.fail >= cfg.coldStartFails && s.ok === 0) {
+        trip(host, s, `${s.fail} failures with 0 successes [${codes}]`);
+      } else if (s.consecutiveFails >= cfg.consecutiveFails) {
+        trip(host, s, `${s.consecutiveFails} consecutive failures after ${s.ok} successes [${codes}]`);
+      } else if (s.ok + s.fail >= cfg.ratioMinSamples && s.fail / (s.ok + s.fail) > cfg.ratioFailFraction) {
+        trip(host, s, `${s.fail}/${s.ok + s.fail} failed [${codes}]`);
+      }
+    },
+
+    skipped(host) { stateFor(host).skipped++; },
+
+    /** True while the host is tripped and its cooldown has not elapsed. */
+    isOpen(host) {
+      const s = hosts.get(host);
+      return !!s?.openedAt && now() - s.openedAt < cfg.cooldownMs;
+    },
+
+    /** Host names currently tripped, for a heartbeat line. */
+    openHosts() {
+      return [...hosts.entries()].filter(([h]) => this.isOpen(h)).map(([h]) => h);
+    },
+
+    /**
+     * One line per host: what it actually served us.
+     *
+     * A failure count with no status beside it is not a measurement. #4588 took
+     * three wrong diagnoses to reach a cause that this table states outright —
+     * the archiver had been logging "617 failed" for a week without ever
+     * recording that they were 400s from one host and 429s from another.
+     */
+    report() {
+      return [...hosts.entries()]
+        .sort((a, b) => (b[1].ok + b[1].fail) - (a[1].ok + a[1].fail))
+        .map(([h, s]) => {
+          const codes = [...s.statuses.entries()].sort((a, b) => b[1] - a[1]).slice(0, 4).map(([c, n]) => `${c}:${n}`).join(',');
+          return `  ${h.padEnd(34)} ok ${String(s.ok).padStart(5)} | fail ${String(s.fail).padStart(5)}`
+            + `${codes ? ` [${codes}]` : ''}${s.skipped ? ` | skipped ${s.skipped}` : ''}${s.openedAt ? ` | PAUSED (${s.reason})` : ''}`;
+        }).join('\n');
+    },
+
+    /** Test/inspection seam. */
+    stateOf(host) { return hosts.get(host); },
+    size() { return hosts.size; },
+  };
+}
+
+/**
+ * Reduce a thrown error to the thing worth counting: an HTTP status, or a class.
+ *
+ * `rateLimitedFetch` throws `Error('HTTP 400')`; timeouts surface as an abort;
+ * everything else is a socket-level failure. Distinguishing these is the whole
+ * point — "400" means the URL can never work and "timeout" means it might.
+ */
+export function classifyFetchError(err) {
+  const msg = String(err?.message ?? err ?? '');
+  const m = msg.match(/\bHTTP (\d{3})\b/) || msg.match(/\b([45]\d\d)\b/);
+  if (m) return m[1];
+  if (/abort/i.test(msg)) return 'timeout';
+  if (/ENOTFOUND|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|fetch failed|socket/i.test(msg)) return 'network';
+  return 'other';
+}

--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -270,7 +270,44 @@ export function upgradeToFullRes(url) {
     // this reason — 0 of 28 sampled books could be archived, while the STORED
     // url returned 200 the moment it was requested unmodified. MDZ escaped only
     // because its rule happens to require a comma (`/full/2000,/`).
-    if (/\/full\/full\/\d+\/[a-z]+\.[a-z0-9]+$/i.test(url)) return url;
+    // IIIF Image API 3.0 REMOVED the size keyword `full`; its spelling is `max`.
+    // A v3 service answers `/full/full/` with `400 Bad Request — Invalid size`,
+    // in ~0.2s, which reads in our logs as an ordinary page failure rather than
+    // as "this URL cannot ever work". Measured on Hetzner 2026-09-04 against
+    // iiif.archive.org (`/image/iiif/3/`), 4 pages of one IA item:
+    //
+    //   /full/full/  ->  400 in 0.5s   (or 504 after 60s on a cold decode)
+    //   /full/max/   ->  200 in 2.9s, 1.3–1.8 MB
+    //
+    // Every unarchived Internet Archive page in the corpus is on this endpoint,
+    // so this single segment is why the archiver's IA books never advanced and
+    // why ~58% of its page attempts failed.
+    //
+    // Keyed on the version declared in the PATH (`/iiif/3/`), not on a hostname,
+    // because that is what the service itself is asserting. dl.ndl.go.jp is
+    // excluded explicitly: it serves a v3-shaped path but 500s on `max` and
+    // wants `full` (the rule further down), and two rules must not fight over
+    // the same URL.
+    const isIiifV3 = /\/iiif\/3\//.test(url) && !url.includes('dl.ndl.go.jp');
+    if (isIiifV3 && /\/full\/full\/\d+\/[a-z]+\.[a-z0-9]+$/i.test(url)) {
+      return url.replace(/\/full\/full\/(\d+\/[a-z]+\.)/i, '/full/max/$1');
+    }
+    // The size keyword this URL's API version understands. Used by the generic
+    // rules below so an upgrade never hands a v3 service a v2-only keyword.
+    const FULL_SIZE = isIiifV3 ? 'max' : 'full';
+    // NDL Japan returns HTTP 500 on /full/max/ (IIIF v3 syntax their server
+    // doesn't honor); /full/full/ returns the native-resolution image. Many
+    // imported NDL URLs use /full/max/ from a v3-style manifest crawl.
+    //
+    // This runs BEFORE the "already at a full-size keyword" early return below,
+    // because that return now recognises `max` as well as `full` and would
+    // otherwise swallow this rule — leaving NDL pinned to the spelling that
+    // 500s. Caught by the negative-control case in
+    // tests/unit/iiif-upgrade-full-res.test.ts, not by reading the diff.
+    if (url.includes('dl.ndl.go.jp') && url.includes('/full/max/')) {
+      return url.replace('/full/max/', '/full/full/');
+    }
+    if (/\/full\/(?:full|max)\/\d+\/[a-z]+\.[a-z0-9]+$/i.test(url)) return url;
     // Harvard MPS rate-limits /full/full/ much more aggressively than /full/2000,/
     // — at 1 req/s the full-res endpoint still 429s out (5 cold-start fails =
     // circuit breaker, 0 successes). The existing 2000px variant in the photo
@@ -279,7 +316,7 @@ export function upgradeToFullRes(url) {
       return url;
     }
     if (url.includes('archive.org') && url.includes('/full/pct:')) {
-      return url.replace(/\/full\/pct:\d+\//, '/full/full/');
+      return url.replace(/\/full\/pct:\d+\//, `/full/${FULL_SIZE}/`);
     }
     if (url.includes('digitale-sammlungen') && url.match(/\/full\/\d+,\//)) {
       return url.replace(/\/full\/\d+,\//, '/full/full/');
@@ -294,14 +331,8 @@ export function upgradeToFullRes(url) {
     if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\/\d+\/[a-z]+\./i)) {
       return url.replace(/\/full\/\d+,?\d*\/(\d+\/[a-z]+\.)/i, '/full/full/$1');
     }
-    // NDL Japan returns HTTP 500 on /full/max/ (IIIF v3 syntax their server
-    // doesn't honor); /full/full/ returns the native-resolution image. Many
-    // imported NDL URLs use /full/max/ from a v3-style manifest crawl.
-    if (url.includes('dl.ndl.go.jp') && url.includes('/full/max/')) {
-      return url.replace('/full/max/', '/full/full/');
-    }
     if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
-      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
+      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, `/full/${FULL_SIZE}/`);
     }
   } catch {}
   return url;

--- a/tests/unit/archiver-heartbeat.test.ts
+++ b/tests/unit/archiver-heartbeat.test.ts
@@ -86,3 +86,74 @@ describe('long-running archivers generally', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * The archiver must schedule its work as a POOL, not as fixed slices.
+ *
+ * ## What broke
+ *
+ * Both loops in `archive-acquired.ts` were `for (i += N) { await
+ * Promise.all(slice) }`. A slice does not advance until its slowest member
+ * finishes, and the members that finished early sit idle in the meantime — so
+ * the run's effective width decays to one for as long as the slowest item
+ * takes.
+ *
+ * Measured on the pipeline box 2026-09-04 (#4588): a 50-minute run archived 53
+ * pages/min for four minutes, completed its one healthy book, and then held the
+ * remaining seven slots for 45 minutes on books whose hosts returned an error
+ * to every single request — at a flat 5 pages/min — while 7,559 books on a host
+ * serving 100% of requests in 0.3s waited unreached in the same 240-row batch.
+ * `books 0/240`, every hour, for days.
+ *
+ * ## What this test is, honestly
+ *
+ * A re-deletion guard, not a proof of behaviour. `archive-acquired.ts` opens a
+ * Mongo connection and an R2 client at import, so it cannot be exercised in a
+ * unit test; the real behavioural coverage for the pieces that COULD be
+ * extracted is in host-breaker.test.ts. What this pins is that the barrier does
+ * not come back — which is not hypothetical for this file: the heartbeat above
+ * was added and silently deleted the same day by a concurrent PR that predated
+ * it, and nothing failed (see the header). A grep-shaped test still runs in
+ * that PR's CI, which is the whole point.
+ */
+describe('archive-acquired schedules with a pool, not a barrier', () => {
+  const src = readFileSync(ARCHIVER, 'utf8');
+
+  it('has no fixed-slice Promise.all over a work list', () => {
+    // `for (...; i += N) await Promise.all(list.slice(i, i + N)...)` is the
+    // shape. Either loop coming back reintroduces the 45-minute stall.
+    expect(src, 'a sliced Promise.all is a barrier: the slice waits for its slowest member')
+      .not.toMatch(/await Promise\.all\(\s*\w+\.slice\(/);
+    expect(src, 'sliced chunk loop over pages or books').not.toMatch(/for \(let i = 0; i < \w+\.length; i \+= /);
+  });
+
+  it('drives both levels from a shared cursor, so a finished slot is refilled', () => {
+    // A pool is: a shared index, workers that loop until it runs out, and
+    // exactly `width` of them started at once.
+    expect(src, 'no book-level worker pool').toMatch(/const bookWorker = async/);
+    expect(src, 'workers must pull from a shared cursor, not own a fixed slice').toMatch(/todo\[nextBook\+\+\]/);
+    expect(src, 'no page-level worker pool').toMatch(/ps\[next\+\+\]/);
+    expect(src, 'pool width must come from the concurrency settings')
+      .toMatch(/Array\.from\(\{ length: Math\.min\(CONCURRENCY/);
+    expect(src).toMatch(/Array\.from\(\{ length: Math\.min\(PAGE_CONCURRENCY/);
+  });
+
+  it('will not send to a host its breaker has paused', () => {
+    // Without this the pool refills its slots and hands them straight back to
+    // the host that emptied them.
+    expect(src, 'the pool must consult the breaker before each page').toMatch(/breaker\.allow\(/);
+    expect(src, 'a success must reopen the host').toMatch(/breaker\.success\(/);
+    expect(src, 'the run must print per-host outcomes').toMatch(/breaker\.report\(\)/);
+  });
+
+  it('never drops a book from the queue that archived nothing', () => {
+    // `archived: true` on a book with 0 pages on R2 removes it from the work
+    // queue for good, with the truth demoted to a note nothing reads — a write
+    // that erases its own repair path (CLAUDE.md, Data Protection). It was
+    // unreachable only because the run was always killed at the 50-minute
+    // ceiling first; fixing the throughput is what makes it reachable.
+    expect(src, 'a partial book must be retried, not marked archived').toMatch(/archive_attempts/);
+    expect(src, 'giving up must be recorded as giving up, not as success').toMatch(/archive_stalled/);
+    expect(src, 'progress must be what decides whether to retry').toMatch(/r2 > have0/);
+  });
+});

--- a/tests/unit/archiver-heartbeat.test.ts
+++ b/tests/unit/archiver-heartbeat.test.ts
@@ -138,6 +138,37 @@ describe('archive-acquired schedules with a pool, not a barrier', () => {
     expect(src).toMatch(/Array\.from\(\{ length: Math\.min\(PAGE_CONCURRENCY/);
   });
 
+  it('parses its width flags safely, and refuses to start on a bad one', () => {
+    // This is the case the grep assertions above did NOT catch, and it shipped
+    // to a live measurement run before being caught by actually running it.
+    //
+    // `parseInt(argv[argv.indexOf('--x') + 1] || 'N')` reads argv[0] — the node
+    // binary path — when the flag is absent, so the value is NaN and the `|| 'N'`
+    // default never fires. `Array.from({length: NaN})` is an EMPTY array, so the
+    // pool started zero workers: 24 books "processed" in one second, nothing
+    // fetched, and the run reported `complete 2, partial 22`.
+    //
+    // A width is load-bearing, so the guard is a throw at startup rather than a
+    // comment. Negative control: restoring the old idiom for any one flag turns
+    // the first assertion red.
+    expect(src, 'the argv[indexOf+1] idiom reads argv[0] when the flag is absent')
+      .not.toMatch(/parseInt\(process\.argv\[process\.argv\.indexOf/);
+    expect(src, 'no safe int-arg reader').toMatch(/const intArg = /);
+    expect(src, 'a bad width must abort the run, not run it empty')
+      .toMatch(/refusing to start/);
+  });
+
+  it('prints its summary on SIGTERM, because SIGTERM is how every run ends', () => {
+    // The cron wrapper always kills this run at its 50-minute ceiling. A summary
+    // printed only on natural completion is a summary nobody ever sees — which
+    // would have made the per-host table added in this PR unreachable in
+    // production, the exact failure it was written to end.
+    expect(src, 'no signal handler — the run summary dies with the process').toMatch(/process\.on\(sig/);
+    expect(src, 'SIGTERM must be handled; it is the normal exit path here').toMatch(/SIGTERM/);
+    expect(src, 'the summary must be callable from both paths').toMatch(/const printSummary = /);
+    expect(src, 'the handler must emit the per-host table too').toMatch(/printSummary\(`stopped by/);
+  });
+
   it('will not send to a host its breaker has paused', () => {
     // Without this the pool refills its slots and hands them straight back to
     // the host that emptied them.

--- a/tests/unit/host-breaker.test.ts
+++ b/tests/unit/host-breaker.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { createHostBreaker, classifyFetchError, BREAKER_DEFAULTS } from '../../scripts/lib/host-breaker.mjs';
+
+/**
+ * The breaker exists to protect the WORKER POOL, not the remote host.
+ *
+ * #4588: a 50-minute archiver run spent 45 of those minutes with every slot
+ * occupied by books on two hosts that were answering 400 and 429 to every
+ * request, while 7,559 books on a host serving 100% of requests in 0.3s waited
+ * behind them in the same batch. Throughput was a flat 5 pages/min.
+ *
+ * So the property under test is: after a host has demonstrated it will not
+ * serve us, `allow()` says no, and keeps saying no until enough time has passed
+ * to be worth re-testing — and then says yes exactly ONCE.
+ *
+ * Negative control run when written: deleting the `openedAt` assignment in
+ * `trip()` turns the three tripping cases red; deleting the `probing` guard in
+ * `allow()` turns "lets exactly one probe through" red; deleting the
+ * `consecutiveFails = 0` reset in `success()` turns "a success resets the
+ * streak" red. All three were confirmed to fail before being restored.
+ */
+
+/** A breaker with a clock we control, so recovery does not need a real 10 min. */
+function harness(opts = {}) {
+  let clock = 1_000_000;
+  const lines: string[] = [];
+  const b = createHostBreaker({ now: () => clock, log: (m: string) => lines.push(m), ...opts });
+  return { b, lines, advance: (ms: number) => { clock += ms; }, at: () => clock };
+}
+
+describe('host breaker — stops scheduling work to a host that will not serve it', () => {
+  it('trips on a cold start: N failures with no success at all', () => {
+    const { b } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) {
+      expect(b.allow('iiif.archive.org'), `request ${i} should still be allowed`).toBe(true);
+      b.failure('iiif.archive.org', '400');
+    }
+    expect(b.allow('iiif.archive.org')).toBe(false);
+    expect(b.isOpen('iiif.archive.org')).toBe(true);
+  });
+
+  it('does NOT trip a host that is merely slow to start but then works', () => {
+    // The failure mode this guards against is over-eagerness: a breaker that
+    // parks a healthy host costs exactly as much throughput as the stall it was
+    // built to prevent.
+    const { b } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails - 1; i++) b.failure('gallica.bnf.fr', 'timeout');
+    b.success('gallica.bnf.fr');
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) b.failure('gallica.bnf.fr', 'timeout');
+    expect(b.isOpen('gallica.bnf.fr'), 'cold-start rule must not apply once the host has served us').toBe(false);
+    expect(b.allow('gallica.bnf.fr')).toBe(true);
+  });
+
+  it('trips on a sustained streak that begins after a healthy stretch', () => {
+    // The mid-run rate-limit storm. A cumulative ratio cannot see this: after
+    // 500 successes, 20 failures is a 96% success rate and looks fine.
+    const { b } = harness();
+    for (let i = 0; i < 500; i++) b.success('gallica.bnf.fr');
+    for (let i = 0; i < BREAKER_DEFAULTS.consecutiveFails - 1; i++) b.failure('gallica.bnf.fr', '429');
+    expect(b.isOpen('gallica.bnf.fr')).toBe(false);
+    b.failure('gallica.bnf.fr', '429');
+    expect(b.isOpen('gallica.bnf.fr')).toBe(true);
+  });
+
+  it('a single success resets the streak, so a blip never trips it', () => {
+    const { b } = harness();
+    for (let i = 0; i < 200; i++) {
+      for (let j = 0; j < BREAKER_DEFAULTS.consecutiveFails - 1; j++) b.failure('h.example', '500');
+      b.success('h.example');
+    }
+    expect(b.isOpen('h.example')).toBe(false);
+  });
+
+  it('trips a noisy host on ratio once there is enough to judge', () => {
+    const { b } = harness();
+    // Alternate so no streak ever reaches the consecutive threshold, and keep
+    // one success early so the cold-start rule cannot fire either. This case
+    // must be the ratio rule or nothing.
+    b.success('noisy.example');
+    for (let i = 0; i < 200; i++) {
+      b.failure('noisy.example', '503');
+      if (i % 19 === 18) b.success('noisy.example');
+    }
+    expect(b.isOpen('noisy.example')).toBe(true);
+  });
+});
+
+describe('host breaker — recovery is half-open, not permanent', () => {
+  it('stays closed for the whole cooldown, then lets exactly one probe through', () => {
+    const { b, advance } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) b.failure('h.example', '429');
+    expect(b.allow('h.example')).toBe(false);
+
+    advance(BREAKER_DEFAULTS.cooldownMs - 1);
+    expect(b.allow('h.example'), 'must not re-test before the cooldown elapses').toBe(false);
+
+    advance(2);
+    expect(b.allow('h.example'), 'the probe').toBe(true);
+    expect(b.allow('h.example'), 'only ONE caller may test a recovering host').toBe(false);
+    expect(b.allow('h.example')).toBe(false);
+  });
+
+  it('a successful probe reopens the host fully', () => {
+    const { b, advance } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) b.failure('h.example', '429');
+    advance(BREAKER_DEFAULTS.cooldownMs + 1);
+    expect(b.allow('h.example')).toBe(true);
+    b.success('h.example');
+    expect(b.isOpen('h.example')).toBe(false);
+    expect(b.allow('h.example')).toBe(true);
+    expect(b.allow('h.example')).toBe(true);
+  });
+
+  it('a failed probe re-arms the cooldown from now, rather than freeing the host', () => {
+    // Without this the breaker would be worse than useless after the first
+    // cooldown: every caller would be let through against a host still down.
+    const { b, advance } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) b.failure('h.example', '429');
+    advance(BREAKER_DEFAULTS.cooldownMs + 1);
+    expect(b.allow('h.example')).toBe(true);
+    b.failure('h.example', '429');
+    expect(b.allow('h.example'), 'still down — back to blocked').toBe(false);
+    advance(BREAKER_DEFAULTS.cooldownMs - 1);
+    expect(b.allow('h.example'), 'cooldown must restart on the failed probe').toBe(false);
+  });
+
+  it('never trips a host it has not been told about', () => {
+    const { b } = harness();
+    expect(b.allow('untouched.example')).toBe(true);
+    expect(b.isOpen('untouched.example')).toBe(false);
+  });
+});
+
+describe('host breaker — the report names the source, not just a count', () => {
+  it('carries the status codes each host actually returned', () => {
+    // "617 failed" was the whole instrument for a week. It is what made #4588
+    // take three wrong diagnoses.
+    const { b } = harness();
+    b.failure('iiif.archive.org', '400');
+    b.failure('iiif.archive.org', '400');
+    b.failure('iiif.archive.org', 'timeout');
+    for (let i = 0; i < 3; i++) b.success('api.digitale-sammlungen.de');
+    const r = b.report();
+    expect(r).toMatch(/iiif\.archive\.org/);
+    expect(r, 'the status the host returned must appear').toMatch(/400:2/);
+    expect(r).toMatch(/timeout:1/);
+    expect(r).toMatch(/api\.digitale-sammlungen\.de/);
+  });
+
+  it('marks a paused host as paused, with the reason', () => {
+    const { b } = harness();
+    for (let i = 0; i < BREAKER_DEFAULTS.coldStartFails; i++) b.failure('h.example', '429');
+    expect(b.report()).toMatch(/PAUSED/);
+    expect(b.report()).toMatch(/0 successes/);
+  });
+});
+
+describe('classifyFetchError — a 400 and a timeout are not the same fact', () => {
+  it('reads the status out of rateLimitedFetch errors', () => {
+    // A 400 means the URL can never work; a timeout means it might. The
+    // archiver logged both as "failed" and could distinguish neither.
+    expect(classifyFetchError(new Error('HTTP 400'))).toBe('400');
+    expect(classifyFetchError(new Error('HTTP 429'))).toBe('429');
+    expect(classifyFetchError(new Error('HTTP 504'))).toBe('504');
+  });
+
+  it('names the classes that carry no status', () => {
+    expect(classifyFetchError(new Error('This operation was aborted'))).toBe('timeout');
+    expect(classifyFetchError(new Error('fetch failed'))).toBe('network');
+    expect(classifyFetchError(new Error('ECONNRESET'))).toBe('network');
+    expect(classifyFetchError(new Error('something else entirely'))).toBe('other');
+    expect(classifyFetchError(undefined)).toBe('other');
+  });
+});

--- a/tests/unit/iiif-upgrade-full-res.test.ts
+++ b/tests/unit/iiif-upgrade-full-res.test.ts
@@ -72,14 +72,78 @@ describe('upgradeToFullRes — still upgrades the size segment', () => {
     expect(upgradeToFullRes(harvard)).toBe(harvard);
   });
 
-  it('rewrites archive.org pct: sizes', () => {
+  it('rewrites archive.org pct: sizes — to the v3 keyword, not the v2 one', () => {
+    // This case previously asserted `/full/full/`, which is exactly the URL the
+    // service rejects. See the v3 block below.
     expect(upgradeToFullRes('https://iiif.archive.org/iiif/3/abc$5/full/pct:50/0/default.jpg'))
-      .toBe('https://iiif.archive.org/iiif/3/abc$5/full/full/0/default.jpg');
+      .toBe('https://iiif.archive.org/iiif/3/abc$5/full/max/0/default.jpg');
   });
 
   it('is a no-op on null, empty and non-IIIF input', () => {
     expect(upgradeToFullRes(null as unknown as string)).toBeNull();
     expect(upgradeToFullRes('')).toBe('');
     expect(upgradeToFullRes('https://example.org/plain.jpg')).toBe('https://example.org/plain.jpg');
+  });
+});
+
+/**
+ * IIIF Image API 3.0 removed the size keyword `full`; the v3 spelling is `max`.
+ *
+ * A v3 service answers `/full/full/` with `400 Bad Request — Invalid size`, in
+ * about 0.2s. That is fast, cheap, and indistinguishable in our logs from any
+ * other page failure — so the archiver reported it as throughput ("~58% of
+ * pages failed") rather than as a URL that can never work, and #4588 spent
+ * three rounds of diagnosis on a cause that was in the response body.
+ *
+ * Measured on the pipeline box 2026-09-04, one Internet Archive item, 4 pages:
+ *
+ *   /full/full/  ->  400 in 0.5s ("Invalid size"), or 504 after 60s
+ *   /full/max/   ->  200 in 2.9s, 1.3–1.8 MB
+ *
+ * The corpus holds BOTH spellings against the same host — 873 sampled pages on
+ * `/full/max/` and 324 on `/full/full/` — which is why the endpoint looked
+ * intermittently healthy rather than systematically broken.
+ *
+ * These cases pin the version keyword to what the URL's own path declares.
+ * Negative control run when written: reverting the v3 branch in
+ * `upgradeToFullRes` turns all four of the first block red, and none of the
+ * v2 cases above.
+ */
+const IA_V3_FULL = 'https://iiif.archive.org/image/iiif/3/itemid%2Fitemid_jp2.zip%2Fitemid_jp2%2Fitemid_0001.jp2/full/full/0/default.jpg';
+const IA_V3_MAX = 'https://iiif.archive.org/image/iiif/3/itemid%2Fitemid_jp2.zip%2Fitemid_jp2%2Fitemid_0001.jp2/full/max/0/default.jpg';
+const KYOTO_V3_SIZED = 'https://rmda.kulib.kyoto-u.ac.jp/iiif/3/abc/full/1000,/0/default.jpg';
+
+describe('upgradeToFullRes — IIIF Image API 3.0 says `max`, not `full`', () => {
+  it('rewrites a v3 /full/full/ URL to /full/max/', () => {
+    expect(upgradeToFullRes(IA_V3_FULL)).toBe(IA_V3_MAX);
+  });
+
+  it('leaves a v3 URL that already says max alone', () => {
+    expect(upgradeToFullRes(IA_V3_MAX)).toBe(IA_V3_MAX);
+  });
+
+  it('upgrades a sized v3 URL to max, not to full', () => {
+    // Kyoto is the other v3-pathed host in the corpus, and it is a
+    // SILENT_CAP_HOST — so this rule reaches it too, and must reach it with
+    // the keyword its API version defines.
+    expect(upgradeToFullRes(KYOTO_V3_SIZED)).toBe('https://rmda.kulib.kyoto-u.ac.jp/iiif/3/abc/full/max/0/default.jpg');
+  });
+
+  it('never emits the v2 keyword on a v3 path', () => {
+    for (const url of [IA_V3_FULL, IA_V3_MAX, KYOTO_V3_SIZED, 'https://iiif.archive.org/iiif/3/abc$5/full/pct:50/0/default.jpg']) {
+      expect(upgradeToFullRes(url), url).not.toMatch(/\/iiif\/3\/[^ ]*\/full\/full\//);
+    }
+  });
+
+  it('leaves v2 hosts on `full` — the keyword change is scoped to v3 paths', () => {
+    // The whole risk of this change is over-reach: `max` on a v2 service is as
+    // wrong as `full` on a v3 one. dl.ndl.go.jp is the live proof — it 500s on
+    // `max` and is explicitly excluded — and every v2 host below must be
+    // untouched by the v3 branch.
+    expect(upgradeToFullRes(GALLICA_SIZED)).toMatch(/\/full\/full\//);
+    expect(upgradeToFullRes(MDZ_SIZED)).toMatch(/\/full\/full\//);
+    expect(upgradeToFullRes(VATICAN_SIZED)).toMatch(/\/full\/full\//);
+    const ndl = 'https://dl.ndl.go.jp/api/iiif/861218/R0000009/full/max/0/default.jpg';
+    expect(upgradeToFullRes(ndl)).toBe('https://dl.ndl.go.jp/api/iiif/861218/R0000009/full/full/0/default.jpg');
   });
 });


### PR DESCRIPTION
Fixes the throughput collapse in #4588.

## Measured on the box, before and after

Same machine, same queue, `--batch 24 --concurrency 8`:

| | pages/min | failure rate |
|---|---|---|
| **before** (live cron, repeatedly, all week) | **5** | 70–78% |
| **after**, healthy cohort | **101** (805 pages / 8 min) | 1.2% |
| **after**, the *poisoned* cohort that caused the stall | **34** (235 pages / 7 min) | 20%, all timeouts — **no 400s** |

The second row is a fresh cohort; the third is the decisive one — I forced the run onto the exact gallica + Internet Archive books that had been producing 5 pages/min and a wall of 400s, and they archive now.

Before, minute by minute, the run collapsed at minute 5 and never recovered:

```
20:49 heartbeat 4.0m | books 0/240 | pages 206 ok,  47 failed | host api.digitale-sammlungen.de
20:50 heartbeat 5.0m | books 1/240 | pages 237 ok,  71 failed   <- the one healthy book finishes
20:51 heartbeat 6.0m | books 1/240 | pages 242 ok,  71 failed | host gallica.bnf.fr
...  +5 pages every minute for the next 45 minutes, to the 50m kill
```

After, it does not:

```
23:48 heartbeat 1.0m | books 1/24 | pages  98 ok,  0 failed | 1.63 pages/s now
23:50 heartbeat 3.0m | books 1/24 | pages 322 ok,  0 failed | 1.95 pages/s now
23:53 heartbeat 6.0m | books 1/24 | pages 685 ok, 10 failed | 2.32 pages/s now
23:54 heartbeat 7.0m | books 1/24 | pages 805 ok, 10 failed | 2.00 pages/s now
```

## The diagnosis, which is not what the issue guessed twice

#4588 carries two retracted causes (the #4396 limiter penalty; an OOM storm). Both were reasoned from the shape of the log. The answer came from asking the three hosts directly — **four minutes of measurement, eight pages each, on the box**:

| host | what it actually answered | verdict |
|---|---|---|
| `iiif.archive.org` | **400 "Invalid size" in 0.2s**; some 504 after 60s | our URL is invalid — it can never work |
| `gallica.bnf.fr` | **429 in 0.08s, to every request** | but serves 200s in ~1.1s when the archiver is idle |
| `api.digitale-sammlungen.de` | **200 in 0.3s, 8 of 8** | perfectly healthy |

Three different failures reported as one number. And the crucial part: **60% of the parked backlog is on the healthy host** — bsb 4,623 + mdz 2,936 books, of 12,433 parked at `archiving`. It was starved, not slow.

The log said so all along, if it had been read as a cliff rather than a slope:

```
20:46 heartbeat 1.0m | books 0/240 | pages  47 ok,  17 failed | 0.78 pages/s | host api.digitale-sammlungen.de
20:49 heartbeat 4.0m | books 0/240 | pages 206 ok,  47 failed | 0.86 pages/s | host api.digitale-sammlungen.de
20:50 heartbeat 5.0m | books 1/240 | pages 237 ok,  71 failed | 0.79 pages/s   <- the MDZ book finishes
20:51 heartbeat 6.0m | books 1/240 | pages 242 ok,  71 failed | 0.67 pages/s | host gallica.bnf.fr
...  +5 pages every minute, for the next 45 minutes, to the 50m kill
```

53 pages/min for four minutes, then exactly 5 pages/min forever. The cumulative average rendered that cliff as a smooth drift from 0.86 to 0.15, which reads as gradual decay.

## What is fixed

**1. IIIF Image API 3.0 removed the size keyword `full`.** The v3 spelling is `max`; a v3 service answers `/full/full/` with `400 Bad Request — Invalid size`. Measured on one IA item: `/full/full/` → 400 in 0.5s (or 504 after 60s), `/full/max/` → **200 in 2.9s, 1.3–1.8 MB**. **91,695 unarchived pages** carry the invalid form. `upgradeToFullRes` now keys the keyword on the version in the URL's own path (`/iiif/3/`), not on a hostname — because that is what the service is asserting.

The corpus holds *both* spellings against the same host (873 `max` vs 324 `full` in a 200k sample), which is why this endpoint read as intermittently flaky for months rather than as systematically misaddressed.

**2. Neither scheduling loop was a pool.** Both were `for (i += N) { await Promise.all(slice) }`. A slice cannot advance past its slowest member, and the workers that finished early sit idle — so a slice holding one book on a refusing host runs at that book's speed with most of its capacity parked. That is the mechanism behind `books 0/240`: the run completed its healthy book at minute 5 and then held seven of eight slots for 45 minutes on books that could not fetch a single page. Both levels are now worker pools over a shared cursor.

**3. A per-host circuit breaker**, or the pool just refills its freed slots and hands them back to the host that emptied them.

**4. Per-host outcome reporting.** `noteFailure` counted only 401/403/429 and dropped every other error on the floor, so `617 failed` was the entire instrument — which is why this took three rounds of diagnosis. Real output from the poisoned-cohort run:

```
00:04:26 SIGTERM received — stopping. In-flight pages are abandoned; the next run
         resumes from the pages that still lack archived_photo.
00:04:26 archive-acquired (stopped by SIGTERM): complete 0, partial 0, stalled 0 |
         books 0/24 | pages 235 ok, 60 failed, 0 skipped in 7.0m (0.56 pages/s) |
         throttled gallica.bnf.fr:9
00:04:26 per-host outcomes this run:
  iiif.archive.org                   ok   205 | fail    51 [timeout:51]
  gallica.bnf.fr                     ok    35 | fail     9 [429:9]
```

That table is the proof of fix #1: **`iiif.archive.org` returns 205 successes and zero 400s**, on the same books that had been answering 400 to essentially every request. The residual 51 are IA's own slow JP2 decode exceeding our 30s timeout — a real tail, but a different and much smaller problem.

The heartbeat rate is also windowed now, so a cliff looks like a cliff.

The heartbeat rate is also windowed now, so a cliff looks like a cliff.

## Prior art, which I nearly ignored

`archive-ocr.mjs` has had this exact breaker since #1909/#1914 — cold-start, sustained-streak, and ratio rules — and `archive-gallica.mjs` and `archive-harvard.mjs` each have partial copies. The version I had already written was the **fourth**, and it was worse: only the sustained rule, missing the two that catch the failure shapes measured here. So the logic moved to `scripts/lib/host-breaker.mjs` instead, with `archive-ocr.mjs` deliberately left on its own copy — swapping a load-bearing worker over belongs in its own PR (follow-up filed).

One thing added that none of the existing copies have: **the breaker is half-open, not permanent.** After a cooldown it lets exactly one request through to test recovery. A breaker that never re-tests is the same half-a-control-loop mistake as a backoff with no recovery (#4396 → #4559); it just fails in the safe direction, so nobody notices.

## Two things found on the way, fixed here because the throughput fix is what makes them reachable

- **A book that archived ZERO pages was marked `archived: true`** and dropped from the queue for good, with the truth demoted to a note (`partial:0/424`) that nothing reads — a write that erases its own repair path (CLAUDE.md, Data Protection). It had been unreachable only because the run was always killed at the 50-minute ceiling first. Books now stay queued while they progress, and are parked with `archive_stalled` only after 8 fruitless attempts. Selection is also ordered least-attempted-first: it had **no sort at all**, so it returned the same head of the queue every hour — which is how one cohort of blocked books held the whole archiver for days.
- **A failure after the bytes arrived** (sharp, R2, Mongo) was about to be charged to the *source's* breaker, so an R2 outage would have paused every institution at once. Host verdicts are now settled at fetch time; local failures counted separately. This is the same rule as "never write an error you did not attribute into `archived_photo`."

## Tests

`tests/unit/host-breaker.test.ts` (13 cases) is behavioural, against a fake clock — tripping on each of the three rules, *not* tripping on the shapes that must not trip it, and the half-open sequence. Writing it found a real defect: **a failed probe left the original trip timestamp in place, so after one cooldown the breaker degraded into no breaker at all** — every caller got a probe slot against a host still down. Negative controls for all three rules are recorded in the file header.

`tests/unit/iiif-upgrade-full-res.test.ts` gains the v3 cases, including the over-reach guard (`max` on a v2 service is as wrong as `full` on a v3 one). That guard immediately caught a regression I had introduced: my widened early-return was swallowing the `dl.ndl.go.jp` rule, which would have pinned NDL to the spelling that 500s.

The `archive-acquired.ts` cases are **grep-shaped and I want to be honest about that** — the file opens a Mongo connection and an R2 client at import, so it cannot be exercised in a unit test. They are a re-deletion guard, not a proof of behaviour, which is not hypothetical for this file: the heartbeat was added and silently deleted the same day by a concurrent PR that predated it, and nothing failed. Verified all nine assertions fail against `origin/main`'s version.

## What is NOT proven

**The circuit breaker never fired in either live run**, because both hosts were in fact serving (gallica gave 35 ok / 9 429s once it was no longer being hammered by a stalled pool). Its production behaviour is therefore unexercised; the confidence in it comes from 13 behavioural unit cases against a fake clock, with negative controls recorded for each rule. Not firing when both hosts are healthy is the correct behaviour, but it is not the same as having watched it trip in anger.

Likewise `archive_stalled` needs 8 fruitless attempts on one book to trigger, so that branch has only unit-level coverage.

## Out of scope, deliberately

- **The importers that mint the bad URLs** — 9 call sites append `/full/full/` to a service id regardless of API version, and they will keep producing invalid pages. Filed as #4655. (I first wrote there that this also breaks images for readers; **it does not** — measured 0 of 213 affected books visible, because acquisitions import hidden and a book only goes visible after it archives. Corrected on the issue.)
- **Unifying the four breakers** — follow-up.
- **Phase 1's missing time-based escape** (option 3 in #4588). It writes status forward on incompletely-archived books; that deserves its own review. This PR does correct `.claude/docs/pipeline.md`, which promised a "24h timeout" that does not exist in `pipeline-orchestrator.mjs` — the doc was the bug.
- **Gallica's real rate tolerance.** It 429s 100% during a run and serves fine when idle, so 3/s is above what it will give us sustained. I did not change the number: raising or lowering a rate without evidence from a clean run is what #4395 warns against, and the breaker now handles it correctly either way. Worth a measured follow-up. Note `archive-ocr.mjs` already lists gallica in `HETZNER_BLOCKED_DOMAINS` and skips it outright — this archiver never got that memo, and now discovers it dynamically instead.
- **`getDomainLimit` matches hostnames exactly**, so `iiif.archive.org` gets `DEFAULT_LIMIT` (5) rather than `archive.org`'s 10. Unchanged for the same reason.
- **Concurrency numbers are untouched.** Per #4527 they are a memory budget (`opj_decompress` at ~1.0 GB per JP2 decode; 687 OOM events, one of which killed `cron.service`), not a throughput dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjUy2ixFz8H713mek7RALo
