### PR TITLE
feat(librarian): replay identical first-turn questions from last week's answer; daily e2e asks a greeting

### DIFF
--- a/e2e/embassy.spec.ts
+++ b/e2e/embassy.spec.ts
@@ -134,11 +134,18 @@ test.describe('Librarian - API Routes', () => {
   test('POST /api/embassy/chat allows a first anonymous request', async ({ request }) => {
     // Commit 4516ebc7 deliberately opened anonymous Librarian access — the
     // old "auth required" contract is gone. Anonymous visitors get 5 free
-    // actions/hour (src/app/api/embassy/chat/route.ts, checkRateLimit). We
-    // only assert the happy path here to avoid burning 5 real LLM calls to
+    // actions/hour (src/app/api/embassy/chat/route.ts, checkRateLimitShared).
+    // We only assert the happy path here to avoid burning 5 real LLM calls to
     // prove the 429-after-quota path; that path is untested by this suite.
+    //
+    // A bare greeting, not a research question: this suite runs on a daily
+    // cron against production, and "What is the Emerald Tablet?" cost a full
+    // Gemini turn and a new public thread every morning (#4704 — 39 of them).
+    // A greeting is answered by the desk without a model call and its thread
+    // stays unlisted, while still proving the route accepts an anonymous
+    // first request and returns a thread + message.
     const res = await request.post('/api/embassy/chat', {
-      data: { message: 'What is the Emerald Tablet?' },
+      data: { message: 'Hello' },
     });
     // 429 is still acceptable if a prior test/run in this window already
     // used up the shared IP's quota.

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -7,6 +7,7 @@ import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/li
 import { applyCitationFixes, applyImageRemovals, type CitationFix } from '@/lib/embassy/citation-fixes';
 import { checkRateLimitShared, getClientIp } from '@/lib/rate-limit';
 import { isBareGreeting, greetingReply } from '@/lib/embassy/greeting';
+import { findReplayableAnswer, firstMessageKey, type ReplayableAnswer } from '@/lib/embassy/replay-cache';
 import { chatRequestSchema } from '@/lib/embassy/chat-request';
 import { threadVisibility } from '@/lib/embassy/thread-visibility';
 import { toUserId } from '@/lib/user-id';
@@ -131,6 +132,15 @@ export async function POST(request: NextRequest) {
   // A bare "hello" gets the desk's welcome, not six searches (see greeting.ts).
   // The thread it opens is kept but unlisted — there is nothing in it to read.
   const bareGreeting = isBareGreeting(message);
+  // An identical first-turn question answered within the last week is replayed
+  // from that answer — no model call, instant, and the feed keeps one copy of
+  // a canonical question instead of one per asker (see replay-cache.ts).
+  // Only for a fresh thread on the default library; a collection context
+  // changes the search weighting, so those always run the agent.
+  const replay: ReplayableAnswer | null =
+    !threadId && history.length === 0 && !collection && !bareGreeting
+      ? await findReplayableAnswer(db, message, lang, now).catch(() => null)
+      : null;
 
   if (threadId) {
     // Continue existing thread — verify ownership. Signed-in users may only
@@ -174,9 +184,10 @@ export async function POST(request: NextRequest) {
     const result = await db.collection('embassy_threads').insertOne({
       type: 'chat',
       title: message.slice(0, 120),
+      firstMessageKey: firstMessageKey(message),
       creatorId: userId,
       creatorName: displayName,
-      visibility: bareGreeting ? 'unlisted' : threadVisibility(userId, visibility === 'public'),
+      visibility: bareGreeting || replay ? 'unlisted' : threadVisibility(userId, visibility === 'public'),
       aiEnabled: true,
       lang,
       messageCount: 0,
@@ -214,9 +225,16 @@ export async function POST(request: NextRequest) {
   async function* greetingSteps(): AsyncGenerator<LibrarianStep> {
     yield { type: 'text', text: greetingReply(lang) };
   }
+  /** The earlier answer, replayed as the same two steps the agent would emit. */
+  async function* replaySteps(answer: ReplayableAnswer): AsyncGenerator<LibrarianStep> {
+    yield { type: 'text', text: answer.content };
+    yield { type: 'sources', sources: answer.sources };
+  }
   const agentSteps = () => bareGreeting
     ? greetingSteps()
-    : streamAgenticResponse(message, history, activeThreadId, { collection, lang });
+    : replay
+      ? replaySteps(replay)
+      : streamAgenticResponse(message, history, activeThreadId, { collection, lang });
 
   const saveAiResponse = async () => {
     if (!fullText && allSources.length === 0) return;
@@ -238,6 +256,8 @@ export async function POST(request: NextRequest) {
           inCollection: s.inCollection,
         })),
         usage: turnUsage,
+        // Provenance of a replayed answer; also stops a replay being replayed.
+        ...(replay ? { cachedFrom: replay.messageId, cachedFromThread: replay.threadId } : {}),
         createdAt: aiMessageTime,
       });
 

--- a/src/lib/embassy/replay-cache.ts
+++ b/src/lib/embassy/replay-cache.ts
@@ -1,0 +1,123 @@
+/**
+ * Replay cache for identical first-turn questions.
+ *
+ * PRIOR ART: src/lib/embassy/greeting.ts — short-circuits a bare "hello"; this
+ * is the same idea one step up: a question the Librarian answered yesterday,
+ * word for word, does not need a second Gemini turn today. Nothing else in
+ * src/lib/embassy memoises across threads.
+ *
+ * Why: the starter prompts ("Tell me about the Emerald Tablet") and the daily
+ * e2e probe produce the same first turn again and again — 39 identical
+ * "What is the Emerald Tablet?" threads in 45 days, each ~13K tokens and a
+ * new row in the public Recent feed (#4704). A reader asking a canonical
+ * question gets the same well-cited answer either way; the difference is
+ * cost, latency (instant vs 20–60s), and feed noise.
+ *
+ * Scope is deliberately narrow: a NEW thread (no history), the default
+ * library (no collection context), and an earlier answer that was full,
+ * cited, carried no sourcing disclaimer, and is under a week old. Anything
+ * else runs the agent. The replayed thread is kept (the visitor can continue
+ * it — the agent takes over from turn two) but unlisted, so the feed shows
+ * one copy of a canonical question, not one per asker.
+ */
+import type { Db, ObjectId } from 'mongodb';
+import type { SourceCard } from '@/lib/embassy/librarian';
+
+export const REPLAY_WINDOW_MS = 7 * 24 * 3600 * 1000;
+const MIN_ANSWER_CHARS = 600;
+
+/** Case/space/punctuation-insensitive key for "the same question". */
+export function firstMessageKey(message: string): string {
+  return message
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\s ]+/g, ' ')
+    .trim()
+    .replace(/[\s?!.。？！]+$/u, '');
+}
+
+export interface ReplayableAnswer {
+  messageId: ObjectId;
+  threadId: ObjectId;
+  content: string;
+  sources: SourceCard[];
+}
+
+interface StoredSource {
+  bookId: string;
+  bookTitle: string;
+  bookAuthor: string;
+  pageNumber?: number;
+  bookSlug?: string;
+  snippet?: string;
+  inCollection?: boolean;
+}
+
+/**
+ * The most recent earlier answer to the same first-turn question, or null.
+ * Older threads predate `firstMessageKey`, so the raw title is matched too.
+ */
+export async function findReplayableAnswer(
+  db: Db,
+  message: string,
+  lang: string,
+  now: Date = new Date(),
+): Promise<ReplayableAnswer | null> {
+  const key = firstMessageKey(message);
+  if (key.length < 8) return null;
+  // Threads that predate `firstMessageKey` are matched on the title, which is
+  // the raw first message: case-insensitive, trailing punctuation optional.
+  // The key comparison after the fetch is what decides; this only narrows.
+  const titleProbe = message.slice(0, 120).trim().replace(/[\s?!.。？！]+$/u, '');
+  const titlePattern = `^\\s*${titleProbe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s?!.。？！]*$`;
+
+  const threads = await db.collection('embassy_threads')
+    .find(
+      {
+        type: 'chat',
+        lang,
+        createdAt: { $gte: new Date(now.getTime() - REPLAY_WINDOW_MS) },
+        messageCount: { $gte: 2 },
+        // A private thread belongs to its reader; only replay what was public.
+        visibility: { $in: ['public', 'unlisted'] },
+        $or: [{ firstMessageKey: key }, { title: { $regex: titlePattern, $options: 'i' } }],
+      },
+      { projection: { _id: 1 }, sort: { createdAt: -1 }, limit: 5 },
+    )
+    .toArray();
+
+  for (const t of threads) {
+    const [human, ai] = await Promise.all([
+      db.collection('embassy_messages').findOne(
+        { threadId: t._id, authorType: 'human' },
+        { projection: { content: 1 }, sort: { createdAt: 1 } },
+      ),
+      db.collection('embassy_messages').findOne(
+        { threadId: t._id, authorType: 'ai' },
+        { projection: { content: 1, sources: 1, cachedFrom: 1 }, sort: { createdAt: 1 } },
+      ),
+    ]);
+    // The title is a prefix; confirm the whole first message matches.
+    if (!human || firstMessageKey(String(human.content ?? '')) !== key) continue;
+    if (!ai || ai.cachedFrom) continue; // never chain a replay off a replay
+    const content = String(ai.content ?? '');
+    const sources = (ai.sources ?? []) as StoredSource[];
+    if (content.length < MIN_ANSWER_CHARS || sources.length === 0) continue;
+    if (/note on sourcing|nota sobre las fuentes/i.test(content)) continue;
+    return {
+      messageId: ai._id,
+      threadId: t._id,
+      content,
+      sources: sources.map(s => ({
+        book_id: s.bookId,
+        bookTitle: s.bookTitle,
+        bookAuthor: s.bookAuthor,
+        pageNumber: s.pageNumber,
+        bookSlug: s.bookSlug,
+        snippet: s.snippet,
+        inCollection: s.inCollection ?? false,
+      })),
+    };
+  }
+  return null;
+}

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -129,6 +129,79 @@ describe('Embassy API', () => {
       expect(thread!.visibility).toBe('public');
     });
 
+    it('replays an identical first-turn question from last week\'s answer, with no model call', async () => {
+      const { auth } = await import('@/lib/auth');
+      (auth as any).mockResolvedValue(null);
+      const { streamAgenticResponse } = await import('@/lib/embassy/librarian');
+      const db = getTestDb();
+
+      // Yesterday: someone asked, the agent answered well (long, cited, no
+      // sourcing disclaimer) in a public thread.
+      const question = 'What is the Emerald Tablet?';
+      const earlier = new Date(Date.now() - 24 * 3600 * 1000);
+      const t = await db.collection('embassy_threads').insertOne({
+        type: 'chat', title: question, creatorId: null, visibility: 'public', lang: 'en',
+        messageCount: 2, createdAt: earlier, lastMessageAt: earlier,
+      });
+      await db.collection('embassy_messages').insertOne({
+        threadId: t.insertedId, authorType: 'human', authorId: null, content: question, createdAt: earlier,
+      });
+      const answer = 'The Emerald Tablet (Tabula Smaragdina) is a short Hermetic text. '.repeat(12)
+        + '— *[The Golden Fleece](https://sourcelibrary.org/book/aureum-vellus)* [Page 241](https://sourcelibrary.org/book/aureum-vellus?page=241)';
+      const original = await db.collection('embassy_messages').insertOne({
+        threadId: t.insertedId, authorType: 'ai', authorName: 'The Librarian', content: answer,
+        sources: [{ bookId: 'b1', bookTitle: 'Aureum Vellus', bookAuthor: 'Trismosin', pageNumber: 241, bookSlug: 'aureum-vellus', inCollection: false }],
+        createdAt: new Date(earlier.getTime() + 30_000),
+      });
+
+      // Today: the same question, differently punctuated.
+      const callsBefore = (streamAgenticResponse as any).mock.calls.length;
+      const res = await chatPost(makeRequest('/api/embassy/chat', { message: 'what is the emerald tablet', visibility: 'public' }) as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect((streamAgenticResponse as any).mock.calls.length).toBe(callsBefore);
+      expect(data.message.content).toBe(answer);
+      expect(data.message.sources[0]).toMatchObject({ book_id: 'b1', pageNumber: 241, bookSlug: 'aureum-vellus' });
+
+      const thread = await db.collection('embassy_threads').findOne({ _id: new ObjectId(data.threadId) });
+      expect(thread!.visibility).toBe('unlisted');
+      expect(thread!.firstMessageKey).toBe('what is the emerald tablet');
+      const saved = await db.collection('embassy_messages').findOne({ threadId: new ObjectId(data.threadId), authorType: 'ai' });
+      expect(String(saved!.cachedFrom)).toBe(String(original.insertedId));
+
+      // A replay is never itself replayed: ask a third time and the newest
+      // candidate (the replay) is skipped in favour of the original.
+      const res3 = await chatPost(makeRequest('/api/embassy/chat', { message: question }) as any);
+      const data3 = await res3.json();
+      expect((streamAgenticResponse as any).mock.calls.length).toBe(callsBefore);
+      const saved3 = await db.collection('embassy_messages').findOne({ threadId: new ObjectId(data3.threadId), authorType: 'ai' });
+      expect(String(saved3!.cachedFrom)).toBe(String(original.insertedId));
+    });
+
+    it('does not replay a short, disclaimed, or private earlier answer', async () => {
+      const { auth } = await import('@/lib/auth');
+      (auth as any).mockResolvedValue(null);
+      const { streamAgenticResponse } = await import('@/lib/embassy/librarian');
+      const db = getTestDb();
+      const earlier = new Date(Date.now() - 3600 * 1000);
+      const seed = async (question: string, content: string, visibility: string) => {
+        const t = await db.collection('embassy_threads').insertOne({ type: 'chat', title: question, creatorId: null, visibility, lang: 'en', messageCount: 2, createdAt: earlier, lastMessageAt: earlier });
+        await db.collection('embassy_messages').insertOne({ threadId: t.insertedId, authorType: 'human', content: question, createdAt: earlier });
+        await db.collection('embassy_messages').insertOne({ threadId: t.insertedId, authorType: 'ai', content, sources: [{ bookId: 'b', bookTitle: 'T', bookAuthor: 'A', pageNumber: 1 }], createdAt: new Date(earlier.getTime() + 1000) });
+      };
+      const long = 'x'.repeat(700);
+      await seed('Who was Marsilio Ficino?', 'Too short.', 'public');
+      await seed('Who was Giordano Bruno?', long + '\n\n---\n*A note on sourcing: this answer contains a link to a page that doesn\'t exist.*', 'public');
+      await seed('Who was Paracelsus?', long, 'private');
+
+      for (const message of ['Who was Marsilio Ficino?', 'Who was Giordano Bruno?', 'Who was Paracelsus?']) {
+        const before = (streamAgenticResponse as any).mock.calls.length;
+        const res = await chatPost(makeRequest('/api/embassy/chat', { message }) as any);
+        expect(res.status).toBe(200);
+        expect((streamAgenticResponse as any).mock.calls.length, message).toBe(before + 1);
+      }
+    });
+
     it('answers a bare greeting from the desk, with no model call, in an unlisted thread', async () => {
       const { auth } = await import('@/lib/auth');
       (auth as any).mockResolvedValueOnce(null);

--- a/tests/unit/librarian-replay-key.test.ts
+++ b/tests/unit/librarian-replay-key.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { firstMessageKey } from '@/lib/embassy/replay-cache';
+
+// "The same question" for the replay cache: case, spacing, and trailing
+// punctuation do not make a new question; a different word does.
+describe('firstMessageKey', () => {
+  it('folds case, whitespace and trailing punctuation', () => {
+    expect(firstMessageKey('What is the Emerald Tablet?')).toBe('what is the emerald tablet');
+    expect(firstMessageKey('  what IS   the emerald tablet!! ')).toBe('what is the emerald tablet');
+    expect(firstMessageKey('¿Qué es la Tabla Esmeralda?')).toBe('¿qué es la tabla esmeralda');
+  });
+
+  it('keeps distinct questions distinct', () => {
+    expect(firstMessageKey('What is the Emerald Tablet?')).not.toBe(firstMessageKey('Who wrote the Emerald Tablet?'));
+  });
+});


### PR DESCRIPTION
Follow-up to #4704. Independent of the five merged PRs.

## Two things Derek asked for
**"Can identical posts just cache?"** Yes. A new thread on the default library whose first question matches an earlier one (case, spacing, trailing punctuation folded) within **7 days** replays that answer: no Gemini call, instant, same text and source cards. Guards, all in `src/lib/embassy/replay-cache.ts`:
- earlier answer must be ≥600 chars, have ≥1 source card, carry **no** "note on sourcing" disclaimer, come from a public/unlisted thread (never private), and not itself be a replay (`cachedFrom` unset — a replay is never chained);
- only a **fresh** thread (no history) with **no collection context** (collection changes search weighting);
- the replayed thread is kept — the visitor can continue it and the agent takes over from turn two — but **unlisted**, so the Recent feed shows one copy of a canonical question instead of one per asker;
- the saved message records `cachedFrom` / `cachedFromThread`.

Threads now store `firstMessageKey`; legacy threads match on title (case-insensitive, punctuation-tolerant), with the key comparison after fetch as the deciding check.

**"Stop the 7am Emerald."** Found it: the sender is `Playwright/1.62.1 (x64; ubuntu 24.04) node/20.20 CI/1` from Azure IPs — **our own `e2e-tests.yml` daily cron** (06:00 UTC, drifting to 11:00 under GitHub queue delay), running `e2e/embassy.spec.ts`. That test only asserts an anonymous first request returns `threadId` + `message`, so it now sends **"Hello"**: answered by the desk with no model call (#4707), thread unlisted. Same contract, zero cost, no feed row. The 39 historical probe threads are left as they are (they were real answers; they will age out of the feed).

## Not in this PR
- No index on `firstMessageKey` — `embassy_threads` is ~5K docs and the lookup is bounded by `createdAt` and `limit: 5`; add one if the collection grows 100x.
- Replay for signed-in users happens too (the answer is the same); their thread is also unlisted. If that reads as wrong for members, flip the condition to `!userId`.

## Tests
- `tests/unit/librarian-replay-key.test.ts` (key folding).
- `tests/integration/embassy-api.test.ts`: replay hit (no agent call, same content/sources, unlisted, `cachedFrom` set, third ask replays the **original** not the replay); three negatives (short / disclaimed / private earlier answers all run the agent). Suite 18/18; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)