### PR TITLE
page-terms: gzip shards, provenance once per run (#4695)

### DIFF
--- a/scripts/maintenance/aggregate-page-terms.mjs
+++ b/scripts/maintenance/aggregate-page-terms.mjs
@@ -29,6 +29,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
+import zlib from 'node:zlib';
 import { MongoClient } from 'mongodb';
 import { isLatinScript } from '../lib/page-terms-parse.mjs';
 
@@ -55,15 +56,16 @@ sql.exec(`
 `);
 
 // ---- load shards (skip books already loaded) ----
-const shards = fs.readdirSync(IN_DIR).filter((f) => f.endsWith('.jsonl'));
+const shards = fs.readdirSync(IN_DIR).filter((f) => f.endsWith('.jsonl') || f.endsWith('.jsonl.gz'));
 const isLoaded = sql.prepare('SELECT 1 FROM loaded WHERE book_id = ?');
 const markLoaded = sql.prepare('INSERT INTO loaded (book_id) VALUES (?)');
 const ins = sql.prepare('INSERT INTO raw VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
 let loaded = 0, rows = 0;
 for (const f of shards) {
-  const bookId = f.replace(/\.jsonl$/, '');
+  const bookId = f.replace(/\.jsonl(\.gz)?$/, '');
   if (isLoaded.get(bookId)) continue;
-  const text = fs.readFileSync(path.join(IN_DIR, f), 'utf8');
+  const buf = fs.readFileSync(path.join(IN_DIR, f));
+  const text = f.endsWith('.gz') ? zlib.gunzipSync(buf).toString('utf8') : buf.toString('utf8');
   sql.exec('BEGIN');
   for (const line of text.split('\n')) {
     if (!line) continue;

--- a/scripts/maintenance/build-page-terms.mjs
+++ b/scripts/maintenance/build-page-terms.mjs
@@ -11,8 +11,10 @@
  *   translation.data  <keywords>silence, hesychia</keywords>      → kind "keyword"
  *   translation.data  <note>original: "ἡσυχίαν" (hesychian)</note>→ kind "original" (verified against ocr.data; 12% are fabricated, #3308)
  *
- * PASS 1 of two. No model call, no DB write. One JSONL shard per book under --out-dir, one row
- * per (page, kind, term_key). Measured on a 218-book pilot (2026-09-09): 21 rows/page, 10.5
+ * PASS 1 of two. No model call, no DB write. One gzipped JSONL shard per book under --out-dir
+ * (`<book_id>.jsonl.gz`, ~8x smaller than plain — the corpus-wide plain estimate was 27 GB
+ * against 24 GB free on Hetzner), one row per (page, kind, term_key). Provenance is written
+ * ONCE per run to `<out-dir>/_meta.json` rather than repeated on every row. Measured on a 218-book pilot (2026-09-09): 21 rows/page, 10.5
  * DISTINCT terms/page, and the global distinct count grows ~linearly with books (mostly one-off
  * names + OCR noise) — ~70M per-book rows corpus-wide. That is a disk artifact, not an Atlas
  * collection. `aggregate-page-terms.mjs` (pass 2) reduces the shards to the curated global
@@ -32,6 +34,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import zlib from 'node:zlib';
 import { MongoClient } from 'mongodb';
 import { parseOcrVocab, parseTranslationTerms, CONTEXT_CHARS } from '../lib/page-terms-parse.mjs';
 
@@ -64,7 +67,13 @@ const books = db.collection('books');
 const pages = db.collection('pages');
 
 fs.mkdirSync(OUT_DIR, { recursive: true });
-const shardPath = (bookId) => path.join(OUT_DIR, `${bookId}.jsonl`);
+const shardPath = (bookId) => path.join(OUT_DIR, `${bookId}.jsonl.gz`);
+fs.writeFileSync(path.join(OUT_DIR, '_meta.json'), JSON.stringify({
+  method: METHOD,
+  sources: { vocab: 'ocr.data <vocab>', term: 'translation.data <term>/<gloss>', keyword: 'translation.data <keywords>', original: 'translation.data <note original>, verified by $indexOfCP against ocr.data' },
+  confidence: { vocab: 0.8, term: 0.8, keyword: 0.8, original_verified: 0.9, original_unverified: 0.3 },
+  started: new Date(), host: process.env.HOSTNAME || null,
+}, null, 1));
 const resumeFrom = RESUME_FROM;
 
 /** Retry transient Atlas/network errors per book instead of dying mid-sweep. */
@@ -142,7 +151,6 @@ async function processBook(book) {
     { $sort: { page_number: 1 } },
   ], { readPreference: 'secondaryPreferred' }).toArray(), `book ${book.id}`);
 
-  const now = new Date();
   const rows = [];
   for (const p of bookPages) {
     if (!p.has_any) continue;
@@ -162,13 +170,8 @@ async function processBook(book) {
     ];
     if (parsed.length) stats.pagesWithAny++;
     for (const r of parsed) {
-      const { source, ...rest } = r;
-      rows.push({
-        book_id: book.id,
-        page_number: p.page_number,
-        ...rest,
-        field_provenance: { source, method: METHOD, confidence: r.kind === 'original' ? (r.verified ? 0.9 : 0.3) : 0.8, date: now },
-      });
+      const { source: _source, ...rest } = r;
+      rows.push({ book_id: book.id, page_number: p.page_number, ...rest });
       bump(stats.byKind, r.kind);
       if (r.kind === 'original') { if (r.verified) stats.originalVerified++; else stats.originalUnverified++; }
       if (r.kind === 'vocab') bump(stats.byLang, srcLang || 'unknown');
@@ -181,7 +184,7 @@ async function processBook(book) {
   // Write to a temp name and rename, so a killed run never leaves a truncated shard that
   // the resume check would then treat as done.
   const tmp = shard + '.tmp';
-  fs.writeFileSync(tmp, rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : ''));
+  fs.writeFileSync(tmp, zlib.gzipSync(rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : ''), { level: 6 }));
   fs.renameSync(tmp, shard);
 
   if (stats.books % 100 === 0) console.log(`${stats.books} books · ${stats.pages} pages · ${stats.rows} rows`);


### PR DESCRIPTION
Follow-up to #4697 before the first corpus run.

**Why.** Plain JSONL with a `field_provenance` object repeated on every row extrapolated to ~27 GB for the corpus; the Hetzner box has 24 GB free (`df`, 2026-09-10). 

**What.** Shards are now `<book_id>.jsonl.gz` (zlib level 6); provenance is written once per run to `<out-dir>/_meta.json`. The aggregator reads both plain and gzipped shards. 12-book test: **2.2 MB instead of ~25 MB**, identical row count (111,583), identical aggregator output. Corpus estimate ≈ 3 GB.

No parser change; tests unchanged (15 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzsLcEGA9Ms2RpvaX54KRh