### PR TITLE
import: ia-ocr-ingest — free OCR for IA books that agree with our Gemini sample

### DIFF
--- a/.claude/docs/data-provenance.md
+++ b/.claude/docs/data-provenance.md
@@ -140,7 +140,12 @@ That last one is not in `prompts` at all — it is a constant in the route/worke
   field: "ocr" | "translation",
   data: "the full previous text content",
   source: "batch_api" | "ai" | "pipeline_preview" | "manual" | "skip" | "system" |
-          "maintenance" | "mineru" | "realtime_api_sequential" | "unknown" | null |
+          "maintenance" | "mineru" | "ia_djvu" | "realtime_api_sequential" | "unknown" | null |
+          // "ia_djvu" (2026-09-11): the Internet Archive's own per-leaf OCR (`<id>_djvu.xml`,
+          // ABBYY/Tesseract — engine in ocr.model as `ia-ocr/<ocr_module_version>`), written by
+          // scripts/import/ia-ocr-ingest.mjs ONLY to pages with no ocr.data, and only for books
+          // whose 25-page Gemini sample agrees with the IA text at a word-sequence median ≥ 0.85
+          // (ocr.agreement_ref). NOT model output: exclude from any Gemini quality measurement.
           "<sweep-label>",   // ad-hoc, e.g. "shift-repair-erara-2026-07",
                              // "reocr-download-failure-fix-2026-07"
   model: "gemini-3-flash-preview",

--- a/scripts/import/ia-ocr-ingest.mjs
+++ b/scripts/import/ia-ocr-ingest.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * PRIOR ART: scripts/maintenance/reocr-launch-books.mjs (re-enrols under-OCR'd books for
+ * a PAID Gemini pass — this script fills the same pages for free where the Internet
+ * Archive already ran OCR); scripts/import/ia-bundle-import.mjs (IA metadata import,
+ * never touched page text). Nothing in the repo reads IA's per-leaf OCR.
+ *
+ * ia-ocr-ingest — fill untranscribed pages of Internet Archive books with the
+ * Archive's own OCR, when it agrees with the Gemini sample we already paid for.
+ *
+ * WHY (2026-09-11). 591,417 untranscribed English pages sit in the library; 578,655
+ * of them (98%) are IA scans, and every IA item ships `<id>_djvu.xml`: one <OBJECT>
+ * per leaf with word coordinates, from the same leaf sequence our `pages.photo`
+ * URLs index (`/page/n<k>/`). Measured on the Shaker shelf against our Gemini OCR
+ * of the same leaf: Lamson 1848 agrees 0.925 (word-sequence ratio); Brown 1812
+ * agrees 0.753 — the long-s era, where ABBYY reads ſ as f. So the rule is a
+ * per-book calibration, not a date: the 25-page preview every stub book already
+ * carries is the free reference; ingest only where the book clears the bar.
+ *
+ * PROVENANCE. Written with `ocr.source: 'ia_djvu'` and `ocr.model:
+ * 'ia-ocr/<ocr_module_version>'` — a distinctive label per data-provenance.md,
+ * never `batch_api`/`ai`. Pages that already have `ocr.data` are never touched;
+ * `saveRevisionsBeforeOverwrite` is still called (no-op on first write, doctrine).
+ * The #4149 ink guard is not run: it exists for a model that writes prose on blank
+ * leaves; ABBYY/Tesseract return no words there, and such leaves are skipped.
+ *
+ * RATE. ≤ 2 requests/s to archive.org with a contact UA; aborts the run after 4
+ * consecutive 429/503 (repo lesson: a guard travels with the file).
+ *
+ * Usage (dry run by default; nothing is written without --apply):
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/ia-ocr-ingest.mjs --collection shakers            # score + plan
+ *   node scripts/import/ia-ocr-ingest.mjs --book <id>                     # one book
+ *   node scripts/import/ia-ocr-ingest.mjs --language english --limit 200  # a slice
+ *   node scripts/import/ia-ocr-ingest.mjs --collection shakers --apply
+ * Options: --min-agreement 0.85  --min-ref-pages 5  --cache <dir> (keeps the XML)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { ObjectId } from 'mongodb';
+import { withMongo } from '../lib/mongo.mjs';
+import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
+
+const arg = (k, d) => { const i = process.argv.indexOf(k); return i > 0 ? process.argv[i + 1] : d; };
+const APPLY = process.argv.includes('--apply');
+const COLLECTION = arg('--collection', null);
+const BOOK = arg('--book', null);
+const LANGUAGE = arg('--language', null);
+const LIMIT = +arg('--limit', 50);
+const MIN_AGREEMENT = +arg('--min-agreement', 0.85);
+const MIN_REF_PAGES = +arg('--min-ref-pages', 5);
+const CACHE = arg('--cache', null);
+const UA = 'SourceLibrary ia-ocr-ingest (team@sourcelibrary.org)';
+const SOURCE = 'ia_djvu';
+
+// ---------- IA fetch, rate-limited, abort on repeated refusal ----------
+let lastReq = 0, consecutiveRefusals = 0;
+async function iaFetch(url) {
+  const wait = 500 - (Date.now() - lastReq); if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  lastReq = Date.now();
+  const res = await fetch(url, { headers: { 'User-Agent': UA }, redirect: 'follow' });
+  if (res.status === 429 || res.status === 503) {
+    consecutiveRefusals++;
+    if (consecutiveRefusals >= 4) { console.error(`ABORT: ${consecutiveRefusals} consecutive ${res.status} from archive.org`); process.exit(3); }
+    await new Promise((r) => setTimeout(r, 15000)); return iaFetch(url);
+  }
+  consecutiveRefusals = 0;
+  return res;
+}
+
+async function iaOcrMeta(id) {
+  const res = await iaFetch(`https://archive.org/metadata/${id}`);
+  if (!res.ok) return {};
+  const j = await res.json(); const m = j?.metadata || {};
+  return { engine: m.ocr || null, version: m.ocr_module_version || null, imagecount: m.imagecount ? +m.imagecount : null };
+}
+
+async function iaDjvuXml(id) {
+  const cached = CACHE ? path.join(CACHE, `${id}_djvu.xml`) : null;
+  if (cached && fs.existsSync(cached)) return fs.readFileSync(cached, 'utf8');
+  const res = await iaFetch(`https://archive.org/download/${id}/${id}_djvu.xml`);
+  if (!res.ok) return null;
+  const xml = await res.text();
+  if (cached) { fs.mkdirSync(CACHE, { recursive: true }); fs.writeFileSync(cached, xml); }
+  return xml;
+}
+
+/** OBJECT[k] → plain text: words joined by spaces, lines by \n, paragraphs by a blank line. */
+function leafTexts(xml) {
+  const out = [];
+  const objs = xml.split(/<OBJECT\b/).slice(1);
+  for (const o of objs) {
+    const paras = [];
+    for (const p of o.split(/<PARAGRAPH\b/).slice(1)) {
+      const lines = [];
+      for (const l of p.split(/<LINE\b/).slice(1)) {
+        const words = [...l.matchAll(/<WORD[^>]*>([\s\S]*?)<\/WORD>/g)].map((m) => decode(m[1]).trim()).filter(Boolean);
+        if (words.length) lines.push(words.join(' '));
+      }
+      if (lines.length) paras.push(lines.join('\n'));
+    }
+    out.push(paras.join('\n\n'));
+  }
+  return out;
+}
+const decode = (s) => s.replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/&#(\d+);/g, (_, n) => String.fromCharCode(+n));
+
+// ---------- agreement: word-sequence ratio (difflib-style 2M/(|a|+|b|)) ----------
+const tokens = (s) => (s || '').replace(/<[^>]+>/g, ' ').toLowerCase().match(/[a-z0-9']+/g) || [];
+function ratio(a, b) {
+  a = a.slice(0, 600); b = b.slice(0, 600);
+  if (!a.length || !b.length) return 0;
+  const prev = new Uint16Array(b.length + 1); const cur = new Uint16Array(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) cur[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], cur[j - 1]);
+    prev.set(cur);
+  }
+  return (2 * prev[b.length]) / (a.length + b.length);
+}
+const median = (xs) => { const s = [...xs].sort((x, y) => x - y); return s.length ? s[Math.floor(s.length / 2)] : 0; };
+
+/** leaf index (0-based) for a page: from the IA photo URL, else page_number - 1 */
+function leafIndex(page) {
+  const m = String(page.photo || page.archived_photo || '').match(/\/page\/n(\d+)\//);
+  return m ? +m[1] : (page.page_number || 1) - 1;
+}
+
+await withMongo(async (db) => {
+  const B = db.collection('books'), P = db.collection('pages');
+  const q = { pages_count: { $gt: 0 }, $expr: { $lt: [{ $ifNull: ['$pages_ocr', 0] }, '$pages_count'] }, hidden_reason: { $in: [null, ''] },
+    $or: [{ ia_identifier: { $exists: true, $ne: null } }, { 'image_source.provider': 'internet_archive' }] };
+  if (COLLECTION) q.collections = COLLECTION;
+  if (LANGUAGE) q.language = new RegExp(`^${LANGUAGE}$`, 'i');
+  if (BOOK) q.$and = [{ $or: [{ id: BOOK }, ...(ObjectId.isValid(BOOK) ? [{ _id: new ObjectId(BOOK) }] : [])] }];
+  const books = await B.find(q, { projection: { id: 1, title: 1, language: 1, published: 1, ia_identifier: 1, image_source: 1, pages_count: 1, pages_ocr: 1, 'pipeline_auto.status': 1 } })
+    .sort({ processing_priority: -1, visible: -1 }).limit(LIMIT).toArray();
+  console.log(`${books.length} candidate books (${APPLY ? 'APPLY' : 'dry run'}; min agreement ${MIN_AGREEMENT}, min ref pages ${MIN_REF_PAGES})`);
+
+  const summary = { scored: 0, accepted: 0, rejected: 0, no_ref: 0, no_xml: 0, pages_written: 0 };
+  for (const b of books) {
+    const bid = b.id || String(b._id);
+    const iaId = b.ia_identifier || (b.image_source?.identifier) || null;
+    if (!iaId) { console.log(`  ${bid} no IA identifier — skip`); continue; }
+    const xml = await iaDjvuXml(iaId);
+    if (!xml) { summary.no_xml++; console.log(`  ${bid} ${iaId}: no _djvu.xml`); continue; }
+    const leaves = leafTexts(xml);
+    const meta = await iaOcrMeta(iaId);
+    const pages = await P.find({ book_id: bid }, { projection: { id: 1, page_number: 1, photo: 1, archived_photo: 1, display_photo: 1, 'ocr.data': 1, hidden: 1 } }).sort({ page_number: 1 }).toArray();
+
+    // reference: pages that already carry model OCR
+    const scores = [];
+    for (const p of pages) { const t = p.ocr?.data; if (!t) continue; const k = leafIndex(p); if (k >= leaves.length) continue; const r = ratio(tokens(t), tokens(leaves[k])); if (tokens(leaves[k]).length >= 20) scores.push(r); }
+    const med = median(scores);
+    const title = (b.title || '').slice(0, 44);
+    if (scores.length < MIN_REF_PAGES) { summary.no_ref++; console.log(`  ${bid} ${String(b.published || '').slice(0, 4)} ${title} | ref pages ${scores.length} < ${MIN_REF_PAGES} — cannot calibrate`); continue; }
+    summary.scored++;
+    const fillable = pages.filter((p) => !p.ocr?.data && !p.hidden).map((p) => ({ p, k: leafIndex(p) })).filter(({ k }) => k < leaves.length && tokens(leaves[k]).length >= 20);
+    const verdict = med >= MIN_AGREEMENT ? 'ACCEPT' : 'REJECT';
+    console.log(`  ${verdict} ${bid} ${String(b.published || '').slice(0, 4)} ${title} | agreement median ${med.toFixed(3)} over ${scores.length} pages | IA leaves ${leaves.length}/${pages.length} | fillable ${fillable.length} | engine ${meta.engine || '?'} ${meta.version || ''}`);
+    if (verdict === 'REJECT') { summary.rejected++; continue; }
+    summary.accepted++;
+    if (!APPLY) { summary.pages_written += fillable.length; continue; }
+
+    const now = new Date();
+    await saveRevisionsBeforeOverwrite(db, fillable.map(({ p }) => p.id), 'ocr', { reason: 'ia_ocr_ingest' });
+    let n = 0;
+    for (const { p, k } of fillable) {
+      const r = await P.updateOne({ _id: p._id, $or: [{ 'ocr.data': { $exists: false } }, { 'ocr.data': null }, { 'ocr.data': '' }] }, { $set: {
+        'ocr.data': leaves[k], 'ocr.source': SOURCE, 'ocr.model': `ia-ocr/${meta.version || meta.engine || 'unknown'}`, 'ocr.language': b.language || null,
+        'ocr.source_url': `https://archive.org/download/${iaId}/${iaId}_djvu.xml#leaf=${k}`, 'ocr.updated_at': now, 'ocr.has_warning': false,
+        'ocr.agreement_ref': { median: +med.toFixed(3), n: scores.length, min_agreement: MIN_AGREEMENT }, updated_at: now } });
+      n += r.modifiedCount;
+    }
+    summary.pages_written += n;
+    const [counts] = await P.aggregate(buildVisiblePageCountPipeline(bookId(b))).toArray();
+    const set = { updated_at: now };
+    if (counts) Object.assign(set, { pages_count: counts.total, pages_ocr: counts.with_ocr, pages_translated: counts.with_translation });
+    const full = counts && counts.with_ocr >= counts.total;
+    if (full && b.pipeline_auto?.status === 'archive_complete') set['pipeline_auto.status'] = 'ocr_complete', set['pipeline_auto.last_updated'] = now;
+    await B.updateOne({ _id: b._id }, { $set: set });
+    await db.collection('book_events').insertOne({ book_id: bid, type: 'ia_ocr_ingest', at: now, source: 'ia-ocr-ingest', details: { ia_identifier: iaId, pages_written: n, agreement_median: +med.toFixed(3), ref_pages: scores.length, engine: meta.engine, version: meta.version, pages_ocr_after: counts?.with_ocr ?? null, status_after: set['pipeline_auto.status'] || b.pipeline_auto?.status || null } });
+    console.log(`     wrote ${n} pages → pages_ocr ${counts?.with_ocr}/${counts?.total}${full ? ' (complete)' : ''}`);
+  }
+  console.log(JSON.stringify(summary));
+}, { timeoutMs: 6 * 60 * 60 * 1000 });
+
+function bookId(b) { return b.id || String(b._id); }


### PR DESCRIPTION
## Why
Derek, 2026-09-11, on cost-optimising English OCR: "do it". 591,417 untranscribed English pages in the library; **578,655 (98%) are Internet Archive scans** whose items already carry a full per-leaf OCR (`<id>_djvu.xml`, word coordinates, one `<OBJECT>` per leaf) in the same leaf sequence our `pages.photo` URLs index (`/page/n<k>/`). At our measured 0.57¢/page that pool is ~$3,400 of Gemini; via IA text it is $0.

## What
`scripts/import/ia-ocr-ingest.mjs` (dry-run by default):
- candidates: IA books with `pages_ocr < pages_count`, no `hidden_reason`; `--collection` / `--book` / `--language` / `--limit`
- **calibration per book, not per date**: word-sequence agreement (difflib-style ratio) between the IA leaf and every page we already OCR'd with Gemini (the 25-page preview every stub carries); accept at median ≥ 0.85 over ≥ 5 pages
- writes only pages with no `ocr.data`, IA leaf ≥ 20 words: `ocr.source: 'ia_djvu'`, `ocr.model: 'ia-ocr/<ocr_module_version>'`, `ocr.source_url` (xml#leaf), `ocr.agreement_ref {median,n,min}`; `saveRevisionsBeforeOverwrite` called (no-op on first write); counters via `buildVisiblePageCountPipeline`; `archive_complete → ocr_complete` only when full; one `book_events` row per book
- ≤ 2 req/s, contact UA, abort after 4 consecutive 429/503
- `.claude/docs/data-provenance.md`: `ia_djvu` added to the `ocr.source` enum with the rule (not model output; exclude from Gemini quality measurement)

## Measured on the Shaker shelf (applied, 2026-09-11)
| verdict | books | agreement median | pages written |
|---|---|---|---|
| ACCEPT | 7 (1810–1888 prose) | 0.851–0.937 | **2,036** |
| REJECT | 6 (three music books with notation 0.53–0.72, the 1812 long-s Brown 0.79, the 1813 hymnal 0.74, the 1883 Manifesto 0.73) | | 0 — stay on the paid queue |

Lamson's *Two Years' Experience* (1848) now serves its worship description from the ingested text: https://sourcelibrary.org/q/BlmU031E4thVb2tij0N (the "quick manner", p.86 printed / p.91 here).

## Out of scope
- Non-English books: IA OCR quality on Latin/Greek/Fraktur is worse and untested here; the calibration would reject most, which is the point — run it with `--language` per shelf and read the score distribution first.
- The #4149 ink guard is not invoked (ABBYY writes no prose on blank leaves; such leaves are skipped and remain for the pipeline).
- The 6 rejected Shaker books and the leaves under 20 words stay at `archive_complete` for Phase 2 under the dial (#4719).
- Supabase page sync: OCR is served from Mongo; nothing else to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)