### PR TITLE
fix(pipeline): finalize sealed fully-OCR'd books as complete with no translation

### DIFF
--- a/scripts/maintenance/requeue-untranslated-complete.mjs
+++ b/scripts/maintenance/requeue-untranslated-complete.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Requeue books that Phase 9 finalized as `complete` while translation never ran.
+ *
+ * PRIOR ART:
+ *   scripts/maintenance/fix-h13-stragglers.mjs — closest shape (find books past a
+ *     phase that still lack its output), but it re-submits OCR for 5 named books
+ *     and does not touch pipeline_auto.status. This moves status.
+ *   scripts/maintenance/archiving-watchdog.mjs — watches pipeline_auto.status for
+ *     the ARCHIVE stage only; it cannot see this because the books are past archive.
+ *   scripts/maintenance/fix-translation-loops.mjs — repairs translation that ran
+ *     and looped; here translation never started.
+ *   none writes a complete -> ocr_complete requeue.
+ *
+ * ── What went wrong ──────────────────────────────────────────────────────────
+ *
+ * Phase 9 (finalize) decides `complete` from OCR coverage ALONE:
+ *
+ *     const ocrPercent = ocrCount / totalPages;
+ *     if (ocrPercent < 0.1) { ...needs_attention... }
+ *     await setPipelineStatus(db, book.id, 'complete', { completed_at: new Date() });
+ *
+ * Translation is never consulted. A book whose OCR finished and whose translation
+ * never ran is therefore finalized as `complete` — and `complete` is terminal for
+ * enrichment: Phase 6 selects strictly on `translate_complete`, Phase 7 on
+ * `summary_indexed`. Neither will ever see it again. No `translate_skipped_reason`
+ * is recorded either, so the #3740 guard has nothing to catch.
+ *
+ * Measured 2026-09-08: 142 books, ~15.4K OCR'd pages, ALL non-Latin-script
+ * (Chinese 71, Arabic 38, Malay 15, Javanese 5, Hindi/Nepali 6, Yucatec Maya 2,
+ * Sundanese/Kannada/Balinese 3). Zero of the 142 carry a skip reason.
+ *
+ * ── What this does NOT touch, and why that matters ───────────────────────────
+ *
+ * The far larger population of `complete` + zero-translation books (~17.5K) is
+ * the DELIBERATE 25-page preview posture: `PREVIEW_PAGE_COUNT = 25` in the
+ * orchestrator, with full OCR bought on demand by
+ * scripts/batch/bulk-reocr-opened-books.mjs once read_count >= 1. Those books are
+ * working as designed and requeueing them would restart ~17K translations nobody
+ * asked for. The selector below therefore requires pages_ocr >= 90% of
+ * pages_count — a genuinely fully-OCR'd book — which excludes every preview.
+ *
+ * That distinction is the whole safety of this script. pipeline-status-truth.md:
+ * "a predicate reading absence as failure would re-stall ~28K books permanently."
+ *
+ * ── Direction of travel ──────────────────────────────────────────────────────
+ *
+ * complete -> ocr_complete is a BACKWARD move: it un-claims work rather than
+ * claiming it. `ocr_complete` is literally true of these books (OCR done,
+ * translation not), so this cannot reproduce the status-ahead-of-output harm.
+ * It is also what the fresh-translate lane selects on
+ * (`'pipeline_auto.status': { $in: ['ocr_complete'] }`), so the books re-enter
+ * the primary queue rather than the gap-fill fallback.
+ *
+ * COST: requeueing all 142 queues ~15.4K pages of translation, ~$44 at the rates
+ * measured 2026-09-04 ($0.00241/pg realtime). Meter it with a scope envelope
+ * (scripts/maintenance/set-scope.mjs) before running without --limit.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/requeue-untranslated-complete.mjs
+ *   node --env-file=.env.production.local scripts/maintenance/requeue-untranslated-complete.mjs --execute --limit 20
+ */
+import { MongoClient } from 'mongodb';
+
+const EXECUTE = process.argv.includes('--execute');
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 ? process.argv[i + 1] : d; };
+const LIMIT = parseInt(arg('--limit', '1000'), 10);
+
+// The edition's own language. English editions need no translation, so their
+// absence of one is not evidence of anything (language-fields.md).
+const ENGLISH = ['English', 'english', 'en', 'eng'];
+
+const SELECTOR = {
+  'pipeline_auto.status': 'complete',
+  language: { $nin: ENGLISH },
+  // Excludes the 25-page preview cohort: a preview book has pages_ocr ~25 against
+  // a much larger pages_count, so it can never satisfy the 90% test.
+  pages_count: { $gt: 30 },
+  $expr: { $gte: ['$pages_ocr', { $multiply: ['$pages_count', 0.9] }] },
+  $or: [{ pages_translated: 0 }, { pages_translated: { $exists: false } }],
+};
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI required'); process.exit(1); }
+const client = new MongoClient(uri, { maxPoolSize: 1 });
+
+try {
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const total = await books.countDocuments(SELECTOR);
+  const todo = await books.find(SELECTOR, {
+    projection: { id: 1, title: 1, language: 1, pages_count: 1, pages_ocr: 1, pipeline_auto: 1 },
+  }).limit(LIMIT).toArray();
+
+  console.log(`${EXECUTE ? 'EXECUTE' : 'DRY-RUN'} — ${todo.length} of ${total} matching books\n`);
+
+  const byLang = {};
+  let pages = 0;
+  for (const b of todo) {
+    byLang[b.language || '?'] = (byLang[b.language || '?'] || 0) + 1;
+    pages += b.pages_ocr || 0;
+  }
+  console.log('by language:', JSON.stringify(byLang));
+  console.log(`pages that would enter the translation queue: ${pages} (~$${(pages * 0.00241).toFixed(2)} at 2026-09-04 rates)\n`);
+
+  let moved = 0;
+  for (const b of todo) {
+    if (!EXECUTE) {
+      console.log(`DRY   ${String(b.pages_ocr) + '/' + b.pages_count}pp  ${(b.language || '?').slice(0, 12).padEnd(13)} ${(b.title || '').slice(0, 52)}`);
+      continue;
+    }
+    // Record WHY on the document, at the moment of the write — the thing Phase 9
+    // failed to do. `completed_at` is preserved rather than dropped: it is
+    // evidence of when the bad finalize happened.
+    const prev = b.pipeline_auto || {};
+    const res = await books.updateOne(
+      { id: b.id, 'pipeline_auto.status': 'complete' },
+      {
+        $set: {
+          'pipeline_auto.status': 'ocr_complete',
+          'pipeline_auto.requeued_from': 'complete',
+          'pipeline_auto.requeued_at': new Date(),
+          'pipeline_auto.requeue_reason':
+            'Phase 9 finalize wrote `complete` from OCR coverage alone; translation never ran '
+            + 'and no translate_skipped_reason was recorded. Requeued to ocr_complete so the '
+            + 'translate lane and Phases 6/7 can reach it.',
+          ...(prev.completed_at ? { 'pipeline_auto.previous_completed_at': prev.completed_at } : {}),
+          updated_at: new Date(),
+        },
+        $unset: { 'pipeline_auto.completed_at': '' },
+      },
+    );
+    if (res.modifiedCount === 1) {
+      moved++;
+      console.log(`OK    ${String(b.pages_ocr) + '/' + b.pages_count}pp  ${(b.language || '?').slice(0, 12).padEnd(13)} ${(b.title || '').slice(0, 52)}`);
+    } else {
+      console.log(`MISS  ${b.id} — status changed under us (modifiedCount ${res.modifiedCount})`);
+    }
+  }
+
+  const after = await books.countDocuments(SELECTOR);
+  console.log(`\n=== ${EXECUTE ? 'EXECUTED' : 'DRY-RUN'} — moved ${moved}; matching now ${after} (was ${total}) ===`);
+  if (EXECUTE && moved) {
+    console.log('These are now in the fresh-translate lane. Watch with:');
+    console.log('  node scripts/audit/scope-progress.mjs --scope <your-envelope>');
+  }
+} finally {
+  await client.close();
+}

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -212,6 +212,10 @@ let TRANSLITERATE_LIMIT = 10;  // Books per run (pages processed inline)
 const TRANSLITERATE_CONCURRENCY = 10;  // Parallel Gemini calls per book
 let MAX_ACTIVE_IMAGE_JOBS = 50;
 const PREVIEW_PAGE_COUNT = 25;
+// How many times finalize will return a fully-OCR'd, untranslated book to the
+// translate lane before parking it as complete WITH a recorded skip reason.
+// Bounded so a language translation genuinely cannot handle cannot ping-pong.
+const FINALIZE_TRANSLATE_REQUEUES = 3;
 let PREVIEW_LIMIT = 20; // Books per run to queue preview OCR
 // How long a submitted preview batch suppresses re-offering its book. Longer
 // than any healthy batch (measured p90 0.4h) so we never double-submit, short
@@ -5404,10 +5408,17 @@ Rules:
       let readyToFinalize = await db.collection('books')
         .find({ 'pipeline_auto.status': 'cover_selected' })
         .sort({ hidden: 1 })
-        .project({ id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1 })
+        // pipeline_auto must survive the projection: the untranslated-finalize
+        // guard below reads finalize_requeues off it, and a projected-away field
+        // read as 0 is the #4563/#4565 starvation family — here it would requeue
+        // the same book forever instead of parking it with a reason.
+        .project({ id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1, pipeline_auto: 1 })
         .limit(FINALIZE_LIMIT)
         .toArray();
-      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1, content_type: 1 });
+      // Same field set as the projection above — applyBookOverride re-fetches, so
+      // a field missing HERE is missing on the scope path only, which is how this
+      // bug family hides (#4563: the guard worked until a scope was active).
+      if (SCOPE_ACTIVE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1, pipeline_auto: 1 });
 
       console.log(`  Books ready to finalize: ${readyToFinalize.length}`);
 
@@ -5458,6 +5469,65 @@ Rules:
           }
           log.needs_attention++;
           log.errors.push(`Finalize blocked ${book.id}: ${ocrCount}/${totalPages} OCR`);
+          continue;
+        }
+
+        // Translation is not consulted anywhere above: `ocrPercent` alone decides
+        // `complete`. But `complete` is TERMINAL for enrichment — Phase 6 selects
+        // strictly on `translate_complete`, Phase 7 on `summary_indexed` — so a
+        // fully-OCR'd book whose translation never ran gets sealed here and is
+        // never seen again by any phase. That is the #3740 shape, and the guard at
+        // setPipelineStatus cannot catch it because nothing claims translation.
+        //
+        // Measured 2026-09-08: 142 books, ~15.4K OCR'd pages, EVERY ONE
+        // non-Latin-script (Chinese 71, Arabic 38, Malay 15, Javanese 5, …), and
+        // not one carrying a translate_skipped_reason.
+        //
+        // The 25-page preview cohort is NOT this case and must still finalize:
+        // PREVIEW_PAGE_COUNT books legitimately carry no translation (full OCR is
+        // bought on demand by bulk-reocr-opened-books.mjs), and refusing them
+        // would re-stall ~17K books — the outage pipeline-status-truth.md warns
+        // about. Hence the `fullyOcrd` conjunct.
+        //
+        // translatedCount is COUNTED from `pages`, exactly as ocrCount is above,
+        // rather than read off `book.pages_translated`: that field is not in this
+        // phase's projection, and a projected-away field read as 0 is the
+        // starvation bug family from #4563/#4565 — here it would bounce every
+        // finalizing book back to ocr_complete forever.
+        const needsTranslation = !['English', 'english', 'en', 'eng'].includes(book.language);
+        const fullyOcrd = ocrCount >= totalPages * 0.9;
+        let untranslatedAndFull = false;
+        if (needsTranslation && fullyOcrd) {
+          const translatedCount = await db.collection('pages').countDocuments({
+            book_id: book.id,
+            'translation.data': { $exists: true, $ne: '', $not: { $eq: null } },
+          });
+          untranslatedAndFull = translatedCount === 0;
+        }
+
+        if (untranslatedAndFull) {
+          // Bounded: send it back to the translate lane, but never more than
+          // FINALIZE_TRANSLATE_REQUEUES times, so a language translation genuinely
+          // cannot handle parks with a REASON instead of ping-ponging forever
+          // (the ocr_complete <-> archive_complete bounce, #4563).
+          const requeues = book.pipeline_auto?.finalize_requeues || 0;
+          if (requeues < FINALIZE_TRANSLATE_REQUEUES) {
+            if (!DRY_RUN) {
+              await setPipelineStatus(db, book.id, 'ocr_complete', {
+                finalize_requeues: requeues + 1,
+                requeue_reason: 'finalize: fully OCR\'d but 0 translated pages — returned to the translate lane',
+              });
+            }
+            log.errors.push(`Finalize requeued ${book.id}: ${ocrCount}/${totalPages} OCR, 0 translated`);
+            continue;
+          }
+          if (!DRY_RUN) {
+            await setPipelineStatus(db, book.id, 'complete', {
+              completed_at: new Date(),
+              translate_skipped_reason: `translation produced nothing after ${requeues} finalize requeues (${book.language})`,
+            });
+          }
+          log.errors.push(`Finalize completed untranslated ${book.id} after ${requeues} requeues (${book.language})`);
           continue;
         }
 


### PR DESCRIPTION
## The bug

Phase 9 (finalize) decided `complete` from **OCR coverage alone**:

```js
const ocrPercent = ocrCount / totalPages;
if (ocrPercent < 0.1) { ...needs_attention... }
await setPipelineStatus(db, book.id, 'complete', { completed_at: new Date() });
```

Translation is never consulted. But `complete` is **terminal for enrichment** —
Phase 6 selects strictly on `translate_complete`, Phase 7 on `summary_indexed`.
So a book whose OCR finished and whose translation never ran was sealed here and
became invisible to every later phase, permanently. No `translate_skipped_reason`
was written either, so the #3740 guard had nothing to catch.

## What it cost

Measured 2026-09-08: **142 books, ~15,400 OCR'd pages already paid for**, sitting
unreadable and unreachable.

The distribution is the interesting part — **every one is non-Latin-script**:

| Language | Books | Pages |
|---|---|---|
| Chinese | 71 | 9,079 |
| Arabic | 38 | 3,460 |
| Malay | 15 | 1,253 |
| Javanese | 5 | 793 |
| Hindi / Nepali | 6 | 1,058 |
| Yucatec Maya | 2 | 176 |
| Sundanese, Kannada, Balinese | 3 | 178 |

Zero Latin, zero German, zero Romance, in a corpus that is overwhelmingly Latin.
Translation is bailing on these scripts and finalize was sealing the result as
finished. **This PR stops the evidence being destroyed; it does not explain why
translation fails on non-Latin scripts.** That remains open and is the bigger
question.

## What it deliberately does NOT change

~17.5K books legitimately sit at `complete` with zero translation: the **25-page
preview** posture (`PREVIEW_PAGE_COUNT`, full OCR bought on demand by
`bulk-reocr-opened-books.mjs` once `read_count >= 1`). A guard reading absence as
failure would re-stall all of them — the precise outage
`pipeline-status-truth.md` warns about ("would re-stall ~28K books
permanently"). The `fullyOcrd` conjunct (`ocrCount >= totalPages * 0.9`) excludes
every preview, since a preview book cannot reach 90% of its own page count.

## Two projection fixes travel with it

This guard is exactly the shape that starved in #4563/#4565, so:

- **`translatedCount` is COUNTED from `pages`**, as `ocrCount` already is, rather
  than read off `book.pages_translated` — which this phase **does not project**.
  Read as `undefined` it would have been treated as 0, bouncing *every*
  finalizing book back to `ocr_complete` forever.
- **`pipeline_auto` added to BOTH** the `find` projection and the
  `applyBookOverride` field set, so `finalize_requeues` survives on the scope
  path too. A field present in one and missing in the other is how that family
  hides — it works until a scope is active.

## Bounded, not ping-ponging

`FINALIZE_TRANSLATE_REQUEUES = 3`. After three returns to the translate lane the
book completes **with** an explicit `translate_skipped_reason` naming the
language, so a script translation genuinely cannot handle parks loudly rather
than bouncing (the `ocr_complete` ↔ `archive_complete` bounce, #4563).

## The repair, already run

`scripts/maintenance/requeue-untranslated-complete.mjs` moved all 142 from
`complete` → `ocr_complete`, each stamped with `requeued_from`, `requeued_at` and
a `requeue_reason`. Verified after: 142 carry the reason, **0 remain stranded**.
`completed_at` preserved as `previous_completed_at` — it is evidence of when the
bad finalize happened.

`complete → ocr_complete` is a **backward** move: it un-claims work rather than
claiming it, and `ocr_complete` is literally true of these books, so the repair
cannot reproduce the harm it fixes.

Cost of the requeue is ~$44 of translation, but it is not new spend — the books
rejoin the normal queue under the existing $5/day dial. The dial was not touched.

## Out of scope

- **Why translation fails on non-Latin scripts.** The real question; needs its own
  investigation.
- `setPipelineStatus` is duplicated in three workers
  (`pipeline-orchestrator`, `enrich-worker`, `image-extract-worker`) rather than
  shared. Not touched here.
- The structural fix the memory calls for — one named projection const per phase,
  shared with `applyBookOverride` — is still open. This PR fixes the two
  projections it needs, not the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014c62S83U7iVRRNuhwKiHH3