### PR TITLE
talks(ai-case-study): staged load-in

### DIFF
--- a/src/content/talks/ai-case-study/index.html
+++ b/src/content/talks/ai-case-study/index.html
@@ -9,6 +9,8 @@
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27%231a1612%27%3E%3Ccircle cx=%2712%27 cy=%2712%27 r=%2710%27/%3E%3Ccircle cx=%2712%27 cy=%2712%27 r=%277%27/%3E%3Ccircle cx=%2712%27 cy=%2712%27 r=%274%27/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&display=swap" rel="stylesheet">
+<link rel="preload" as="image" href="/talks/ai-case-study/assets/covers-true.jpg">
+<link rel="preload" as="fetch" crossorigin href="/talks/ai-case-study/assets/covers-true.json">
 <link rel="stylesheet" href="/talks/ai-case-study/styles.css">
 <script>try{document.documentElement.dataset.theme=localStorage.getItem('sl-talk-theme')||'light'}catch(e){}</script>
 </head>

--- a/src/content/talks/ai-case-study/styles.css
+++ b/src/content/talks/ai-case-study/styles.css
@@ -790,3 +790,25 @@ footer.colophon{background:#f6efe5}
 #smallscreen h1{font-size:22px;font-weight:600;margin:18px 0 8px;letter-spacing:-.01em}
 #smallscreen p{margin:0;color:#b3a890;font-size:15px;line-height:1.5;max-width:30em}
 @media (max-width:1023px),(hover:none) and (pointer:coarse) and (max-width:1366px){#smallscreen{display:grid}}
+
+/* ===== load-in ===== */
+#hero #wall{opacity:0;transition:opacity 1.6s ease}
+#hero.ready #wall{opacity:1}
+#hero .in>*{opacity:0;transform:translateY(16px);transition:opacity .9s cubic-bezier(.2,.7,.2,1),transform .9s cubic-bezier(.2,.7,.2,1)}
+#hero.ready .in>*{opacity:1;transform:none}
+#hero.ready .in>.eyebrow{transition-delay:.35s}
+#hero.ready .in>h1{transition-delay:.5s}
+#hero.ready .in>.pills{transition-delay:.85s}
+#hero.ready .in>.meta{transition-delay:1.05s}
+#hero .pill{opacity:0;transform:translateY(8px);transition:opacity .6s,transform .6s}
+#hero.ready .pill{opacity:1;transform:none}
+#hero.ready .pill:nth-child(1){transition-delay:.9s}#hero.ready .pill:nth-child(2){transition-delay:1s}#hero.ready .pill:nth-child(3){transition-delay:1.1s}#hero.ready .pill:nth-child(4){transition-delay:1.2s}#hero.ready .pill:nth-child(5){transition-delay:1.3s}
+.site{opacity:0;transition:opacity .8s .2s}
+body.booted .site{opacity:1}
+.slide:not(#hero) .head>*{opacity:0;transform:translateY(12px);transition:opacity .7s cubic-bezier(.2,.7,.2,1),transform .7s cubic-bezier(.2,.7,.2,1)}
+.slide:not(#hero).on-screen .head>*{opacity:1;transform:none}
+.slide:not(#hero).on-screen .head>.sub{transition-delay:.15s}
+.slide:not(#hero) .stage{opacity:0;transition:opacity .7s .25s}
+.slide:not(#hero).on-screen .stage{opacity:1}
+#advice .dd{opacity:1}
+@media (prefers-reduced-motion:reduce){#hero #wall,#hero .in>*,#hero .pill,.site,.slide .head>*,.slide .stage{opacity:1!important;transform:none!important;transition:none!important}}

--- a/src/content/talks/ai-case-study/styles.css
+++ b/src/content/talks/ai-case-study/styles.css
@@ -812,3 +812,6 @@ body.booted .site{opacity:1}
 .slide:not(#hero).on-screen .stage{opacity:1}
 #advice .dd{opacity:1}
 @media (prefers-reduced-motion:reduce){#hero #wall,#hero .in>*,#hero .pill,.site,.slide .head>*,.slide .stage{opacity:1!important;transform:none!important;transition:none!important}}
+
+/* the wall paints its own entrance; no CSS fade on top of it */
+#hero #wall{opacity:1;transition:none}

--- a/src/content/talks/ai-case-study/talk.js
+++ b/src/content/talks/ai-case-study/talk.js
@@ -283,12 +283,19 @@ if($('#eth'))$('#eth').innerHTML=[
  new MutationObserver(()=>window.syncTabs()).observe(document.body,{attributes:true,subtree:true,attributeFilter:['class']});
 })();
 
-/* covers wall: true proportions, a strip of ground between */
-(function(){const c=$('#wall');if(!c)return;const ctx=c.getContext('2d');const img=new Image();img.src='/talks/ai-case-study/assets/covers-true.jpg';let meta=null;const hero=$('#hero');let readyDone=false;const ready=()=>{if(readyDone)return;readyDone=true;hero.classList.add('ready')};const fontsReady=(document.fonts&&document.fonts.ready)||Promise.resolve();const imgReady=new Promise(r=>{img.complete?r():(img.onload=r,img.onerror=r)});Promise.all([fontsReady,imgReady]).then(()=>setTimeout(ready,120));setTimeout(ready,1800);fetch('/talks/ai-case-study/assets/covers-true.json').then(r=>r.json()).then(m=>meta=m);const t0=performance.now();
- let rows=null;function layout(W,H){const gap=10,top=56+gap,rowsFit=Math.max(3,Math.floor((H-top)/(150+gap))),rowH=Math.floor((H-top-gap*(rowsFit-1))/rowsFit);rows=[];let i=0,y=top;while(y+rowH<=H+1){const row={y,h:rowH,items:[],w:0};let x=0;while(x<W*2){const it=meta.items[i%meta.n];i++;const w=it.w*rowH/it.h;row.items.push({it,x,w});x+=w+gap}row.w=x;rows.push(row);y+=rowH+gap}}
+/* covers wall: true proportions, a strip of ground between; tiles arrive one by one, then drift */
+(function(){const c=$('#wall');if(!c)return;const ctx=c.getContext('2d');const img=new Image();img.src='/talks/ai-case-study/assets/covers-true.jpg';let meta=null;const hero=$('#hero');let readyDone=false,born=0;
+ const ready=()=>{if(readyDone)return;readyDone=true;born=performance.now();hero.classList.add('ready')};
+ const fontsReady=(document.fonts&&document.fonts.ready)||Promise.resolve();const imgReady=new Promise(r=>{img.complete?r():(img.onload=r,img.onerror=r)});
+ fetch('/talks/ai-case-study/assets/covers-true.json').then(r=>r.json()).then(m=>{meta=m;Promise.all([fontsReady,imgReady]).then(()=>setTimeout(ready,80))});setTimeout(ready,2200);
+ let rows=null;function layout(W,H){const gap=10,top=56+gap,rowsFit=Math.max(3,Math.floor((H-top)/(150+gap))),rowH=Math.floor((H-top-gap*(rowsFit-1))/rowsFit);rows=[];let i=0,y=top,seed=3;const rnd=()=>{seed=(seed*9301+49297)%233280;return seed/233280};
+  while(y+rowH<=H+1){const row={y,h:rowH,items:[],w:0};let x=0;while(x<W*2){const it=meta.items[i%meta.n];i++;const w=it.w*rowH/it.h;const wave=(x/W)*0.9+((y-top)/H)*0.5;row.items.push({it,x,w,delay:wave+rnd()*0.7});x+=w+gap}row.w=x;rows.push(row);y+=rowH+gap}}
+ const ease=t=>1-Math.pow(1-t,3);
  function draw(now){if(!meta||!img.complete){requestAnimationFrame(draw);return}const dpr=Math.min(2,devicePixelRatio||1);const W=c.clientWidth,H=c.clientHeight;if(c.width!==W*dpr){c.width=W*dpr;c.height=H*dpr;rows=null}ctx.setTransform(dpr,0,0,dpr,0,0);if(!rows)layout(W,H);ctx.clearRect(0,0,W,H);
-  const t=RM?0:(now-t0)/1000;rows.forEach((row,ri)=>{const off=((t*(ri%2?6:9))%row.w);for(const q of row.items){let x=q.x-off;if(x+q.w<0)x+=row.w;if(x>W)continue;ctx.drawImage(img,q.it.x,q.it.y,q.it.w,q.it.h,x,row.y,q.w,row.h)}});
-  requestAnimationFrame(draw)}requestAnimationFrame(draw)})();
+  if(!readyDone){requestAnimationFrame(draw);return}
+  const age=(now-born)/1000;const drift=RM?0:Math.max(0,age-1.6);
+  rows.forEach((row,ri)=>{const off=((drift*(ri%2?6:9))%row.w);for(const q of row.items){let x=q.x-off;if(x+q.w<0)x+=row.w;if(x>W)continue;const p=RM?1:Math.min(1,Math.max(0,(age-q.delay)/0.9));if(p<=0)continue;const e=ease(p);ctx.globalAlpha=e;const sc=0.94+0.06*e;const dw=q.w*sc,dh=row.h*sc;ctx.drawImage(img,q.it.x,q.it.y,q.it.w,q.it.h,x+(q.w-dw)/2,row.y+(row.h-dh)/2+(1-e)*14,dw,dh)}});
+  ctx.globalAlpha=1;requestAnimationFrame(draw)}requestAnimationFrame(draw)})();
 
 /* slides */
 const slides=$$('.slide'),rail=$('#rail');rail.innerHTML=slides.map(s=>`<a href="#${s.id}" data-part="${s.dataset.part||''}" title="${esc(s.dataset.title||s.id)}"></a>`).join('');const dots=$$('#rail a');let active=0;

--- a/src/content/talks/ai-case-study/talk.js
+++ b/src/content/talks/ai-case-study/talk.js
@@ -7,6 +7,7 @@ const tip=$('#tip');
 function hover(el,text){el.addEventListener('mousemove',e=>{tip.innerHTML=text;tip.style.opacity=1;tip.style.left=(e.clientX+14)+'px';tip.style.top=(e.clientY+14)+'px'});el.addEventListener('mouseleave',()=>tip.style.opacity=0)}
 const strip=s=>s.replace(/<(language|page-type|page-num|scan-quality|script|lang)>[\s\S]*?<\/\1>/g,'').replace(/<vocab>[\s\S]*?<\/vocab>/g,'').replace(/<detected-images>[\s\S]*?<\/detected-images>/g,'').replace(/<meta>[\s\S]*?<\/meta>/g,'').replace(/<insert>|<\/insert>/g,'').replace(/<gloss>(.*?)<\/gloss>/g,'').replace(/<note>(.*?)<\/note>/g,'').replace(/<[^>]+>/g,'').replace(/^#+ /gm,'').replace(/\*\*|\*   /g,'').replace(/-> (.*?) <-/g,'$1').trim();
 
+document.body.classList.add('booted');
 /* theme */
 const themeBtn=$('#theme');function setTheme(t){document.documentElement.dataset.theme=t;themeBtn.textContent=t==='dark'?'Light':'Dark';try{localStorage.setItem('sl-talk-theme',t)}catch(e){}}
 setTheme(document.documentElement.dataset.theme||'light');themeBtn.addEventListener('click',()=>setTheme(document.documentElement.dataset.theme==='dark'?'light':'dark'));
@@ -283,7 +284,7 @@ if($('#eth'))$('#eth').innerHTML=[
 })();
 
 /* covers wall: true proportions, a strip of ground between */
-(function(){const c=$('#wall');if(!c)return;const ctx=c.getContext('2d');const img=new Image();img.src='/talks/ai-case-study/assets/covers-true.jpg';let meta=null;fetch('/talks/ai-case-study/assets/covers-true.json').then(r=>r.json()).then(m=>meta=m);const t0=performance.now();
+(function(){const c=$('#wall');if(!c)return;const ctx=c.getContext('2d');const img=new Image();img.src='/talks/ai-case-study/assets/covers-true.jpg';let meta=null;const hero=$('#hero');let readyDone=false;const ready=()=>{if(readyDone)return;readyDone=true;hero.classList.add('ready')};const fontsReady=(document.fonts&&document.fonts.ready)||Promise.resolve();const imgReady=new Promise(r=>{img.complete?r():(img.onload=r,img.onerror=r)});Promise.all([fontsReady,imgReady]).then(()=>setTimeout(ready,120));setTimeout(ready,1800);fetch('/talks/ai-case-study/assets/covers-true.json').then(r=>r.json()).then(m=>meta=m);const t0=performance.now();
  let rows=null;function layout(W,H){const gap=10,top=56+gap,rowsFit=Math.max(3,Math.floor((H-top)/(150+gap))),rowH=Math.floor((H-top-gap*(rowsFit-1))/rowsFit);rows=[];let i=0,y=top;while(y+rowH<=H+1){const row={y,h:rowH,items:[],w:0};let x=0;while(x<W*2){const it=meta.items[i%meta.n];i++;const w=it.w*rowH/it.h;row.items.push({it,x,w});x+=w+gap}row.w=x;rows.push(row);y+=rowH+gap}}
  function draw(now){if(!meta||!img.complete){requestAnimationFrame(draw);return}const dpr=Math.min(2,devicePixelRatio||1);const W=c.clientWidth,H=c.clientHeight;if(c.width!==W*dpr){c.width=W*dpr;c.height=H*dpr;rows=null}ctx.setTransform(dpr,0,0,dpr,0,0);if(!rows)layout(W,H);ctx.clearRect(0,0,W,H);
   const t=RM?0:(now-t0)/1000;rows.forEach((row,ri)=>{const off=((t*(ri%2?6:9))%row.w);for(const q of row.items){let x=q.x-off;if(x+q.w<0)x+=row.w;if(x>W)continue;ctx.drawImage(img,q.it.x,q.it.y,q.it.w,q.it.h,x,row.y,q.w,row.h)}});


### PR DESCRIPTION
The gated deck's hero now waits for the covers atlas to decode and fonts to settle, then fades the wall up and rises the eyebrow, title, pills and footnote in sequence; every other slide eases its headline and content in as it arrives. Atlas preloaded; reduced motion disables all of it. Content-only change under src/content/talks/ai-case-study.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gJ3bJuM1Vb8Xitr3pa7mv