### PR TITLE
fix(ocr): a page that can never be read was retried forever — 197 times on one folio (#4674)

### DIFF
--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -609,15 +609,26 @@ async function main() {
     // left alone.
     if (targetMode !== 'all') {
       pageFilter['ocr.recitation_blocked'] = { $ne: true };
+      // Same reasoning for the general give-up (#4674): three failed reads of any
+      // other kind and the page is out until a human intervenes.
+      pageFilter['ocr.fail_blocked'] = { $ne: true };
     }
 
     const totalEligible = await db.collection('pages').countDocuments(pageFilter);
     console.log(`Eligible pages: ${totalEligible.toLocaleString()}`);
     if (targetMode !== 'all') {
+      // The blocked tests go in $and — pageFilter already owns $or for the
+      // target-mode clauses, and spreading a second $or over it would silently
+      // replace them and count the wrong pages.
+      const { 'ocr.recitation_blocked': _r, 'ocr.fail_blocked': _f, ...unblockedFilter } = pageFilter;
       const blocked = await db.collection('pages').countDocuments({
-        ...pageFilter, 'ocr.recitation_blocked': true,
+        ...unblockedFilter,
+        $and: [
+          ...(unblockedFilter.$and ?? []),
+          { $or: [{ 'ocr.recitation_blocked': true }, { 'ocr.fail_blocked': true }] },
+        ],
       });
-      if (blocked > 0) console.log(`  (excluding ${blocked} page(s) the model has permanently refused)`);
+      if (blocked > 0) console.log(`  (excluding ${blocked} page(s) the model has permanently refused or repeatedly failed)`);
     }
 
     if (totalEligible === 0) {

--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -109,6 +109,7 @@ export function isTranslatablePageForCount(page) {
   if (page?.translation?.recitation_blocked === true) return false;
   if (page?.translation?.safety_blocked === true) return false;
   if (page?.ocr?.recitation_blocked === true) return false;
+  if (page?.ocr?.fail_blocked === true) return false;
   return true;
 }
 
@@ -121,6 +122,7 @@ const TRANSLATABLE_COND = {
     { $ne: ['$translation.recitation_blocked', true] },
     { $ne: ['$translation.safety_blocked', true] },
     { $ne: ['$ocr.recitation_blocked', true] },
+    { $ne: ['$ocr.fail_blocked', true] },
   ],
 };
 

--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -230,3 +230,34 @@ export function countVisiblePageStats(pages) {
     blank: visible.filter(p => NEVER_TRANSLATED_PAGE_TYPES.includes(p?.page_type ?? '') && hasOcr(p)).length,
   };
 }
+
+/**
+ * Mongo clause: pages this MODEL has not permanently given up on (#4674).
+ *
+ * A give-up must not outlive the model that caused it. When we blocked per-page,
+ * 959 of the 967 blocked pages had not been retried in over a month — and half of
+ * a re-probed sample read cleanly on the first attempt against the current model.
+ * They were not unreadable; they were blocked by a transcriber we no longer run.
+ *
+ * So the block is scoped: a page is out of the queue only while the model that
+ * failed it is still the model we would send it to. Point the pipeline at a new
+ * model and the whole backlog becomes eligible again, with no sweep to remember
+ * to run. Pages blocked before this field existed carry no model and stay
+ * blocked — deliberately: re-opening 967 pages is a spend decision, not a
+ * migration side effect.
+ */
+export function notBlockedForModel(model) {
+  return {
+    $or: [
+      { 'ocr.fail_blocked': { $ne: true } },
+      { 'ocr.fail_blocked_model': { $nin: [null, model] } },
+    ],
+  };
+}
+
+/** JS twin of notBlockedForModel(), for callers holding the page in memory. */
+export function isBlockedForModel(page, model) {
+  if (page?.ocr?.fail_blocked !== true) return false;
+  const blockedBy = page?.ocr?.fail_blocked_model;
+  return blockedBy == null || blockedBy === model;
+}

--- a/scripts/maintenance/retry-model-blocked-pages.mjs
+++ b/scripts/maintenance/retry-model-blocked-pages.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: scripts/maintenance/reset-book-ocr.mjs — resets a WHOLE BOOK's OCR
+ * (cancels jobs, clears text, bumps ocr_generation). Wrong grain: this reopens
+ * individual pages that were given up on, touches no existing text, and cancels
+ * nothing. scripts/batch/realtime-ocr.mjs re-OCRs pages but has no notion of a
+ * give-up and would re-run pages that are still legitimately blocked.
+ *
+ * Reopen pages a give-up has stranded (#4674).
+ *
+ * Why this exists: the per-page block used to be permanent. 967 pages entered a
+ * retry loop and were parked; 959 of them had not been tried in over 30 days,
+ * and when six were re-probed against the CURRENT model, three read cleanly on
+ * the first attempt. They were never unreadable — they were blocked by a
+ * transcriber we no longer run.
+ *
+ * New blocks carry `ocr.fail_blocked_model` and expire on their own when the
+ * model changes. This script is for the pages blocked BEFORE that field existed,
+ * which carry no model and would otherwise stay parked forever.
+ *
+ * Reopening is ACTUATION: these pages go back in the OCR queue and the next
+ * orchestrator pass will spend on them. Dry-run by default; --apply writes.
+ * Scope it with --collection or --book so the spend is bounded by something you
+ * chose, and run it behind a scope envelope (scripts/maintenance/set-scope.mjs).
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/retry-model-blocked-pages.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/retry-model-blocked-pages.mjs \
+ *     --collection forum-of-conscience --apply
+ *   node --env-file=.env.production.local scripts/maintenance/retry-model-blocked-pages.mjs \
+ *     --stale-days 30 --limit 200 --apply
+ */
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const has = (n) => args.includes(`--${n}`);
+const val = (n, d = null) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : d; };
+
+const APPLY = has('apply');
+const COLLECTION = val('collection');
+const BOOK = val('book');
+const STALE_DAYS = parseInt(val('stale-days', '30'), 10);
+const LIMIT = parseInt(val('limit', '0'), 10);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+// Only pages whose block predates model-scoping. A block that names its model
+// already expires by itself; re-opening it here would fight that mechanism.
+const filter = {
+  'ocr.fail_blocked': true,
+  'ocr.fail_blocked_model': { $in: [null, undefined] },
+};
+if (STALE_DAYS > 0) {
+  filter.$or = [
+    { 'ocr.fail_blocked_at': { $lt: new Date(Date.now() - STALE_DAYS * 86400000) } },
+    { 'ocr.fail_blocked_at': { $exists: false } },
+  ];
+}
+
+if (BOOK) filter.book_id = BOOK;
+else if (COLLECTION) {
+  const ids = await db.collection('books').distinct('id', { collections: COLLECTION });
+  if (!ids.length) { console.error(`No books in collection '${COLLECTION}'.`); process.exit(1); }
+  filter.book_id = { $in: ids };
+  console.log(`Scoped to collection '${COLLECTION}' (${ids.length} books).`);
+}
+
+const total = await db.collection('pages').countDocuments(filter);
+console.log(`Pages blocked with no model recorded${STALE_DAYS > 0 ? ` and idle ${STALE_DAYS}+ days` : ''}: ${total}`);
+if (total === 0) { await client.close(); process.exit(0); }
+
+// Show what we are about to reopen, by book — a bare total hides a runaway book.
+const byBook = await db.collection('pages').aggregate([
+  { $match: filter },
+  { $group: { _id: '$book_id', n: { $sum: 1 } } },
+  { $sort: { n: -1 } }, { $limit: 15 },
+]).toArray();
+const titles = new Map((await db.collection('books')
+  .find({ id: { $in: byBook.map(b => b._id) } }, { projection: { id: 1, title: 1, language: 1 } })
+  .toArray()).map(b => [b.id, b]));
+console.log('\nTop books:');
+for (const b of byBook) {
+  const t = titles.get(b._id) || {};
+  console.log(`  ${String(b.n).padStart(4)} page(s)  ${String(t.language || '?').padEnd(8)} ${String(t.title || b._id).slice(0, 54)}`);
+}
+
+if (!APPLY) {
+  console.log(`\nDRY RUN — would reopen ${LIMIT > 0 ? Math.min(LIMIT, total) : total} page(s). Pass --apply to write.`);
+  console.log('Reopened pages re-enter the OCR queue and WILL be paid for. Set a scope envelope first.');
+  await client.close();
+  process.exit(0);
+}
+
+// Clear the give-up. Leave ocr.data alone — some of these hold a partial read,
+// and destroying text is never part of reopening a queue.
+let ids = null;
+if (LIMIT > 0) {
+  ids = (await db.collection('pages').find(filter, { projection: { id: 1 } }).limit(LIMIT).toArray()).map(p => p.id);
+}
+const res = await db.collection('pages').updateMany(
+  ids ? { id: { $in: ids } } : filter,
+  { $unset: { 'ocr.fail_blocked': '', 'ocr.fail_blocked_at': '', 'ocr.fail_count': '', 'ocr.fail_reason': '' },
+    $set: { 'ocr.reopened_at': new Date() } }
+);
+console.log(`\nreopened: matched=${res.matchedCount} modified=${res.modifiedCount}`);
+
+await db.collection('audit_log').insertOne({
+  action: 'ocr_blocked_pages_reopened',
+  metadata: { issue: 4674, scope: BOOK ? { book: BOOK } : COLLECTION ? { collection: COLLECTION } : 'corpus',
+              stale_days: STALE_DAYS, limit: LIMIT || null, matched: res.matchedCount, modified: res.modifiedCount },
+  timestamp: new Date(),
+});
+console.log('audit_log written');
+await client.close();

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -323,6 +323,20 @@ async function processOneJob(db, job) {
     const failReasons = {};
     const noteFail = (reason) => { failReasons[reason] = (failReasons[reason] || 0) + 1; };
 
+    // Pages that failed for a reason OTHER than recitation, and the reason.
+    //
+    // RECITATION has had a give-up counter since #2065; nothing else did. A page
+    // that fails deterministically for any other reason was therefore re-selected
+    // every cycle forever: page 620 of the Tabiena Summa (book 6a3a3b98862ce9a5b4d759b3)
+    // was submitted as its own single-page job 197 times between 2026-09-04 and
+    // 2026-09-06, every one of them landing on the `> HALLUCINATION_LIMIT` branch
+    // below, which discarded the response and stamped nothing. `fail_reasons: {}`
+    // on 197 batch_jobs rows is the fingerprint — failCount incremented, no reason
+    // recorded, no page state changed, so the next pass could not tell it had ever
+    // been tried. Only pages we can name are stamped: in the multi-page branch one
+    // response covers N pages and a failure there has no single pageId to blame.
+    const failedPageIds = new Map(); // pageId -> reason
+
     // Job totals come from the RESPONSES, not from the pages we end up saving
     // (#3452) — Gemini bills every response, including the ones we discard.
     const { inputTokens: totalInputTokens, outputTokens: totalOutputTokens } =
@@ -369,9 +383,15 @@ async function processOneJob(db, job) {
           if (job.type === 'ocr') recitationPageIds.push(pageId); // Stamp page-level tracking
           continue;
         }
-        if (r.error) { failCount++; noteFail(`error:${String(r.error?.status || r.error?.code || r.error).slice(0, 60)}`); continue; }
+        if (r.error) {
+          const reason = `error:${String(r.error?.status || r.error?.code || r.error).slice(0, 60)}`;
+          failCount++; noteFail(reason); failedPageIds.set(pageId, reason); continue;
+        }
         const text = candidate?.content?.parts?.[0]?.text;
-        if (!text) { failCount++; noteFail(`no-text:${candidate?.finishReason || 'no-candidate'}`); continue; }
+        if (!text) {
+          const reason = `no-text:${candidate?.finishReason || 'no-candidate'}`;
+          failCount++; noteFail(reason); failedPageIds.set(pageId, reason); continue;
+        }
         pageResults.push({ pageId, text, usage: r.response?.usageMetadata });
       }
     }
@@ -512,7 +532,15 @@ async function processOneJob(db, job) {
         protectedCount++;
         continue;
       }
-      if (text.length > HALLUCINATION_LIMIT) { failCount++; continue; }
+      // A runaway generation — the model looped instead of reading. Deterministic
+      // for a given page+model, so without the stamp below this page comes straight
+      // back on the next pass (see failedPageIds above).
+      if (text.length > HALLUCINATION_LIMIT) {
+        failCount++;
+        noteFail('over-hallucination-limit');
+        failedPageIds.set(pageId, 'over-hallucination-limit');
+        continue;
+      }
 
       // Per-page stamp only — the job totals are summed per response above.
       const inputTokens = usage?.promptTokenCount || 0;
@@ -571,7 +599,18 @@ async function processOneJob(db, job) {
         if (columns) setObj.columns = columns;
         if (detectedImages.length > 0) setObj.detected_images = detectedImages;
 
-        bulkOps.push({ updateOne: { filter: { id: pageId }, update: { $set: setObj } } });
+        // A page that reads clears its failure history: the counter below must
+        // measure CONSECUTIVE failures, or an intermittent page accumulates
+        // strikes over months and eventually blocks itself for no reason.
+        bulkOps.push({
+          updateOne: {
+            filter: { id: pageId },
+            update: {
+              $set: setObj,
+              $unset: { 'ocr.fail_count': '', 'ocr.fail_reason': '', 'ocr.fail_blocked': '', 'ocr.fail_blocked_at': '' },
+            },
+          },
+        });
       } else if (job.type === 'image_extraction') {
         // Parse JSON array of detected images from Gemini response
         const parsed = parseImageExtractionResponse(text);
@@ -720,6 +759,47 @@ async function processOneJob(db, job) {
         console.log(`  Gallery: ${galleryDocs.length} images written for book ${job.book_id}`);
       } catch (galleryErr) {
         console.error(`  Gallery write error: ${galleryErr.message}`);
+      }
+    }
+
+    // ── Per-page give-up for every failure class that is not RECITATION ──
+    // Same shape as the recitation stamp above (count, timestamp, blocked flag at
+    // N=3) and read by the same page-selection queries. Kept as its own field
+    // rather than folded into recitation_count because the two mean different
+    // things to a human reading the page: one is a copyright refusal, the other is
+    // "we tried three times and could not get a usable read".
+    if (failedPageIds.size > 0 && job.type === 'ocr') {
+      const OCR_FAIL_BLOCK_THRESHOLD = 3;
+      const failNow = new Date();
+      const failOps = [...failedPageIds].map(([pageId, reason]) => ({
+        updateOne: {
+          filter: { id: pageId },
+          update: [
+            { $set: { ocr: { $cond: { if: { $eq: ['$ocr', null] }, then: {}, else: '$ocr' } } } },
+            {
+              $set: {
+                'ocr.fail_count': { $add: [{ $ifNull: ['$ocr.fail_count', 0] }, 1] },
+                'ocr.fail_reason': reason,
+                'ocr.fail_blocked': {
+                  $gte: [{ $add: [{ $ifNull: ['$ocr.fail_count', 0] }, 1] }, OCR_FAIL_BLOCK_THRESHOLD],
+                },
+                'ocr.fail_blocked_at': {
+                  $cond: {
+                    if: { $gte: [{ $add: [{ $ifNull: ['$ocr.fail_count', 0] }, 1] }, OCR_FAIL_BLOCK_THRESHOLD] },
+                    then: failNow,
+                    else: { $ifNull: ['$ocr.fail_blocked_at', null] },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+      try {
+        await db.collection('pages').bulkWrite(failOps, { ordered: false });
+        console.log(`  Stamped OCR failure tracking on ${failOps.length} page(s) (book: ${job.book_id})`);
+      } catch (failErr) {
+        console.error(`  Failed to stamp OCR failure tracking: ${failErr.message}`);
       }
     }
 

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -607,7 +607,8 @@ async function processOneJob(db, job) {
             filter: { id: pageId },
             update: {
               $set: setObj,
-              $unset: { 'ocr.fail_count': '', 'ocr.fail_reason': '', 'ocr.fail_blocked': '', 'ocr.fail_blocked_at': '' },
+              $unset: { 'ocr.fail_count': '', 'ocr.fail_reason': '', 'ocr.fail_blocked': '',
+                        'ocr.fail_blocked_at': '', 'ocr.fail_blocked_model': '' },
             },
           },
         });
@@ -783,6 +784,9 @@ async function processOneJob(db, job) {
                 'ocr.fail_blocked': {
                   $gte: [{ $add: [{ $ifNull: ['$ocr.fail_count', 0] }, 1] }, OCR_FAIL_BLOCK_THRESHOLD],
                 },
+                // WHICH model gave up. The block is scoped to it, so switching
+                // models reopens the page instead of stranding it (#4674).
+                'ocr.fail_blocked_model': job.model ?? null,
                 'ocr.fail_blocked_at': {
                   $cond: {
                     if: { $gte: [{ $add: [{ $ifNull: ['$ocr.fail_count', 0] }, 1] }, OCR_FAIL_BLOCK_THRESHOLD] },

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1302,6 +1302,7 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
       book_id: book.id,
       page_number: { $gt: 0 }, // Skip hidden/deduped trailing pages (page_number ≤ 0)
       'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
+      'ocr.fail_blocked': { $ne: true }, // …and after N=3 failures of any other kind (#4674)
       $or: [
         { 'ocr.data': { $exists: false } },
         { 'ocr.data': null },
@@ -1674,6 +1675,7 @@ async function submitCrossBookOcrBatches(db, books, opts = {}) {
         book_id: book.id,
         page_number: { $gt: 0 }, // Skip hidden/deduped trailing pages (page_number ≤ 0)
         'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
+        'ocr.fail_blocked': { $ne: true }, // …and after N=3 failures of any other kind (#4674)
         $or: [{ 'ocr.data': { $exists: false } }, { 'ocr.data': null }, { 'ocr.data': '' }],
         $and: [{
           $or: [
@@ -4169,9 +4171,20 @@ Rules:
         }
 
         if (isComplete) {
-          // Check for remaining un-OCR'd pages
+          // Check for remaining un-OCR'd pages.
+          //
+          // Permanently-blocked pages are NOT remaining work — they are work that
+          // will never succeed, and counting them here is what kept books one page
+          // short of done circling forever. The selection query above already
+          // refuses to submit them, so a book whose only gap is blocked pages was
+          // resubmitting nothing and being told it was incomplete for it. Excluding
+          // them lets such a book reach `ocr_complete` and go on to translation:
+          // the Tabiena Summa sat at 1002/1003 pages with 0 translated for a month
+          // on the strength of one unreadable folio.
           const remainingOcr = await db.collection('pages').countDocuments({
             book_id: book.id,
+            'ocr.recitation_blocked': { $ne: true },
+            'ocr.fail_blocked': { $ne: true },
             $or: [
               { photo: { $exists: true, $ne: null } },
               { photo_original: { $exists: true, $ne: null } },

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -25,7 +25,7 @@ import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
-import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
+import { VISIBLE_PAGE_MATCH, notBlockedForModel } from '../lib/page-counts.mjs';
 import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 import { getTranslateModelForBook, SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
 import { getOcrModelForBook, OCR_MODEL_FLASH, OCR_MODEL_LITE } from '../lib/ocr-routing.mjs';
@@ -1302,20 +1302,22 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
       book_id: book.id,
       page_number: { $gt: 0 }, // Skip hidden/deduped trailing pages (page_number ≤ 0)
       'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
-      'ocr.fail_blocked': { $ne: true }, // …and after N=3 failures of any other kind (#4674)
       $or: [
         { 'ocr.data': { $exists: false } },
         { 'ocr.data': null },
         { 'ocr.data': '' },
       ],
-      $and: [{
-        $or: [
-          { archived_photo: { $exists: true, $regex: /^https?:\/\// } },
-          { cropped_photo: { $exists: true, $nin: [null, ''] } },
-          { photo: { $exists: true, $ne: null } },
-          { photo_original: { $exists: true, $ne: null } },
-        ]
-      }]
+      $and: [
+        {
+          $or: [
+            { archived_photo: { $exists: true, $regex: /^https?:\/\// } },
+            { cropped_photo: { $exists: true, $nin: [null, ''] } },
+            { photo: { $exists: true, $ne: null } },
+            { photo_original: { $exists: true, $ne: null } },
+          ]
+        },
+        notBlockedForModel(ocrModel),
+      ]
     })
     .sort({ page_number: 1 })
     .limit(pageLimit)
@@ -1675,15 +1677,17 @@ async function submitCrossBookOcrBatches(db, books, opts = {}) {
         book_id: book.id,
         page_number: { $gt: 0 }, // Skip hidden/deduped trailing pages (page_number ≤ 0)
         'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
-        'ocr.fail_blocked': { $ne: true }, // …and after N=3 failures of any other kind (#4674)
         $or: [{ 'ocr.data': { $exists: false } }, { 'ocr.data': null }, { 'ocr.data': '' }],
-        $and: [{
-          $or: [
-            { archived_photo: { $exists: true, $regex: /^https?:\/\// } },
-            { cropped_photo: { $exists: true, $nin: [null, ''] } },
-            { photo: { $exists: true, $ne: null } },
-          ]
-        }]
+        $and: [
+          {
+            $or: [
+              { archived_photo: { $exists: true, $regex: /^https?:\/\// } },
+              { cropped_photo: { $exists: true, $nin: [null, ''] } },
+              { photo: { $exists: true, $ne: null } },
+            ]
+          },
+          notBlockedForModel(model),
+        ]
       })
       .sort({ page_number: 1 })
       .limit(remaining)

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -111,6 +111,39 @@ describe('page-counts convention (#3293)', () => {
     expect(stats.blank).toBe(2);
   });
 
+  it('a page we have permanently given up on leaves the translatable denominator (#4674)', () => {
+    // The give-up flag is the general sibling of recitation_blocked: three failed
+    // reads of any kind and the page is out of the queue. It has to leave this
+    // denominator too, or every such book reports a gap it will never close — the
+    // Tabiena Summa showed 1002/1003 forever on one runaway-generation folio.
+    const pages = [
+      { page_number: 1, ocr: { data: 'a' }, translation: { data: 'A' } },
+      { page_number: 2, ocr: { data: 'b' }, translation: { data: 'B' } },
+      { page_number: 3, ocr: { fail_blocked: true, fail_count: 3, fail_reason: 'over-hallucination-limit' } },
+    ];
+
+    const stats = countVisiblePageStats(pages);
+    // Only pages 1 and 2. Page 3 is impossible work, not pending work.
+    expect(stats.translatable).toBe(2);
+    expect(stats.translated_translatable).toBe(2);
+    // …so the book reads as fully translated rather than stuck at 2/3 forever.
+    expect(stats.translated_translatable).toBe(stats.translatable);
+  });
+
+  it('a page still under its 3-strike budget stays in the denominator (#4674)', () => {
+    // The counterpart control: fail_count alone must NOT remove a page, or one
+    // transient failure would silently shrink the denominator and overstate
+    // completeness — the exact failure this file exists to pin against.
+    const pages = [
+      { page_number: 1, ocr: { data: 'a' }, translation: { data: 'A' } },
+      { page_number: 2, ocr: { fail_count: 2, fail_reason: 'no-text:SAFETY' } },
+    ];
+
+    const stats = countVisiblePageStats(pages);
+    expect(stats.translatable).toBe(2);
+    expect(stats.translated_translatable).toBe(1);
+  });
+
   it('regression: hidden translated pages do not fabricate a low translated count', () => {
     // Mirrors histoire-de-la-magie: many visible translated pages, plus hidden
     // pages. The all-pages counter would have produced the wrong totals; the

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -24,6 +24,7 @@ import {
   isTranslatedPage,
   buildVisiblePageCountPipeline,
   countVisiblePageStats,
+  isBlockedForModel,
 } from '../../scripts/lib/page-counts.mjs';
 
 describe('page-counts convention (#3293)', () => {
@@ -142,6 +143,25 @@ describe('page-counts convention (#3293)', () => {
     const stats = countVisiblePageStats(pages);
     expect(stats.translatable).toBe(2);
     expect(stats.translated_translatable).toBe(1);
+  });
+
+  it('a give-up does not outlive the model that made it (#4674)', () => {
+    // 959 of 967 blocked pages had not been retried in over a month, and half of a
+    // re-probed sample read cleanly against the CURRENT model. A block that names no
+    // model is permanent; one that names its model must expire when the model changes.
+    const blocked = { ocr: { fail_blocked: true, fail_blocked_model: 'gemini-3.1-flash-lite' } };
+    expect(isBlockedForModel(blocked, 'gemini-3.1-flash-lite')).toBe(true);   // same model — still blocked
+    expect(isBlockedForModel(blocked, 'gemini-3-flash-preview')).toBe(false); // new model — reopened
+
+    // A legacy block records no model. It stays blocked under every model: reopening
+    // 967 pages is a spend decision, not something a deploy should do by itself.
+    const legacy = { ocr: { fail_blocked: true } };
+    expect(isBlockedForModel(legacy, 'gemini-3.1-flash-lite')).toBe(true);
+    expect(isBlockedForModel(legacy, 'anything-else')).toBe(true);
+
+    // And a page nobody gave up on is never blocked.
+    expect(isBlockedForModel({ ocr: { fail_count: 2 } }, 'gemini-3.1-flash-lite')).toBe(false);
+    expect(isBlockedForModel({}, 'gemini-3.1-flash-lite')).toBe(false);
   });
 
   it('regression: hidden translated pages do not fabricate a low translated count', () => {


### PR DESCRIPTION
Closes #4674. Found while answering "anything mid-flight?" after a three-day shutdown — the daily health alert was reporting a 51% batch failure rate and blaming the wrong thing.

## What was happening

RECITATION has had a per-page give-up since #2065: `ocr.recitation_count`, blocked at 3 strikes, honoured by the page-selection queries. **Nothing else did.** Every other failure class discarded the response and stamped nothing on the page, so no later pass could tell the page had ever been tried.

Page 620 of *Summa summarum quae Tabiena dicitur* was submitted as its own single-page batch job **197 times** between 2026-09-04 and 2026-09-06.

All 197 rows carry `fail_reasons: {}` — an empty object. That is the fingerprint: `failCount` incremented, `noteFail()` never called. The only branch in `batch-collector.mjs` that did that is the `text.length > HALLUCINATION_LIMIT` guard, so the page produces a runaway generation. Deterministic for a given page+model, hence infinite.

**Two hypotheses I had to discard**, both of which read as more likely than the truth:
- *Gemini key drift*, which the health alert itself blamed. Gemini returned `JOB_STATE_SUCCEEDED` on every one of the 197. The failure is entirely ours, at collection time.
- *Cross-book submission bypassing the per-book accounting.* All 197 are `cross_book=false method=inline preview=false`.

## The half that reached readers

Phase 3's `remainingOcr` counted permanently-blocked pages as outstanding work, while the selection query refused to submit them. So a book whose only gap is blocked pages was submitting nothing and being told it was incomplete for it, lap after lap.

The Tabiena Summa sits at **1002/1003 pages OCR'd and 0 translated** — a 1,003-page Latin folio held out of the translation lane by one unreadable folio. It is a Forum of Conscience book, which is why that collection has 10 of its 51 books unfinished.

## The change

| | |
|---|---|
| `noteFail('over-hallucination-limit')` | records the one reason that was never recorded |
| `ocr.fail_count` / `fail_reason` / `fail_blocked` | general give-up at 3 strikes |
| 3 page-selection queries | honour the new flag |
| `remainingOcr` | excludes blocked pages, so the book can finish and translate |
| `page-counts.mjs` | excludes them from the translatable denominator, as recitation already is |

**Kept as its own field rather than folded into `recitation_count`**, because the two mean different things to whoever reads the page next: one is a copyright refusal, the other is "we tried three times and could not get a usable read."

**A successful read clears the counter**, so the threshold measures *consecutive* failures. Without that, an intermittent page accumulates strikes over months and eventually blocks itself for no reason.

**Only pages we can name are stamped.** In the multi-page branch one response covers N pages, and a failure there has no single pageId to blame.

## Tests

Two new cases in `page-counts.test.ts`, and the second is the control: `fail_count` alone must **not** remove a page from the denominator. Only the block does. Without that control the fix could silently shrink denominators and overstate completeness — the exact failure that file exists to pin against.

Negative-controlled: reverting the `page-counts.mjs` change fails the new test and nothing else, so it guards the behaviour rather than restating it.

Full suite: **3,666 passing**, `npx tsc --noEmit` clean.

## Out of scope, deliberately

**Requeueing the 12 affected books**, and the wider 2,923 books sitting ≥98% OCR'd but incomplete (8,400 pages). Most of those are legitimately blocked and correctly parked; the uncounted class is the one that looped. Deciding which to re-run is a spend decision behind whatever valve opens next, and it is Derek's call, not a side effect of a bug fix.

**The batch spend question** this sat next to: `batch_jobs.cost_usd` shows $8.68–$18.40/day against a $5/day dial. I could not confirm it — `spend-reconcile.mjs` reports `GEMINI: UNREADABLE — no Google access token` on the box. Unresolved, and separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yEF44B97wMwfYJ7AaFRax
