### PR TITLE
feat(librarian): nudge period editions above later compendia in retrieval

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -401,6 +401,9 @@ async function executeSearch(query: string, collection?: string | null): Promise
   const { passages, books } = await hybridSearch(query, {
     tenantId: null,
     collection: collectionUsed,
+    // Ad fontes: at comparable relevance, hand the model the 1591 imprint
+    // before the 1928 handbook that paraphrases it (#4704).
+    preferPeriodEditions: true,
     // collectionWeight defaults to 2 in hybridSearch.
   });
   return { passages, books, collectionUsed };

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -23,6 +23,7 @@ import {
 import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { authorSlug as toAuthorSlug } from '@/lib/slugify';
+import { editionYear } from '@/lib/dedup';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -73,6 +74,12 @@ export interface HybridSearchOptions {
   tenantId?: string | null;
   /** Max passages to return (default 8). */
   limit?: number;
+  /**
+   * Nudge period editions (printed or written up to PERIOD_EDITION_YEAR) above
+   * later compendia at equal relevance. Off by default so site search is
+   * untouched; the Librarian turns it on. See applyPeriodEditionBoost.
+   */
+  preferPeriodEditions?: boolean;
   /** Max book-level results in `books` (default 5). */
   bookLimit?: number;
   /**
@@ -282,6 +289,42 @@ async function collectionScopedSources(
  * k=60 is the canonical default. Eval showed k=20 vs k=60 produce identical
  * rankings on the current golden set — stick with 60 for posterity.
  */
+/** A book printed or written in or before this year counts as a period edition. */
+export const PERIOD_EDITION_YEAR = 1800;
+/** Multiplier on the fused score of a period-edition hit. */
+export const PERIOD_EDITION_BOOST = 1.25;
+
+/**
+ * Nudge period editions above later compendia at comparable relevance.
+ *
+ * Why: over 45 days, 35% of the Librarian's page citations landed on
+ * 1850–1949 English compendia — Waite's Hermetic Museum and Hall's Secret
+ * Teachings were the #2 and #3 most-cited books — while the originals they
+ * paraphrase sat lower in the same result lists (#4704). Those books are dense
+ * in the reader's keywords and in fluent English, so every lane ranks them
+ * well; nothing in the fusion knew a 1928 handbook from a 1591 imprint.
+ *
+ * Mechanism: multiply the fused score of hits whose edition year is known and
+ * ≤ PERIOD_EDITION_YEAR by PERIOD_EDITION_BOOST, then re-sort the head. A
+ * nudge, not a filter — a compendium that is clearly the best hit stays
+ * first, and a book with no known year is left alone. Only the top `head`
+ * hits are considered, which is all the caller will read anyway.
+ */
+export function applyPeriodEditionBoost(
+  hits: RawHit[],
+  head: number,
+  yearOf: (bookId: string) => number | null,
+): RawHit[] {
+  const top = hits.slice(0, head).map(h => {
+    const year = yearOf(h.book_id);
+    return year != null && year <= PERIOD_EDITION_YEAR
+      ? { ...h, score: h.score * PERIOD_EDITION_BOOST }
+      : h;
+  });
+  top.sort((a, b) => b.score - a.score);
+  return [...top, ...hits.slice(head)];
+}
+
 function rrfMerge(rankedLists: RawHit[][], k = 60, weights?: number[]): RawHit[] {
   const scores = new Map<string, { hit: RawHit; score: number; sources: Set<string> }>();
   for (let li = 0; li < rankedLists.length; li++) {
@@ -488,16 +531,25 @@ export async function hybridSearch(
   // Optional cross-encoder rerank (no-op without API key)
   merged = await maybeRerank(query, merged);
 
-  // Resolve book metadata for the top passages (slug + display title)
-  const passageBookIds = [...new Set(merged.slice(0, limit * 2).map(h => h.book_id))];
+  // Resolve book metadata for the top passages (slug + display title). Three
+  // pages' worth, not two, so the period-edition boost below has candidates
+  // from just below the cut to promote.
+  const passageBookIds = [...new Set(merged.slice(0, limit * 3).map(h => h.book_id))];
   const db = await getDb();
   const bookDocs = passageBookIds.length > 0
     ? await db.collection('books')
         .find({ id: { $in: passageBookIds }, ...tenantBookFilter(opts.tenantId) })
-        .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, text_role: 1 })
+        .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, text_role: 1 })
         .toArray()
     : [];
   const bookMap = new Map(bookDocs.map(b => [b.id, b]));
+
+  if (opts.preferPeriodEditions) {
+    merged = applyPeriodEditionBoost(merged, limit * 3, id => {
+      const b = bookMap.get(id);
+      return b ? editionYear(b as { year?: number | null; published?: string | null }) : null;
+    });
+  }
 
   // Build final passage list — drop any hit whose book is hidden / wrong tenant
   const passages: SearchPassage[] = [];

--- a/tests/unit/librarian-period-boost.test.ts
+++ b/tests/unit/librarian-period-boost.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { applyPeriodEditionBoost, PERIOD_EDITION_BOOST, PERIOD_EDITION_YEAR } from '@/lib/search/librarian-search';
+
+// The Librarian's retrieval hands the model a 1928 handbook as readily as the
+// 1591 imprint it paraphrases (#4704: 35% of citations on 1850–1949
+// compendia). This nudge is a multiplier on the fused score, applied to the
+// head of the list only, and it must stay a nudge: a clearly better modern hit
+// keeps first place, and an undated book is left alone.
+const hit = (book_id: string, score: number) => ({ book_id, page_number: 1, text: '', score, source: 'kw' });
+
+describe('applyPeriodEditionBoost', () => {
+  const years: Record<string, number | null> = { hall1928: 1928, khunrath1595: 1595, undated: null, waite1893: 1893 };
+  const yearOf = (id: string) => years[id] ?? null;
+
+  it('lifts a period edition above a slightly better-scored compendium', () => {
+    const out = applyPeriodEditionBoost([hit('hall1928', 0.050), hit('khunrath1595', 0.045)], 8, yearOf);
+    expect(out.map(h => h.book_id)).toEqual(['khunrath1595', 'hall1928']);
+    expect(out[0].score).toBeCloseTo(0.045 * PERIOD_EDITION_BOOST, 6);
+  });
+
+  it('is a nudge, not a filter: a clearly better compendium stays first', () => {
+    const out = applyPeriodEditionBoost([hit('hall1928', 0.080), hit('khunrath1595', 0.045)], 8, yearOf);
+    expect(out.map(h => h.book_id)).toEqual(['hall1928', 'khunrath1595']);
+  });
+
+  it('leaves undated books and the tail beyond the head untouched', () => {
+    const list = [hit('waite1893', 0.05), hit('undated', 0.04), hit('khunrath1595', 0.03), hit('khunrath1595', 0.02)];
+    const out = applyPeriodEditionBoost(list, 3, yearOf);
+    expect(out[1].book_id).toBe('undated');
+    expect(out[1].score).toBe(0.04);
+    // Fourth hit is beyond head=3: same object, same score, same position.
+    expect(out[3]).toBe(list[3]);
+  });
+
+  it('treats the boundary year as period', () => {
+    const out = applyPeriodEditionBoost([hit('a', 0.05), hit('b', 0.045)], 8, id => (id === 'b' ? PERIOD_EDITION_YEAR : PERIOD_EDITION_YEAR + 1));
+    expect(out[0].book_id).toBe('b');
+  });
+});


### PR DESCRIPTION
Follow-up to #4704 and #4717 — the ranking lever the ad-fontes PR deferred.

## Why
35% of the Librarian's page citations over 45 days landed on 1850–1949 English compendia. #4717 told the model which edition it was looking at; this PR changes what it is handed. Those books are dense in the reader's keywords and in fluent English, so every retrieval lane ranks them well, and nothing in the RRF fusion knew a 1928 handbook from a 1591 imprint.

## Mechanism
`applyPeriodEditionBoost` (`src/lib/search/librarian-search.ts`): multiply the fused score of hits whose `editionYear` is known and ≤ 1800 by 1.25, re-sort the head (top 3×limit). A **nudge, not a filter** — a clearly stronger modern hit keeps first place; a book with no known year is left alone. Opt-in via `preferPeriodEditions`; the Librarian sets it, `/api/search` and voice-search are untouched. Book docs for 3×limit are fetched instead of 2×limit so there are candidates below the cut to promote (one `$in` query either way).

## Measured (14 queries from the audit, top-8 passages, flag off vs on)
| | off | on |
|---|---|---|
| period-edition share | 77/109 (71%) | 95/109 (87%) |
| queries reordered | — | 8/14 |

Spot checks: *Emerald Tablet* drops Hall's *Secret Teachings* (1928) from #2 for the 1532 *Pymander*; *Splendor Solis* now leads with *Aureum Vellus* (1598) instead of the 1920 English; *tetrahedron* keeps *Occult Chemistry* (1919) at #1 because it is clearly the strongest hit. Six queries were already all-period and did not move.

## Tests
`tests/unit/librarian-period-boost.test.ts` (lift, nudge-not-filter, undated and tail untouched, boundary year). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)