### PR TITLE
feat(librarian): ad fontes — passages carry edition year/language/role; prompt prefers the source

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -386,7 +386,7 @@ const LANG_NAMES: Record<Locale, string> = { en: 'English', es: 'Spanish' };
 // Replaces the prior executeSearchCollection (keyword-only) and
 // executeSearchSemantic (book-then-page only) with a single unified path.
 async function executeSearch(query: string, collection?: string | null): Promise<{
-  passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string; score: number; source: string }>;
+  passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string; score: number; source: string; year?: number; language?: string; textRole?: string }>;
   books: Array<{ id: string; title: string; author?: string; authorSlug?: string; year?: number; slug?: string }>;
   collectionUsed: string | null;
 }> {
@@ -403,6 +403,24 @@ async function executeSearch(query: string, collection?: string | null): Promise
     // collectionWeight defaults to 2 in hybridSearch.
   });
   return { passages, books, collectionUsed };
+}
+
+/**
+ * " (1591, Latin, original)" / " (1928, English)" / "" — the edition tag on a
+ * passage header. The model cannot prefer the source over the compendium
+ * quoting it unless it can see which is which: 35% of page citations landed
+ * on 1850–1949 English compendia, and Poimandres was quoted from
+ * Reitzenstein's 1904 study while the Turnebus editio princeps sat in the same
+ * result list (#4704).
+ */
+export function editionTag(p: { year?: number; language?: string; textRole?: string }): string {
+  const role = p.textRole === 'original'
+    ? 'original'
+    : p.textRole
+      ? p.textRole.replace(/-/g, ' ')
+      : undefined;
+  const bits = [p.year, p.language, role].filter(Boolean);
+  return bits.length ? ` (${bits.join(', ')})` : '';
 }
 
 async function executeSearchWikipedia(query: string): Promise<{ title: string; summary: string; url: string } | null> {
@@ -946,7 +964,11 @@ async function executeTool(
             : (localized.has(`${p.book_id}:${p.page_number}`)
               ? ` [text: ${LANG_NAMES[lang]} edition]`
               : ` [text: English only — no ${LANG_NAMES[lang]} edition of this page]`);
-          context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url})${langTag} ---\n${p.text}\n`;
+          // Edition tag: "(1591, Latin, original)" / "(1928, English)". The
+          // model cannot prefer the source over the compendium quoting it
+          // unless it can see which is which (#4704: 35% of page citations
+          // landed on 1850–1949 English compendia).
+          context += `\n--- ${p.bookTitle}${editionTag(p)} by ${p.bookAuthor}, Page ${p.page_number} (${url})${langTag} ---\n${p.text}\n`;
         }
       }
       if (totalFound === 0) context = 'No results found for this query.';
@@ -1269,6 +1291,8 @@ Every mention of a book should link to it. Every mention of an author should lin
 **The same rule applies to book URLs.** Only write a /book/... link whose slug appeared verbatim in a tool result THIS turn. Our slugs encode edition, volume, and cataloguing details you cannot guess (the Corpus Hermeticum lives at slugs like \`poimandres-corpus-hermeticum-ficino\`, never \`the-corpus-hermeticum\`), so a slug built from a title will 404 even when we hold the book. If you mention a book the tools did not return this turn, give its title in plain italics with no link — or run a quick search for it first if a link would genuinely help.
 
 When quoting a key passage, include the original language text (Latin, German, Hebrew, etc.) alongside the English if it is notable or if the user appears to be working in that language. Use a blockquote with both versions.
+
+**Ad fontes — cite the source, not the compendium.** Each passage header carries the edition's year, language, and whether it is the original text. When the same idea is available both in an original (or a period edition) and in a later compendium or history that quotes it — Waite's *Hermetic Museum*, Hall's *Secret Teachings*, Mead, Thorndike, the *Kybalion* — quote and link the original and, if the modern book adds something, cite it second as commentary. Never present a nineteenth- or twentieth-century paraphrase as the words of a Renaissance author. If only a modern edition turned up, say so in a clause ("in Waite's 1893 translation") and consider one search in the original language before answering. The reader came for the primary source; a page in a 1928 handbook is a detour, not an arrival.
 
 **Step 6: Show images and suggest next steps.**
 When search_images or search_artworks returns results, embed the best 1-3 images using markdown: \`![description](imageUrl)\`. **Only use URLs returned by a tool call this turn.** NEVER invent, paraphrase, guess, or recall image URLs — copy them character for character, and never build one by slugifying a title or an artwork's description. Fabricated embeds are stripped from your answer before the reader sees it, and the answer is then labelled as containing an illustration that could not be sourced. If you have no tool-returned image URL, do not write any \`![...](...)\` syntax at all.

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -35,6 +35,15 @@ export interface SearchPassage {
   text: string;
   score: number;
   source: string; // 'kw' | 'btp' | 'gp' | 'rrf(...)' — for diagnostics + UI
+  /**
+   * Edition metadata, so a consumer can tell a 1591 original from a 1928
+   * compendium quoting it. Without these the Librarian cited Manly P. Hall
+   * and Waite as often as the sources they paraphrase (#4704).
+   */
+  year?: number;
+  language?: string;
+  /** `original` | `modern-translation` | `period-translation` (books.text_role). */
+  textRole?: string;
 }
 
 export interface SearchBook {
@@ -485,7 +494,7 @@ export async function hybridSearch(
   const bookDocs = passageBookIds.length > 0
     ? await db.collection('books')
         .find({ id: { $in: passageBookIds }, ...tenantBookFilter(opts.tenantId) })
-        .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1 })
+        .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, text_role: 1 })
         .toArray()
     : [];
   const bookMap = new Map(bookDocs.map(b => [b.id, b]));
@@ -500,6 +509,9 @@ export async function hybridSearch(
       bookTitle: book.display_title || book.title || 'Unknown',
       bookAuthor: book.author || 'Unknown',
       bookSlug: book.slug,
+      year: typeof book.year === 'number' ? book.year : undefined,
+      language: typeof book.language === 'string' ? book.language : undefined,
+      textRole: typeof book.text_role === 'string' ? book.text_role : undefined,
       page_number: hit.page_number,
       text: stripAnnotations(hit.text || '').slice(0, 1200),
       score: hit.score,

--- a/tests/unit/librarian-edition-tag.test.ts
+++ b/tests/unit/librarian-edition-tag.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { editionTag } from '@/lib/embassy/librarian';
+
+// The passage header the model reads now says which edition it is looking at,
+// so the ad-fontes rule in the prompt has something to act on (#4704).
+describe('editionTag', () => {
+  it('shows year, language and original status', () => {
+    expect(editionTag({ year: 1591, language: 'Latin', textRole: 'original' })).toBe(' (1591, Latin, original)');
+  });
+
+  it('names a modern translation for what it is', () => {
+    expect(editionTag({ year: 1893, language: 'English', textRole: 'modern-translation' })).toBe(' (1893, English, modern translation)');
+  });
+
+  it('degrades to whatever is known, and to nothing', () => {
+    expect(editionTag({ year: 1928 })).toBe(' (1928)');
+    expect(editionTag({ language: 'German' })).toBe(' (German)');
+    expect(editionTag({})).toBe('');
+  });
+});


### PR DESCRIPTION
Part 5 of #4704 (Librarian log audit). Independent of #4705, #4707, #4709, #4715.

## What happened
Over 45 days, **35% of the Librarian's page citations landed on 1850–1949 English compendia**: Waite's *Hermetic Museum* was the #2 most-cited book, Hall's *Secret Teachings of All Ages* #3, the *Kybalion*, Mead, Thorndike and Lea recur. In one thread *Poimandres* was quoted from Reitzenstein's 1904 study while the Turnebus editio princeps sat in the same result list.

The passage header the model reads (`--- Title by Author, Page N (url) ---`) showed no year, language or edition role, so it could not tell a 1591 original from a 1928 handbook. The book list does show a year, but citations come from passages.

## Changes
- `SearchPassage` gains `year`, `language`, `textRole` (from `books.year/language/text_role`), populated from the book docs `hybridSearch` already fetches — three fields added to an existing projection, no extra query.
- Passage headers now read `--- Title (1591, Latin, original) by Author, Page N (url) ---` or `(1893, English, modern translation)`; `editionTag()` is exported and unit-tested.
- Prompt: an **ad fontes** rule under Step 5 — when both an original and a later compendium are in hand, quote and link the original and cite the compendium second as commentary; never present a modern paraphrase as a Renaissance author's words; if only a modern edition turned up, say so and consider one original-language search.

## What this does not do
It does not change ranking. Retrieval still surfaces English compendia freely (they are readable and dense in keywords); this PR gives the model the information to choose and the instruction to do so. If the share of pre-1800 citations does not move, the next lever is a ranking nudge toward `text_role: original` when both are retrieved — measurable with the same query as the audit.

## Tests
`tests/unit/librarian-edition-tag.test.ts`; existing Librarian unit suites green; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tru9fGPrYXGMdHh9314v1r