### PR TITLE
fix(ocr): three page types the prompt asked for were dropped between model and database (#4455)

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -209,7 +209,7 @@ async function processOneJob(db, job) {
       if (text.length > 25000) { failCount++; continue; }
 
       if (job.type === 'ocr') {
-        const pageType = extractPageType(text, { validate: false });
+        const pageType = extractPageType(text);
         const columns = extractColumns(text);
         const detectedImages = parseDetectedImages(text);
 

--- a/scripts/batch/collect-multipage-ocr.mjs
+++ b/scripts/batch/collect-multipage-ocr.mjs
@@ -158,7 +158,7 @@ async function main() {
           continue;
         }
 
-        const pageType = extractPageType(ocrText, { validate: false });
+        const pageType = extractPageType(ocrText);
         const columns = extractColumns(ocrText);
         const detectedImages = parseDetectedImages(ocrText);
 

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -331,7 +331,7 @@ async function processPage(page, promptText, db) {
       return { pageId: page.id, status: 'skip', reason: 'hallucination (>25k chars)', durationMs };
     }
 
-    const pageType = extractPageType(result.text, { validate: false });
+    const pageType = extractPageType(result.text);
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
 

--- a/scripts/batch/realtime-reocr-efm.mjs
+++ b/scripts/batch/realtime-reocr-efm.mjs
@@ -168,7 +168,7 @@ async function processPage(page, promptText, db) {
     }
 
     // Extract metadata
-    const pageType = extractPageType(result.text, { validate: false });
+    const pageType = extractPageType(result.text);
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
 

--- a/scripts/lib/ocr-result-parse.mjs
+++ b/scripts/lib/ocr-result-parse.mjs
@@ -38,32 +38,47 @@ import { VALID_IMAGE_TYPES } from './gallery-image-types.mjs';
  */
 export const PROMPT_VERSION = 'v6.1.2026-05';
 
-/** Page-type vocabulary accepted from the model. Mirrors VALID_PAGE_TYPES in defaults.ts. */
-export const VALID_PAGE_TYPES = new Set([
+/**
+ * Page types the OCR prompt offers, in prompt order. Mirrors PROMPT_PAGE_TYPES in
+ * defaults.ts, where the prompt's own `One of:` line is interpolated from it.
+ *
+ * Scripts cannot import the TS module, so this is a copy — but the parity test
+ * asserts element-for-element equality *including order*, which is what makes the
+ * prompt's list and this one one vocabulary rather than two (#4455).
+ */
+export const PROMPT_PAGE_TYPES = [
   'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
-  'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
-  'digitizer-insert', 'exlibris', 'bookplate',
-]);
+  'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map',
+  'musical-score', 'table', 'cover', 'text', 'digitizer-insert', 'exlibris',
+];
+
+/**
+ * Accepted but not offered — values from an older prompt or a non-OCR writer that
+ * must survive a re-parse. Mirrors LEGACY_PAGE_TYPES in defaults.ts; see its
+ * docblock for why each one is here.
+ */
+export const LEGACY_PAGE_TYPES = ['bookplate', 'digitizer-notice'];
+
+/** Page-type vocabulary accepted from the model. Mirrors VALID_PAGE_TYPES in defaults.ts. */
+export const VALID_PAGE_TYPES = new Set([...PROMPT_PAGE_TYPES, ...LEGACY_PAGE_TYPES]);
 
 /**
  * Extract <page-type> from OCR text. Returns undefined if not found or invalid.
  *
- * `validate: false` returns whatever the model emitted (trimmed, lower-cased)
- * without screening it against VALID_PAGE_TYPES. That is not a preference — it is
- * what four batch collectors have always done, and the two vocabularies genuinely
- * disagree: the OCR prompt offers `musical-score`, `table` and `cover`, none of
- * which VALID_PAGE_TYPES lists. Flipping those callers to validating would
- * silently stop three prompt-sanctioned types from being recorded, so the
- * divergence is a parameter rather than a fork. See #4455 for the gap itself.
+ * The `validate: false` escape hatch is gone (#4455). It existed because the
+ * prompt offered `musical-score` / `table` / `cover` and this set did not, so the
+ * four batch collectors screened nothing rather than lose three real answers.
+ * The set is now derived from the prompt's list, so screening loses nothing and
+ * an unrecognised value is a genuine mis-answer. Widen PROMPT_PAGE_TYPES (in both
+ * files) instead of reintroducing the flag.
  *
  * Unlike the TS canonical this tolerates a non-string argument, because
  * `split-book.mjs` passes `page.ocr`, which is null on an un-OCR'd page.
  */
-export function extractPageType(ocrText, { validate = true } = {}) {
+export function extractPageType(ocrText) {
   const match = ocrText?.match(/<page-type>([\s\S]*?)<\/page-type>/i);
   if (!match) return undefined;
   const type = match[1].trim().toLowerCase();
-  if (!validate) return type || undefined;
   return VALID_PAGE_TYPES.has(type) ? type : undefined;
 }
 

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -6,16 +6,64 @@ import { VALID_IMAGE_TYPES } from "../../gallery-image-types";
 export const PROMPT_VERSION = 'v6.1.2026-05';
 
 /**
- * Page-type vocabulary accepted from the model.
+ * Page types the OCR prompt offers the model, in the order the prompt lists them.
+ *
+ * THIS IS THE SOURCE OF TRUTH FOR THE PROMPT'S OWN `One of:` LINE — that line is
+ * interpolated from this array in `DEFAULT_PROMPTS.ocr` below, not written out a
+ * second time. It used to be written out, and the two halves drifted twice in
+ * opposite directions: #3591 was a reader branch for a value the prompt could not
+ * produce, and #4455 was the inverse — the prompt was widened with
+ * `musical-score`, `table` and `cover`, `VALID_PAGE_TYPES` was not, and
+ * `extractPageType` dropped all three on the floor between the model and the
+ * database. A value can no longer be offered without being accepted.
+ *
+ * Adding one here changes what the model is asked for corpus-wide: give it a
+ * `Use "<type>" when …` line in the prompt too (asserted by
+ * `tests/unit/page-type-vocabulary.test.ts`), and bump `PROMPT_VERSION`.
+ */
+export const PROMPT_PAGE_TYPES = [
+  'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
+  'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map',
+  'musical-score', 'table', 'cover', 'text', 'digitizer-insert', 'exlibris',
+] as const;
+
+/**
+ * Accepted from the model, but deliberately NOT offered by the current prompt.
+ *
+ * Screening happens on re-parses of OCR text we already stored, so a value an
+ * older prompt produced has to survive one — dropping it would silently retype a
+ * real page to nothing. Both of these are also read by live code paths:
+ *
+ *   bookplate        — the pre-`exlibris` name for an ownership plate. Read by
+ *                      SKIP_TRANSLATION_PAGE_TYPES / NEVER_TRANSLATED_PAGE_TYPES.
+ *   digitizer-notice — written by the pipeline's digitizer detection and
+ *                      `scripts/maintenance/backfill-digitizer-pages.mjs`, not by
+ *                      the OCR prompt. Read by SKIP_TRANSLATION_PAGE_TYPES and by
+ *                      `cover-scoring` (a -90 penalty).
+ *
+ * Nothing should be added here to work around a prompt gap — that is what #4455
+ * was. This list is for values the prompt has stopped asking for.
+ *
+ * NOT here, deliberately: `archived-spread` (176,548 pages as of 2026-09-07).
+ * `split-book.mjs` writes it directly onto the pre-split spread so the original
+ * stays recoverable, and a dozen read paths filter on it. It is a *writer's*
+ * label, never a model answer — the model must not be able to type a live page
+ * `archived-spread`, because that would hide it from the reader. Same for
+ * `scanner_metadata` (see `scripts/lib/cover-write.mjs`). Script-written page
+ * types are not part of this vocabulary, which screens model output only.
+ */
+export const LEGACY_PAGE_TYPES = ['bookplate', 'digitizer-notice'] as const;
+
+/**
+ * Page-type vocabulary accepted from the model. Derived, never hand-listed.
  *
  * Exported so the scripts-side twin (`scripts/lib/ocr-result-parse.mjs`) can be
  * pinned against it — six scripts each carried a private, separately-drifted copy
  * of this set until #4443.
  */
-export const VALID_PAGE_TYPES = new Set([
-  'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
-  'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
-  'digitizer-insert', 'exlibris', 'bookplate',
+export const VALID_PAGE_TYPES: ReadonlySet<string> = new Set<string>([
+  ...PROMPT_PAGE_TYPES,
+  ...LEGACY_PAGE_TYPES,
 ]);
 
 // Page types that should be skipped during translation — no meaningful text content
@@ -37,23 +85,19 @@ export const IMAGE_CANDIDATE_PAGE_TYPES = [
 /**
  * Extract <page-type> from OCR text. Returns undefined if not found or invalid.
  *
- * `validate: false` returns whatever the model emitted (trimmed, lower-cased)
- * without screening it against VALID_PAGE_TYPES. That is not a preference — it
- * is what four batch collectors have always done (#4443), and the vocabularies
- * genuinely disagree: the OCR prompt offers `musical-score`, `table` and
- * `cover`, which VALID_PAGE_TYPES does not list. Flipping those callers to
- * validating would silently stop three prompt-sanctioned types from being
- * recorded, so the divergence is a parameter here rather than a fork out there.
- * See #4455 for closing the vocabulary gap itself.
+ * There is no longer a `validate: false` escape hatch. It existed for exactly one
+ * reason (#4443): four batch collectors screened nothing, and screening them
+ * would have discarded `musical-score` / `table` / `cover` — real, prompt-
+ * sanctioned answers that `VALID_PAGE_TYPES` had simply never been widened to
+ * include. Now that the accepted set is derived from the prompt's own list, an
+ * unrecognised value is a genuine mis-answer rather than a vocabulary gap, and
+ * storing it raw is how 99 gallery rows came to hold free model text (#3419).
+ * Don't reintroduce the flag; widen `PROMPT_PAGE_TYPES` instead.
  */
-export function extractPageType(
-  ocrText: string,
-  { validate = true }: { validate?: boolean } = {},
-): string | undefined {
+export function extractPageType(ocrText: string): string | undefined {
   const match = ocrText?.match(/<page-type>([\s\S]*?)<\/page-type>/i);
   if (!match) return undefined;
   const type = match[1].trim().toLowerCase();
-  if (!validate) return type || undefined;
   return VALID_PAGE_TYPES.has(type) ? type : undefined;
 }
 
@@ -211,7 +255,7 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 
 **Metadata tags (hidden from readers):**
 - <language>X</language> — the detected language of this page (REQUIRED — always identify the language, e.g. Latin, German, French, English)
-- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, musical-score, table, cover, text, digitizer-insert, exlibris
+- <page-type>X</page-type> — classify this page (REQUIRED). One of: ${PROMPT_PAGE_TYPES.join(', ')}
   - Use "digitizer-insert" for pages added by the digitizer (NOT part of the original book): Internet Archive credit pages, Google Books inserts, "Digitized by Google" pages, library barcode/scan sheets, digital watermark pages
   - Use "exlibris" for an ownership bookplate pasted into the book (usually on a pastedown or endpaper): an armorial or emblematic plate naming or marking the owner, often with a motto. It is provenance, not the book's content — do NOT treat its motto as body text.
   - Use "musical-score" when the page is engraved or printed music with no running prose — staves, notation, tablature. A header, signature or a few words of underlaid text do not make it a "text" page.

--- a/tests/unit/ocr-result-parse.test.ts
+++ b/tests/unit/ocr-result-parse.test.ts
@@ -24,6 +24,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   PROMPT_VERSION,
+  PROMPT_PAGE_TYPES,
+  LEGACY_PAGE_TYPES,
   VALID_PAGE_TYPES,
   extractPageType,
   extractColumns,
@@ -33,6 +35,8 @@ import {
 } from '@/lib/types/prompts/defaults';
 import {
   PROMPT_VERSION as PROMPT_VERSION_JS,
+  PROMPT_PAGE_TYPES as PROMPT_PAGE_TYPES_JS,
+  LEGACY_PAGE_TYPES as LEGACY_PAGE_TYPES_JS,
   VALID_PAGE_TYPES as VALID_PAGE_TYPES_JS,
   extractPageType as extractPageTypeJs,
   extractColumns as extractColumnsJs,
@@ -140,15 +144,20 @@ describe('TS canonical and scripts JS twin agree — extractPageType', () => {
     }
   });
 
-  it('validate:false mode returns identical results for every fixture', () => {
-    for (const [name, text] of Object.entries(pageTypeFixtures)) {
-      expect(extractPageTypeJs(text, { validate: false }), name)
-        .toBe(extractPageType(text, { validate: false }));
-    }
-  });
-
   it('the two vocabulary sets are the same set', () => {
     expect([...VALID_PAGE_TYPES_JS].sort()).toEqual([...VALID_PAGE_TYPES].sort());
+  });
+
+  it('the prompt-offered list matches element-for-element, IN ORDER', () => {
+    // Order matters here in a way it does not for the set: the TS side
+    // interpolates this array into the prompt's `One of:` line, so a reordering
+    // on one side alone would mean the scripts twin is mirroring a list the
+    // model was never shown.
+    expect([...PROMPT_PAGE_TYPES_JS]).toEqual([...PROMPT_PAGE_TYPES]);
+  });
+
+  it('the accepted-but-not-offered list is mirrored', () => {
+    expect([...LEGACY_PAGE_TYPES_JS].sort()).toEqual([...LEGACY_PAGE_TYPES].sort());
   });
 });
 
@@ -196,20 +205,34 @@ describe('extractPageType behaviour', () => {
     expect(extractPageType(pageTypeFixtures.plain)).toBe('title-page');
   });
 
-  it('validate:false passes the model string through, screening nothing', () => {
-    expect(extractPageType(pageTypeFixtures.garbage, { validate: false }))
-      .toBe('a page of some kind');
+  it('the three formerly-dropped prompt types now survive (#4455)', () => {
+    // These were the gap: the OCR prompt offered them and the reader rendered
+    // them (tests/unit/page-type-vocabulary.test.ts), but VALID_PAGE_TYPES did
+    // not list them, so the canonical parser returned undefined and the page was
+    // stored with no type at all. This is the assertion that was inverted.
+    for (const t of ['musical-score', 'table', 'cover']) {
+      expect(VALID_PAGE_TYPES.has(t), `${t} missing from VALID_PAGE_TYPES`).toBe(true);
+      expect(extractPageType(`<page-type>${t}</page-type>`)).toBe(t);
+    }
   });
 
-  it('the three prompt-only types are the measured vocabulary gap (#4455)', () => {
-    // The OCR prompt offers musical-score / table / cover and the reader renders
-    // them (tests/unit/page-type-vocabulary.test.ts), but VALID_PAGE_TYPES does
-    // not list them — which is why the four unvalidated collectors could NOT be
-    // flipped to validating in #4443 without silently dropping all three.
-    for (const t of ['musical-score', 'table', 'cover']) {
-      expect(VALID_PAGE_TYPES.has(t), `${t} unexpectedly in VALID_PAGE_TYPES`).toBe(false);
-      expect(extractPageType(`<page-type>${t}</page-type>`)).toBeUndefined();
-      expect(extractPageType(`<page-type>${t}</page-type>`, { validate: false })).toBe(t);
+  it('there is no unvalidated mode left to reintroduce the gap', () => {
+    // The bypass is gone, not merely unused: an extra argument must not revive
+    // it. `extractPageType` takes one parameter, and a stray options object is
+    // ignored rather than honoured.
+    expect(extractPageType.length).toBe(1);
+    // @ts-expect-error — the option no longer exists; this pins that it is inert.
+    expect(extractPageType(pageTypeFixtures.garbage, { validate: false })).toBeUndefined();
+    // @ts-expect-error — same, on the scripts twin.
+    expect(extractPageTypeJs(pageTypeFixtures.garbage, { validate: false })).toBeUndefined();
+  });
+
+  it('accepts the two legacy types the prompt no longer offers', () => {
+    // Screening runs over OCR text we already stored, so a value an older prompt
+    // produced has to survive a re-parse — otherwise a re-collect retypes a real
+    // page to nothing.
+    for (const t of LEGACY_PAGE_TYPES) {
+      expect(extractPageType(`<page-type>${t}</page-type>`), t).toBe(t);
     }
   });
 
@@ -223,7 +246,7 @@ describe('extractPageType behaviour', () => {
   });
 
   it('an empty tag is undefined, never the empty string', () => {
-    expect(extractPageType(pageTypeFixtures.empty, { validate: false })).toBeUndefined();
+    expect(extractPageType(pageTypeFixtures.empty)).toBeUndefined();
   });
 });
 

--- a/tests/unit/page-type-vocabulary.test.ts
+++ b/tests/unit/page-type-vocabulary.test.ts
@@ -18,7 +18,15 @@
  * construction, and nothing in CI reported it. This test is that report.
  */
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_PROMPTS } from '@/lib/types/prompts/defaults';
+import {
+  DEFAULT_PROMPTS,
+  PROMPT_PAGE_TYPES,
+  LEGACY_PAGE_TYPES,
+  VALID_PAGE_TYPES,
+  SKIP_TRANSLATION_PAGE_TYPES,
+  HIDDEN_PAGE_TYPES,
+  extractPageType,
+} from '@/lib/types/prompts/defaults';
 import { DESCRIPTION_ONLY_PAGE_TYPES } from '@/components/reader/NotesRenderer';
 
 const DEFAULT_OCR_PROMPT = DEFAULT_PROMPTS.ocr;
@@ -49,6 +57,67 @@ describe('page-type vocabulary', () => {
     for (const t of ['cover', 'musical-score', 'table']) {
       expect(offered.has(t), `"${t}" must stay in the OCR prompt vocabulary`).toBe(true);
     }
+  });
+
+  /**
+   * #4455 was the inverse of the bug above, one layer down: the prompt was
+   * widened, `VALID_PAGE_TYPES` — which sits between the prompt and the database
+   * — was not, and `extractPageType` returned undefined for three values the
+   * model had been explicitly asked to produce. Offered, rendered, dropped in
+   * the middle.
+   *
+   * The prompt's `One of:` line is now interpolated from `PROMPT_PAGE_TYPES`, so
+   * these first two assertions cannot fail by editing the prompt text — they
+   * fail if someone hard-codes the list back into the prompt string, which is
+   * exactly how it drifted the first two times.
+   */
+  it('the prompt enumerates PROMPT_PAGE_TYPES and nothing else', () => {
+    expect(promptPageTypes()).toEqual([...PROMPT_PAGE_TYPES]);
+  });
+
+  it('every type the prompt offers is accepted by the parser', () => {
+    const dropped = promptPageTypes().filter(t => !VALID_PAGE_TYPES.has(t));
+    expect(dropped).toEqual([]);
+  });
+
+  it('every type the prompt offers round-trips through extractPageType', () => {
+    // The set membership above is necessary but not sufficient — this is the
+    // path the pipeline actually takes from model answer to `page_type`.
+    for (const t of PROMPT_PAGE_TYPES) {
+      expect(extractPageType(`<page-type>${t}</page-type>`), t).toBe(t);
+    }
+  });
+
+  it('every type the reader special-cases round-trips too', () => {
+    // DESCRIPTION_ONLY_PAGE_TYPES reachability, end to end: the prompt can ask
+    // for it AND the parser will store it.
+    for (const t of DESCRIPTION_ONLY_PAGE_TYPES) {
+      expect(extractPageType(`<page-type>${t}</page-type>`), t).toBe(t);
+    }
+  });
+
+  it('the accepted set is exactly the offered set plus the declared legacy ones', () => {
+    // Pins that VALID_PAGE_TYPES stays *derived*. A hand-added member — the
+    // #4455 shape — shows up here as an extra.
+    expect([...VALID_PAGE_TYPES].sort())
+      .toEqual([...PROMPT_PAGE_TYPES, ...LEGACY_PAGE_TYPES].sort());
+  });
+
+  it('every page type the pipeline BRANCHES on is a declared one', () => {
+    // The other half of the #4455 audit. `SKIP_TRANSLATION_PAGE_TYPES` named
+    // `digitizer-notice`, which appeared in neither the prompt nor the accepted
+    // set — so it read as a typo when it is in fact written by the digitizer
+    // detection path (321 pages). Any name here that isn't declared is either a
+    // dead branch or an undeclared writer; both are worth failing over.
+    const declared = new Set([...PROMPT_PAGE_TYPES, ...LEGACY_PAGE_TYPES]);
+    const undeclared = [...SKIP_TRANSLATION_PAGE_TYPES, ...HIDDEN_PAGE_TYPES]
+      .filter(t => !declared.has(t));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('no legacy type is also an offered type', () => {
+    const overlap = LEGACY_PAGE_TYPES.filter(t => (PROMPT_PAGE_TYPES as readonly string[]).includes(t));
+    expect(overlap).toEqual([]);
   });
 
   it('gives the model guidance for each newly added type, not just the bare word', () => {


### PR DESCRIPTION
Closes #4455.

## The gap

`VALID_PAGE_TYPES` sits between the OCR prompt and the `pages` collection. The prompt offered 19 page types; the set listed 17. So when the model did exactly what it was asked and answered `musical-score`, `table` or `cover`, `extractPageType` returned `undefined` and the page was stored **with no page type at all** — while `NotesRenderer.DESCRIPTION_ONLY_PAGE_TYPES` carried a render branch for all three.

This is the inverse of #3591 (a reader branch the prompt could not reach). Same constant, opposite direction, twice — because the vocabulary was written out in two places and nothing compared them.

## The fix: stop writing it out twice

`PROMPT_PAGE_TYPES` is now the source of truth, and the prompt's own `One of:` line is **interpolated from it**. A value can no longer be offered to the model without being accepted by the parser — the two cannot drift a third time, because there is only one list.

The accepted set is derived, never hand-listed:

```
VALID_PAGE_TYPES = PROMPT_PAGE_TYPES + LEGACY_PAGE_TYPES
```

`LEGACY_PAGE_TYPES` is `bookplate` and `digitizer-notice` — the issue's fourth checkbox. Neither is a prompt gap: `digitizer-notice` (321 pages) is written by the pipeline's digitizer detection and `backfill-digitizer-pages.mjs`, and both are read by `SKIP_TRANSLATION_PAGE_TYPES`. Screening runs over OCR text we already stored, so a value an older prompt produced has to survive a re-parse or a re-collect would retype a real page to nothing.

**`PROMPT_VERSION` is deliberately NOT bumped.** The interpolated line is byte-identical to the hard-coded one (verified by diffing the joined array against `git show HEAD:` before committing). The model sees the same text; bumping would restamp provenance on pages whose prompt did not change.

## `{ validate: false }` is gone

The issue named this as its own marker: *every `{ validate: false }` call site should disappear when this is fixed.* All four are gone, and so is the parameter — the escape hatch existed for exactly one reason (screening would have discarded three real types), and that reason no longer holds.

This makes the four collectors stricter, so I checked what that costs. All four guard the write (`else if (pageType)` or a conditional spread), so an unrecognised answer now **leaves the existing `page_type` untouched** rather than storing raw model text. Nothing is wiped. What it stops is new pollution of the kind already in the data:

| value | pages |
|---|---|
| `boilerplate` | 94 |
| `advertisement` | 5 |
| `bibliography` / `front-matter` | 4 each |
| `privilege`, `copyright`, `fragment` | 3 each |
| `front-cover`, `binding` | 2 / 1 |
| `text, toc`, `notae`, `approbatio`, `manuscript fragment`, `digitization_stamp`, … | 1 each |

That tail is the #3419 shape (99 gallery rows holding free model text because the write path consulted no vocabulary).

## Measured: the issue's last checkbox

Full `page_type` distribution over all 20.1M pages, plus a per-book scan of the 11 Musurgia editions (~7,900 pages, the most engraved-music-heavy work we hold):

- **`musical-score`, `table`, `cover`: 0 pages each.** Not "a few" — zero.
- **0 stored OCR texts contain a `<page-type>musical-score</page-type>` tag**, in any Musurgia volume.

So the issue's premise that the four unvalidated collectors "*do* write" those three is not borne out by the data — those books were OCR'd under a prompt version predating the widening. **There is nothing to backfill and no cleanup to do.** The gap's cost was entirely forward-looking: it would have silently dropped every future answer. Kircher's Musurgia Vol. I currently has its engraved music spread across `text` (779), `illustration` (259) and `diagram` (249); reclaiming those needs a re-OCR, which is a separate decision about spend, not part of this fix.

## Guards, with negative controls

`tests/unit/page-type-vocabulary.test.ts` gains six assertions, the load-bearing ones being:

- the prompt enumerates `PROMPT_PAGE_TYPES` **and nothing else** — this is what fails if someone hard-codes the list back into the prompt string, which is how it drifted both previous times;
- every offered type **round-trips through `extractPageType`** (set membership is necessary but not sufficient — this is the path the pipeline actually takes);
- the accepted set is *exactly* offered + declared-legacy, so a hand-added member shows up as an extra;
- every type the pipeline **branches on** (`SKIP_TRANSLATION_PAGE_TYPES`, `HIDDEN_PAGE_TYPES`) is a declared one — the check that would have surfaced the `digitizer-notice` question without a human noticing it.

`tests/unit/ocr-result-parse.test.ts` has its inverted assertions flipped (they previously *pinned the bug*, asserting all three were absent), and gains one that the bypass is inert rather than merely unused.

**Negative control, run:** re-hardcoding the stale 17-value list into the prompt fails 3 tests by name (`the prompt enumerates PROMPT_PAGE_TYPES and nothing else`, plus both #3591 guards). Restoring the interpolation passes.

## Not in scope

- **`archived-spread` (176,548 pages) is NOT added to the vocabulary**, and the docblock says why at length — it is a *writer's* label from `split-book.mjs`, marking a pre-split spread kept for recoverability, and a dozen read paths filter on it. Letting the model type a live page `archived-spread` would hide it from readers. Same for `scanner_metadata`. This vocabulary screens model output only. Flagging it because adding it is the obvious wrong fix for the next person who reads the distribution.
- **`IMAGE_CANDIDATE_PAGE_TYPES` contains `mixed`, which is dead** — not a valid page type, 0 pages, so the branch can never fire. It is also forked into **six** copies with differing contents (three include `title-page`, `defaults.ts` does not). That is a #4443-shaped consolidation for a different constant; bundling it here would mix two concerns. Worth its own issue.
- **No re-OCR** to reclaim the engraved-music pages now typed `text`.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 261 files, 3,664 tests, all pass
- `eslint` on all four touched files — clean (the one warning is pre-existing, on an untouched line)
- Measurements run against production `bookstore` read-only; the three throwaway query scripts were deleted, not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
