### PR TITLE
feat(jobs): record why a job was run by hand (initiated_reason) (#4336)

### DIFF
--- a/scripts/batch/bulk-ocr-lambda.mjs
+++ b/scripts/batch/bulk-ocr-lambda.mjs
@@ -10,6 +10,7 @@
  *   node scripts/batch/bulk-ocr-lambda.mjs --book-ids=id1,id2,id3
  *   node scripts/batch/bulk-ocr-lambda.mjs --provider=efm --incomplete-only
  *   node scripts/batch/bulk-ocr-lambda.mjs --dry-run
+ *   node scripts/batch/bulk-ocr-lambda.mjs --reason="why by hand"
  */
 
 import { MongoClient } from 'mongodb';
@@ -17,6 +18,7 @@ import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // Load .env.production.local
 try {
@@ -56,6 +58,8 @@ const PROVIDER = getArg('provider');
 const DRY_RUN = hasFlag('dry-run');
 const INCOMPLETE_ONLY = hasFlag('incomplete-only') || true; // default: only pages missing OCR
 const LIMIT = parseInt(getArg('limit') || '0', 10);
+const INITIATED_BY = 'bulk-ocr-script';
+const REASON = parseInitiatedReason(process.argv.slice(2), INITIATED_BY);
 
 // SQS client
 const sqsClient = new SQSClient({ region: AWS_REGION });
@@ -180,7 +184,8 @@ async function main() {
       book_title: book.title,
       progress: { total: pageIds.length, completed: 0, failed: 0 },
       config: { page_ids: pageIds, language: book.language || 'Unknown' },
-      initiated_by: 'bulk-ocr-script',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date(),
       started_at: new Date(),

--- a/scripts/batch/bulk-reocr-local.mjs
+++ b/scripts/batch/bulk-reocr-local.mjs
@@ -16,6 +16,7 @@
  *   --book-id=ID     Process a single book
  *   --new-only       Only target pages WITHOUT OCR (instead of re-OCR)
  *   --provider=X     Filter by provider (e.g. 'efm', 'ia')
+ *   --reason="..."   Why this batch is being run by hand (recorded on each job, #4336)
  *
  * Requires: MONGODB_URI, GEMINI_API_KEY_TIER3 (or GEMINI_API_KEY) in env
  */
@@ -23,6 +24,7 @@
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -55,6 +57,8 @@ const PROVIDER = getArg('provider');
 // image (bypasses the possibly-downscaled archived R2 copy). Used by the batch-OCR
 // contamination repair (#3362) so re-OCR reads full-res, correct source images.
 const SOURCE = getArg('source');
+const INITIATED_BY = 'script:bulk-reocr-local';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // --- Gemini API ---
 function getApiKey() {
@@ -473,6 +477,8 @@ async function main() {
             prompt_version: TARGET_PROMPT,
             submission_method: useFileBased ? 'file' : 'inline',
             force: !NEW_ONLY,
+            initiated_by: INITIATED_BY,
+            ...initiatedReasonFields(REASON),
             created_at: new Date(),
             updated_at: new Date(),
           });
@@ -531,6 +537,8 @@ async function main() {
         language,
         prompt_version: TARGET_PROMPT,
         force: !NEW_ONLY,
+        initiated_by: INITIATED_BY,
+        ...initiatedReasonFields(REASON),
         created_at: new Date(),
         updated_at: new Date(),
       });

--- a/scripts/batch/bulk-reocr-opened-books.mjs
+++ b/scripts/batch/bulk-reocr-opened-books.mjs
@@ -13,12 +13,14 @@
  *   --dry-run     Show what would be queued without actually submitting
  *   --limit N     Only process the first N books (sorted by read_count desc)
  *   --book-id ID  Process a single book by ID
+ *   --reason="..." Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { PAGE_RATE_USD, PAGE_RATES_MEASURED_ON } from '../lib/model-pricing.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // --- Config ---
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -44,6 +46,8 @@ const limitIdx = args.indexOf('--limit');
 const LIMIT = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
 const bookIdIdx = args.indexOf('--book-id');
 const SINGLE_BOOK_ID = bookIdIdx >= 0 ? args[bookIdIdx + 1] : null;
+const INITIATED_BY = 'script:bulk-reocr-opened-books';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // --- Image fetching ---
 async function fetchImageAsBase64(url, timeout = 30000) {
@@ -221,6 +225,8 @@ async function run() {
       language,
       prompt_version: PROMPT_VERSION,
       force: true,
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date()
     });
@@ -281,6 +287,8 @@ async function run() {
           language,
           prompt_version: PROMPT_VERSION,
           force: true,
+          initiated_by: INITIATED_BY,
+          ...initiatedReasonFields(REASON),
           created_at: new Date(),
           updated_at: new Date()
         });

--- a/scripts/batch/bulk-translate-lambda.mjs
+++ b/scripts/batch/bulk-translate-lambda.mjs
@@ -22,6 +22,7 @@
  *   --max-pages=N    Skip books with more than N untranslated pages (default: 9999)
  *   --smallest       Sort smallest books first (default — fastest to complete)
  *   --largest        Sort largest books first
+ *   --reason="..."   Why this batch is being run by hand (recorded on each job, #4336)
  *
  * Requires env: MONGODB_URI, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, SQS_PAGE_TRANSLATION_QUEUE_URL
  */
@@ -32,6 +33,7 @@ import { nanoid } from 'nanoid';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // Load .env.production.local for MONGODB_URI + SQS URLs
 try {
@@ -79,6 +81,8 @@ const DRY_RUN = hasFlag('dry-run');
 const SINGLE_BOOK = getArg('book-id');
 const MAX_PAGES = parseInt(getArg('max-pages') || '9999', 10);
 const SORT_LARGEST = hasFlag('largest');
+const INITIATED_BY = 'bulk-translate-script';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // --- SQS ---
 const sqsClient = new SQSClient({ region: AWS_REGION });
@@ -237,7 +241,8 @@ async function main() {
         model: DEFAULT_MODEL,
         language: book.language || 'auto-detect',
       },
-      initiated_by: 'bulk-translate-script',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date(),
     });

--- a/scripts/batch/queue-efm-priority.mjs
+++ b/scripts/batch/queue-efm-priority.mjs
@@ -7,11 +7,17 @@
  * Usage:
  *   set -a; source .env.production.local; set +a; node scripts/queue-efm-priority.mjs --dry-run
  *   set -a; source .env.production.local; set +a; node scripts/queue-efm-priority.mjs
+ *
+ * Options:
+ *   --dry-run        Show what would be queued without queuing
+ *   --top=N          How many priority books to consider (default: 100)
+ *   --reason="..."   Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 const OCR_QUEUE_URL = process.env.SQS_PAGE_OCR_QUEUE_URL;
 const TRANSLATION_QUEUE_URL = process.env.SQS_PAGE_TRANSLATION_QUEUE_URL;
@@ -21,6 +27,8 @@ const AWS_REGION = process.env.AWS_REGION || 'eu-central-1';
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const TOP_N = parseInt(args.find(a => a.startsWith('--top='))?.split('=')[1] || '100');
+const INITIATED_BY = 'script:queue-efm-priority';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 async function main() {
   if (!MONGODB_URI) throw new Error('MONGODB_URI not set');
@@ -130,7 +138,8 @@ async function main() {
       status: 'pending',
       progress: { total: pageIds.length, completed: 0, failed: 0 },
       config: { page_ids: pageIds, model: 'gemini-3-flash-preview', language: book.language || 'auto-detect' },
-      initiated_by: 'script:queue-efm-priority',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date()
     });
@@ -204,7 +213,8 @@ async function main() {
       status: 'pending',
       progress: { total: pageIds.length, completed: 0, failed: 0 },
       config: { page_ids: pageIds, model: 'gemini-3-flash-preview', language: book.language || 'auto-detect' },
-      initiated_by: 'script:queue-efm-priority',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date()
     });

--- a/scripts/batch/queue-efm-translations.mjs
+++ b/scripts/batch/queue-efm-translations.mjs
@@ -11,12 +11,14 @@
  *   --dry-run     Show what would be queued
  *   --biggest     Sort by largest gap first (default: smallest first)
  *   --book-id=ID  Queue a single book
+ *   --reason="..." Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
 import { SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // --- Config ---
 const SKIP_PAGE_TYPES = SKIP_TRANSLATION_PAGE_TYPES; // canonical (#3734)
@@ -34,6 +36,8 @@ const LIMIT = parseInt(getArg('limit') || '50', 10);
 const DRY_RUN = hasFlag('dry-run');
 const BIGGEST_FIRST = hasFlag('biggest');
 const SINGLE_BOOK = getArg('book-id');
+const INITIATED_BY = 'script:queue-efm-translations';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // --- SQS setup ---
 const sqsClient = new SQSClient({
@@ -184,7 +188,10 @@ async function main() {
             model: DEFAULT_MODEL,
             language: book.language || 'auto-detect',
           },
-          initiated_by: 'script',
+          // Was the bare 'script', which named no lane — reconstruction needs to know
+          // WHICH hand-run script, not just that one ran (#4336).
+          initiated_by: INITIATED_BY,
+          ...initiatedReasonFields(REASON),
           created_at: new Date(),
           updated_at: new Date(),
         });

--- a/scripts/batch/queue-ocr-direct.mjs
+++ b/scripts/batch/queue-ocr-direct.mjs
@@ -7,11 +7,17 @@
  *   set -a; source .env.local; source .env.production.local; set +a
  *   node scripts/queue-ocr-direct.mjs --limit 600
  *   node scripts/queue-ocr-direct.mjs --dry-run --limit 10
+ *
+ * Options:
+ *   --limit N        Max books to consider (default: 100)
+ *   --dry-run        Show what would be queued without queuing
+ *   --reason="..."   Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { randomBytes } from 'crypto';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const SQS_QUEUE_URL = process.env.SQS_PAGE_OCR_QUEUE_URL;
@@ -24,6 +30,8 @@ const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const limIdx = args.indexOf('--limit');
 const LIMIT = limIdx >= 0 ? parseInt(args[limIdx + 1], 10) : 100;
+const INITIATED_BY = 'script:queue-ocr-direct';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 const sqs = new SQSClient({ region: AWS_REGION });
 
@@ -142,6 +150,9 @@ async function run() {
         progress: { total: pageIds.length, completed: 0, failed: 0 },
         config: { page_ids: pageIds },
         failed_page_ids: [],
+        // This lane is hand-run, so it says so on every row it writes (#4336).
+        initiated_by: INITIATED_BY,
+        ...initiatedReasonFields(REASON),
         created_at: new Date(),
         updated_at: new Date(),
         started_at: new Date(),

--- a/scripts/batch/queue-translations-to-80pct.mjs
+++ b/scripts/batch/queue-translations-to-80pct.mjs
@@ -10,11 +10,13 @@
  * Options:
  *   --dry-run    Show what would be queued without queuing
  *   --limit=N    Max books to queue (default: 519)
+ *   --reason="..." Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 const TRANSLATION_QUEUE_URL = process.env.SQS_PAGE_TRANSLATION_QUEUE_URL;
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -23,6 +25,8 @@ const AWS_REGION = process.env.AWS_REGION || 'eu-central-1';
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const LIMIT = parseInt(args.find(a => a.startsWith('--limit='))?.split('=')[1] || '519');
+const INITIATED_BY = 'script:queue-translations-to-80pct';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 async function main() {
   if (!MONGODB_URI) throw new Error('MONGODB_URI not set');
@@ -118,7 +122,8 @@ async function main() {
         model: 'gemini-3-flash-preview',
         language: book.language || 'auto-detect'
       },
-      initiated_by: 'script:queue-translations-to-80pct',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date()
     });

--- a/scripts/batch/queue-translations.mjs
+++ b/scripts/batch/queue-translations.mjs
@@ -10,11 +10,13 @@
  *   --book-id=ID     Queue a specific book
  *   --dry-run        Show what would be queued without actually queuing
  *   --limit=N        Max books to queue (default: all in BOOKS list)
+ *   --reason="..."   Why this batch is being run by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { nanoid } from 'nanoid';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // ── Configuration ──────────────────────────────────────────────────────
 
@@ -112,6 +114,8 @@ const DRY_RUN = args.includes('--dry-run');
 const SPECIFIC_BOOK = args.find(a => a.startsWith('--book-id='))?.split('=')[1];
 const LIMIT = parseInt(args.find(a => a.startsWith('--limit='))?.split('=')[1] || '999');
 const AUTO_MODE = args.includes('--auto');
+const INITIATED_BY = 'script:queue-translations';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // ── Main ───────────────────────────────────────────────────────────────
 
@@ -212,7 +216,8 @@ async function main() {
         model: 'gemini-3-flash-preview',
         language: book.language || 'auto-detect'
       },
-      initiated_by: 'script:queue-translations',
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date()
     });

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -27,6 +27,7 @@
  *   --limit=N          Max pages to process (default: 2000)
  *   --concurrency=N    Parallel API calls (default: 30)
  *   --dry-run          Show what would be processed, don't call Gemini
+ *   --reason="..."     Why this run is being done by hand (recorded on the run, #4336)
  */
 
 import fs from 'node:fs';
@@ -34,6 +35,7 @@ import { MongoClient } from 'mongodb';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { extractPageType, extractColumns, parseDetectedImages } from '../lib/ocr-result-parse.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -58,6 +60,8 @@ const SINGLE_BOOK = getArg('book-id');
 const OFFSET = parseInt(getArg('offset') || '0', 10);
 const PIPELINE_STATUS = getArg('status');
 const PROVIDER = getArg('provider');
+const INITIATED_BY = 'script:realtime-ocr';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // Targeting mode
 const MODE_NO_OCR = hasFlag('no-ocr');
@@ -685,6 +689,8 @@ async function main() {
       },
       book_ids: uniqueBookIds,
       progress: { completed: 0, failed: 0, skipped: 0, total: pages.length },
+      initiated_by: INITIATED_BY,
+      ...initiatedReasonFields(REASON),
       created_at: new Date(),
       updated_at: new Date(),
     });

--- a/scripts/batch/retranslate-stale.mjs
+++ b/scripts/batch/retranslate-stale.mjs
@@ -7,17 +7,22 @@
  *
  * Usage:
  *   set -a; source .env.production.local; set +a; node scripts/batch/retranslate-stale.mjs [--dry-run] [--limit=N] [--book-id=ID]
+ *
+ * Also accepts --reason="..." — why this run is being done by hand (#4336).
  */
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenAI } from '@google/genai';
 import { SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT_ARG = process.argv.find(a => a.startsWith('--limit='));
 const BOOK_LIMIT = LIMIT_ARG ? parseInt(LIMIT_ARG.split('=')[1]) : Infinity;
 const BOOK_ID_ARG = process.argv.find(a => a.startsWith('--book-id='));
 const SINGLE_BOOK_ID = BOOK_ID_ARG ? BOOK_ID_ARG.split('=')[1] : null;
+const INITIATED_BY = 'script:retranslate-stale';
+const REASON = parseInitiatedReason(process.argv.slice(2), INITIATED_BY);
 
 const CURRENT_MODEL = 'gemini-3-flash-preview';
 const BATCH_MODEL = 'gemini-3-flash-preview';
@@ -244,6 +249,8 @@ async function main() {
           page_ids: batchRequests.map(r => r.key),
           page_count: batchRequests.length,
           status: job.state,
+          initiated_by: INITIATED_BY,
+          ...initiatedReasonFields(REASON),
           created_at: new Date(),
           updated_at: new Date(),
         });

--- a/scripts/experiments/batch-size-experiment.mjs
+++ b/scripts/experiments/batch-size-experiment.mjs
@@ -14,6 +14,8 @@
  * Usage:
  *   set -a; source .env.production.local; set +a
  *   node scripts/experiments/batch-size-experiment.mjs [--size=1000] [--dry-run]
+ *
+ * Also accepts --reason="..." — why this run is being done by hand (#4336).
  */
 
 import { MongoClient } from 'mongodb';
@@ -22,6 +24,7 @@ import { nanoid } from 'nanoid';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY_3 || process.env.GEMINI_API_KEY;
@@ -31,6 +34,8 @@ const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const TARGET_SIZE = parseInt(args.find(a => a.startsWith('--size='))?.split('=')[1] || '1000');
+const INITIATED_BY = 'script:batch-size-experiment';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 const IMAGE_CONCURRENCY = 20;
 
@@ -223,6 +228,8 @@ async function run() {
     submission_method: 'file',
     experiment: 'large-batch-size',
     experiment_target: TARGET_SIZE,
+    initiated_by: INITIATED_BY,
+    ...initiatedReasonFields(REASON),
     created_at: new Date(),
     updated_at: new Date(),
   });

--- a/scripts/lib/initiated-reason.mjs
+++ b/scripts/lib/initiated-reason.mjs
@@ -1,0 +1,70 @@
+/**
+ * `--reason="..."` for manual queue scripts — the WHY behind a hand-dispatched job.
+ *
+ * PRIOR ART: scripts/lib/sweep-log.mjs — records a sweep's verdict about a BOOK as
+ * a row in `sweep_log`. Different question: this records why a HUMAN dispatched a
+ * processing job, and it belongs on the `jobs` row itself (that is what
+ * `src/lib/book-history.ts` reads, and what `initiated_by` already lives on).
+ *
+ * WHY (issue #4336): the `jobs` ledger stamps every dispatch with `initiated_by`
+ * (`user`, `script:queue-translations`, `bulk-translate-script`, …), which was enough
+ * to reconstruct 715 manually-processed books in 19 episodes — but the *reason* was
+ * never captured at queue time, so each episode had to be inferred from what its
+ * books had in common. Recoverable today, unrecoverable in a year.
+ *
+ * Usage in a queue script:
+ *
+ *   import { parseInitiatedReason } from '../lib/initiated-reason.mjs';
+ *   const REASON = parseInitiatedReason(args, 'script:queue-translations');
+ *   // ...
+ *   await db.collection('jobs').insertOne({
+ *     ...,
+ *     initiated_by: 'script:queue-translations',
+ *     ...initiatedReasonFields(REASON),
+ *   });
+ *
+ * Warns (never fails) when omitted: a missing reason must not stop an operator
+ * from queueing work at 2am. The nudge is the point, not a gate.
+ */
+
+/**
+ * Read `--reason="..."` (or `--reason ...`) out of an argv slice.
+ *
+ * @param {string[]} args - `process.argv.slice(2)`
+ * @param {string} initiatedBy - the `initiated_by` value the caller writes, used in the warning
+ * @returns {string|undefined} the trimmed reason, or undefined when absent/blank
+ */
+export function parseInitiatedReason(args, initiatedBy) {
+  let raw;
+  const inline = args.find(a => a.startsWith('--reason='));
+  if (inline) {
+    raw = inline.slice('--reason='.length);
+  } else {
+    const idx = args.indexOf('--reason');
+    if (idx >= 0) raw = args[idx + 1];
+  }
+
+  // A following flag is not a reason — `--reason --dry-run` means the value is missing.
+  if (raw && raw.startsWith('--')) raw = undefined;
+
+  const reason = raw?.trim();
+  if (!reason) {
+    console.warn(
+      `WARNING: no --reason="..." given. Jobs will record initiated_by="${initiatedBy}" with no\n` +
+      `         reason, and why this batch was run by hand will not be recoverable later (#4336).`
+    );
+    return undefined;
+  }
+  return reason;
+}
+
+/**
+ * Spread into a job document. Omits the key entirely when there is no reason, so
+ * absent stays absent rather than becoming an empty string.
+ *
+ * @param {string|undefined} reason
+ * @returns {{initiated_reason?: string}}
+ */
+export function initiatedReasonFields(reason) {
+  return reason ? { initiated_reason: reason } : {};
+}

--- a/scripts/migration/backfill-ocr-near-complete.mjs
+++ b/scripts/migration/backfill-ocr-near-complete.mjs
@@ -12,12 +12,14 @@
  *   --dry-run         List books and pages, don't submit
  *   --limit=N         Max books to process (default: 50)
  *   --max-missing=N   Max missing pages per book (default: 50)
+ *   --reason="..."    Why this run is being done by hand (recorded on each job, #4336)
  */
 
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { getOcrModelForBook } from '../lib/ocr-routing.mjs';
+import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
 
 // ── Config ──
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -31,6 +33,8 @@ const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const LIMIT = parseInt(args.find(a => a.startsWith('--limit='))?.split('=')[1] || '50');
 const MAX_MISSING = parseInt(args.find(a => a.startsWith('--max-missing='))?.split('=')[1] || '50');
+const INITIATED_BY = 'script:backfill-ocr-near-complete';
+const REASON = parseInitiatedReason(args, INITIATED_BY);
 
 // ── Gemini Batch API keys ──
 const GEMINI_BATCH_KEYS = [
@@ -337,6 +341,8 @@ async function main() {
         model: ocrModel,
         status: 'pending',
         api_key_index: batchJob.keyIndex ?? 0,
+        initiated_by: INITIATED_BY,
+        ...initiatedReasonFields(REASON),
         created_at: new Date(),
         source: 'backfill-ocr-near-complete',
       });

--- a/src/app/api/jobs/queue-books/route.ts
+++ b/src/app/api/jobs/queue-books/route.ts
@@ -16,7 +16,8 @@ import { withAuth } from '@/lib/auth-helpers';
  *   bookId: string,
  *   pageIds: string[],
  *   action: JobType,  // 'ocr' | 'translation' | 'image_extraction'
- *   customPrompt?: string  // Optional, for OCR and Translation only
+ *   customPrompt?: string,  // Optional, for OCR and Translation only
+ *   reason?: string  // Optional: why an operator is running this by hand (#4336)
  * }
  *
  * Flow:
@@ -39,12 +40,14 @@ export const POST = withAuth(async (request, session) => {
       bookId,
       pageIds,
       action,
-      customPrompt
+      customPrompt,
+      reason
     }: {
       bookId: string;
       pageIds: string[];
       action: JobType;
       customPrompt?: string;
+      reason?: string;
     } = await request.json();
 
     // Validate required fields
@@ -61,6 +64,10 @@ export const POST = withAuth(async (request, session) => {
         { status: 400 }
       );
     }
+
+    // Free text from an operator: trimmed, and capped so a paste cannot bloat the row.
+    const initiatedReason =
+      typeof reason === 'string' ? reason.trim().slice(0, 500) || undefined : undefined;
 
     const db = await getDb();
 
@@ -109,6 +116,9 @@ export const POST = withAuth(async (request, session) => {
         language: book.language || "auto-detect"
       },
       initiated_by: 'user',
+      // Why a human queued this, captured at queue time — the field is absent, not
+      // empty, when no reason was given, so "unrecorded" stays distinguishable (#4336).
+      ...(initiatedReason ? { initiated_reason: initiatedReason } : {}),
       created_at: new Date(),
       updated_at: new Date()
     });

--- a/src/components/analytics/tabs/LogsTab.tsx
+++ b/src/components/analytics/tabs/LogsTab.tsx
@@ -97,6 +97,7 @@ export default function LogsTab() {
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Status</th>
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Type</th>
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>User</th>
+                  <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Reason</th>
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Book</th>
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Pages</th>
                   <th className="px-4 py-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>Model / Prompt</th>
@@ -128,6 +129,12 @@ export default function LogsTab() {
                       </td>
                       <td className="px-4 py-3 text-xs" style={{ color: 'var(--text-muted)' }}>
                         {job.initiated_by || '-'}
+                      </td>
+                      {/* Why a human ran this by hand — blank for automated lanes (#4336) */}
+                      <td className="px-4 py-3 text-xs max-w-[220px]" style={{ color: 'var(--text-muted)' }}>
+                        <div className="truncate" title={job.initiated_reason || ''}>
+                          {job.initiated_reason || '-'}
+                        </div>
                       </td>
                       <td className="px-4 py-3 max-w-[200px]">
                         {job.book_id ? (

--- a/src/components/book/BookHistory.tsx
+++ b/src/components/book/BookHistory.tsx
@@ -24,6 +24,7 @@ interface HistoryEvent {
   doi?: string;
   action?: string;
   triggered_by?: string;
+  reason?: string;
 }
 
 interface HistoryResponse {
@@ -238,6 +239,15 @@ export default function BookHistory({ bookId }: BookHistoryProps) {
                                   </>
                                 )}
                               </div>
+                              {/* Why a human ran this by hand — a sentence, so it gets its own line (#4336) */}
+                              {event.reason && (
+                                <p
+                                  className="text-xs text-stone-500 italic mt-1"
+                                  title="Reason recorded when this job was queued"
+                                >
+                                  “{event.reason}”
+                                </p>
+                              )}
                             </div>
                           </div>
                         </div>

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -43,6 +43,7 @@ export default function BookPagesSection({ bookId, bookPath, bookTitle, pages: i
   // const [selectedModel, setSelectedModel] = useState(DEFAULT_MODEL);
   const [showPromptSettings, setShowPromptSettings] = useState(false);
   const [overwriteMode, setOverwriteMode] = useState(false); // Force re-process pages that already have data
+  const [reason, setReason] = useState(''); // Why this batch is being run by hand (#4336)
   const [visibleCount, setVisibleCount] = useState(9); // Pagination — mobile default (3×3); desktop bumps to PAGES_PER_LOAD on mount
 
   // Desktop shows a fuller first screen (2 rows on the 10-col grid); mobile keeps 9.
@@ -389,7 +390,8 @@ export default function BookPagesSection({ bookId, bookPath, bookTitle, pages: i
         bookId,
         pageIds: pageIdsToProcess,
         action,
-        customPrompt
+        customPrompt,
+        reason: reason.trim() || undefined
       });
 
       // Set current job to show progress UI immediately
@@ -407,11 +409,13 @@ export default function BookPagesSection({ bookId, bookPath, bookTitle, pages: i
         config: {},
         created_at: new Date(),
         updated_at: new Date(),
-        initiated_by: 'user'
+        initiated_by: 'user',
+        initiated_reason: reason.trim() || undefined
       });
 
       // Clear selection and exit batch mode
       setSelectedPages(new Set());
+      setReason('');
       setBatchMode(false);
     } catch (error) {
       console.error('Failed to queue job:', error);

--- a/src/components/book/ProcessingPanel.tsx
+++ b/src/components/book/ProcessingPanel.tsx
@@ -18,6 +18,8 @@ interface ProcessingPanelProps {
   queueing: boolean;
   brightness?: number;
   previewUrl?: string | null;
+  /** Optional free text: why this batch is being run by hand (#4336). */
+  reason?: string;
   onActionChange: (action: ActionType) => void;
   onOverwriteModeChange: (overwrite: boolean) => void;
   onSelectAll: () => void;
@@ -27,6 +29,7 @@ interface ProcessingPanelProps {
   onEditPrompt: (action: JobType, value: string) => void;
   onStartProcess: () => void;
   onBrightnessChange?: (value: number) => void;
+  onReasonChange?: (value: string) => void;
 }
 
 const actionIcons: Record<ActionType, any> = {
@@ -61,6 +64,7 @@ export default function ProcessingPanel({
   queueing,
   brightness = 1.0,
   previewUrl,
+  reason = '',
   onActionChange,
   onOverwriteModeChange,
   onSelectAll,
@@ -69,7 +73,8 @@ export default function ProcessingPanel({
   onSelectPrompt,
   onEditPrompt,
   onStartProcess,
-  onBrightnessChange
+  onBrightnessChange,
+  onReasonChange
 }: ProcessingPanelProps) {
   const isBrightnessAction = action === 'adjust_images';
 
@@ -230,6 +235,26 @@ export default function ProcessingPanel({
           <p className="text-xs text-stone-400">
             Use {'{language}'} and {'{target_language}'} as placeholders. Changes apply to this batch only.
           </p>
+        </div>
+      )}
+
+      {/* Reason — why this is being run by hand. Optional, never a gate: the point is
+          that "there is always a reason" survives the run (#4336). Not shown for
+          brightness, which writes no job row. */}
+      {!isBrightnessAction && onReasonChange && (
+        <div className="flex items-center gap-2">
+          <label htmlFor="job-reason" className="text-sm text-stone-600 whitespace-nowrap">
+            Reason:
+          </label>
+          <input
+            id="job-reason"
+            type="text"
+            value={reason}
+            maxLength={500}
+            onChange={e => onReasonChange(e.target.value)}
+            placeholder="Optional — why by hand? (e.g. reader request, bad OCR on plates)"
+            className="flex-1 px-3 py-1.5 text-sm bg-white border border-accent-gold/20 rounded-lg text-stone-700 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus-visible:ring-accent-rust"
+          />
         </div>
       )}
 

--- a/src/lib/api-client/types/jobs.ts
+++ b/src/lib/api-client/types/jobs.ts
@@ -33,6 +33,7 @@ export interface JobLog {
   book_id?: string;
   book_title?: string;
   initiated_by?: string;
+  initiated_reason?: string;   // Why a human ran this by hand (#4336)
   created_at: string;
   updated_at: string;
   started_at?: string;

--- a/src/lib/api-client/types/queues.ts
+++ b/src/lib/api-client/types/queues.ts
@@ -23,4 +23,5 @@ export interface QueueBooksRequest {
   pageIds: string[];       // Specific page IDs to process
   action: JobType;         // 'ocr' | 'translation' | 'image_extraction'
   customPrompt?: string;   // Optional custom prompt for OCR/translation
+  reason?: string;         // Optional: why this is being run by hand (#4336)
 }

--- a/src/lib/book-history.ts
+++ b/src/lib/book-history.ts
@@ -52,6 +52,8 @@ export interface HistoryEvent {
   doi?: string;
   action?: string;
   triggered_by?: string;
+  /** Why a human ran this by hand, recorded at queue time (`jobs.initiated_reason`, #4336). */
+  reason?: string;
   changes?: Array<{ field: string; previous: unknown; new_value: unknown }>;
 }
 
@@ -111,6 +113,8 @@ interface JobRow {
   status: string;
   progress?: { completed?: number; total?: number; failed?: number };
   config?: { model?: string };
+  initiated_by?: string;
+  initiated_reason?: string;
   created_at: Date | string;
   completed_at?: Date | string;
 }
@@ -300,7 +304,13 @@ export async function assembleBookHistory(
         .collection('jobs')
         .find(
           { book_id: resolvedBookId },
-          { projection: { id: 1, type: 1, status: 1, progress: 1, config: 1, created_at: 1, completed_at: 1 } },
+          {
+            projection: {
+              id: 1, type: 1, status: 1, progress: 1, config: 1,
+              initiated_by: 1, initiated_reason: 1,
+              created_at: 1, completed_at: 1,
+            },
+          },
         )
         .sort({ created_at: 1 })
         .toArray()
@@ -476,6 +486,9 @@ export async function assembleBookHistory(
       cost_usd: cost && cost > 0 ? Math.round(cost * 1_000_000) / 1_000_000 : undefined,
       model: job.config?.model,
       status: job.status,
+      triggered_by: job.initiated_by,
+      // Answers "why was this done by hand?" — only hand-initiated lanes set it (#4336).
+      reason: job.initiated_reason,
     });
   }
 

--- a/src/lib/types/job.ts
+++ b/src/lib/types/job.ts
@@ -60,6 +60,12 @@ export interface Job {
 
   // Metadata
   initiated_by?: string;  // Name/email of user who started the job
+  /**
+   * Why a HUMAN started this job, captured at queue time (#4336). Only ever set on
+   * hand-initiated lanes (`initiated_by: 'user'` or a `script:*` queue script) —
+   * automated lanes (orchestrator, import_preview) have no human reason to record.
+   */
+  initiated_reason?: string;
   created_at: Date;
   updated_at: Date;
   started_at?: Date;

--- a/tests/unit/initiated-reason.test.ts
+++ b/tests/unit/initiated-reason.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import {
+  parseInitiatedReason,
+  initiatedReasonFields,
+} from '../../scripts/lib/initiated-reason.mjs';
+
+/**
+ * A hand-dispatched job that cannot say WHY it was dispatched is a job whose
+ * reason has to be guessed later from what its books have in common (#4336).
+ *
+ * That reconstruction has been done once: 715 manually-processed books across 19
+ * episodes, recoverable in 2026 only because `initiated_by` distinguished the
+ * lanes. The reason itself was never recorded, so every episode's purpose was
+ * inferred — and an inference that is merely plausible today is indistinguishable
+ * from a fact in a year.
+ *
+ * So the property is asserted at the write, not documented in a comment: a script
+ * that inserts a job row for a HUMAN must stamp both the lane (`initiated_by`) and
+ * the offered reason (`initiated_reason`). Automated lanes are exempt by name below
+ * — a cron has no human reason to record, and demanding one would make the guard a
+ * list to maintain rather than a property to hold.
+ */
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+
+/** Directories that hold job-dispatching scripts. */
+const SCRIPT_DIRS = ['scripts/batch', 'scripts/maintenance', 'scripts/migration', 'scripts/workers', 'scripts/experiments'];
+
+/**
+ * A file "dispatches a job" if it inserts a row into the ledger a worker consumes.
+ * Both collections count: `jobs` (SQS/realtime lanes) and `batch_jobs` (Gemini
+ * Batch API lanes). Matching the insert call rather than the collection name is
+ * deliberate — dozens of audits merely READ these collections, and a guard that
+ * flagged all of them would grow an allowlist and stop meaning anything.
+ */
+const DISPATCHES_JOB = /collection\((['"`])(jobs|batch_jobs)\1\)\s*\.\s*insertOne/;
+
+/**
+ * Lanes with no human behind them: a cron or a queue worker fires these, so there
+ * is no reason to prompt for and nobody to prompt. Exempt by name, because the
+ * exemption is a claim about the lane that a reader can check.
+ */
+const AUTOMATED_LANES = new Set([
+  'scripts/workers/pipeline-orchestrator.mjs',  // cron-driven pipeline phases
+  'scripts/workers/translate-worker.mjs',       // SQS consumer, re-queues its own follow-on work
+]);
+
+/**
+ * Asserts the VALUE is written, not that the helper is in scope. An earlier draft
+ * matched the bare identifier and stayed green when the spread was deleted but the
+ * import left behind — see invariants/tests-that-are-not-guards.md.
+ */
+const WRITES_REASON = /\.\.\.initiatedReasonFields\(/;
+const WRITES_LANE = /initiated_by\s*:/;
+
+function listJobDispatchers(): string[] {
+  const found: string[] = [];
+  for (const dir of SCRIPT_DIRS) {
+    let entries: string[];
+    try {
+      entries = readdirSync(path.join(PROJECT_ROOT, dir), { recursive: true } as never) as string[];
+    } catch {
+      continue;
+    }
+    for (const rel of entries) {
+      if (!/\.mjs$/.test(String(rel))) continue;
+      const repoPath = path.posix.join(dir, String(rel).split(path.sep).join('/'));
+      let src: string;
+      try {
+        src = readFileSync(path.join(PROJECT_ROOT, repoPath), 'utf8');
+      } catch {
+        continue;
+      }
+      if (DISPATCHES_JOB.test(src)) found.push(repoPath);
+    }
+  }
+  return found.sort();
+}
+
+const dispatchers = listJobDispatchers();
+const handRun = dispatchers.filter((f) => !AUTOMATED_LANES.has(f));
+const read = (f: string) => readFileSync(path.join(PROJECT_ROOT, f), 'utf8');
+
+describe('hand-run job dispatch records its reason (#4336)', () => {
+  it('finds the job dispatchers at all (guards the guard)', () => {
+    // Without this, deleting the detector's pattern would turn every assertion
+    // below into a vacuous pass over an empty list.
+    expect(dispatchers.length).toBeGreaterThanOrEqual(10);
+    expect(dispatchers).toContain('scripts/batch/queue-translations.mjs');
+    expect(dispatchers).toContain('scripts/workers/pipeline-orchestrator.mjs');
+  });
+
+  it('every automated lane named as exempt still exists', () => {
+    // A stale exemption silently excuses a file that was renamed or replaced.
+    for (const f of AUTOMATED_LANES) {
+      expect(dispatchers, `${f} is listed as an automated lane but no longer dispatches jobs`).toContain(f);
+    }
+  });
+
+  it('every hand-run dispatcher names its lane', () => {
+    const missing = handRun.filter((f) => !WRITES_LANE.test(read(f)));
+    expect(missing, 'hand-run dispatchers writing job rows with no initiated_by').toEqual([]);
+  });
+
+  it('every hand-run dispatcher offers --reason and writes it', () => {
+    const missing = handRun.filter((f) => !WRITES_REASON.test(read(f)));
+    expect(
+      missing,
+      'hand-run dispatchers that do not record initiated_reason — import scripts/lib/initiated-reason.mjs ' +
+        'and spread ...initiatedReasonFields(REASON) into the job row',
+    ).toEqual([]);
+  });
+});
+
+describe('parseInitiatedReason', () => {
+  it('reads the inline --reason=... form', () => {
+    expect(parseInitiatedReason(['--limit=5', '--reason=reader request #123'], 'script:x'))
+      .toBe('reader request #123');
+  });
+
+  it('reads the space-separated --reason ... form', () => {
+    expect(parseInitiatedReason(['--reason', 'bad OCR on plates', '--dry-run'], 'script:x'))
+      .toBe('bad OCR on plates');
+  });
+
+  it('keeps = signs inside the reason', () => {
+    expect(parseInitiatedReason(['--reason=model=flash-lite regression'], 'script:x'))
+      .toBe('model=flash-lite regression');
+  });
+
+  it('does not swallow the next flag as a reason', () => {
+    // `--reason --dry-run` means the operator forgot the value. Recording
+    // "--dry-run" as the reason would be worse than recording nothing.
+    expect(parseInitiatedReason(['--reason', '--dry-run'], 'script:x')).toBeUndefined();
+  });
+
+  it('treats whitespace-only and absent as unrecorded', () => {
+    expect(parseInitiatedReason(['--reason=   '], 'script:x')).toBeUndefined();
+    expect(parseInitiatedReason(['--limit=5'], 'script:x')).toBeUndefined();
+  });
+
+  it('omits the key entirely when there is no reason, so absent stays absent', () => {
+    // An empty string would make "queued without a reason" and "queued with a
+    // blank reason" the same row, and only one of those is a real state.
+    expect(initiatedReasonFields(undefined)).toEqual({});
+    expect(initiatedReasonFields('reader request')).toEqual({ initiated_reason: 'reader request' });
+  });
+});


### PR DESCRIPTION
Closes #4336.

## What

The `jobs` ledger stamps every dispatch with `initiated_by`, so it can say *which* lane ran — but never *why*. That was enough to reconstruct 715 hand-processed books in 19 episodes; each episode's purpose still had to be inferred from what its books had in common. This captures the reason at queue time instead.

**`scripts/lib/initiated-reason.mjs`** (new) — parses `--reason="..."` (both `--reason=x` and `--reason x`, and refuses to swallow a following flag as the value), and `initiatedReasonFields()` which **omits the key** when there is no reason, so "queued without a reason" and "queued with a blank reason" stay distinguishable. It **warns, never fails**: a missing reason must not stop an operator queueing work at 2am. The nudge is the point, not a gate.

**Scripts** — `--reason=` now writes `initiated_reason` on the job row. Two incidental fixes fell out: `queue-ocr-direct.mjs` wrote no `initiated_by` at all, and `queue-efm-translations.mjs` wrote the bare `'script'`, which names no lane.

**API + UI** — `POST /api/jobs/queue-books` takes an optional `reason` (trimmed, capped at 500 chars); `ProcessingPanel` gains the text field.

**Surfacing** — `book-history.ts` projects `initiated_by`/`initiated_reason` and puts them on job events, so a book's timeline answers "why was this done by hand?". The staff jobs log (`LogsTab`) gains a Reason column — that table is the closest thing to Derek's original ask, "a good list of the books I've manually done."

## Scope: widened deliberately, and why

The issue named four scripts. The guard test found **thirteen** hand-run job dispatchers, all the same lane class, and a guard is only meaningful if it covers the class rather than four filenames — partial coverage leaves the ledger partially blind, which is the exact failure this issue is about. So all thirteen are wired (the change is three lines each):

`queue-translations` · `bulk-reocr-local` · `bulk-translate-lambda` · `queue-ocr-direct` (the four named) · `bulk-ocr-lambda` · `bulk-reocr-opened-books` · `queue-efm-priority` · `queue-efm-translations` · `queue-translations-to-80pct` · `realtime-ocr` · `retranslate-stale` · `batch-size-experiment` · `backfill-ocr-near-complete`

## A check, not a comment

`tests/unit/initiated-reason.test.ts` finds every script that inserts into `jobs`/`batch_jobs`, exempts the two genuinely automated lanes **by name** (`pipeline-orchestrator`, `translate-worker` — a cron has no human reason to record), and requires every other one to write both fields. It also asserts the exemptions still exist, so a rename can't silently excuse a file.

It matches `...initiatedReasonFields(` rather than the bare identifier: a detector that fires on an import asserts a symbol is in scope, not that a value is written (`invariants/tests-that-are-not-guards.md`). Negative control run: deleting the spread from `queue-translations.mjs` fails the guard and names the file; restoring it passes.

## Not in scope

- **No backfill** of past runs — the reconstruction artifact in the issue is the best-effort record, and inventing reasons for old rows would be worse than leaving them blank.
- **No change to automated lanes** (orchestrator, `import_preview`, translate-worker).
- **The `ProcessingPanel` dialog is not currently mounted anywhere** (`git grep ProcessingPanel` finds only its own definition and a type import). The field is wired end-to-end — panel → `BookPagesSection` → `queueBooks` → API → Mongo — but it is inert until that panel is remounted. Flagging rather than fixing: remounting a dormant admin panel is a different concern. The API accepts `reason` today, so any other client works now.
- **`batch_jobs` reasons are recorded but not yet surfaced.** `book-history.ts` and `/api/jobs` read `jobs` only, so the five Gemini-Batch lanes write a reason that no UI reads yet. Worth a follow-up issue; not folded in here.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 261 files, 3655 tests, all pass
- `eslint` on new files — clean; the pre-existing errors in `ProcessingPanel`/`BookHistory`/`LogsTab` are on untouched lines and present on `main`
- Live dry-runs against production Mongo (nothing queued): `queue-translations`, `queue-ocr-direct`, `bulk-translate-lambda`, `bulk-reocr-local` — each ran clean, warned when `--reason` was omitted and stayed silent when it was given

## Privacy

An operator's free text is staff-only by construction: both `/history` routes are `withAuth({ minRole: 'editor' })`, and the public `/history/public` route builds its payload with an explicit field allow-list that includes neither `reason` nor `triggered_by`. Verified, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
