### PR TITLE
fix(librarian): image guard no longer strips plates shown earlier in the thread

### DIFF
--- a/src/lib/embassy/citation-fixes.ts
+++ b/src/lib/embassy/citation-fixes.ts
@@ -113,6 +113,40 @@ export function findEmbeddedImageUrls(text: string): string[] {
   return urls;
 }
 
+/**
+ * Image URLs the Librarian may legitimately re-embed on a later turn: every
+ * embed that SURVIVED an earlier assistant message in this thread.
+ *
+ * The fabricated-image guard allows only URLs a tool returned THIS turn. Built
+ * per turn, it called a plate the Librarian itself showed on turn one
+ * "fabricated" on turn three — measured over 45 days, 281 of 508 stripped
+ * embeds had appeared verbatim earlier in the same thread (#4704). Prior
+ * assistant text is persisted after removals were applied, so anything still
+ * embedded there was tool-sourced when it was first shown.
+ *
+ * History is client-supplied, so only our own image hosts are trusted from it;
+ * an off-site URL must still be re-returned by a tool to be embeddable.
+ */
+export function priorTurnImageUrls(history: Array<{ role: string; content: string }>): string[] {
+  const urls = new Set<string>();
+  for (const msg of history) {
+    if (msg.role !== 'assistant' || !msg.content) continue;
+    for (const url of findEmbeddedImageUrls(msg.content)) {
+      if (isOwnImageHost(url)) urls.add(url);
+    }
+  }
+  return [...urls];
+}
+
+function isOwnImageHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'sourcelibrary.org' || host.endsWith('.sourcelibrary.org');
+  } catch {
+    return false;
+  }
+}
+
 export function applyImageRemovals(text: string, removeUrls: string[]): string {
   let out = text;
   for (const url of removeUrls) {

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -4,6 +4,7 @@ import {
   findCitedBookLinks,
   findCitedCollectionSlugs,
   findEmbeddedImageUrls,
+  priorTurnImageUrls,
   type CitationFix,
 } from '@/lib/embassy/citation-fixes';
 import { PREFIXED_LOCALES, type Locale } from '@/lib/locale-path';
@@ -1399,9 +1400,10 @@ export async function* streamAgenticResponse(
   // (search hits + get_book_page + read_nearby_pages). Used to ground the
   // page citations in the final answer — see verifyCitations.
   const retrievedPageKeys = new Set<string>();
-  // Every image URL any tool returned this turn. The model is allowed to embed
-  // these and nothing else; anything else in an `![](...)` is fabricated.
-  const toolImageUrls = new Set<string>();
+  // Every image URL any tool returned this turn, plus every embed that survived
+  // an earlier answer in this thread (see priorTurnImageUrls). The model may
+  // embed these and nothing else; anything else in an `![](...)` is fabricated.
+  const toolImageUrls = new Set<string>(priorTurnImageUrls(history));
   // Text the model produced THIS turn. `contents` is seeded with the thread
   // history, so scanning it for citations re-flags every earlier answer's
   // broken links — which crowds real, new breakage out of the repair budget.

--- a/tests/unit/librarian-prior-turn-images.test.ts
+++ b/tests/unit/librarian-prior-turn-images.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { priorTurnImageUrls } from '@/lib/embassy/citation-fixes';
+
+// The fabricated-image allowlist used to be rebuilt empty each turn, so a
+// plate the Librarian showed on turn one was "fabricated" on turn three —
+// 281 of 508 strips over 45 days were its own earlier images (#4704). Prior
+// assistant text now seeds the allowlist, but only for our own image hosts,
+// because history is client-supplied.
+describe('priorTurnImageUrls', () => {
+  it('returns embeds from earlier assistant messages', () => {
+    const history = [
+      { role: 'user', content: 'Show me the tetrahedron' },
+      { role: 'assistant', content: 'Here:\n![Tetrahedron](https://images.sourcelibrary.org/archived/69de988c/191.jpg)\n*Pacioli.*' },
+      { role: 'user', content: 'And Fludd?' },
+    ];
+    expect(priorTurnImageUrls(history)).toEqual([
+      'https://images.sourcelibrary.org/archived/69de988c/191.jpg',
+    ]);
+  });
+
+  it('ignores user messages, even when they contain an embed', () => {
+    const history = [
+      { role: 'user', content: '![x](https://images.sourcelibrary.org/archived/abc/1.jpg)' },
+    ];
+    expect(priorTurnImageUrls(history)).toEqual([]);
+  });
+
+  it('trusts only our own image hosts from client-supplied history', () => {
+    const history = [
+      { role: 'assistant', content: [
+        '![ok](https://images.sourcelibrary.org/artwork/art-x.jpg)',
+        '![apex](https://sourcelibrary.org/brand/x.png)',
+        '![offsite](https://www.e-rara.ch/i3f/v20/1/full/full/0/default.jpg)',
+        '![lookalike](https://sourcelibrary.org.evil.example/x.jpg)',
+        '![lookalike2](https://notsourcelibrary.org/x.jpg)',
+        '![junk](not-a-url)',
+      ].join('\n') },
+    ];
+    expect(priorTurnImageUrls(history)).toEqual([
+      'https://images.sourcelibrary.org/artwork/art-x.jpg',
+      'https://sourcelibrary.org/brand/x.png',
+    ]);
+  });
+
+  it('dedupes a URL embedded on several earlier turns', () => {
+    const u = 'https://images.sourcelibrary.org/archived/abc/7.jpg';
+    const history = [
+      { role: 'assistant', content: `![a](${u})` },
+      { role: 'assistant', content: `again ![b](${u})` },
+    ];
+    expect(priorTurnImageUrls(history)).toEqual([u]);
+  });
+});


### PR DESCRIPTION
Part 1 of #4704 (Librarian log audit).

## What
The fabricated-image allowlist (`toolImageUrls`) was rebuilt empty every turn, so a plate the Librarian showed on turn one was called "fabricated" on turn three: the image rendered during streaming, vanished at `image_removals`, and the answer gained *"an illustration I could not source, which I removed."*

Measured over 45 days of `embassy_errors`: **281 of 508 stripped embeds had appeared verbatim earlier in the same thread**; 25 of 41 HEAD-checked strips return 200.

## How
`priorTurnImageUrls(history)` (new, `citation-fixes.ts`) collects every `![](url)` embed from prior **assistant** messages and seeds the allowlist. Prior assistant text is persisted after removals were applied, so anything still embedded there was tool-sourced when first shown. Because `history` is client-supplied, only `sourcelibrary.org` / `*.sourcelibrary.org` URLs are trusted from it; an off-site URL still needs a tool to return it this turn.

## Out of scope
- HEAD-checking same-host URLs the model composes on a first turn (e.g. `archived/<book_id>/<n>.jpg`) — those often exist, but a real page image of the wrong page is worse than no image, so left as-is.
- The empty-answer path, slug repair for diacritic-stripped slugs, the bot rate limit, and ranking toward original editions — separate PRs, same issue.

## Tests
`tests/unit/librarian-prior-turn-images.test.ts` (4 cases: assistant-only, host trust incl. look-alike hosts, dedupe). `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tru9fGPrYXGMdHh9314v1r