### PR TITLE
fix(librarian): repair slugs with dropped umlauts and Latin inflection; never swap shelfmarks

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -1867,7 +1867,70 @@ const SLUG_STOPWORDS = new Set([
   // Cataloguing / format words — describe the artefact, not the work.
   'manuscript', 'manuscripts', 'codex', 'facsimile', 'collection',
   'collections', 'compilation', 'digitization', 'unknown', 'author', 'authors',
+  // Jesuit imprint boilerplate the model copies into Kircher slugs
+  // (`athanasii-kircheri-e-societate-iesu-…`) — describes the author's order,
+  // never the work, and our titles rarely carry it.
+  'societate', 'soc', 'iesu', 'jesu', 'iesv', 'hoc', 'est',
 ]);
+
+/** 2–4 digit numbers in a slug or title: years, shelfmarks (`reg-lat-1266`), volumes. */
+function numbersOf(s: string): Set<string> {
+  return new Set(s.match(/\d{2,4}/g) ?? []);
+}
+
+/**
+ * Never swap shelfmarks or dates: when both the broken slug and the candidate
+ * carry numbers and share none, the candidate is a different object.
+ * `reg-lat-1266` was "repaired" onto `…-reg-lat-1228` — a different Vatican
+ * manuscript — because the digits were filtered out before matching.
+ */
+export function numbersAgree(slug: string, cand: Pick<RepairCandidate, 'slug' | 'title' | 'display_title'>): boolean {
+  const want = numbersOf(slug);
+  const have = numbersOf(`${cand.slug} ${cand.title ?? ''} ${cand.display_title ?? ''}`);
+  if (want.size === 0 || have.size === 0) return true;
+  return [...want].some(n => have.has(n));
+}
+
+/** Levenshtein distance, capped: returns 3 as soon as it cannot be ≤ 2. */
+function editDistance(a: string, b: string): number {
+  if (Math.abs(a.length - b.length) > 2) return 3;
+  const prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const tmp = prev[j];
+      prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+      diag = tmp;
+    }
+  }
+  return prev[b.length];
+}
+
+/**
+ * The fuzzy tier's acceptance test: every DISTINCTIVE token of the broken slug
+ * (5+ characters) must correspond to some word of the candidate's title or
+ * author — as a substring, or within a small edit distance (1 for short
+ * tokens, 2 for 8+). That tolerates the ways a model-composed slug drifts
+ * from the catalogue (dropped umlauts: `weytber-mpten`/`weytberuempten` for
+ * *weytberümpten*; Latin inflection: `subterranei` for *subterraneus*) while
+ * still refusing a candidate that lacks a real title word: Gassendi's *Life of
+ * Tycho* shares six tokens with `tychonis-brahe-…-astronomiae-instauratae` but
+ * has no `instauratae`, and Meder's judgment on the Rosicrucians has no
+ * `fraternity`. Measured on 195 unrepaired slugs: 14 accepted, 0 wrong (#4704).
+ */
+export function distinctiveTokensAccounted(tokens: string[], cand: Pick<RepairCandidate, 'title' | 'display_title' | 'english_title' | 'author'>): boolean {
+  const words = normalizeForMatch([cand.title, cand.display_title, cand.english_title, cand.author].filter(Boolean).join(' '))
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean);
+  return tokens
+    .filter(t => t.length >= 5)
+    .every(t => {
+      const tok = normalizeForMatch(t);
+      const tolerance = tok.length >= 8 ? 2 : 1;
+      return words.some(w => w.includes(tok) || editDistance(tok, w) <= tolerance);
+    });
+}
 
 /**
  * Fields carried by the `books_search` Atlas index. `slug` is NOT among them,
@@ -1927,6 +1990,7 @@ async function findRepairCandidates(
   tokens: string[],
   minimumShouldMatch: number,
   excludeSlug: string,
+  fuzzy = false,
 ): Promise<RepairCandidate[]> {
   const db = await getDb();
   const pipeline = [
@@ -1934,7 +1998,17 @@ async function findRepairCandidates(
       $search: {
         index: BOOK_SEARCH_INDEX,
         compound: {
-          should: tokens.map(t => ({ text: { query: t, path: REPAIR_SEARCH_PATHS } })),
+          should: tokens.map(t => ({
+            text: {
+              query: t,
+              path: REPAIR_SEARCH_PATHS,
+              // One edit per token, first two letters fixed: catches dropped
+              // diacritics and inflection without letting `vita` find `vitae`
+              // in every book. The acceptance test after the query is what
+              // keeps this honest (distinctiveTokensAccounted).
+              ...(fuzzy ? { fuzzy: { maxEdits: 1, prefixLength: 2 } } : {}),
+            },
+          })),
           minimumShouldMatch,
         },
       },
@@ -2003,6 +2077,19 @@ export async function resolveSlugToHeldBook(
     candidates = await findRepairCandidates(tokens, tokens.length - 1, slug);
   }
 
+  // Third tier: the composed slug is the RIGHT book spelled slightly wrong —
+  // dropped umlauts, Latin case endings, a typo. Exact matching cannot see
+  // that, so query fuzzily for 60% of the tokens and then insist that every
+  // distinctive token is accounted for within edit distance (the acceptance
+  // test is what makes this tier safe; the query only proposes).
+  let fuzzyTier = false;
+  if (candidates.length === 0 && tokens.length >= 2) {
+    const msm = Math.max(2, Math.ceil(tokens.length * 0.6));
+    candidates = (await findRepairCandidates(tokens, Math.min(msm, tokens.length), slug, true))
+      .filter(cand => distinctiveTokensAccounted(tokens, cand));
+    fuzzyTier = true;
+  }
+
   // Never swap volumes: if both slugs carry a volume designator and they
   // disagree, the candidate is a different physical book of the same work.
   const wantVol = volumeOf(slug);
@@ -2010,9 +2097,28 @@ export async function resolveSlugToHeldBook(
     const candVol = volumeOf(cand.slug);
     return !(wantVol && candVol && wantVol !== candVol);
   });
+  // Never swap shelfmarks or dates (reg-lat-1266 is not reg-lat-1228).
+  candidates = candidates.filter(cand => numbersAgree(slug, cand));
   // Never swap works: an author-only match is a different book by the same hand.
   candidates = candidates.filter(cand => matchesBeyondAuthor(tokens, cand));
   if (candidates.length === 0) return null;
+
+  if (fuzzyTier) {
+    // Rank by how many tokens landed in the title; a tie between two
+    // DIFFERENT titles is ambiguity, and ambiguity is a dead link, not a guess.
+    // A tie between editions of the same work (`…-khunrath-2`/`-3`) is fine.
+    const hits = (cand: RepairCandidate) => tokens.filter(t => {
+      const tok = normalizeForMatch(t);
+      return normalizeForMatch([cand.title, cand.display_title, cand.english_title].filter(Boolean).join(' ')).includes(tok);
+    }).length;
+    candidates.sort((a, b) => hits(b) - hits(a) || (b.read_count || 0) - (a.read_count || 0));
+    const [first, second] = candidates;
+    if (second && hits(second) === hits(first)) {
+      const titleOf = (c: RepairCandidate) => normalizeForMatch(c.display_title || c.title || '');
+      if (titleOf(first) !== titleOf(second)) return null;
+    }
+    return { slug: first.slug, title: first.display_title || first.title || first.slug };
+  }
 
   candidates.sort((a, b) => (b.read_count || 0) - (a.read_count || 0) || (b.pages_count || 0) - (a.pages_count || 0));
   const best = candidates[0];

--- a/tests/unit/librarian-slug-repair-fuzzy.test.ts
+++ b/tests/unit/librarian-slug-repair-fuzzy.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { distinctiveTokensAccounted, numbersAgree } from '@/lib/embassy/librarian';
+
+// The slug resolver's third tier proposes candidates fuzzily; these two pure
+// checks are what keep a proposal from becoming a wrong-book substitution.
+// Cases are the real ones from the 195-slug probe behind #4704.
+
+const tokens = (slug: string) => slug.split('-').filter(t => t.length >= 3);
+
+describe('distinctiveTokensAccounted', () => {
+  it('accepts a slug whose umlauts were dropped or expanded', () => {
+    const cand = { title: 'Temporal. Dess weytberümpten M. Johan Künigspergers natürlicher kunst der Astronomei', author: 'Regiomontanus, Johannes' };
+    expect(distinctiveTokensAccounted(tokens('temporal-dess-weytberuempten-johan-kuenigspergers-regiomontanus'), cand)).toBe(true);
+  });
+
+  it('accepts Latin inflection within two edits on long tokens', () => {
+    const cand = { title: 'Mundus subterraneus, in XII libros digestus, quibus mundi subterranei fructus exponuntur', author: 'Kircher, Athanasius' };
+    // athanasii→Athanasius (2 edits on a 9-letter token), kircheri→Kircher (1).
+    expect(distinctiveTokensAccounted(tokens('athanasii-kircheri-mundi-subterranei-libros'), cand)).toBe(true);
+    // A short token gets only one edit: "vitae" must not pass on "vita" + anything.
+    expect(distinctiveTokensAccounted(['mundi'], { title: 'Mundus subterraneus' })).toBe(false);
+  });
+
+  it('rejects a same-author candidate that lacks a real title word', () => {
+    // Gassendi's Life of Tycho shares six tokens with Brahe's own book but has
+    // no "instauratae" — a wrong-book substitution the old tiers could make.
+    const gassendi = { title: 'Tychonis Brahei equitis Dani astronomorum coryphaei vita', author: 'Gassendi, Pierre' };
+    expect(distinctiveTokensAccounted(tokens('tichonis-brahe-equitis-dani-astronomorum-coryphaei-astronomiae-instauratae'), gassendi)).toBe(false);
+  });
+
+  it('rejects a commentary that names the work it is about', () => {
+    const meder = { title: 'Iudicium theologicum de Fama et Confessione Fraternitatis Roseae Crucis', english_title: 'Theological Judgment on the Rosicrucian Brotherhood', author: 'Meder, David' };
+    expect(distinctiveTokensAccounted(tokens('the-fame-and-confession-of-the-fraternity-of-the-rosie-cross'), meder)).toBe(false);
+  });
+
+  it('ignores short tokens so articles and particles never decide', () => {
+    expect(distinctiveTokensAccounted(['der', 'und', 'von'], { title: 'Anything at all' })).toBe(true);
+  });
+});
+
+describe('numbersAgree', () => {
+  it('refuses a different shelfmark', () => {
+    expect(numbersAgree('reg-lat-1266', { slug: 'hesychast-theological-treatises-reg-lat-1228', title: 'Lectures on Baths' })).toBe(false);
+  });
+
+  it('allows a candidate with no number, and a shared year', () => {
+    expect(numbersAgree('atalanta-fugiens-1618-maier', { slug: 'atalanta-fleeing-maier', title: 'Atalanta Fleeing' })).toBe(true);
+    expect(numbersAgree('de-umbris-idearum-1582-bruno', { slug: 'giordano-bruno-de-umbris-idearum-1582-first-edition-bruno', title: 'De Umbris Idearum (1582)' })).toBe(true);
+  });
+});


### PR DESCRIPTION
Part 4 of #4704 (Librarian log audit). Independent of #4705, #4707, #4709.

## What
The citation repairer (`resolveSlugToHeldBook`) fixes 79% of title-composed slugs but gave up on *the right book spelled slightly wrong*: `temporal-dess-weytber-mpten-…` for *weytberümpten*, `subterranei` for *subterraneus*, `kuenigspergers` for *Künigspergers*. Those went out as "a record not currently available in the collection" for a book we hold.

It also made one **wrong-book** repair that was live: `reg-lat-1266` → `…-reg-lat-1228`, a different Vatican manuscript, because digits were filtered out before matching.

## Changes
1. **Third tier, fuzzy but gated.** When the exact tiers find nothing, query Atlas with `fuzzy: {maxEdits: 1, prefixLength: 2}` for ≥60% of tokens, then accept a candidate only if **every distinctive token (5+ chars) corresponds to a title/author word** as a substring or within edit distance 1 (2 for 8+ letters) — `distinctiveTokensAccounted`. A tie between two different titles returns null: ambiguity is a dead link, not a guess.
2. **Numbers must agree** (`numbersAgree`): if both the slug and the candidate carry a 2–4 digit number and share none, reject. Applies to all tiers.
3. Jesuit imprint boilerplate (`societate`, `iesu`, `soc`, `hoc`, `est`) added to `SLUG_STOPWORDS` — it is in every model-composed Kircher slug and in none of our titles.

## Measured (probe over the 195 slugs the verifier could not repair, Jul 28–Sep 10)
| rule | repairs | wrong |
|---|---|---|
| current | 18–20 | 1 (reg-lat) |
| loose fuzzy (60% tokens, margin) | 68 | ≥4 (Gassendi *Life of Tycho* for Brahe's *Astronomiae instauratae*; Meder for the *Fama*; Moehsen catalogue for *Magische Bibliothek*; St Gallen codex for *Aureum vellus*) |
| **this PR (accounted-tokens gate)** | **+14** | **0** in sample |

Most of the remaining 160 are books we do not hold or hidden records — a dead link is the correct outcome there. The probe script is in my scratchpad, not committed.

## Tests
`tests/unit/librarian-slug-repair-fuzzy.test.ts` pins the acceptance test on the real cases above (umlauts, inflection, the two wrong-book rejections, short-token tolerance) and the shelfmark guard. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tru9fGPrYXGMdHh9314v1r