### PR TITLE
ocr: OCR_LITE_ONLY — every batch OCR submission on flash-lite, in the meantime

### DIFF
--- a/scripts/lib/ocr-routing.mjs
+++ b/scripts/lib/ocr-routing.mjs
@@ -33,15 +33,39 @@ export const OCR_MODEL_FLASH = MODEL_FLASH;
 export const OCR_MODEL_LITE = MODEL_LITE;
 
 /**
+ * OCR_LITE_ONLY — the deliberate divergence the header comment reserves.
+ *
+ * Derek, 2026-09-11: "OCR should only be flash-lite batch, in the meantime."
+ * The August usage log showed the OCR lane dominated by gemini-3-flash-preview
+ * rows (BPH, non-Latin/unknown language, and recitation tier 2 all route there)
+ * at ~2x the input price, while the spend dial is $5/day. Until the dial is
+ * raised, every batch OCR submission uses flash-lite, and the recitation ladder
+ * skips its flash-preview tier (tier 3, MinerU, is not a Gemini model and is
+ * unaffected). Translation routing is untouched — this is OCR only.
+ *
+ * Default ON. Set OCR_LITE_ONLY=0 in the orchestrator's environment (Hetzner
+ * crontab / .env) to restore script-aware routing without a deploy.
+ * tests/unit/translate-core-parity.test.ts pins both behaviours.
+ */
+export const OCR_LITE_ONLY = process.env.OCR_LITE_ONLY !== '0';
+
+/** Model for the recitation escalation tier that used to be flash-preview. */
+export function ocrEscalationModel() {
+  return OCR_LITE_ONLY ? OCR_MODEL_LITE : OCR_MODEL_FLASH;
+}
+
+/**
  * THE model routing for OCR. Mirrors getModelForBook in
- * src/lib/types/ai-models.ts and getTranslateModelForBook in translate-core.mjs.
+ * src/lib/types/ai-models.ts and getTranslateModelForBook in translate-core.mjs
+ * — except under OCR_LITE_ONLY (above), when every book routes to flash-lite.
  *
  * - BPH books: full flash (high-quality manuscripts)
  * - Non-Latin scripts: full flash (flash-lite hallucinates)
  * - Latin-script European languages: flash-lite (50% cheaper)
  * - Unknown/null language: full flash (safer default)
  */
-export function getOcrModelForBook(book) {
+export function getOcrModelForBook(book, { liteOnly = OCR_LITE_ONLY } = {}) {
+  if (liteOnly) return OCR_MODEL_LITE;
   if (book?.image_source?.provider === 'bph') return OCR_MODEL_FLASH;
   const lang = (book?.language || '').toLowerCase().trim();
   if (!lang || !LATIN_SCRIPT_LANGUAGES.has(lang)) return OCR_MODEL_FLASH;

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -28,7 +28,7 @@ import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 import { budgetAllowsDispatchScoped } from '../lib/spend-guard.mjs';
 import { getTranslateModelForBook, SKIP_TRANSLATION_PAGE_TYPES } from '../lib/translate-core.mjs';
-import { getOcrModelForBook, OCR_MODEL_FLASH, OCR_MODEL_LITE } from '../lib/ocr-routing.mjs';
+import { getOcrModelForBook, ocrEscalationModel, OCR_MODEL_FLASH, OCR_MODEL_LITE } from '../lib/ocr-routing.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
@@ -4081,12 +4081,14 @@ Rules:
           // recitation filter and then corrected against its own image.
           const isLiteRetry = book.pipeline_auto?.recitation_retry_lite === true;
           const isRecitationRetry = book.pipeline_auto?.recitation_retry === true;
+          // Tier 2 is flash-preview only when OCR_LITE_ONLY is off (ocr-routing.mjs);
+          // under lite-only it re-runs lite, and a second refusal still falls to tier 3.
           const ocrOpts = isLiteRetry
-            ? { modelOverride: OCR_MODEL_FLASH }
+            ? { modelOverride: ocrEscalationModel() }
             : isRecitationRetry
               ? { modelOverride: OCR_MODEL_LITE }
               : {};
-          if (isLiteRetry) console.log(`  RECITATION retry (tier 2) with ${OCR_MODEL_FLASH}: ${label}`);
+          if (isLiteRetry) console.log(`  RECITATION retry (tier 2) with ${ocrEscalationModel()}: ${label}`);
           else if (isRecitationRetry) console.log(`  RECITATION retry (tier 1) with ${OCR_MODEL_LITE}: ${label}`);
           else console.log(`  Submitting OCR: ${label}...`);
           const result = await submitOcrDirectly(db, book, ocrOpts);

--- a/tests/unit/translate-core-parity.test.ts
+++ b/tests/unit/translate-core-parity.test.ts
@@ -80,23 +80,53 @@ describe('translate-core routing parity', () => {
   });
 });
 
+// The script-aware rule is pinned with the OCR_LITE_ONLY switch held OFF, so the
+// parity guarantee survives the "flash-lite only, in the meantime" period
+// (2026-09-11) and is what returns the day the switch is lifted.
+const scriptAware = { liteOnly: false };
+
 describe('OCR routing parity (batch OCR vs translation vs API)', () => {
   it.each(probes)('$name', ({ book }) => {
-    expect(routeOcr(book)).toBe(routeTs(book));
-    expect(routeOcr(book)).toBe(routeMjs(book));
+    expect(routeOcr(book, scriptAware)).toBe(routeTs(book));
+    expect(routeOcr(book, scriptAware)).toBe(routeMjs(book));
   });
 
   it('routes Malay (Jawi) OCR to full flash — the orchestrator drift', () => {
     for (const lang of ['malay', 'ms', 'msa']) {
-      expect(routeOcr({ language: lang })).toBe(MODEL_FLASH);
+      expect(routeOcr({ language: lang }, scriptAware)).toBe(MODEL_FLASH);
     }
   });
 
   it('routes plain Latin-script books to lite for OCR too', () => {
-    expect(routeOcr({ language: 'latin' })).toBe(MODEL_LITE);
+    expect(routeOcr({ language: 'latin' }, scriptAware)).toBe(MODEL_LITE);
   });
 
   it('sends BPH books to full flash regardless of language', () => {
-    expect(routeOcr({ image_source: { provider: 'bph' }, language: 'latin' })).toBe(MODEL_FLASH);
+    expect(routeOcr({ image_source: { provider: 'bph' }, language: 'latin' }, scriptAware)).toBe(MODEL_FLASH);
+  });
+});
+
+describe('OCR_LITE_ONLY (2026-09-11): every batch OCR submission is flash-lite', () => {
+  const liteOnly = { liteOnly: true };
+
+  it('overrides the BPH branch', () => {
+    expect(routeOcr({ image_source: { provider: 'bph' }, language: 'latin' }, liteOnly)).toBe(MODEL_LITE);
+  });
+
+  it('overrides the non-Latin and unknown-language branches', () => {
+    for (const language of ['malay', 'tibetan', 'chinese', 'arabic', null, '']) {
+      expect(routeOcr({ language }, liteOnly)).toBe(MODEL_LITE);
+    }
+  });
+
+  it('is the default unless OCR_LITE_ONLY=0 is set in the environment', () => {
+    // The module reads the env once at import; this pins the default of that read.
+    expect(process.env.OCR_LITE_ONLY === '0' ? MODEL_FLASH : MODEL_LITE)
+      .toBe(routeOcr({ image_source: { provider: 'bph' } }));
+  });
+
+  it('does not touch translation routing', () => {
+    expect(routeMjs({ image_source: { provider: 'bph' }, language: 'latin' })).toBe(MODEL_FLASH);
+    expect(routeMjs({ language: 'tibetan' })).toBe(MODEL_FLASH);
   });
 });


### PR DESCRIPTION
## Why
Derek, 2026-09-11: "OCR should only be flash-lite batch, in the meantime." The recent OCR usage rows are dominated by `gemini-3-flash-preview` (BPH, non-Latin/unknown-language, recitation tier 2 all route there) at about 2x the input price, while the spend dial is $5/day.

## What
- `scripts/lib/ocr-routing.mjs`: `OCR_LITE_ONLY` (default **on**; `OCR_LITE_ONLY=0` in the orchestrator env restores script-aware routing without a deploy). `getOcrModelForBook(book, { liteOnly })` returns flash-lite for every book under the switch. `ocrEscalationModel()` for the recitation ladder.
- `pipeline-orchestrator.mjs`: recitation tier 2 uses `ocrEscalationModel()` (lite under the switch; a second refusal still falls to tier 3 MinerU, which is not a Gemini model).
- `tests/unit/translate-core-parity.test.ts`: parity with translation/TS routing pinned with the switch held off; a new block pins lite-only behaviour and that translation routing is untouched.

## Out of scope, deliberately
- `src/lib/types/ai-models.ts` `getModelForBook` (used by the legacy queue-books route and the translation processor) is unchanged: the instruction is batch OCR only, and translation must keep script-aware routing.
- The known flash-lite fabrication on cursive Tibetan (#4523) is not made worse: those books are already withheld from the general path; but any *new* non-Latin OCR under this switch is on lite and should be treated as preview quality until the switch is lifted.

## Takes effect
On merge; Hetzner pulls main hourly at :17.

Tests: `vitest run tests/unit/translate-core-parity.test.ts tests/unit/preview-ocr-batch.test.ts` green with the switch on and with `OCR_LITE_ONLY=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)