### PR TITLE
lint: enable no-undef for scripts/**/*.mjs, fix the 9 crashes it found (#4702)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,9 +29,11 @@ jobs:
 
       # `node --check` validates syntax, not scope; tsc does not cover plain
       # .mjs. This is the only guard against an undeclared identifier in the
-      # 1,100+ scripts that run against production Mongo (#4702).
+      # 1,100+ scripts that run against production Mongo (#4702). It uses its
+      # own config on purpose: eslint.config.mjs loads eslint-config-next's
+      # TypeScript layer, which crashes on load under the lockfile's ESLint 10.
       - name: Lint plain-node scripts (no-undef)
-        run: npx eslint "scripts/**/*.mjs" --quiet
+        run: npx eslint -c eslint.scripts.config.mjs "scripts/**/*.mjs" --quiet
 
       # Static source check — no network, no secrets — so it gates PRs here
       # rather than running nightly. Vercel Blob is retired in favour of R2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # `node --check` validates syntax, not scope; tsc does not cover plain
+      # .mjs. This is the only guard against an undeclared identifier in the
+      # 1,100+ scripts that run against production Mongo (#4702).
+      - name: Lint plain-node scripts (no-undef)
+        run: npx eslint "scripts/**/*.mjs" --quiet
+
       # Static source check — no network, no secrets — so it gates PRs here
       # rather than running nightly. Vercel Blob is retired in favour of R2
       # (#3645); this refuses new hardcoded Blob URLs (plain OR percent-encoded)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,36 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  // Plain-node scripts. `node --check` validates syntax, not scope: four
+  // scripts referenced an undeclared `db` and passed it (#4700), and the
+  // nightly stage-coverage cron threw a ReferenceError on its last line for
+  // a month. The TypeScript configs above disable `no-undef` (tsc owns it for
+  // src/), so nothing covered scripts/**/*.mjs until #4702.
+  {
+    files: ["scripts/**/*.mjs"],
+    ignores: ["scripts/**/*-workflow.mjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        process: "readonly", console: "readonly", fetch: "readonly", Buffer: "readonly",
+        setTimeout: "readonly", clearTimeout: "readonly", setInterval: "readonly",
+        clearInterval: "readonly", setImmediate: "readonly", clearImmediate: "readonly",
+        URL: "readonly", URLSearchParams: "readonly",
+        TextEncoder: "readonly", TextDecoder: "readonly", AbortSignal: "readonly",
+        AbortController: "readonly", structuredClone: "readonly", crypto: "readonly",
+        performance: "readonly", __dirname: "readonly", __filename: "readonly",
+        require: "readonly", module: "readonly", exports: "readonly", global: "readonly",
+        globalThis: "readonly", Blob: "readonly", FormData: "readonly", Headers: "readonly",
+        Request: "readonly", Response: "readonly", ReadableStream: "readonly",
+        WritableStream: "readonly", queueMicrotask: "readonly", btoa: "readonly", atob: "readonly",
+      },
+    },
+    rules: { "no-undef": "error" },
+  },
+  // Workflow-tool scripts (`*-workflow.mjs`) run inside the Claude Code
+  // Workflow tool, which injects `args`, `phase`, `log`, `parallel`, `agent`
+  // at runtime — they are correct as written, so no-undef stays off for them.
 ]);
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import { scriptsIgnores, scriptsNoUndef } from "./eslint.scripts.config.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -13,36 +14,11 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
-  // Plain-node scripts. `node --check` validates syntax, not scope: four
-  // scripts referenced an undeclared `db` and passed it (#4700), and the
-  // nightly stage-coverage cron threw a ReferenceError on its last line for
-  // a month. The TypeScript configs above disable `no-undef` (tsc owns it for
-  // src/), so nothing covered scripts/**/*.mjs until #4702.
-  {
-    files: ["scripts/**/*.mjs"],
-    ignores: ["scripts/**/*-workflow.mjs"],
-    languageOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
-      globals: {
-        process: "readonly", console: "readonly", fetch: "readonly", Buffer: "readonly",
-        setTimeout: "readonly", clearTimeout: "readonly", setInterval: "readonly",
-        clearInterval: "readonly", setImmediate: "readonly", clearImmediate: "readonly",
-        URL: "readonly", URLSearchParams: "readonly",
-        TextEncoder: "readonly", TextDecoder: "readonly", AbortSignal: "readonly",
-        AbortController: "readonly", structuredClone: "readonly", crypto: "readonly",
-        performance: "readonly", __dirname: "readonly", __filename: "readonly",
-        require: "readonly", module: "readonly", exports: "readonly", global: "readonly",
-        globalThis: "readonly", Blob: "readonly", FormData: "readonly", Headers: "readonly",
-        Request: "readonly", Response: "readonly", ReadableStream: "readonly",
-        WritableStream: "readonly", queueMicrotask: "readonly", btoa: "readonly", atob: "readonly",
-      },
-    },
-    rules: { "no-undef": "error" },
-  },
-  // Workflow-tool scripts (`*-workflow.mjs`) run inside the Claude Code
-  // Workflow tool, which injects `args`, `phase`, `log`, `parallel`, `agent`
-  // at runtime — they are correct as written, so no-undef stays off for them.
+  // Plain-node scripts: `no-undef` for scripts/**/*.mjs. The block lives in
+  // eslint.scripts.config.mjs so CI can run it without this file's TypeScript
+  // layer (see the header there, #4702).
+  scriptsIgnores,
+  scriptsNoUndef,
 ]);
 
 export default eslintConfig;

--- a/eslint.scripts.config.mjs
+++ b/eslint.scripts.config.mjs
@@ -1,0 +1,63 @@
+// ESLint config for the plain-node script tree — scripts/**/*.mjs (#4702).
+//
+// Why a separate file: `node --check` validates syntax, not scope. Four
+// maintenance scripts referenced an undeclared `db` and passed it (#4700); the
+// nightly stage-coverage cron's last line referenced two names that were never
+// declared; auto-cancel-stuck-jobs.mjs had a `*/` inside a doc comment and had
+// never parsed. The TypeScript configs in eslint.config.mjs disable `no-undef`
+// (tsc owns it for src/), so nothing covered these 1,100+ scripts that run
+// against production Mongo.
+//
+// This file is loaded on its own by CI (`npx eslint -c eslint.scripts.config.mjs`)
+// so the gate does not depend on eslint-config-next's TypeScript layer, which
+// crashes on load under the lockfile's ESLint 10 ("Class extends value
+// undefined" from @typescript-eslint/utils). eslint.config.mjs also spreads
+// this block so editors get the same rule.
+//
+// Workflow-tool scripts (`*-workflow.mjs`) are exempt: the Claude Code Workflow
+// tool injects `args`, `phase`, `log`, `parallel`, `agent` at runtime, so they
+// are correct as written.
+
+const nodeGlobals = {
+  process: "readonly", console: "readonly", fetch: "readonly", Buffer: "readonly",
+  setTimeout: "readonly", clearTimeout: "readonly", setInterval: "readonly",
+  clearInterval: "readonly", setImmediate: "readonly", clearImmediate: "readonly",
+  URL: "readonly", URLSearchParams: "readonly",
+  TextEncoder: "readonly", TextDecoder: "readonly", AbortSignal: "readonly",
+  AbortController: "readonly", structuredClone: "readonly", crypto: "readonly",
+  performance: "readonly", __dirname: "readonly", __filename: "readonly",
+  require: "readonly", module: "readonly", exports: "readonly", global: "readonly",
+  globalThis: "readonly", Blob: "readonly", FormData: "readonly", Headers: "readonly",
+  Request: "readonly", Response: "readonly", ReadableStream: "readonly",
+  WritableStream: "readonly", queueMicrotask: "readonly", btoa: "readonly", atob: "readonly",
+};
+
+// Browser globals, for the callbacks scripts hand to puppeteer's
+// `page.evaluate(() => document...)` (iiif-discovery/leiden, blurry-image-sweep,
+// generate-og-images, kuleuven-gap-harvest). Those bodies run in the browser,
+// so `document`/`window`/`sessionStorage` are real there. The cost is that a
+// stray `document` in node code is not caught; the composed eslint.config.mjs
+// already allowed this via eslint-config-next's browser globals.
+const browserGlobals = {
+  window: "readonly", document: "readonly", navigator: "readonly", location: "readonly",
+  localStorage: "readonly", sessionStorage: "readonly", HTMLElement: "readonly",
+  Element: "readonly", Node: "readonly", NodeList: "readonly", Image: "readonly",
+  MutationObserver: "readonly", getComputedStyle: "readonly", requestAnimationFrame: "readonly",
+  XMLHttpRequest: "readonly", DOMParser: "readonly", Event: "readonly", CustomEvent: "readonly",
+};
+
+// Global ignore (its own object, no `files`): the Workflow-tool scripts use a
+// top-level `return`, which is a parse error outside the tool's runtime.
+export const scriptsIgnores = { ignores: ["scripts/**/*-workflow.mjs"] };
+
+export const scriptsNoUndef = {
+  files: ["scripts/**/*.mjs"],
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    globals: { ...nodeGlobals, ...browserGlobals },
+  },
+  rules: { "no-undef": "error" },
+};
+
+export default [scriptsIgnores, scriptsNoUndef];

--- a/scripts/analysis/cluster-works-by-embedding.mjs
+++ b/scripts/analysis/cluster-works-by-embedding.mjs
@@ -161,7 +161,7 @@ for (const c of multi) {
 const stat = a => { if (!a.length) return { n: 0 }; a = [...a].sort((x, y) => x - y); const m = a.reduce((s, v) => s + v, 0) / a.length; return { n: a.length, mean: +m.toFixed(3), p50: +a[a.length >> 1].toFixed(3), p90: +a[Math.floor(a.length * 0.9)].toFixed(3), p10: +a[Math.floor(a.length * 0.1)].toFixed(3) }; };
 const sweep = (T, G) => { const tp = calPos.filter(p => p.s >= T && p.ts >= G).length, fp = calNeg.filter(p => p.s >= T && p.ts >= G).length; return { tp, fp, prec: (tp + fp) ? tp / (tp + fp) : 0, rec: calPos.length ? tp / calPos.length : 0 }; };
 const at = sweep(THRESHOLD, TITLE_GATE);
-const labeledPrecision = at.prec, recallProxy = at.rec;
+const labeledPrecision = at.prec, recallProxy = at.rec, labTP = at.tp, labFP = at.fp;
 
 console.log('\n── Calibration (within-author labeled pairs) ──');
 console.log('same-work (positives) emb:', JSON.stringify(stat(calPos.map(p => p.s))), ' title:', JSON.stringify(stat(calPos.map(p => p.ts))));

--- a/scripts/migration/bulk-copy-pages-to-supabase.mjs
+++ b/scripts/migration/bulk-copy-pages-to-supabase.mjs
@@ -275,11 +275,6 @@ async function main() {
     }
   }
 
-  // Flush remaining
-  if (batch.length > 0) {
-    copied += await upsertWithRetry(batch);
-  }
-
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
   console.log(`\n\nDone: ${copied.toLocaleString()} copied, ${skipped} skipped, ${errors} errors in ${elapsed}s`);
   console.log(`Mode: ${USE_DIRECT_PG ? 'direct Postgres' : 'REST API'}, batch size: ${BATCH_SIZE}`);

--- a/scripts/workers/auto-cancel-stuck-jobs.mjs
+++ b/scripts/workers/auto-cancel-stuck-jobs.mjs
@@ -5,8 +5,10 @@
  * - Pings the browse API to detect DB saturation early.
  * - Clears the book.job lock so the pipeline can re-submit.
  *
- * Run via Hetzner cron every 30 minutes:
- *   */30 * * * * cd /root/sourcelibrary && set -a && source .env.production.local && set +a && node scripts/workers/auto-cancel-stuck-jobs.mjs >> /tmp/auto-cancel.log 2>&1
+ * Run via Hetzner cron every 30 minutes. The crontab schedule is star-slash-30
+ * on the minute field; it is not written literally here because a star-slash
+ * sequence terminates this comment and broke the file's syntax (#4702):
+ *   (every 30 min) cd /root/sourcelibrary && set -a && source .env.production.local && set +a && node scripts/workers/auto-cancel-stuck-jobs.mjs >> /tmp/auto-cancel.log 2>&1
  */
 
 import { MongoClient } from 'mongodb';

--- a/scripts/workers/stage-coverage-snapshot.mjs
+++ b/scripts/workers/stage-coverage-snapshot.mjs
@@ -135,6 +135,10 @@ await withMongo(async (db) => {
   }
 
   // One-line human summary — this is what the cron log shows.
+  // NOTE: #3794 described a `sensors` block (health-gate-held pages, OCR
+  // warning-page count) but only the log line landed; it referenced two
+  // undeclared names and threw a ReferenceError here every night from
+  // 2026-08-08 until #4702. If the sensors are built, add them to `doc` first.
   const pct = (s) =>
     s.status !== 'ok' ? 'BROKEN' : s.total ? `${((100 * s.covered) / s.total).toFixed(1)}%` : '—';
   const parts = stages.map((s) => `${s.stage} ${pct(s)}`);
@@ -143,6 +147,6 @@ await withMongo(async (db) => {
     `[stage-coverage] ${parts.join(' | ')} | stalled: ${stalled.length ? stalled.join(',') : 'none'}` +
       `${broken.length ? ` | PROBE BROKEN: ${broken.join(',')}` : ''}` +
       ` | dial: ${doc.dial.paused ? 'PAUSED' : 'running'} budget=$${doc.dial.daily_budget_usd ?? 'unset'}` +
-      ` spend=$${doc.spend_today_usd.toFixed(2)} | gate-held=${healthBlocked ?? '?'} warn-pages=${ocrWarnings ?? '?'} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
+      ` spend=$${doc.spend_today_usd.toFixed(2)} | ${doc.duration_ms}ms${DRY_RUN ? ' (dry-run)' : ''}`,
   );
 }, { timeoutMs: 30 * 60_000, socketTimeoutMs: 15 * 60_000 });


### PR DESCRIPTION
Closes #4702.

## What
- `eslint.scripts.config.mjs` (new): flat config for `scripts/**/*.mjs` with `no-undef: error`, node globals, and browser globals for puppeteer `page.evaluate` callbacks. `*-workflow.mjs` globally ignored — the Workflow tool injects `args`/`phase`/`log`/`parallel`/`agent` at runtime and those scripts use a top-level `return`.
- `eslint.config.mjs`: spreads the same exports so editors get the rule.
- `.github/workflows/unit-tests.yml`: runs `npx eslint -c eslint.scripts.config.mjs "scripts/**/*.mjs" --quiet` on every PR. **Own config on purpose:** the composed `eslint.config.mjs` crashes on load under the lockfile's ESLint 10 (Dependabot #4005 → `@typescript-eslint/utils` 8.49 extends a class ESLint 10 removed). That is a pre-existing break of `npm run lint` on any clean install, filed as #4710; the first CI run of this PR is what exposed it.
- Fixes for everything error-level the rule surfaced (0 errors after).

## The fixes
| file | what was wrong | fix |
|---|---|---|
| `scripts/workers/stage-coverage-snapshot.mjs:146` | `healthBlocked`/`ocrWarnings` never declared — #3794's message describes a "sensors block" that isn't in the diff | dropped from the log line; note left where the sensors belong |
| `scripts/migration/bulk-copy-pages-to-supabase.mjs:279` | final `batch` flush after the loop; `batch` only ever existed inside it, and every buffered row is already batched there | dead flush removed |
| `scripts/analysis/cluster-works-by-embedding.mjs:199` | `labTP`/`labFP` unbound in the calibration block | bound to the operating point's tp/fp |
| `scripts/workers/auto-cancel-stuck-jobs.mjs:9` | **not in the issue** — the linter found it as a parse error: a `*/30 * * * *` crontab line inside the doc comment, `*/` closes the comment. Never parsed since #552 | comment reworded |

## Verification
- Under ESLint **10.9.0** exactly (`npx -p eslint@10.9.0 eslint -c eslint.scripts.config.mjs "scripts/**/*.mjs" --quiet`): exit 0.
- Negative control under the same: a probe with `await someUndefinedDb.collection("books")` → `'someUndefinedDb' is not defined  no-undef`. Removed after.
- Composed config still loads under the laptop's ESLint 9.39.1 and applies the rule to the same files.
- `node --check` on all four scripts + both configs: OK.

## Found on the way, not fixed here
- `auto-cancel-stuck-jobs.mjs` is **not in the Hetzner crontab**, so its syntax error never bit anyone. Whether it should be scheduled is a separate question.
- `stage_coverage_snapshots` holds **one row ever** (2026-08-08). Today's 04:15 cron log reads `Script timeout after 1800s — forcing exit`, so the ReferenceError fixed here was never the live failure — the run dies in `measureAllStages` before the insert, and `/platform/admin/line` has shown month-old data. Filed as #4708.
- `npm run lint` is dead on a clean install (#4710).

## Out of scope
- The 100+ pre-existing `no-explicit-any` / `no-require-imports` errors in `scripts/**/*.ts` and `.js`. This PR gates `.mjs` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)