### PR TITLE
feat(collections): a Further reading band — adjacent works we hold, and the ones we don't (#4653)

### DIFF
--- a/.claude/docs/invariants/visibility-and-stats.md
+++ b/.claude/docs/invariants/visibility-and-stats.md
@@ -80,4 +80,31 @@ hold a non-plain-year value. The numeric `year` field is populated on **19,012 o
   discriminator is **not** "published is Unknown" — the Bodleian Gospels manuscripts at
   895/927/950 also lack one and their dates are genuine. The oldest object actually
   held is the 550 CE Bodleian Gospels.
-||||||| b0a919ae
+
+## `isTranslationReadable()` answers "of what we transcribed", not "of the book" (#4653)
+
+The readable bar above divides by `pages_ocr − pages_blank`. That is the right
+denominator for the question it was built for — a badged first translation is a
+claim about text we hold in transcription — but it is the WRONG one for any
+surface that shows a book the pipeline has not finished, and it fails in the
+direction that over-claims.
+
+Measured on the 18 books in `forum-of-conscience`'s `further_reading`: the
+typical shape is **223 pages, 25 OCR'd, 0 translated**. Translate those 25 and
+`translationCoverage()` returns **1.0** — "Translated", fully readable — while
+**198 pages have never been transcribed at all**. Nothing in the numerator or
+the denominator can see them, because a page awaiting OCR is in neither.
+
+- **The tell:** you are rendering a book selected for NOT being finished —
+  an acquisition list, a wishlist, a coverage report, an untranslated-backlog
+  surface. On the ordinary public corpus the two denominators nearly agree,
+  which is exactly why this stays invisible until a surface deliberately
+  populated with unfinished books renders one.
+- **The rule:** before saying "Translated", require the transcription to be
+  complete too (`pages_ocr >= pages_count`) — a CONJUNCTION with the existing
+  bar, never a second competing threshold. `furtherReadingStatus()` in
+  `src/lib/further-reading.ts` is the worked example; its negative control lives
+  in `tests/unit/further-reading.test.ts`.
+- Related: the same asymmetry from the other end — a page awaiting OCR belongs
+  in the DENOMINATOR of any corpus-wide translation-completeness figure (#4516).
+  One number cannot serve both questions; say which one you measured.

--- a/scripts/maintenance/set-further-reading-4653.mjs
+++ b/scripts/maintenance/set-further-reading-4653.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: `scripts/maintenance/` holds no writer for any authored collection
+ * field — `curate-collection` (the skill) writes `highlighted_books` /
+ * `expanded_description` through the admin API, and the closest scripts
+ * (`create-proposed-collections-2026-08.mjs`, `import/create-slime-moulds-collection.mjs`)
+ * create whole collection documents rather than editing one field of an existing
+ * one, and neither verifies the book ids it writes. `scripts/lib/revalidate.mjs`
+ * is REUSED here for the purge rather than hand-rolling the fetch, which is the
+ * copy-paste bug that file was created to end.
+ *
+ * Populate `collections.further_reading` for forum-of-conscience (#4653).
+ *
+ * WHAT THIS WRITES AND WHAT IT DOES NOT
+ * ------------------------------------
+ * `further_reading` is an ADJACENCY list, not membership. These books are not
+ * tagged into `collections`, so nothing here moves `book_count`,
+ * `total_book_count`, the works grid, or the Supabase `books_catalog` (no book
+ * document is touched at all — the only write is one `$set` on one collection
+ * document). The script asserts both counters are unchanged afterwards.
+ *
+ * WHY EVERY ID IS RE-VERIFIED BEFORE THE WRITE
+ * --------------------------------------------
+ * An id in a proposal is a claim, not a fact — every batch of agent-proposed
+ * book ids reviewed here has contained at least one that resolves to a
+ * different book or to nothing, and `updateOne` would swallow the gap in
+ * silence. So each entry carries the slug it is supposed to be, and the script
+ * refuses to write unless the id resolves to a VISIBLE book whose slug matches.
+ * Ids are `books.id`, never the Mongo `_id`.
+ *
+ * TWO OF THE TWENTY CANDIDATES ARE NOT WRITTEN
+ * --------------------------------------------
+ * #4653 excluded the `restitutio in integrum` law-faculty disputations as false
+ * friends — a Roman-law remedy, not the moral duty of restitution. Two entries
+ * on its own shortlist are the same false friend one word over, and reading the
+ * scans says so outright:
+ *
+ *   - Cellarius, *Dissertatio iuridica de poenitentia in contractibus
+ *     innominatis* (Halle 1699). Chapter I is *De origine contractuum
+ *     innominatorum*; the text argues from the Pandects, the *actio de
+ *     praescriptis verbis* and Gnaeus Flavius. This is the *ius poenitendi* —
+ *     withdrawal from a contract — not penance.
+ *   - Draing, *Disputatio iuridica inauguralis de poenitentia* (Strasbourg
+ *     1671). Thesis III opens "Etymologiam insequitur Poenitentiae Homonymia,
+ *     certissima errorum genitrix, **in Jure nostro civili** probe
+ *     investiganda", then enumerates the three civil-law senses with Pandect
+ *     citations. The volume is bound with eight other Strasbourg civil-law
+ *     theses (*De collatione bonorum*, *De delegatione debitoris*, …).
+ *
+ * They stay in CANDIDATES with `verdict: 'exclude'` and the evidence attached,
+ * so re-including one is a one-word edit and a re-run rather than a rediscovery.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/set-further-reading-4653.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/set-further-reading-4653.mjs --apply
+ *
+ * Dry-run by default: it verifies everything and prints the document it would
+ * write. `--apply` performs the write and the cache purge.
+ *
+ * Verify afterwards:
+ *   node --env-file=.env.production.local scripts/audit/collection-page-live.mjs --slug forum-of-conscience
+ */
+
+import { MongoClient } from 'mongodb';
+import { revalidateCollection } from '../lib/revalidate.mjs';
+
+const SLUG = 'forum-of-conscience';
+const APPLY = process.argv.includes('--apply');
+
+/**
+ * The 20 candidates from #4653, in the issue's order, each with the slug its id
+ * must resolve to. `note` is drawn from the book's own title page — a genre
+ * label, not a reading of the text.
+ */
+const CANDIDATES = [
+  {
+    verdict: 'include',
+    book_id: '6a4f7563eeef22aafac6164b',
+    slug: 'breve-directorium-ad-confessarii-et-confitentis-munus-recte-polanco',
+    note: 'A Jesuit handbook for the office of confessor — and of the one confessing.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4a53e7e4a335875e1d5319',
+    slug: 'vel-necessaria-vel-valde-utilia-sunt-confessariis-in-primo-agostini',
+    note: 'What a confessor needs to know, set out briefly.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4cc200e11a1ca1e7c7c6f2',
+    slug: 'industriae-pro-confessariis-maxime-monialium-ad-eas-in-sua-polacco',
+    note: 'Practical guidance for confessors, especially those of nuns.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a500179e39653852101a3e7',
+    slug: 'de-poenitentia-et-confessione-secreta-semper-in-ecclesia-eck',
+    note: 'Johann Eck on private confession as an unbroken practice of the Church — the Catholic side of the Reformation quarrel over penance.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4377ee9a1e0c918b6878fe',
+    slug: 'de-poenitentia-et-de-justificatione-adhortatio-et-palladius',
+    note: 'An exhortation on penance and justification from the Lutheran side of the same argument.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4d6135e91798b676b43aa7',
+    slug: 'speculum-curatorum-una-cum-confessionalia-ac-tractatu-de-fillon',
+    note: 'A mirror for parish clergy, bound with a confessional manual.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4f397872a0f5a8d3809f3c',
+    slug: 'resolutiones-practicae-ex-universa-theologia-morali-quas-in-herterer',
+    note: 'Practical resolutions drawn from the whole of moral theology.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4c4c5942f9b6155899d269',
+    slug: 'discursus-iuris-canonici-de-poenitentia-ecclesiastica-von-knorre',
+    note: 'A canon-law discourse on ecclesiastical penance — the Kirchen-Buße of the title page, 1678.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a43b1433c91e2a63d4daf9e',
+    slug: 'discursus-iuris-canonici-de-poenitentia-ecclesiastica-quem-muller',
+    note: 'The same 1678 disputation in a second copy: Knorr wrote it, Peter Müller presided.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4ccd51000086439953bcfc',
+    slug: 'resolutiones-selectae-in-materia-de-restitutione-ad-puritanus',
+    note: 'Restitution "ad dirigendam et pacandam conscientiam" — the moral duty to give back, not the Roman-law remedy of the same name.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4b2a9c7c38d5e8eb9bebf1',
+    slug: 'de-usuris-et-cambiis-tractatus-de-censuris-ecclesiasticis-cattaneus',
+    note: 'Ecclesiastical censures, with an appendix on usury and exchange.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4a6fcad1c07a59a7512497',
+    slug: 'confessionale-contins-tractatum-decem-preceptorum-et-septem-kunhofer',
+    note: 'An early confessional, opening with a treatise on the Ten Commandments.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4bb61b241e69221d26e45c',
+    slug: 'sancta-cathedra-confessionalis-in-s-scripturis-fundata-ab-polz',
+    note: 'A defence of the confessional, grounded in Scripture.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4bb84a241e69221d26e99b',
+    slug: 'casus-conscientiae-an-christianus-judaeum-meta-mian-kai-senst',
+    note: 'A single disputed case of conscience, in the scholastic casus form.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4c9c624e20e918504f02b6',
+    slug: 'impietas-jesuitica-in-probabilismo-morali-elucens-quam-harhoff',
+    note: 'A polemic against Jesuit probabilism — the case against casuistry, from inside the same literature.',
+  },
+  {
+    verdict: 'exclude',
+    book_id: '6a4a4c83547be098cf67f38c',
+    slug: 'disputatio-iuridica-inauguralis-de-poenitentia-quam-ex-draing',
+    why: 'False friend. Thesis III: "Poenitentiae Homonymia … in Jure nostro civili probe investiganda", then the three civil-law senses with Pandect citations. Bound with eight other Strasbourg civil-law theses. Roman law, not penance.',
+  },
+  {
+    verdict: 'exclude',
+    book_id: '6a50db823c25d10492e21f58',
+    slug: 'dissertatio-iuridica-de-poenitentia-in-contractibus-cellarius',
+    why: 'False friend. Chapter I is "De origine contractuum innominatorum"; argues from the Pandects and the actio de praescriptis verbis. This is the ius poenitendi — withdrawal from a contract — not penance.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4a493760cc4860acc5480d',
+    slug: 'theses-theologicae-ex-praeceptis-decalogi-primae-tabulae-trinckhel',
+    note: 'Theological theses on the precepts of the Decalogue, first table.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4a5b694107674feb04d3be',
+    slug: 'theses-ex-theologia-morali-de-eucharistiae-sacramento-quas-herschl',
+    note: 'Moral-theology theses on the sacrament of the Eucharist.',
+  },
+  {
+    verdict: 'include',
+    book_id: '6a4ef16e451d36458a838649',
+    slug: 'ex-theologia-morali-theses-de-materia-forma-intentione-et-keuslin',
+    note: 'Moral-theology theses on matter, form and intention.',
+  },
+];
+
+function die(msg) {
+  console.error(`\nREFUSING TO WRITE: ${msg}`);
+  process.exit(1);
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const collection = await db.collection('collections').findOne({ slug: SLUG });
+if (!collection) die(`collection "${SLUG}" not found`);
+
+const before = {
+  book_count: collection.book_count,
+  total_book_count: collection.total_book_count,
+  artwork_count: collection.artwork_count,
+  further_reading: collection.further_reading,
+};
+console.log(`Collection "${SLUG}"`);
+console.log(`  book_count=${before.book_count} total_book_count=${before.total_book_count}`);
+console.log(`  further_reading currently: ${before.further_reading ? `${before.further_reading.length} entries` : 'absent'}`);
+console.log(`  reading_list_gaps: ${(collection.reading_list_gaps || []).length} entries (rendered by the same band, unchanged here)\n`);
+
+const wanted = CANDIDATES.filter(c => c.verdict === 'include');
+const excluded = CANDIDATES.filter(c => c.verdict === 'exclude');
+
+// --- Verify every id resolves to the book it claims to be -------------------
+const problems = [];
+const members = [];
+for (const c of wanted) {
+  const book = await db.collection('books').findOne(
+    { id: c.book_id },
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1, collections: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1 } },
+  );
+  if (!book) { problems.push(`${c.book_id} — no book with this id`); continue; }
+  if (book.slug !== c.slug) { problems.push(`${c.book_id} — slug is "${book.slug}", expected "${c.slug}"`); continue; }
+  if (book.visible !== true) { problems.push(`${c.book_id} — not visible (${JSON.stringify(book.visible)})`); continue; }
+  // Membership would double-count: the band must not restate the works grid.
+  if ((book.collections || []).includes(SLUG)) {
+    problems.push(`${c.book_id} — already tagged into ${SLUG}; it belongs in the grid, not the band`);
+    continue;
+  }
+  members.push({ c, book });
+}
+
+if (problems.length) {
+  console.error('Verification failed:');
+  for (const p of problems) console.error(`  ✗ ${p}`);
+  die(`${problems.length} of ${wanted.length} entries did not verify`);
+}
+
+for (const { book } of members) {
+  const readable = (book.pages_translated || 0) > 0 ? `${book.pages_translated} translated` : 'not yet translated';
+  console.log(`  ✓ ${book.slug}\n      ${(book.display_title || book.title || '').slice(0, 70)} — ${book.author} · ${book.pages_count}pp · ${readable}`);
+}
+console.log(`\n  ${members.length} verified.`);
+for (const e of excluded) console.log(`  – excluded ${e.slug}\n      ${e.why}`);
+
+const further_reading = members.map(({ c }) => ({ book_id: c.book_id, note: c.note }));
+
+if (!APPLY) {
+  console.log(`\nDRY RUN — would $set further_reading (${further_reading.length} entries) and bump updated_at.`);
+  console.log('Re-run with --apply to write.');
+  await client.close();
+  process.exit(0);
+}
+
+// --- Write ------------------------------------------------------------------
+const res = await db.collection('collections').updateOne(
+  { slug: SLUG },
+  { $set: { further_reading, updated_at: new Date() } },
+);
+console.log(`\nmatched=${res.matchedCount} modified=${res.modifiedCount}`);
+if (res.matchedCount !== 1) die('update did not match exactly one collection');
+
+// --- Read back and assert ---------------------------------------------------
+const after = await db.collection('collections').findOne({ slug: SLUG });
+if (!Array.isArray(after.further_reading) || after.further_reading.length !== further_reading.length) {
+  die(`read-back has ${after.further_reading?.length} entries, expected ${further_reading.length}`);
+}
+const writtenIds = after.further_reading.map(e => e.book_id).join(',');
+const expectedIds = further_reading.map(e => e.book_id).join(',');
+if (writtenIds !== expectedIds) die('read-back order or ids differ from what was written');
+
+// The whole point of the field: it must not have moved a counter.
+if (after.book_count !== before.book_count || after.total_book_count !== before.total_book_count) {
+  die(`counters moved — book_count ${before.book_count}→${after.book_count}, total_book_count ${before.total_book_count}→${after.total_book_count}`);
+}
+console.log(`Verified: ${after.further_reading.length} entries, order preserved, book_count=${after.book_count} total_book_count=${after.total_book_count} (unchanged).`);
+
+await client.close();
+
+// --- Purge ------------------------------------------------------------------
+// A write that changes what a page should show is not finished until the cache
+// is told; revalidateCollection throws if the server revalidates nothing.
+await revalidateCollection(SLUG);
+console.log('\nDone. Verify the reader gets it:');
+console.log('  node --env-file=.env.production.local scripts/audit/collection-page-live.mjs --slug forum-of-conscience');

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -12,6 +12,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import collectionRedirects from '@/lib/collection-redirects.json';
 import CollectionSchema from '@/components/seo/CollectionSchema';
 import CollectionAllBooks from '@/components/collections/CollectionAllBooks';
+import CollectionFurtherReading from '@/components/collections/CollectionFurtherReading';
 import IndexCatalogBrowser from '@/components/collections/IndexCatalogBrowser';
 import ExhibitionLayout from '@/components/collections/ExhibitionLayout';
 import SignUpCTA from '@/components/auth/SignUpCTA';
@@ -27,6 +28,12 @@ import { browseBooks } from '@/lib/books-catalog';
 import { supabase } from '@/lib/supabase';
 import { authorUrl } from '@/lib/slugify';
 import { localizedEditionFilter } from '@/lib/localized';
+import {
+  resolveFurtherReading,
+  resolveReadingListGaps,
+  type FurtherReadingBook,
+  type FurtherReadingRef,
+} from '@/lib/further-reading';
 import { ObjectId } from 'mongodb';
 
 // ISR: rebuild at most once per day
@@ -486,6 +493,17 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     .map((m: { book_id: string }) => m.book_id)
     .filter(Boolean);
 
+  // Further reading — books we HOLD that are adjacent to this collection without
+  // being members of it (#4653). Deliberately NOT part of `collections`, so it
+  // never reaches `book_count` / `total_book_count` or the works grid: those
+  // describe membership, and these books are not members. The ids are
+  // `books.id`, matching `highlighted_books` / `mentioned_books` — never the
+  // Mongo `_id`, which 16,343 books have had re-minted.
+  const furtherReadingRefs: FurtherReadingRef[] = Array.isArray(collection.further_reading)
+    ? (collection.further_reading as FurtherReadingRef[])
+    : [];
+  const furtherReadingIds = furtherReadingRefs.map(r => r?.book_id).filter(Boolean);
+
   // Art collections share one canonical filter with the manifest API
   // (/api/collections/[id]?mode=manifest) — keep them in sync or the
   // server-rendered grid and the expanded grid show different works.
@@ -599,7 +617,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     }
   }
 
-  const [books, highlights, galleryImages, mentionedBooks, firstTranslations] = await Promise.all([
+  const [books, highlights, galleryImages, mentionedBooks, firstTranslations, furtherReadingBooks] = await Promise.all([
     fetchBooksWithFallback(),
     curatedBookIds.length > 0
       ? withTimeout(
@@ -690,6 +708,24 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
           .toArray(),
         8000, [],
       ),
+    // Further reading — resolved by id, NOT by a `pages_translated > 0` filter:
+    // the whole point of the band is books we hold and cannot yet read. The
+    // `visible: true` filter is load-bearing, not decorative — an authored id
+    // list inside a collection document is a takedown surface, and this is the
+    // only thing standing between a removed book and a dead link on a public
+    // page (visibility-and-stats.md, /collections/freemasonry). Order is
+    // restored from the authored refs afterwards; `$in` does not preserve it.
+    furtherReadingIds.length > 0
+      ? withTimeout(
+        db.collection('books')
+          .find(
+            { id: { $in: furtherReadingIds }, visible: true, ...(tenantId ? { tenantId } : {}) },
+            { projection, maxTimeMS: 8000 },
+          )
+          .toArray(),
+        8000, [],
+      )
+      : Promise.resolve([]),
   ]);
 
   const artworks = await artworksPromise;
@@ -859,6 +895,12 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     galleryImages: JSON.parse(JSON.stringify(galleryImages)) as any[],
     mentionedBooks: sanitizeBookThumbs(mentionedBooks) as unknown as BookItem[],
+    furtherReading: resolveFurtherReading(
+      furtherReadingRefs,
+      (sanitizeBookThumbs(furtherReadingBooks as Record<string, unknown>[]) as unknown as FurtherReadingBook[])
+        .map(b => ({ ...b, title: b.title || '' })),
+    ),
+    readingListGaps: resolveReadingListGaps(collection.reading_list_gaps),
     parentCollection,
     galleryCollectionSlug,
     galleryTotalCount,
@@ -947,7 +989,10 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
   // tenant-scoped mismatch can still return null here.
   if (!data) notFound();
 
-  const { collection, books, highlights: curatedHighlightsData, firstTranslations, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, galleryTotalCount, exhibition, exhibitionBooks, childCollections, artworks, spanishBookCount } = data;
+  const { collection, books, highlights: curatedHighlightsData, firstTranslations, galleryImages, total, mentionedBooks, furtherReading, readingListGaps, parentCollection, galleryCollectionSlug, galleryTotalCount, exhibition, exhibitionBooks, childCollections, artworks, spanishBookCount } = data;
+
+  // The band self-gates on empty, but the hero anchor needs to know in advance.
+  const hasFurtherReading = furtherReading.length > 0 || readingListGaps.length > 0;
 
   // Collections that carry an Index catalogue (index_catalogs editions) render
   // the catalogue browser as their centrepiece — hide the Visual Art section
@@ -1154,6 +1199,21 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
             >
               {total.toLocaleString('en-US')} {itemLabel}
             </a>
+            {/* Counts the band, not the collection — the two are different sets
+                on purpose, and this link lands on exactly what it counts. */}
+            {hasFurtherReading && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <a
+                  href="#further-reading"
+                  className="hover:text-white/80 transition-colors underline underline-offset-2 decoration-white/30"
+                >
+                  {furtherReading.length > 0
+                    ? `${furtherReading.length.toLocaleString('en-US')} further reading`
+                    : 'Further reading'}
+                </a>
+              </>
+            )}
             {languages.length > 0 && (
               <>
                 <span className="w-px h-4 bg-white/20" />
@@ -1771,6 +1831,16 @@ async function CollectionDetailContent({ id, tenantId, tenantSlug, provider }: {
           defaultView={(collection as { all_books_default_view?: 'grid' | 'list' }).all_books_default_view}
         />
       </div>
+
+      {/* Further reading — adjacent works we hold, and the ones we don't. Sits
+          AFTER the works grid on purpose: it is a handoff, not a member list,
+          and it feeds no counter above it. Self-gates when both halves empty. */}
+      <CollectionFurtherReading
+        books={furtherReading}
+        gaps={readingListGaps}
+        tenantSlug={tenantSlug}
+      />
+
       <SignUpCTA />
     </div>
   );

--- a/src/components/collections/CollectionFurtherReading.tsx
+++ b/src/components/collections/CollectionFurtherReading.tsx
@@ -1,0 +1,167 @@
+/**
+ * PRIOR ART: the "Featured books" band inside `src/app/collections/[id]/page.tsx`
+ * is the closest existing thing and its card markup is deliberately mirrored
+ * here (same cover ratio, same type ramp, same tokens) — but it renders
+ * COLLECTION MEMBERS and assumes a readable book, so it cannot carry a list of
+ * unreadable non-members or the second, bookless half. `CollectionAllBooks` is a
+ * client component over the paginated catalogue; `CollectionListView` is its
+ * table view. Neither renders an authored, ordered list.
+ *
+ * Further reading — two halves, one band.
+ *
+ *   1. Works we HOLD that sit next to the collection without belonging to it
+ *      (`collections.further_reading`). Adjacent, not member: nothing here
+ *      feeds `book_count` or `total_book_count`.
+ *   2. Works we do NOT hold (`collections.reading_list_gaps`), named with their
+ *      manuscript or edition witnesses — which doubles as a public acquisition
+ *      wishlist. That field had been carried on the collection document with
+ *      nothing in `src/` reading it (#4653).
+ *
+ * DESIGN: every value maps to an existing token — the band reuses the warm
+ * surface, the hairline divider, the display serif for headings, and the
+ * primary/secondary/muted text tokens already used by the sibling bands. No new
+ * typefaces, sizes, colours, radii or spacing scales
+ * (`.claude/docs/collection-page-redesign-spec.md` §0).
+ */
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookOpen } from 'lucide-react';
+import { bookTitle } from '@/lib/collections-utils';
+import { tenantBookUrl } from '@/lib/slugify';
+import {
+  furtherReadingStatus,
+  type FurtherReadingEntry,
+  type ReadingListGap,
+} from '@/lib/further-reading';
+
+interface Props {
+  books: FurtherReadingEntry[];
+  gaps: ReadingListGap[];
+  tenantSlug?: string | null;
+}
+
+export default function CollectionFurtherReading({ books, gaps, tenantSlug }: Props) {
+  if (books.length === 0 && gaps.length === 0) return null;
+
+  return (
+    <section id="further-reading" className="border-t border-border-light bg-warm">
+      <div className="max-w-[1500px] mx-auto px-6 py-10">
+        <h2 className="text-2xl sm:text-3xl text-primary font-display mb-2">
+          Further reading
+        </h2>
+        <p className="text-sm text-secondary leading-relaxed max-w-3xl mb-8">
+          Works that sit beside this collection rather than inside it — held here but
+          not part of its claim, or not held at all. Nothing below is counted among
+          the collection&rsquo;s works.
+        </p>
+
+        {books.length > 0 && (
+          <div className="mb-10">
+            <h3 className="text-lg sm:text-xl text-primary font-display mb-1">
+              In the library
+            </h3>
+            <p className="text-xs text-muted mb-5">
+              {books.length.toLocaleString('en-US')} adjacent {books.length === 1 ? 'work' : 'works'} we
+              hold. Most are scanned but not yet translated — the page images and
+              whatever has been transcribed are readable now.
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-5">
+              {books.map((b) => {
+                const status = furtherReadingStatus(b);
+                return (
+                  <Link
+                    key={b.id}
+                    href={tenantBookUrl({ id: b.id, slug: b.slug }, tenantSlug)}
+                    className="group block"
+                  >
+                    <div className="aspect-[3/4] relative rounded-lg overflow-hidden bg-white shadow-sm group-hover:shadow-md transition-shadow mb-2">
+                      {b.thumbnail ? (
+                        <Image
+                          src={b.thumbnail}
+                          alt={bookTitle(b)}
+                          fill
+                          className="object-cover group-hover:scale-105 transition-transform duration-300"
+                          sizes="(min-width: 1024px) 280px, (min-width: 640px) 30vw, 45vw"
+                        />
+                      ) : (
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <BookOpen className="w-8 h-8 text-muted" />
+                        </div>
+                      )}
+                    </div>
+                    <h4 className="text-sm font-semibold text-primary group-hover:text-accent-rust transition-colors line-clamp-2 leading-snug">
+                      {bookTitle(b)}
+                    </h4>
+                    {(b.author || b.year || b.published) && (
+                      <p className="text-xs text-muted line-clamp-1 mt-0.5">
+                        {[b.author, b.year || (b.published !== 'Unknown' ? b.published : undefined)]
+                          .filter(Boolean).join(', ')}
+                      </p>
+                    )}
+                    {b.note && (
+                      <p className="text-xs text-secondary leading-relaxed line-clamp-2 mt-1">
+                        {b.note}
+                      </p>
+                    )}
+                    {/* Readability, stated rather than implied. A book with no
+                        translated pages says so — see furtherReadingStatus. */}
+                    <p className="text-xs text-muted mt-1">
+                      {[b.language, b.pages_count ? `${b.pages_count.toLocaleString('en-US')} pp` : null]
+                        .filter(Boolean).join(' · ')}
+                      {b.language || b.pages_count ? ' · ' : ''}
+                      <span className={status.readable ? 'text-accent-gold-dark' : undefined}>
+                        {status.label}
+                      </span>
+                    </p>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {gaps.length > 0 && (
+          <div>
+            <h3 className="text-lg sm:text-xl text-primary font-display mb-1">
+              Not yet in the library
+            </h3>
+            <p className="text-xs text-muted mb-5">
+              Works this collection wants and does not hold, with the witnesses a
+              digitisation would come from. If you can point us at a scan of one of
+              these,{' '}
+              <Link href="/feedback" className="text-accent-rust hover:underline">
+                tell us
+              </Link>
+              .
+            </p>
+            <ul className="divide-y divide-border-light border-y border-border-light">
+              {gaps.map((g, i) => (
+                <li key={g.n || `${i}-${g.want}`} className="py-3 flex gap-3">
+                  {g.n && (
+                    <span className="text-xs text-muted tabular-nums pt-0.5 w-10 flex-shrink-0">
+                      {g.n}
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <p
+                      className="text-sm text-primary leading-snug"
+                      style={{ fontFamily: 'var(--font-serif)' }}
+                    >
+                      {g.want}
+                    </p>
+                    {g.witnesses && (
+                      <p className="text-xs text-muted leading-relaxed mt-0.5">
+                        {g.witnesses}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/further-reading.ts
+++ b/src/lib/further-reading.ts
@@ -1,0 +1,154 @@
+/**
+ * PRIOR ART: `src/lib/first-translation/derive.ts` already owns the readable
+ * threshold (`isTranslationReadable` / `FIRST_TRANSLATION_READABLE_MIN`) and is
+ * REUSED here rather than re-implemented — this file adds no second threshold.
+ * `src/lib/collections-utils.ts` holds title/thumbnail helpers for collection
+ * surfaces but nothing about reading lists; `src/lib/page-counts.ts` counts
+ * translated PAGES and has no view of a book's overall readiness. Nothing in
+ * `src/lib` resolved an authored id list against fetched books before (the
+ * collection page inlined that merge for `highlighted_books`), and nothing
+ * described a book we hold but cannot yet read.
+ *
+ * Further reading — books adjacent to a collection, and the works it lacks.
+ *
+ * WHAT THIS IS FOR
+ * ----------------
+ * `collections.further_reading` lists books we HOLD that sit next to a
+ * collection's claim without belonging to it. Tagging them into `collections`
+ * would inflate `book_count`, reorder the works grid, and blur what the
+ * collection asserts; a separate band puts them in front of a reader without
+ * any of that. Nothing here touches a counter — see
+ * `.claude/docs/invariants/visibility-and-stats.md`: a card must count what its
+ * target page renders, and `book_count` / `total_book_count` describe
+ * MEMBERSHIP, which further reading deliberately is not.
+ *
+ * THE HONESTY PROBLEM THIS SOLVES
+ * -------------------------------
+ * Every book in the first `further_reading` list (forum-of-conscience, #4653)
+ * has **zero translated pages** and only a sampled transcription — 25 OCR'd
+ * pages of 223 is typical. The band therefore has to render a book we hold and
+ * cannot yet read WITHOUT implying it is readable.
+ *
+ * `isTranslationReadable()` alone cannot answer that, and fails in the
+ * dangerous direction: its denominator is `pages_ocr − pages_blank`, so a book
+ * with 25 OCR'd pages of 223, all 25 translated, scores 100% and reads as
+ * "Translated" while 198 pages have never been transcribed. That is exactly the
+ * population this band is made of. So {@link furtherReadingStatus} requires the
+ * readable verdict AND a complete transcription before it will say "Translated",
+ * and otherwise states raw page counts rather than a verdict. The conjunction is
+ * strictly more conservative than the existing bar — it is not a competing one.
+ */
+
+import { isTranslationReadable, type TranslationCoverageBook } from './first-translation/derive';
+
+/** An authored entry in `collections.further_reading`. */
+export interface FurtherReadingRef {
+  /** `books.id` — NOT the Mongo `_id` (16,343 books have a re-minted `_id`). */
+  book_id: string;
+  /** One short clause on why this book is adjacent. Optional. */
+  note?: string;
+}
+
+/** The minimum a resolved book needs to render in the band. */
+export interface FurtherReadingBook extends TranslationCoverageBook {
+  id: string;
+  slug?: string;
+  /** Required so `bookTitle()` can be called without a coercion at each site. */
+  title: string;
+  display_title?: string;
+  author?: string;
+  year?: number;
+  published?: string;
+  language?: string;
+  thumbnail?: string;
+}
+
+export type FurtherReadingEntry = FurtherReadingBook & { note?: string };
+
+/** An entry in `collections.reading_list_gaps` — a work we do NOT hold. */
+export interface ReadingListGap {
+  /** Curator's running number ("N01"). Display only; may be absent. */
+  n?: string;
+  /** The work wanted, as the curator named it. */
+  want: string;
+  /** Manuscript or edition witnesses, free text. */
+  witnesses?: string;
+}
+
+export type FurtherReadingStatusKind = 'untranslated' | 'partial' | 'translated';
+
+export interface FurtherReadingStatus {
+  kind: FurtherReadingStatusKind;
+  /** Reader-facing phrase. Never claims readability the data does not support. */
+  label: string;
+  /** True only when the whole book is transcribed AND readably translated. */
+  readable: boolean;
+}
+
+/**
+ * What we can honestly say about reading this book today.
+ *
+ * Three states, in order of how much they claim:
+ *   - `untranslated` — no translated pages at all. Says so plainly.
+ *   - `partial`      — states counts, never a verdict.
+ *   - `translated`   — the full book is transcribed and clears the existing
+ *                      readable bar (`FIRST_TRANSLATION_READABLE_MIN`, 90%).
+ *
+ * `pages_ocr >= pages_count` is the transcription condition. Missing page
+ * counts are treated as unknown, not as zero — the same rule
+ * `translationCoverage` follows — so a book with no `pages_count` is judged on
+ * the readable bar alone rather than being demoted on absent data.
+ */
+export function furtherReadingStatus(book: TranslationCoverageBook): FurtherReadingStatus {
+  const translated = book.pages_translated ?? 0;
+  if (translated <= 0) {
+    return { kind: 'untranslated', label: 'Not yet translated', readable: false };
+  }
+
+  const pages = book.pages_count ?? 0;
+  const ocr = book.pages_ocr ?? 0;
+  const fullyTranscribed = pages <= 0 || ocr >= pages;
+
+  if (fullyTranscribed && isTranslationReadable(book)) {
+    return { kind: 'translated', label: 'Translated', readable: true };
+  }
+
+  const denominator = pages > 0 ? pages : Math.max(ocr - (book.pages_blank ?? 0), translated);
+  return {
+    kind: 'partial',
+    label: `${translated.toLocaleString('en-US')} of ${denominator.toLocaleString('en-US')} pages translated`,
+    readable: false,
+  };
+}
+
+/**
+ * Resolve authored refs against the books actually fetched, preserving the
+ * curator's order.
+ *
+ * A ref whose book is absent from `books` is DROPPED, silently and on purpose:
+ * the loader fetches with `visible: true`, so a hidden or removed book cannot
+ * reach this list. Authored prose inside a collection document is a takedown
+ * surface (`visibility-and-stats.md` — /collections/freemasonry named 13 removed
+ * books for six weeks), and the only structural defence is that a resolve which
+ * cannot find the book renders nothing rather than a bare id or a dead link.
+ */
+export function resolveFurtherReading(
+  refs: FurtherReadingRef[] | undefined | null,
+  books: FurtherReadingBook[],
+): FurtherReadingEntry[] {
+  if (!Array.isArray(refs) || refs.length === 0) return [];
+  const byId = new Map(books.map(b => [b.id, b]));
+  return refs.flatMap(ref => {
+    const book = ref?.book_id ? byId.get(ref.book_id) : undefined;
+    if (!book) return [];
+    return [{ ...book, note: ref.note }];
+  });
+}
+
+/** Drop malformed gap rows — `want` is the only field that must be there. */
+export function resolveReadingListGaps(
+  gaps: ReadingListGap[] | undefined | null,
+): ReadingListGap[] {
+  if (!Array.isArray(gaps)) return [];
+  return gaps.filter(g => g && typeof g.want === 'string' && g.want.trim().length > 0);
+}

--- a/tests/unit/further-reading.test.ts
+++ b/tests/unit/further-reading.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  furtherReadingStatus,
+  resolveFurtherReading,
+  resolveReadingListGaps,
+  type FurtherReadingBook,
+} from '@/lib/further-reading';
+
+/**
+ * Fixtures are copied from the production `books` rows the first further-reading
+ * list points at (forum-of-conscience, #4653), measured 2026-09-04 — not
+ * invented to reach a wanted verdict. Polanco's *Breve directorium* really is
+ * 223 pages with 25 OCR'd, 0 blank, 0 translated; every one of the eighteen has
+ * `pages_translated: 0`.
+ */
+const POLANCO: FurtherReadingBook = {
+  id: '6a4f7563eeef22aafac6164b',
+  slug: 'breve-directorium-ad-confessarii-et-confitentis-munus-recte-polanco',
+  title: 'Breve directorium ad confessarii et confitentis munus recte obeundum',
+  author: 'Polanco, Juan de',
+  published: '1586',
+  language: 'Latin',
+  pages_count: 223,
+  pages_ocr: 25,
+  pages_blank: 0,
+  pages_translated: 0,
+};
+
+describe('furtherReadingStatus', () => {
+  it('says so plainly when a held book has no translated pages', () => {
+    const s = furtherReadingStatus(POLANCO);
+    expect(s.kind).toBe('untranslated');
+    expect(s.readable).toBe(false);
+    expect(s.label).toBe('Not yet translated');
+  });
+
+  /**
+   * The guard this file exists for. `isTranslationReadable()` divides by
+   * `pages_ocr − pages_blank`, so a sampled transcription that happens to be
+   * fully translated scores 100% and reads as "Translated" while 198 of 223
+   * pages have never been transcribed. That is the exact shape of the books in
+   * this band, so the status must NOT claim readable here.
+   *
+   * Negative control: drop the `fullyTranscribed` conjunct from
+   * furtherReadingStatus and this assertion goes red while every other test in
+   * the file stays green.
+   */
+  it('does not call a sampled-but-fully-translated book readable', () => {
+    const s = furtherReadingStatus({ ...POLANCO, pages_translated: 25 });
+    expect(s.readable).toBe(false);
+    expect(s.kind).toBe('partial');
+    expect(s.label).toBe('25 of 223 pages translated');
+  });
+
+  it('reports a genuinely partial translation in raw counts, not a verdict', () => {
+    const s = furtherReadingStatus({
+      ...POLANCO, pages_count: 100, pages_ocr: 100, pages_blank: 0, pages_translated: 40,
+    });
+    expect(s.kind).toBe('partial');
+    expect(s.readable).toBe(false);
+    expect(s.label).toBe('40 of 100 pages translated');
+  });
+
+  it('only says "Translated" when the whole book is transcribed and clears the existing readable bar', () => {
+    const s = furtherReadingStatus({
+      ...POLANCO, pages_count: 100, pages_ocr: 100, pages_blank: 0, pages_translated: 100,
+    });
+    expect(s.kind).toBe('translated');
+    expect(s.readable).toBe(true);
+    expect(s.label).toBe('Translated');
+  });
+
+  it('withholds "Translated" from a fully transcribed book below the 90% bar', () => {
+    const s = furtherReadingStatus({
+      ...POLANCO, pages_count: 100, pages_ocr: 100, pages_blank: 0, pages_translated: 89,
+    });
+    expect(s.readable).toBe(false);
+  });
+
+  it('judges a book with no page counts on the readable bar alone, not as zero', () => {
+    const s = furtherReadingStatus({
+      id: 'x', pages_translated: 5,
+    } as FurtherReadingBook);
+    // Unknown coverage is "not shown to be thin" — the same rule
+    // translationCoverage() follows. It must not be demoted on absent data.
+    expect(s.kind).toBe('translated');
+  });
+});
+
+describe('resolveFurtherReading', () => {
+  const A: FurtherReadingBook = { ...POLANCO, id: 'a', title: 'A' };
+  const B: FurtherReadingBook = { ...POLANCO, id: 'b', title: 'B' };
+  const C: FurtherReadingBook = { ...POLANCO, id: 'c', title: 'C' };
+
+  it("preserves the curator's order, not the order the books came back in", () => {
+    const out = resolveFurtherReading(
+      [{ book_id: 'c' }, { book_id: 'a' }, { book_id: 'b' }],
+      [A, B, C],
+    );
+    expect(out.map(b => b.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  /**
+   * The loader fetches with `visible: true`, so a hidden or removed book never
+   * reaches this function. Dropping the ref is what stops an authored id list
+   * from publishing a dead link after a takedown — the failure that left 13
+   * removed books linked on /collections/freemasonry for six weeks.
+   */
+  it('drops a ref whose book was not returned, rather than rendering a bare id', () => {
+    const out = resolveFurtherReading(
+      [{ book_id: 'a' }, { book_id: 'hidden-or-removed' }, { book_id: 'b' }],
+      [A, B],
+    );
+    expect(out.map(b => b.id)).toEqual(['a', 'b']);
+  });
+
+  it('carries the authored note through onto the book', () => {
+    const out = resolveFurtherReading([{ book_id: 'a', note: 'Confessor’s manual.' }], [A]);
+    expect(out[0].note).toBe('Confessor’s manual.');
+  });
+
+  it('returns nothing for an absent or empty field', () => {
+    expect(resolveFurtherReading(undefined, [A])).toEqual([]);
+    expect(resolveFurtherReading([], [A])).toEqual([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(resolveFurtherReading({ book_id: 'a' } as any, [A])).toEqual([]);
+  });
+});
+
+describe('resolveReadingListGaps', () => {
+  // Copied verbatim from forum-of-conscience's stored `reading_list_gaps`.
+  const REAL = [
+    { n: 'N01', want: 'Burchard of Worms, Decretum lib. XIX (Corrector)', witnesses: 'Bamberg Msc.Can.6 (c. 1020); BSB Clm 4570 (1108)' },
+    { n: 'N07', want: 'Berthold von Freiburg, Rechtssumme', witnesses: 'Bämler, Augsburg 1472' },
+  ];
+
+  it('keeps well-formed rows intact', () => {
+    expect(resolveReadingListGaps(REAL)).toEqual(REAL);
+  });
+
+  it('drops rows with no work named', () => {
+    const out = resolveReadingListGaps([
+      ...REAL,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { n: 'N09', witnesses: 'orphaned witness with no work' } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { n: 'N10', want: '   ' } as any,
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('returns nothing for an absent field', () => {
+    expect(resolveReadingListGaps(undefined)).toEqual([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(resolveReadingListGaps('not an array' as any)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #4653.

## What ships

A **Further reading** band on `/collections/[id]`, after the works grid, anchor `#further-reading`, with the two halves the issue asked for:

1. **In the library** — 18 held books adjacent to the collection, from the new `collections.further_reading` field.
2. **Not yet in the library** — the collection's `reading_list_gaps`, named with their manuscript witnesses. That field has been carried on the document with **nothing in `src/` reading it**; this is the first time that scholarship reaches a reader.

The band self-gates: a collection with neither field renders nothing. The hero stat row gains a `18 further reading` link only when the band exists.

Live now on `/collections/forum-of-conscience` once this merges — the Mongo write is already applied (see *Data* below).

## The design question the issue flagged

> *"The band must render a book we hold but cannot yet read, without implying it is readable."*

**All 20 candidates have zero translated pages** — the issue said 17; measured 2026-09-04 it is 20 — and only a *sampled* transcription: 25 OCR'd pages of 223 is the typical shape.

`isTranslationReadable()` cannot answer this, and it fails in the dangerous direction. Its denominator is `pages_ocr − pages_blank`, so a book with 25 OCR'd pages of 223, **all 25 translated**, scores 100% and would render as **"Translated"** while 198 pages have never been transcribed. That is precisely the population this band is made of.

So `furtherReadingStatus()` (`src/lib/further-reading.ts`) requires the existing readable bar **and** a complete transcription before it will say "Translated", and otherwise states raw counts instead of a verdict:

| condition | label |
|---|---|
| `pages_translated === 0` | `Not yet translated` |
| partial, or transcription incomplete | `40 of 100 pages translated` |
| whole book transcribed **and** ≥ `FIRST_TRANSLATION_READABLE_MIN` | `Translated` |

The conjunction is **strictly more conservative** than the existing threshold — it is not a second competing one, and `FIRST_TRANSLATION_READABLE_MIN` is imported, not re-derived.

## Counters

`further_reading` is an **adjacency list, not membership**. These books are not tagged into `collections`, so nothing here reaches `book_count`, `total_book_count`, the works grid, or the Supabase `books_catalog` — no `books` document is touched at all. The population script asserts both counters are unchanged after its write, and they are: `book_count=31 total_book_count=34` before and after.

Per `visibility-and-stats.md` ("a card must count what its target page renders"), the hero link counts the band and lands on exactly what it counts.

## Two of the twenty are NOT written

#4653 excluded the `restitutio in integrum` law-faculty disputations as false friends — a Roman-law remedy, not the moral duty of restitution. **Two entries on its own shortlist are the same false friend one word over**, and reading the scans says so outright:

- **Cellarius**, *Dissertatio iuridica de poenitentia in contractibus innominatis* (Halle 1699). Chapter I is *De origine contractuum innominatorum*; the text argues from the Pandects, the *actio de praescriptis verbis*, and Gnaeus Flavius. This is the *ius poenitendi* — withdrawal from a contract.
- **Draing**, *Disputatio iuridica inauguralis de poenitentia* (Strasbourg 1671). Thesis III: *"Etymologiam insequitur Poenitentiae Homonymia, certissima errorum genitrix, **in Jure nostro civili** probe investiganda"*, then the three civil-law senses with Pandect citations. The volume is bound with eight other Strasbourg civil-law theses (*De collatione bonorum*, *De delegatione debitoris*, …).

They stay in `CANDIDATES` with `verdict: 'exclude'` and the evidence attached, so **re-including one is a one-word edit and a re-run**, not a rediscovery. If you'd rather ship all 20, say so and I'll flip them.

The four remaining ambiguous titles were checked the same way and all held up: Knorre/Müller are one 1678 canon-law disputation on ecclesiastical penance in two copies (Knorr wrote it, Müller presided); Puritanus' title page reads *"ad dirigendam et pacandam conscientiam"* — moral restitution, the exact discriminator; Cattaneus is *De censuris ecclesiasticis cum appendice de usuris et cambiis* by a Dominican theologian to the Archbishop of Salzburg.

## Data

Already applied to production Mongo (`scripts/maintenance/set-further-reading-4653.mjs --apply`) — **inert until this merges**, since nothing else in the codebase reads the field. Verified before/after:

```
matched=1 modified=1
Verified: 18 entries, order preserved, book_count=31 total_book_count=34 (unchanged).
  revalidated 3 path(s): /collections/forum-of-conscience, /collections, /collections/all
```

The script is **dry-run by default**, verifies every id against the slug it claims to be (an agent-supplied id is a claim, and `updateOne` swallows the gap), refuses ids that are not visible or that are already collection members, reads back and asserts order, asserts the counters did not move, and purges through `scripts/lib/revalidate.mjs` rather than hand-rolling a fetch.

`scripts/workers/sync-books-catalog.mjs` is deliberately **not** run: it syncs `books` → Supabase, and no book document changed.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run` — **259 files / 3621 tests pass.**
- Rendered against real production data on a local dev server: all 18 cards, all 5 gap rows, 18 `/book/` links, hero reads `18 further reading`, no soft-404 marker.
- **Negative control run, as `tests-that-are-not-guards.md` requires**: dropping the `fullyTranscribed` conjunct turns exactly one assertion red (`does not call a sampled-but-fully-translated book readable`) and leaves the other 12 green. Restored, all 13 pass.
- Test fixtures are copied from the real production rows, not invented.

I could not get a browser screenshot (the shared devtools Chrome profile was locked by another session) — **the preview deploy is the visual check.** The card markup mirrors the existing "Featured books" band value for value, so the risk is low, but it has not been looked at by an eye.

## Design constraints

`collection-page-redesign-spec.md` §0 — **no new design primitives.** Every value maps to a token already used in the sibling bands: `bg-warm`, `border-border-light`, `divide-border-light`, `text-primary/secondary/muted`, `accent-rust`, `accent-gold-dark`, `font-display`, `var(--font-serif)`, `aspect-[3/4]`, `rounded-lg`, `shadow-sm`, `max-w-[1500px] px-6 py-10`. No new typeface, size, colour, radius, shadow or spacing scale.

`field-sprawl.md` — one new field on `collections` (not `books`, so `new-field-writes.mjs` and the `books` validator are unaffected), sitting alongside its existing siblings `highlighted_books` / `mentioned_books` / `reading_list_gaps`. It describes what the collection *is*, not what a job *did*, so it is a field rather than a `sweep_log` row.

## Out of scope

Tagging any of these into the collection proper; the borderline books #4653 set aside (law-faculty *de usuris* theses, Possevino, Manuzio); the Forum description rewrite (rule 11c — it names 0 of its 34 books). (Second commit, same concern: `visibility-and-stats.md` — the doc that already owns the readable denominator — now records the trap above, since the next surface to hit it will not be this one. It also deletes a stray `||||||| b0a919ae` diff3 conflict marker that has sat at the end of that file on `main` since 951f0890. Nothing was lost — that commit was 59 insertions, 0 deletions; the marker is one junk line at EOF.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxoDa9FW8a35C1Ce3LpAJ
