### PR TITLE
fix(import): a missing imagecount is a missing FIELD, not a missing book

### DIFF
--- a/scripts/lib/ia-page-count.mjs
+++ b/scripts/lib/ia-page-count.mjs
@@ -1,0 +1,86 @@
+/**
+ * PRIOR ART: src/app/api/import/ia/route.ts — has the correct four-step chain, but
+ * inline in a Vercel route handler, so no script can import it. The ~12 scripts that
+ * need a page count (`git grep -l imagecount -- scripts`) each re-derive it, and every
+ * one of them trusts `imagecount` alone. This module is that chain, extracted, so the
+ * script side stops guessing. The route is deliberately NOT changed here.
+ *
+ * WHY THIS EXISTS. An IA item whose page images ship inside a `Single Page Processed
+ * JP2 ZIP` or a DjVu container reports **no** `imagecount`, and the obvious fallback —
+ * count `.jp2` entries in the file listing — sees the container as ONE file. The item
+ * then looks like a 1-page book, i.e. like a PDF-only item with no page images at all.
+ *
+ * That is not hypothetical. On 2026-09-07 al-Maqrizi's *Khiṭaṭ* (MIFAO 30/33) was set
+ * aside as "PDF-only" on exactly that reading. It has 207 and 127 IIIF canvases, and it
+ * carries Ibn Sulaym al-Aswani's eyewitness account of medieval Nubia. Three more
+ * pre-1930 acquisitions were nearly dropped the same way in the same session.
+ *
+ * The rule: **a missing `imagecount` is a missing FIELD, not a missing BOOK.** Ask the
+ * IIIF manifest, which counts actual canvases and does not care how the images are
+ * packaged.
+ *
+ * Precedence here is manual → IIIF → imagecount → loose .jp2. Note this differs from
+ * the route, where step 1 assigns unconditionally and therefore silently overwrites an
+ * explicit `pages_count` whenever a manifest exists — contradicting its own comment
+ * ("prefer manual override, then IIIF"). Harmless today because manual override is only
+ * used for items that have no manifest, but it is a real discrepancy; see the PR.
+ */
+
+const IIIF_TIMEOUT_MS = 15000;
+const UA = 'SourceLibrary/1.0 (+https://sourcelibrary.org)';
+
+/**
+ * Count the pages of an Internet Archive item.
+ *
+ * @param {string} identifier                  IA identifier
+ * @param {object} [opts]
+ * @param {object} [opts.metadata]             pre-fetched https://archive.org/metadata/<id> body
+ * @param {number} [opts.manual]               explicit override; wins outright when > 0
+ * @param {typeof fetch} [opts.fetchImpl]      injectable for tests
+ * @returns {Promise<{pages:number, source:string}>} source ∈ manual|iiif_v3|iiif_v2|imagecount|jp2_files|none
+ */
+export async function iaPageCount(identifier, opts = {}) {
+  const { metadata, manual, fetchImpl = fetch } = opts;
+
+  // 0. Explicit override wins. The caller knows something we do not.
+  if (Number.isInteger(manual) && manual > 0) return { pages: manual, source: 'manual' };
+
+  // 1. IIIF manifest — counts canvases, so packaging (zip, DjVu, loose files) is irrelevant.
+  try {
+    for (const url of [
+      `https://iiif.archive.org/iiif/3/${identifier}/manifest.json`,
+      `https://iiif.archive.org/iiif/${identifier}/manifest.json`,
+    ]) {
+      const res = await fetchImpl(url, {
+        signal: AbortSignal.timeout(IIIF_TIMEOUT_MS),
+        headers: { 'User-Agent': UA },
+      });
+      if (!res.ok) continue;
+      const manifest = await res.json();
+      if (Array.isArray(manifest.items) && manifest.items.length) {
+        return { pages: manifest.items.length, source: 'iiif_v3' };
+      }
+      const canvases = manifest.sequences?.[0]?.canvases;
+      if (Array.isArray(canvases) && canvases.length) {
+        return { pages: canvases.length, source: 'iiif_v2' };
+      }
+    }
+  } catch {
+    // fall through — a dead manifest must not stop the acquisition
+  }
+
+  // 2. imagecount, when present. Absent for container-packaged items — that is the whole point.
+  const raw = metadata?.metadata?.imagecount;
+  if (raw) {
+    const n = parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return { pages: n, source: 'imagecount' };
+  }
+
+  // 3. Loose .jp2 files, only when they are genuinely listed one-per-page.
+  //    `> 1` is load-bearing: a lone .jp2 is almost always a container or a thumbnail.
+  const files = metadata?.files || [];
+  const jp2 = files.filter((f) => typeof f?.name === 'string' && f.name.endsWith('.jp2') && !f.name.includes('thumb'));
+  if (jp2.length > 1) return { pages: jp2.length, source: 'jp2_files' };
+
+  return { pages: 0, source: 'none' };
+}

--- a/src/lib/api-client/images.ts
+++ b/src/lib/api-client/images.ts
@@ -219,7 +219,13 @@ const ia = {
    *
    * @example
    * const metadata = await ia.fetchMetadata('theatrumchemicu00sethgoog');
-   * const pageCount = metadata.metadata.imagecount;
+   *
+   * Do NOT read `metadata.metadata.imagecount` as the page count. It is ABSENT on any
+   * item whose page images ship inside a `Single Page Processed JP2 ZIP` or a DjVu
+   * container, and such an item then reads as having no pages at all — this is how
+   * al-Maqrizi's Khitat (MIFAO 30/33, 207 and 127 canvases) was once passed over as
+   * "PDF-only". Use the IIIF canvas count, via `scripts/lib/ia-page-count.mjs`
+   * (`iaPageCount`), which falls back to `imagecount` only when no manifest exists.
    */
   fetchMetadata: async (identifier: string): Promise<IAMetadata> => {
     const url = `https://archive.org/metadata/${identifier}`;

--- a/tests/unit/ia-page-count.test.ts
+++ b/tests/unit/ia-page-count.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { iaPageCount } from '../../scripts/lib/ia-page-count.mjs';
+
+/**
+ * The case this guards, from 2026-09-07: al-Maqrizi's Khitat (MIFAO 30/33) was set
+ * aside as "PDF-only" because IA reported no `imagecount` and its page images live
+ * inside a Single Page Processed JP2 ZIP. It has 207 canvases.
+ */
+const MAQRIZI_METADATA = {
+  metadata: { identifier: 'MIFAO30', title: 'MIFAO 30 Maqrīzī - El-mawâ\'iz wa\'l-i\'tibâr' },
+  files: [
+    { name: 'MIFAO30.pdf', format: 'Text PDF' },
+    { name: 'MIFAO30_jp2.zip', format: 'Single Page Processed JP2 ZIP' },
+    { name: 'MIFAO30_djvu.txt', format: 'DjVuTXT' },
+    { name: '__ia_thumb.jpg', format: 'Item Tile' },
+  ],
+};
+
+const manifestFetch = (canvases: number, version: 3 | 2 = 3) => async (url: string) => {
+  if (version === 3 && !url.includes('/iiif/3/')) return { ok: false } as any;
+  if (version === 2 && url.includes('/iiif/3/')) return { ok: false } as any;
+  return {
+    ok: true,
+    json: async () =>
+      version === 3
+        ? { items: Array.from({ length: canvases }, (_, i) => ({ id: `c${i}` })) }
+        : { sequences: [{ canvases: Array.from({ length: canvases }, (_, i) => ({ id: `c${i}` })) }] },
+  } as any;
+};
+
+describe('iaPageCount', () => {
+  it('counts IIIF canvases when imagecount is absent and images are zipped (the Maqrizi case)', async () => {
+    const r = await iaPageCount('MIFAO30', { metadata: MAQRIZI_METADATA, fetchImpl: manifestFetch(207) });
+    expect(r).toEqual({ pages: 207, source: 'iiif_v3' });
+  });
+
+  it('NEGATIVE CONTROL: without the IIIF step the same item reads as an empty book', async () => {
+    // Simulate the bug: no manifest reachable, so we fall through to metadata alone.
+    const deadManifest = async () => ({ ok: false }) as any;
+    const r = await iaPageCount('MIFAO30', { metadata: MAQRIZI_METADATA, fetchImpl: deadManifest });
+    // 0, NOT 1 — the lone _jp2.zip must never be counted as a page. A caller seeing 0
+    // knows it failed; a caller seeing 1 believes it has a one-page book.
+    expect(r.pages).toBe(0);
+    expect(r.source).toBe('none');
+  });
+
+  it('falls back to imagecount when there is no manifest', async () => {
+    const meta = { metadata: { imagecount: '794' }, files: [] };
+    const r = await iaPageCount('egyptiansdni01budguoft', { metadata: meta, fetchImpl: async () => ({ ok: false }) as any });
+    expect(r).toEqual({ pages: 794, source: 'imagecount' });
+  });
+
+  it('supports IIIF v2 manifests', async () => {
+    const r = await iaPageCount('old-item', { metadata: MAQRIZI_METADATA, fetchImpl: manifestFetch(141, 2) });
+    expect(r).toEqual({ pages: 141, source: 'iiif_v2' });
+  });
+
+  it('counts loose .jp2 pages, excluding thumbnails, and never a single one', async () => {
+    const loose = {
+      metadata: {},
+      files: [
+        { name: 'p0001.jp2' }, { name: 'p0002.jp2' }, { name: 'p0003.jp2' },
+        { name: 'thumb_p0001.jp2' },
+      ],
+    };
+    const r = await iaPageCount('loose', { metadata: loose, fetchImpl: async () => ({ ok: false }) as any });
+    expect(r).toEqual({ pages: 3, source: 'jp2_files' });
+
+    const single = { metadata: {}, files: [{ name: 'container.jp2' }] };
+    const one = await iaPageCount('single', { metadata: single, fetchImpl: async () => ({ ok: false }) as any });
+    expect(one.pages).toBe(0);
+  });
+
+  it('an explicit override wins over the manifest (unlike the route, see module header)', async () => {
+    const r = await iaPageCount('MIFAO30', { metadata: MAQRIZI_METADATA, manual: 12, fetchImpl: manifestFetch(207) });
+    expect(r).toEqual({ pages: 12, source: 'manual' });
+  });
+
+  it('a dead manifest endpoint does not throw', async () => {
+    const boom = async () => { throw new Error('ECONNRESET'); };
+    const r = await iaPageCount('x', { metadata: { metadata: { imagecount: '5' }, files: [] }, fetchImpl: boom });
+    expect(r).toEqual({ pages: 5, source: 'imagecount' });
+  });
+});


### PR DESCRIPTION
Follow-up to #4680, which recorded this as a lesson and said outright that it wanted a **check, not a doc line**. This is the check.

## The bug

An IA item whose page images ship inside a `Single Page Processed JP2 ZIP` or a DjVu container reports **no** `imagecount`. The obvious fallback — count `.jp2` entries in the file listing — sees the container as one file. The item then reads as a 1-page book: indistinguishable from a PDF-only item with no page images at all.

**It cost a real acquisition.** Yesterday al-Maqrizi's *Khiṭaṭ* (MIFAO 30/33) was set aside as "PDF-only" on exactly that reading. It has **207 and 127 IIIF canvases**, and it carries Ibn Sulaym al-Aswani's eyewitness account of medieval Nubia — the most important Arabic description of that region we did not hold. Three more pre-1930 acquisitions were nearly dropped the same way in the same session. Both volumes are now imported.

## Why a helper

`/api/import/ia` already gets this right — manual → IIIF → `imagecount` → loose `.jp2` — but the logic is inline in a route handler, so no script can import it. `git grep -l imagecount -- scripts` finds ~12 scripts that each re-derive a page count, and every one of them trusts `imagecount` alone. The `@example` in `src/lib/api-client/images.ts` documented that wrong pattern in as many words:

> `const pageCount = metadata.metadata.imagecount;`

So the wrong thing was the *documented* thing.

## What's here

- **`scripts/lib/ia-page-count.mjs`** — the chain, extracted, with an injectable `fetchImpl` so it tests offline. Tries IIIF v3 then v2; `> 1` on the loose-`.jp2` branch is load-bearing, since a lone `.jp2` is almost always a container or thumbnail.
- **`src/lib/api-client/images.ts`** — the `@example` now says what not to do and points at the helper.
- **`tests/unit/ia-page-count.test.ts`** — 7 cases, fixtured on MIFAO30's real file listing.

## The negative control

Per `invariants/tests-that-are-not-guards.md`, verified by hand rather than assumed. Removing the IIIF step and loosening the `.jp2` threshold to `>= 1` — reintroducing the original bug exactly — turns **3 of 7 red**, including the Maqrizi case. Restoring turns them green.

There is also a standing negative control *in* the suite: the container item must resolve to `0`, never `1`. A caller seeing 0 knows the count failed; a caller seeing 1 believes it holds a one-page book.

## Out of scope

The route itself is unchanged. Flagging for a follow-up that its step 1 assigns unconditionally, so an explicit `pages_count` is silently overwritten whenever a manifest exists — contradicting its own comment ("prefer manual override, then IIIF"). Harmless today, because manual override is only used for items that have no manifest. The helper implements the documented precedence instead, and its header says so.

`npx tsc --noEmit` clean; 7/7 green.