### PR TITLE
fix(librarian): shared rate limit, daily anonymous ceiling, no model call for a bare hello

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -5,7 +5,8 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/lib/embassy/librarian';
 import { applyCitationFixes, applyImageRemovals, type CitationFix } from '@/lib/embassy/citation-fixes';
-import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { checkRateLimitShared, getClientIp } from '@/lib/rate-limit';
+import { isBareGreeting, greetingReply } from '@/lib/embassy/greeting';
 import { chatRequestSchema } from '@/lib/embassy/chat-request';
 import { threadVisibility } from '@/lib/embassy/thread-visibility';
 import { toUserId } from '@/lib/user-id';
@@ -16,6 +17,9 @@ export const dynamic = 'force-dynamic';
 // 110s elapsed. The killed function severs the SSE stream and the client shows
 // "The Librarian seems to be away." 300 matches our other long-running routes.
 export const maxDuration = 300;
+
+/** Anonymous Librarian turns per UTC day, across all IPs. See the gate below. */
+const ANON_DAILY_CEILING = Number(process.env.LIBRARIAN_ANON_DAILY_CEILING) || 500;
 
 
 /**
@@ -46,7 +50,12 @@ export async function POST(request: NextRequest) {
   const userId = session?.user?.id ?? null;
 
   if (!userId) {
-    const rl = checkRateLimit(
+    // Shared (Mongo-backed) counter, not the in-memory one: the in-memory
+    // limiter is private to each Vercel instance, so a steady low-rate hitter
+    // fanned across lambdas never trips it — a bot opened 3,106 threads in a
+    // week that way, each a full Gemini turn (#4704). Falls back to in-memory
+    // only when Mongo is slow or down.
+    const rl = await checkRateLimitShared(
       { name: 'librarian-chat', limit: 5, windowSeconds: 3600 },
       getClientIp(request),
     );
@@ -57,6 +66,23 @@ export async function POST(request: NextRequest) {
           code: 'SIGNIN_REQUIRED',
         },
         { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } },
+      );
+    }
+    // Global daily ceiling on ANONYMOUS turns, all IPs together — a per-IP cap
+    // is worthless against rotation. Baseline anonymous traffic is a few dozen
+    // turns a day; a ceiling ~10x that never touches real visitors, and when it
+    // does trip the door stays open via free sign-in.
+    const ceiling = await checkRateLimitShared(
+      { name: 'librarian-chat-anon-global', limit: ANON_DAILY_CEILING, windowSeconds: 86400 },
+      'all',
+    );
+    if (!ceiling.allowed) {
+      return NextResponse.json(
+        {
+          error: 'The Librarian\'s free desk is fully booked for today. Sign in (free) to keep talking.',
+          code: 'SIGNIN_REQUIRED',
+        },
+        { status: 429, headers: { 'Retry-After': String(ceiling.retryAfter) } },
       );
     }
   }
@@ -102,6 +128,9 @@ export async function POST(request: NextRequest) {
 
   const now = new Date();
   let activeThreadId: string;
+  // A bare "hello" gets the desk's welcome, not six searches (see greeting.ts).
+  // The thread it opens is kept but unlisted — there is nothing in it to read.
+  const bareGreeting = isBareGreeting(message);
 
   if (threadId) {
     // Continue existing thread — verify ownership. Signed-in users may only
@@ -147,7 +176,7 @@ export async function POST(request: NextRequest) {
       title: message.slice(0, 120),
       creatorId: userId,
       creatorName: displayName,
-      visibility: threadVisibility(userId, visibility === 'public'),
+      visibility: bareGreeting ? 'unlisted' : threadVisibility(userId, visibility === 'public'),
       aiEnabled: true,
       lang,
       messageCount: 0,
@@ -180,6 +209,14 @@ export async function POST(request: NextRequest) {
   /** The text as the reader should see it: links repaired, dead images dropped. */
   const finalizeText = (text: string) =>
     applyImageRemovals(applyCitationFixes(text, citationFixes), imageRemovals);
+
+  /** One canned step in place of the agentic loop, for a bare greeting. */
+  async function* greetingSteps(): AsyncGenerator<LibrarianStep> {
+    yield { type: 'text', text: greetingReply(lang) };
+  }
+  const agentSteps = () => bareGreeting
+    ? greetingSteps()
+    : streamAgenticResponse(message, history, activeThreadId, { collection, lang });
 
   const saveAiResponse = async () => {
     if (!fullText && allSources.length === 0) return;
@@ -215,7 +252,7 @@ export async function POST(request: NextRequest) {
 
   if (!stream) {
     try {
-      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection, lang })) {
+      for await (const step of agentSteps()) {
         if (step.type === 'text') {
           fullText += step.text || '';
         } else if (step.type === 'sources') {
@@ -299,7 +336,7 @@ export async function POST(request: NextRequest) {
     try {
       await send({ type: 'threadId', threadId: activeThreadId });
 
-      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection, lang })) {
+      for await (const step of agentSteps()) {
         lastStepType = step.type;
         switch (step.type) {
           case 'thinking':

--- a/src/lib/embassy/greeting.ts
+++ b/src/lib/embassy/greeting.ts
@@ -1,0 +1,54 @@
+/**
+ * Bare-greeting short-circuit for the Librarian.
+ *
+ * PRIOR ART: src/lib/anon-gate.ts — meters WHO may ask; nothing decides whether
+ * a message is worth an agentic turn at all. src/lib/embassy/librarian.ts
+ * answers "Hello" today with a full Gemini turn (~13K tokens, 1.5 tool rounds).
+ *
+ * Why: a bot opened 3,106 "Hello" threads in a week (Aug 22–29 2026, one every
+ * ~8s overnight), each a full agentic turn — ~40M tokens for a wave (#4704).
+ * A real visitor who says "hello" wants the desk to say hello back and invite a
+ * question, not to watch six searches run. So a bare greeting gets a canned
+ * welcome with no model call, and the thread it opens stays out of the Recent
+ * feed (there is nothing in it to read).
+ *
+ * Strict by design: only messages made ENTIRELY of greeting words match. "Hello,
+ * who was Ficino?" is a question and goes to the model.
+ */
+import type { Locale } from '@/lib/locale-path';
+
+const GREETING_WORDS = new Set([
+  // en
+  'hello', 'hi', 'hey', 'hiya', 'yo', 'greetings', 'good', 'morning', 'afternoon',
+  'evening', 'there', 'librarian', 'test', 'testing', 'ping',
+  // es / pt / it / fr / de / nl
+  'hola', 'buenos', 'buenas', 'dias', 'días', 'tardes', 'noches', 'olá', 'ola', 'oi',
+  'ciao', 'salve', 'buongiorno', 'buonasera', 'bonjour', 'bonsoir', 'salut',
+  'hallo', 'guten', 'tag', 'morgen', 'abend', 'servus', 'hoi', 'goedemorgen',
+  'goedemiddag', 'goedenavond', 'dag',
+  // zh / ja / ko / ru / ar (single-token greetings)
+  '你好', '您好', '嗨', 'こんにちは', 'こんばんは', 'おはよう', '안녕', '안녕하세요',
+  'привет', 'здравствуйте', 'مرحبا', 'سلام',
+]);
+
+/** True when the message is nothing but a greeting (or a "test"). */
+export function isBareGreeting(message: string): boolean {
+  const words = message
+    .toLowerCase()
+    // Strip punctuation, emoji, and symbols — keep letters (any script), digits, spaces.
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0 || words.length > 4) return false;
+  return words.every(w => GREETING_WORDS.has(w));
+}
+
+const WELCOME: Record<Locale, string> = {
+  en: 'Welcome to the reading room. I can find passages, page references, and illustrations across the collection — alchemy, Hermetica, Kabbalah, astrology, natural philosophy, and more.\n\nAsk me about an author, a work, or an idea — for example *"Where does Agrippa discuss the celestial harmony?"* or *"Show me the earliest emblem of the green lion."*',
+  es: 'Bienvenido a la sala de lectura. Puedo encontrar pasajes, referencias de página e ilustraciones en toda la colección: alquimia, Hermetica, Cábala, astrología, filosofía natural y más.\n\nPregúntame por un autor, una obra o una idea — por ejemplo *"¿Dónde trata Agripa la armonía celeste?"* o *"Muéstrame el emblema más antiguo del león verde."*',
+};
+
+/** The canned welcome for a bare greeting, in the reader's chrome language. */
+export function greetingReply(lang: Locale = 'en'): string {
+  return WELCOME[lang] ?? WELCOME.en;
+}

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -108,7 +108,7 @@ describe('Embassy API', () => {
       (auth as any).mockResolvedValueOnce(null);
 
       const req = makeRequest('/api/embassy/chat', {
-        message: 'Hello',
+        message: 'Where does Agrippa discuss celestial harmony?',
         visibility: 'public',
       });
 
@@ -127,6 +127,33 @@ describe('Embassy API', () => {
       });
       expect(thread!.creatorId).toBeNull();
       expect(thread!.visibility).toBe('public');
+    });
+
+    it('answers a bare greeting from the desk, with no model call, in an unlisted thread', async () => {
+      const { auth } = await import('@/lib/auth');
+      (auth as any).mockResolvedValueOnce(null);
+      const { streamAgenticResponse } = await import('@/lib/embassy/librarian');
+      const callsBefore = (streamAgenticResponse as any).mock.calls.length;
+
+      const req = makeRequest('/api/embassy/chat', {
+        message: 'Hello',
+        visibility: 'public',
+      });
+
+      const res = await chatPost(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      // The agentic loop never ran — a "Hello" used to cost a full Gemini turn
+      // (#4704: 3,106 of them in one week).
+      expect((streamAgenticResponse as any).mock.calls.length).toBe(callsBefore);
+      expect(data.message.content).toMatch(/Welcome to the reading room/);
+
+      const db = getTestDb();
+      const thread = await db.collection('embassy_threads').findOne({
+        _id: new ObjectId(data.threadId),
+      });
+      // Kept (the visitor can continue it) but out of the Recent feed.
+      expect(thread!.visibility).toBe('unlisted');
     });
 
     it('honours an anonymous opt-out as unlisted, not private', async () => {

--- a/tests/unit/librarian-greeting.test.ts
+++ b/tests/unit/librarian-greeting.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isBareGreeting, greetingReply } from '@/lib/embassy/greeting';
+
+// A bot opened 3,106 "Hello" threads in a week, each a full Gemini turn
+// (#4704). A bare greeting now gets a canned welcome with no model call. The
+// detector must be STRICT: anything with a question in it goes to the model.
+describe('isBareGreeting', () => {
+  it('matches bare greetings across scripts and punctuation', () => {
+    for (const m of ['Hello', 'hello!', 'Hi there', 'HEY', 'hola', 'Buenos días', 'Hallo',
+      'bonjour', 'ciao', '你好', 'こんにちは', 'привет', 'test', 'hello librarian', 'Good morning', ' hi 👋 ']) {
+      expect(isBareGreeting(m), m).toBe(true);
+    }
+  });
+
+  it('does not match anything with a question or a topic in it', () => {
+    for (const m of ['Hello, who was Ficino?', 'What is the Emerald Tablet?', 'Hermes', 'hi, alchemy',
+      'good morning, I am looking for Paracelsus', 'Tetraëder', '18', 'Numerology of 8!', '', '   ']) {
+      expect(isBareGreeting(m), m).toBe(false);
+    }
+  });
+
+  it('caps at four words so a long greeting-shaped sentence still reaches the model', () => {
+    expect(isBareGreeting('hello hello hello hello hello')).toBe(false);
+  });
+});
+
+describe('greetingReply', () => {
+  it('answers in the chrome language and falls back to English', () => {
+    expect(greetingReply('es')).toMatch(/Bienvenido/);
+    expect(greetingReply('en')).toMatch(/Welcome/);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(greetingReply('fr' as any)).toMatch(/Welcome/);
+  });
+});


### PR DESCRIPTION
Part 2 of #4704 (Librarian log audit). Independent of #4705.

## What happened
A bot opened **3,106 "Hello" threads in a week** (Aug 22–29, one every ~8s, 23:00–07:00 UTC), each a full Gemini turn (avg 13K tokens, 1.5 tool rounds; ~40M tokens for the wave). All of them qualified for the public Recent feed.

The per-IP 5/hour limit on `POST /api/embassy/chat` was `checkRateLimit` — **in-memory per Vercel instance** — so a steady low-rate hitter fanned across lambdas never tripped it.

## Changes
1. **Shared limiter.** The 5/hour anonymous cap now uses `checkRateLimitShared` (Mongo-backed `rate_limits`, cross-instance; already used by voice, page-ask, transliterate). Falls back to in-memory only when Mongo is slow/down.
2. **Global daily ceiling on anonymous turns**, all IPs together — a per-IP cap is worthless against rotation. `LIBRARIAN_ANON_DAILY_CEILING` env, default **500/UTC day** (baseline anonymous traffic is a few dozen turns/day). When it trips, the reply is the existing `SIGNIN_REQUIRED` shape, so the client shows the sign-in-free prompt. Real visitors are never walled, only asked to sign in on a runaway day.
3. **Bare greeting → canned welcome, no model call** (`src/lib/embassy/greeting.ts`). "Hello", "hola", "你好", "test"… get the desk's welcome and an invitation to ask. The thread is kept (the visitor can continue it) but **unlisted**, so it stays out of the Recent feed. Detector is strict: any message with a topic or question in it goes to the model (`'Hello, who was Ficino?'` → model).

## Not in this PR
- The daily 07:00 UTC "What is the Emerald Tablet?" thread (39 in 45 days) looks like an external uptime monitor. It is cheap; if you know what sends it, point it at a non-agentic endpoint.
- Backfilling the 3,106 historical Hello threads to unlisted — trivial `updateMany`, but a data change, so left for a separate decision.

## Tests
- `tests/unit/librarian-greeting.test.ts` (detector across scripts/punctuation; negatives incl. `'Tetraëder'`, `'18'`, `'Numerology of 8!'`).
- `tests/integration/embassy-api.test.ts`: new case pins that a "Hello" never calls `streamAgenticResponse` and lands in an unlisted thread; the anonymous-listing case now sends a real question (it used "Hello", which is exactly what changed).
- `npx tsc --noEmit` clean; integration suite 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tru9fGPrYXGMdHh9314v1r