### PR TITLE
fix(ocr): route every OCR producer and the Lambda by book — no more flash fallback (#4729)

### DIFF
--- a/.claude/docs/worker-architecture.md
+++ b/.claude/docs/worker-architecture.md
@@ -5,7 +5,7 @@
 The pipeline uses two execution environments for page processing:
 
 1. **Hetzner workers** (primary) — `translate-worker.mjs` handles all production translation inline via Gemini API. `batch-collector.mjs` collects OCR results from Gemini Batch API. No SQS or Lambda involved.
-2. **AWS Lambda workers** (secondary) — handle preview OCR, image extraction, and serve as a fallback for translation. Each Lambda invocation handles ONE page via SQS queues.
+2. **AWS Lambda workers** (secondary) — handle image extraction, user-triggered single-book OCR, and serve as a fallback for translation. Each Lambda invocation handles ONE page via SQS queues. (Import-time preview OCR used to run here; #4432 removed it — the lane bypassed the pause and the dial.)
 
 A **Writer Lambda** receives results from Lambda workers via a write-results queue and performs MongoDB writes, preventing connection storms.
 
@@ -13,7 +13,7 @@ A **Writer Lambda** receives results from Lambda workers via a write-results que
 
 | Worker | Handler | Logic | Queue | Concurrency | Active Use |
 |--------|---------|-------|-------|-------------|------------|
-| OCR | `src/workers/ocr-processor.ts` | `ocr-processor-logic.ts` | Standard (parallel) | Reserved: 10 | Preview OCR (first 25 pages) |
+| OCR | `src/workers/ocr-processor.ts` | `ocr-processor-logic.ts` | Standard (parallel) | Reserved: 10 | User-triggered OCR (`/api/jobs/queue-books`, `/api/scan/start-ocr`, job retry) and hand-run `scripts/batch/{bulk-ocr-lambda,queue-ocr-direct}.mjs`. Model = the book's (`getModelForBook`) unless `job.config.model` overrides (#4729). |
 | Translation | `src/workers/translation-processor.ts` | `translation-processor-logic.ts` | FIFO (sequential per job) | N/A | Preview translation, manual jobs only |
 | Image Extraction | `src/workers/image-extraction-processor.ts` | `image-extraction-processor-logic.ts` | Standard (parallel) | Reserved: 10 | All image extraction (Phase 8) |
 | **Writer** | `src/workers/write-processor.ts` | `write-processor-logic.ts` | Standard (batched) | Reserved: 50 | All Lambda result writes |
@@ -132,7 +132,7 @@ The Writer Lambda receives batches of up to 10 write result messages:
 
 **Classification:** `classifyError()` in `src/lib/errors.ts` → `rate_limit`, `safety_filter`, `network`, `invalid_input`, `unknown`
 
-**RECITATION fallback (OCR only):** On safety filter error with "RECITATION", retries with fallback model chain: `gemini-2.5-flash` → `gemini-2.0-flash` → `gemini-1.5-flash`
+**RECITATION fallback (OCR only):** On safety filter error with "RECITATION", retries once on the other model — lite → flash always; flash → lite only when the book is lite-eligible (`getModelForBook` would have chosen lite). Non-Latin books never step down to lite (#4523, #4729).
 
 **Logging:** All AI calls logged to `gemini_usage` via `logGeminiCall()` (non-blocking — failures don't crash workers).
 

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -26,7 +26,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Translation | **Hetzner** (`translate-worker.mjs`) | Direct Gemini calls, 40 concurrent books |
 | Batch result collection | **Hetzner** (`batch-collector.mjs`) | Polls Gemini API every 10 min |
 | Archiving | **Hetzner** (`archive-ocr.mjs`, `archive-bulk.mjs`) | Downloads → Cloudflare R2 |
-| Preview OCR (25 pages) | **Lambda** via SQS | Fast preview path, still active |
+| OCR, user-triggered / hand-run | **Lambda** via SQS (`ocr-processor-logic.ts`) | `/api/jobs/queue-books`, `/api/scan/start-ocr`, job retry, `scripts/batch/{bulk-ocr-lambda,queue-ocr-direct,queue-efm-priority}.mjs`. Realtime rate, so NOT for bulk — see "OCR lanes" below. Import-time preview OCR was removed (#4432). |
 | Image extraction | **Lambda** via SQS | Still active (Phase 8) |
 | Metadata enrichment | **Hetzner** (orchestrator Phase 3.5) | HTTP fetch to Vercel `/api/books/[id]/verify-metadata` |
 | Summary + Index | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, every 5 min, 30 books/run |
@@ -46,6 +46,35 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Translation | `gemini-3-flash-preview` | `gemini-3.1-flash-lite` |
 | Transliteration | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
 | Summary/Index/Chapters | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
+
+## OCR lanes — which producer, which lane, which model (#4729, measured 2026-09-11)
+
+The model is the BOOK's, decided by one router in three faces (`getModelForBook` TS,
+`getOcrModelForBook` / `getTranslateModelForBook` .mjs; parity pinned by
+`tests/unit/translate-core-parity.test.ts`): Latin-script allowlist → `gemini-3.1-flash-lite`,
+BPH / non-Latin script / unknown language → `gemini-3-flash-preview`. There is no
+"default batch model" constant any more; a producer that names no model gets the book's.
+
+| Producer | Lane | Model | $/1K pages (measured) |
+|---|---|---|---|
+| Orchestrator Phase 2 (`submitOcrDirectly`, cross-book pool) — ALL new pages | Hetzner → Gemini **Batch** | book's (lite for most) | **$0.85** lite batch (3,309 in + 587 out tokens/page); flash batch ≈ $1.75 |
+| Orchestrator Phase 1.5 preview (25 pages post-archive) | Batch | lite | $0.85 |
+| RECITATION ladder (orchestrator) | Batch | lite → flash → MinerU | — |
+| `/api/admin/bulk-ocr-new`, `/api/admin/bulk-reocr`, `/api/books/[id]/batch-ocr-multi` | Vercel → Gemini Batch | book's | as above |
+| `/api/jobs/queue-books`, `/api/scan/start-ocr`, `/api/jobs/[id]/retry` | SQS → **Lambda realtime** | book's (`job.config.model` overrides) | lite realtime ≈ $1.70; **flash realtime $3.42** (3,194 in + 609 out tokens/page) |
+| `scripts/batch/bulk-ocr-lambda.mjs`, `queue-ocr-direct.mjs` | SQS → Lambda realtime | book's, stamped on the job | as above |
+| `scripts/batch/queue-efm-priority.mjs` | SQS → Lambda realtime | flash (EFM/BPH by policy) | $3.42 |
+| `scripts/batch/realtime-ocr.mjs` (hand-run re-OCR) | direct Gemini realtime | flash (its selection depends on it) | ≈ $3.4, unmetered (cost 0 on rows) |
+
+Realtime is for latency (a user waiting, a retry of a handful of pages); everything
+bulk goes through the orchestrator's batch pool, which is dial-gated. The incident that
+produced this table: 125,585 import-preview pages (mostly Latin MDZ/IIIF/IA) ran through
+the Lambda on flash in four days, $430 — the Lambda fell back to a flash constant whenever
+the producer named no model. Producer removed in #4432; sink fixed in #4729.
+
+**Meter caveat:** batch rows carry `cost_usd: 0` at submission and are reconciled
+later (#4566/#4567) — `$/1K` for batch comes from the reconciled lite row (273 pages,
+$0.23), not from summing submissions.
 
 ## The Budget Dial (#3737)
 

--- a/scripts/batch/bulk-ocr-lambda.mjs
+++ b/scripts/batch/bulk-ocr-lambda.mjs
@@ -19,6 +19,7 @@ import { nanoid } from 'nanoid';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
+import { getOcrModelForBook } from '../lib/ocr-routing.mjs';
 
 // Load .env.production.local
 try {
@@ -120,7 +121,7 @@ async function main() {
 
   const books = await db.collection('books')
     .find(bookQuery, {
-      projection: { id: 1, title: 1, language: 1, pages_count: 1, pages_ocr: 1, job: 1, _id: 0 },
+      projection: { id: 1, title: 1, language: 1, 'image_source.provider': 1, pages_count: 1, pages_ocr: 1, job: 1, _id: 0 },
     })
     .sort({ pages_count: 1 })
     .toArray();
@@ -183,7 +184,9 @@ async function main() {
       book_id: book.id,
       book_title: book.title,
       progress: { total: pageIds.length, completed: 0, failed: 0 },
-      config: { page_ids: pageIds, language: book.language || 'Unknown' },
+      // The Lambda routes by book when no model is named; stamping it here makes
+      // the decision visible on the job row (#4729).
+      config: { page_ids: pageIds, model: getOcrModelForBook(book), language: book.language || 'Unknown' },
       initiated_by: INITIATED_BY,
       ...initiatedReasonFields(REASON),
       created_at: new Date(),

--- a/scripts/batch/queue-ocr-direct.mjs
+++ b/scripts/batch/queue-ocr-direct.mjs
@@ -18,6 +18,7 @@ import { MongoClient } from 'mongodb';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { randomBytes } from 'crypto';
 import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
+import { getOcrModelForBook } from '../lib/ocr-routing.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const SQS_QUEUE_URL = process.env.SQS_PAGE_OCR_QUEUE_URL;
@@ -73,7 +74,7 @@ async function run() {
   const books = await db.collection('books')
     .find({ 'pipeline_auto.status': 'archive_complete', hidden: { $ne: true } })
     .sort({ read_count: -1 })
-    .project({ id: 1, title: 1, pages_count: 1, job: 1 })
+    .project({ id: 1, title: 1, language: 1, 'image_source.provider': 1, pages_count: 1, job: 1 })
     .limit(LIMIT)
     .toArray();
 
@@ -148,7 +149,9 @@ async function run() {
         book_id: book.id,
         book_title: book.title,
         progress: { total: pageIds.length, completed: 0, failed: 0 },
-        config: { page_ids: pageIds },
+        // The Lambda routes by book when no model is named; stamping it here makes
+        // the decision visible on the job row (#4729).
+        config: { page_ids: pageIds, model: getOcrModelForBook(book) },
         failed_page_ids: [],
         // This lane is hand-run, so it says so on every row it writes (#4336).
         initiated_by: INITIATED_BY,

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -75,7 +75,6 @@ function assertModelsAreNotBroken(constants) {
   }
 }
 
-const OCR_MODEL = OCR_MODEL_FLASH; // Legacy fallback for recitation retry path
 const OCR_PROMPT_VERSION = 'v10'; // Read from DB at runtime; this label is for batch_jobs metadata only
 
 // Code provenance (#2297): the git SHA actually checked out on this worker box.

--- a/src/app/api/[tenant]/books/[id]/batch-ocr-multi/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-ocr-multi/route.ts
@@ -8,7 +8,7 @@ import { images } from '@/lib/api-client';
 import { getPageImageUrl } from '@/lib/utils';
 import { createBatchJobInline, type BatchRequest } from '@/lib/gemini-batch';
 import { PROMPT_VERSION } from '@/lib/types/prompts/defaults';
-import { DEFAULT_BATCH_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook } from '@/lib/types/ai-models';
 import type { BatchJob } from '@/lib/types/batch-job';
 import type { JobType, JobStatus } from '@/lib/types/job';
 import type { Book } from '@/lib/types/book';
@@ -66,6 +66,8 @@ export const POST = withAuth(async (request, session, context) => {
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
+    // Routed per book: Latin-script allowlist → lite, BPH / non-Latin / unknown → flash (#4729).
+    const ocrModel = getModelForBook(book);
 
     // Build filter: pages must have images, optionally filter by OCR status
     let query: any = {
@@ -193,7 +195,7 @@ export const POST = withAuth(async (request, session, context) => {
 
       // Submit to Gemini Batch API using helper
       const batchJob = await createBatchJobInline(
-        DEFAULT_BATCH_MODEL,
+        ocrModel,
         batchRequests,
         `ocr-${bookId}-${childJobId}-${Date.now()}`
       );
@@ -230,7 +232,7 @@ export const POST = withAuth(async (request, session, context) => {
         page_ids: child.pageIds,
         page_count: child.pageCount,
         status: pendingStatus,
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         language,
         prompt_id: promptRef.id,
         prompt_name: promptRef.name,
@@ -247,7 +249,7 @@ export const POST = withAuth(async (request, session, context) => {
       await logGeminiCall({
         type: jobType,
         mode: 'batch',
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         book_id: bookId,
         book_title: book.title,
         page_ids: child.pageIds,

--- a/src/app/api/admin/bulk-ocr-new/route.ts
+++ b/src/app/api/admin/bulk-ocr-new/route.ts
@@ -7,7 +7,7 @@ import { images } from '@/lib/api-client';
 import { getPageImageUrl } from '@/lib/utils';
 import { createBatchJobInline, type BatchRequest } from '@/lib/gemini-batch';
 import { PROMPT_VERSION } from '@/lib/types/prompts/defaults';
-import { DEFAULT_BATCH_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook, type RoutableBook } from '@/lib/types/ai-models';
 import { verifyCronAuth } from '@/lib/cron-auth';
 
 export const maxDuration = 300;
@@ -93,6 +93,7 @@ export async function GET(request: NextRequest) {
       projection: {
         _id: 0, id: 1, title: 1, display_title: 1,
         language: 1, original_language: 1, read_count: 1, pages_count: 1,
+        'image_source.provider': 1, // getModelForBook reads it (BPH → flash)
       }
     })
       .sort({ read_count: -1, pages_count: -1 })
@@ -156,6 +157,8 @@ export async function GET(request: NextRequest) {
 
       // Get OCR prompt for this book's language
       const language = book.original_language || book.language || '';
+      // Routed per book: Latin-script allowlist → lite, BPH / non-Latin / unknown → flash (#4729).
+      const ocrModel = getModelForBook(book as RoutableBook);
       const promptResult = await getOcrPrompt();
       const prompt = promptResult.text;
 
@@ -204,7 +207,7 @@ export async function GET(request: NextRequest) {
         try {
           const childJobId = nanoid();
           const batchJob = await createBatchJobInline(
-            DEFAULT_BATCH_MODEL,
+            ocrModel,
             batchRequests,
             `ocr-new-${book.id}-${childJobId}`
           );
@@ -218,7 +221,7 @@ export async function GET(request: NextRequest) {
             page_ids: batchRequests.map(r => r.key),
             page_count: batchRequests.length,
             status: 'pending',
-            model: DEFAULT_BATCH_MODEL,
+            model: ocrModel,
             language,
             prompt_version: PROMPT_VERSION,
             force: false,
@@ -232,7 +235,7 @@ export async function GET(request: NextRequest) {
           await logGeminiCall({
             type: 'ocr',
             mode: 'batch',
-            model: DEFAULT_BATCH_MODEL,
+            model: ocrModel,
             book_id: book.id,
             book_title: book.title,
             page_ids: batchRequests.map(r => r.key),
@@ -271,7 +274,7 @@ export async function GET(request: NextRequest) {
           pending: bookPagesSubmitted, total: bookPagesSubmitted,
         },
         status: 'pending',
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         language,
         prompt_version: PROMPT_VERSION,
         force: false,

--- a/src/app/api/admin/bulk-reocr/route.ts
+++ b/src/app/api/admin/bulk-reocr/route.ts
@@ -7,7 +7,7 @@ import { images } from '@/lib/api-client';
 import { getPageImageUrl } from '@/lib/utils';
 import { createBatchJobInline, type BatchRequest } from '@/lib/gemini-batch';
 import { PROMPT_VERSION } from '@/lib/types/prompts/defaults';
-import { DEFAULT_BATCH_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook, type RoutableBook } from '@/lib/types/ai-models';
 import { verifyCronAuth } from '@/lib/cron-auth';
 import type { Page } from '@/lib/types/page';
 
@@ -82,6 +82,7 @@ export async function GET(request: NextRequest) {
       projection: {
         _id: 0, id: 1, title: 1, display_title: 1,
         language: 1, original_language: 1, read_count: 1,
+        'image_source.provider': 1, // getModelForBook reads it (BPH → flash)
       }
     })
       .sort({ read_count: -1, pages_ocr: -1 })
@@ -148,6 +149,8 @@ export async function GET(request: NextRequest) {
 
       // Get OCR prompt for this book's language
       const language = book.original_language || book.language || '';
+      // Routed per book: Latin-script allowlist → lite, BPH / non-Latin / unknown → flash (#4729).
+      const ocrModel = getModelForBook(book as RoutableBook);
       const promptResult = await getOcrPrompt();
       const prompt = promptResult.text;
 
@@ -196,7 +199,7 @@ export async function GET(request: NextRequest) {
         try {
           const childJobId = nanoid();
           const batchJob = await createBatchJobInline(
-            DEFAULT_BATCH_MODEL,
+            ocrModel,
             batchRequests,
             `reocr-${book.id}-${childJobId}`
           );
@@ -210,7 +213,7 @@ export async function GET(request: NextRequest) {
             page_ids: batchRequests.map(r => r.key),
             page_count: batchRequests.length,
             status: 'pending',
-            model: DEFAULT_BATCH_MODEL,
+            model: ocrModel,
             language,
             prompt_version: PROMPT_VERSION,
             force: true,
@@ -224,7 +227,7 @@ export async function GET(request: NextRequest) {
           await logGeminiCall({
             type: 'ocr',
             mode: 'batch',
-            model: DEFAULT_BATCH_MODEL,
+            model: ocrModel,
             book_id: book.id,
             book_title: book.title,
             page_ids: batchRequests.map(r => r.key),
@@ -263,7 +266,7 @@ export async function GET(request: NextRequest) {
           pending: bookPagesSubmitted, total: bookPagesSubmitted,
         },
         status: 'pending',
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         language,
         prompt_version: PROMPT_VERSION,
         force: true,

--- a/src/app/api/books/[id]/batch-ocr-multi/route.ts
+++ b/src/app/api/books/[id]/batch-ocr-multi/route.ts
@@ -8,7 +8,7 @@ import { images } from '@/lib/api-client';
 import { getPageImageUrl } from '@/lib/utils';
 import { createBatchJobInline, type BatchRequest } from '@/lib/gemini-batch';
 import { PROMPT_VERSION } from '@/lib/types/prompts/defaults';
-import { DEFAULT_BATCH_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook } from '@/lib/types/ai-models';
 import type { BatchJob } from '@/lib/types/batch-job';
 import type { JobType, JobStatus } from '@/lib/types/job';
 import type { Book } from '@/lib/types/book';
@@ -59,6 +59,8 @@ export const POST = withAuth(async (request, session, context) => {
     if (!book) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
+    // Routed per book: Latin-script allowlist → lite, BPH / non-Latin / unknown → flash (#4729).
+    const ocrModel = getModelForBook(book);
 
     // Build filter: pages must have images, optionally filter by OCR status
     let query: any = {
@@ -184,7 +186,7 @@ export const POST = withAuth(async (request, session, context) => {
 
       // Submit to Gemini Batch API using helper
       const batchJob = await createBatchJobInline(
-        DEFAULT_BATCH_MODEL,
+        ocrModel,
         batchRequests,
         `ocr-${bookId}-${childJobId}-${Date.now()}`
       );
@@ -220,7 +222,7 @@ export const POST = withAuth(async (request, session, context) => {
         page_ids: child.pageIds,
         page_count: child.pageCount,
         status: pendingStatus,
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         language,
         prompt_id: promptRef.id,
         prompt_name: promptRef.name,
@@ -237,7 +239,7 @@ export const POST = withAuth(async (request, session, context) => {
       await logGeminiCall({
         type: jobType,
         mode: 'batch',
-        model: DEFAULT_BATCH_MODEL,
+        model: ocrModel,
         book_id: bookId,
         book_title: book.title,
         page_ids: child.pageIds,

--- a/src/app/api/scan/start-ocr/route.ts
+++ b/src/app/api/scan/start-ocr/route.ts
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { nanoid } from 'nanoid';
-import { DEFAULT_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook, type RoutableBook } from '@/lib/types/ai-models';
 import type { JobStatus } from '@/lib/types/job';
 import { enqueuePagesForJob } from '@/lib/queue-utils';
 
@@ -84,7 +84,8 @@ export async function POST(request: NextRequest) {
       },
       config: {
         page_ids: pageIds,
-        model: DEFAULT_MODEL,
+        // Routed per book, not a flash constant (#4729): Latin-script → lite, BPH / non-Latin / unknown → flash.
+        model: getModelForBook(book as RoutableBook),
         language: book.language || 'auto-detect',
       },
       initiated_by: 'scan_ui',

--- a/src/lib/types/ai-models.ts
+++ b/src/lib/types/ai-models.ts
@@ -10,8 +10,9 @@ export const DEFAULT_MODEL = 'gemini-3-flash-preview';
 // Cost-efficient model for standard OCR and translation
 export const DEFAULT_LITE_MODEL = 'gemini-3.1-flash-lite';
 
-// Default model for batch operations (50% cheaper via Batch API)
-export const DEFAULT_BATCH_MODEL = 'gemini-3-flash-preview';
+// There is deliberately NO "default batch model". Batch vs realtime is a
+// lane, not a quality tier; the model is the book's (`getModelForBook`). A
+// flash constant here let three batch routes ignore the router (#4729).
 
 /**
  * Languages written in Latin script that are well-represented in flash-lite's
@@ -89,7 +90,10 @@ function isLatinScriptLanguage(language: string | null | undefined): boolean {
  * - Latin-script European languages: flash-lite (50% cheaper, comparable quality)
  * - Unknown/null language: full flash (safer default)
  */
-export function getModelForBook(book: { image_source?: { provider?: string }; language?: string | null } | null): string {
+/** The two book fields the router reads. Project exactly these when looking a book up for routing. */
+export type RoutableBook = { image_source?: { provider?: string }; language?: string | null };
+
+export function getModelForBook(book: RoutableBook | null): string {
   if (book?.image_source?.provider === 'bph') {
     return DEFAULT_MODEL;
   }

--- a/src/workers/ocr-processor-logic.ts
+++ b/src/workers/ocr-processor-logic.ts
@@ -13,6 +13,7 @@
  * - jobs.findOne (check if cancelled)
  * - jobs.updateOne (set status to 'processing' — once per job)
  * - pages.findOne (get page data)
+ * - books.findOne (language + provider, for model routing — #4729)
  * - prompts.findOne (get OCR prompt)
  * - createRevision (snapshot before overwrite)
  * - jobs.updateOne (skip/already-current progress increment)
@@ -22,7 +23,7 @@ import { getDb } from '@/lib/mongodb';
 import type { PageProcessingMessage } from '@/lib/types/sqs';
 import type { OcrWriteResult, GeminiUsagePayload } from '@/lib/types/sqs';
 import { performOCRWithBuffer } from '@/lib/ai';
-import { DEFAULT_MODEL } from '@/lib/types/ai-models';
+import { DEFAULT_MODEL, DEFAULT_LITE_MODEL, getModelForBook, type RoutableBook } from '@/lib/types/ai-models';
 import { PROMPT_VERSION, extractPageType, extractColumns, extractScriptType, parseDetectedImages } from '@/lib/types/prompts/defaults';
 import { images } from '@/lib/api-client/images';
 import type { Page } from '@/lib/types/page';
@@ -116,7 +117,19 @@ export async function processOcrPage(message: PageProcessingMessage): Promise<vo
     return;
   }
 
-  const modelId = job.config.model || DEFAULT_MODEL;
+  // Model choice belongs to the BOOK, not to this worker. `job.config.model` is
+  // the override for deliberate re-OCR jobs; when the producer named nothing we
+  // consult the canonical router (BPH / non-Latin script / unknown → flash,
+  // Latin-script allowlist → lite). The old `|| DEFAULT_MODEL` here sent every
+  // model-less job to full flash: 125,585 mostly-Latin import-preview pages in
+  // four days at $3.42/1K instead of $0.85/1K (#4729; producer removed in #4432).
+  // A missing book routes to flash, the safe side of the allowlist.
+  const bookDoc = await db.collection('books').findOne(
+    { id: bookId },
+    { projection: { _id: 0, language: 1, 'image_source.provider': 1 } }
+  ) as RoutableBook | null;
+  const bookModel = getModelForBook(bookDoc);
+  const modelId: string = job.config.model || bookModel;
 
   // Get image URL with priority fallbacks
   const imageUrl = getPageImageUrl(page);
@@ -255,13 +268,16 @@ export async function processOcrPage(message: PageProcessingMessage): Promise<vo
     const classified = classifyError(error);
     console.error(`[OCR] Failed to process page ${pageId} [${classified.category}]:`, error);
 
-    // RECITATION errors: Retry with fallback model
+    // RECITATION errors: retry once on the OTHER model — but only a model the
+    // book is allowed to use. Stepping a non-Latin book down to lite is the
+    // documented hallucination case (#4523), so lite is a fallback only when
+    // the router would have chosen it for this book in the first place.
     if (classified.category === 'safety_filter' && error instanceof Error && error.message.includes('RECITATION')) {
-      const fallbackModels = ['gemini-3-flash-preview', 'gemini-3.1-flash-lite'];
-      const currentModelIndex = fallbackModels.indexOf(modelId);
-      const nextModel = fallbackModels[currentModelIndex + 1];
+      const nextModel = modelId !== DEFAULT_MODEL
+        ? DEFAULT_MODEL
+        : bookModel === DEFAULT_LITE_MODEL ? DEFAULT_LITE_MODEL : undefined;
 
-      if (nextModel && currentModelIndex < fallbackModels.length - 1) {
+      if (nextModel) {
         console.log(`[OCR] RECITATION error on ${modelId}, retrying page ${pageId} with ${nextModel}`);
         try {
           const { buffer, mimeType } = await images.fetchBufferWithMimeType(imageUrl);

--- a/tests/unit/ocr-lambda-routing.test.ts
+++ b/tests/unit/ocr-lambda-routing.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The OCR Lambda picks its Gemini model by the page's BOOK, not by a constant.
+ *
+ * `tests/unit/translate-core-parity.test.ts` pins the three routing functions
+ * against each other. This test pins the one call site that used to ignore all
+ * three: `src/workers/ocr-processor-logic.ts` read `job.config.model ||
+ * DEFAULT_MODEL`, so every job whose producer forgot to name a model ran on
+ * full flash. That is how 125,585 pages of mostly-Latin import previews went
+ * through the realtime lane at $3.42/1K instead of $0.85/1K (issue #4729;
+ * the producer was removed in #4432, this pins the sink).
+ *
+ * Probes are the same shape as the parity test: allowlist language → lite,
+ * non-Latin / unknown / BPH → flash, and an explicit `job.config.model` wins
+ * because deliberate re-OCR jobs set one on purpose.
+ *
+ * Also pinned: the RECITATION fallback ladder. It used to be a fixed
+ * `flash → lite` chain, so a Tibetan page that hit RECITATION on flash was
+ * retried on lite — the documented hallucination case (#4523). The fallback
+ * may only step onto a model the book is allowed to use.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DEFAULT_MODEL, DEFAULT_LITE_MODEL } from '@/lib/types/ai-models';
+
+type Doc = Record<string, unknown>;
+const store: Record<string, Doc[]> = { jobs: [], pages: [], books: [] };
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      findOne: async (filter: Doc) => {
+        const rows = store[name] || [];
+        return rows.find((r) => Object.entries(filter).every(([k, v]) => r[k] === v)) ?? null;
+      },
+      updateOne: vi.fn(async () => ({ modifiedCount: 1 })),
+    }),
+  })),
+}));
+
+const performOCRWithBuffer = vi.fn();
+vi.mock('@/lib/ai', () => ({ performOCRWithBuffer: (...args: unknown[]) => performOCRWithBuffer(...args) }));
+vi.mock('@/lib/sqs-client', () => ({ sendWriteResult: vi.fn(async () => undefined) }));
+vi.mock('@/lib/page-revisions', () => ({ createRevision: vi.fn(async () => undefined) }));
+vi.mock('@/lib/prompts', () => ({
+  getOcrPrompt: vi.fn(async () => ({
+    text: 'OCR PROMPT',
+    reference: { id: 'prompt-1', content_hash: 'abc', name: 'ocr', version: 1 },
+  })),
+}));
+vi.mock('@/lib/api-client/images', () => ({
+  images: { fetchBufferWithMimeType: vi.fn(async () => ({ buffer: Buffer.from('jpg'), mimeType: 'image/jpeg' })) },
+}));
+
+import { processOcrPage } from '@/workers/ocr-processor-logic';
+
+const OK = { text: 'lorem ipsum', usage: { inputTokens: 10, outputTokens: 5 } };
+
+function seed(book: Doc, jobConfig: Doc = {}) {
+  store.books = [{ id: 'b1', title: 'T', ...book }];
+  store.pages = [{ id: 'p1', book_id: 'b1', page_number: 1, archived_photo: 'https://r2.example/b1/1.jpg' }];
+  store.jobs = [{ id: 'j1', type: 'ocr', status: 'pending', config: { page_ids: ['p1'], ...jobConfig }, created_at: new Date() }];
+}
+
+const modelsUsed = () => performOCRWithBuffer.mock.calls.map((c) => c[4] as string);
+
+beforeEach(() => {
+  performOCRWithBuffer.mockReset();
+  performOCRWithBuffer.mockResolvedValue(OK);
+});
+
+describe('OCR Lambda routes by book when the job names no model', () => {
+  it.each([
+    ['latin', DEFAULT_LITE_MODEL],
+    ['English', DEFAULT_LITE_MODEL],
+    ['german', DEFAULT_LITE_MODEL],
+    ['tibetan', DEFAULT_MODEL],
+    ['malay', DEFAULT_MODEL],
+    ['sanskrit', DEFAULT_MODEL],
+    ['', DEFAULT_MODEL],
+  ])('language %j → %s', async (language, expected) => {
+    seed({ language });
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([expected]);
+  });
+
+  it('null language → flash (unknown is the unsafe case)', async () => {
+    seed({ language: null });
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL]);
+  });
+
+  it('BPH provider → flash even for Latin', async () => {
+    seed({ language: 'latin', image_source: { provider: 'bph' } });
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL]);
+  });
+
+  it('a missing book document → flash, never a throw', async () => {
+    seed({ language: 'latin' });
+    store.books = [];
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL]);
+  });
+
+  it('an explicit job.config.model wins over the book (deliberate re-OCR)', async () => {
+    seed({ language: 'latin' }, { model: DEFAULT_MODEL });
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL]);
+  });
+});
+
+describe('RECITATION fallback respects the allowlist', () => {
+  const recitation = () =>
+    Promise.reject(new Error('Gemini API error: Candidate was blocked due to RECITATION'));
+
+  it('Latin on lite → retries on flash', async () => {
+    seed({ language: 'latin' });
+    performOCRWithBuffer.mockImplementationOnce(recitation);
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_LITE_MODEL, DEFAULT_MODEL]);
+  });
+
+  it('Tibetan on flash → does NOT step down to lite', async () => {
+    seed({ language: 'tibetan' });
+    performOCRWithBuffer.mockImplementationOnce(recitation);
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL]);
+  });
+
+  it('Latin forced onto flash by the job → may step down to lite', async () => {
+    seed({ language: 'latin' }, { model: DEFAULT_MODEL });
+    performOCRWithBuffer.mockImplementationOnce(recitation);
+    await processOcrPage({ bookId: 'b1', pageId: 'p1', jobId: 'j1' });
+    expect(modelsUsed()).toEqual([DEFAULT_MODEL, DEFAULT_LITE_MODEL]);
+  });
+});


### PR DESCRIPTION
Closes #4729. Derek: "ok, move default to 3.1 flash lite batch." Handoff in the private ops repo (`handoffs/2026-09-11-ocr-default-lite-batch.md`).

## What was measured

`gemini_usage`, `type: ocr`, 30 days to 2026-09-11: **125,585 pages** through the Lambda realtime lane on `gemini-3-flash-preview` at **$3.42 / 1K pages** ($429.85; 3,194 in + 609 out tokens/page). By book: Latin 113K (MDZ / IIIF / IA / Gallica), German 4.5K, Sanskrit 3K, English 2.7K. Only 447 pages used lite. The lite batch row we have: 273 pages, $0.23 → **$0.85 / 1K**.

Attributed to `jobs`: 5,298 jobs, all `initiated_by: 'import_preview'`, `config: {page_ids, preview: true}`, 25 pages each, 2026-08-26 → 08-30. That is the import-time `queuePreviewOcr` lane, which **#4432 removed on 08-30** — so the producer is already gone (3 realtime pages since). What was still open is the *sink*: the Lambda fell back to a flash constant whenever a producer named no model, and three batch routes plus the scan route hard-coded flash too. The next forgetful producer would have repeated #4432 at 4× the price.

## What changes

- **`ocr-processor-logic.ts`** — no model on the job → look the book up (`language`, `image_source.provider`) and `getModelForBook()`. Explicit `job.config.model` still wins (deliberate re-OCR). Missing book → flash (safe side). The RECITATION fallback was a fixed `flash → lite` chain, which retried Tibetan on lite (#4523); now lite → flash always, flash → lite only when the book is lite-eligible.
- **`DEFAULT_BATCH_MODEL` deleted.** `admin/bulk-ocr-new`, `admin/bulk-reocr`, `books/[id]/batch-ocr-multi` (+ tenant copy) route by book. Projections gain `image_source.provider` so BPH still gets flash.
- **`scan/start-ocr`** wrote `model: DEFAULT_MODEL` on every job → `getModelForBook(book)`.
- **`bulk-ocr-lambda.mjs`, `queue-ocr-direct.mjs`** stamp `getOcrModelForBook(book)` on the job row so the decision is visible in `jobs`.
- **`pipeline-orchestrator.mjs`** — dead `OCR_MODEL` constant removed. (Its batch lane already routed by book; `MAX_ACTIVE_BATCH_OCR` and the dial are untouched.)
- **`memory/pipeline-ops.md`** — producer → lane → model table with the $/1K figures; the "Preview OCR (25 pages) | Lambda | still active" row is gone. `worker-architecture.md` RECITATION paragraph (still listed gemini-2.5/2.0/1.5) and the Lambda OCR row now describe the code.

## The test (red before, green after)

`tests/unit/ocr-lambda-routing.test.ts` mocks Mongo/Gemini/SQS and drives `processOcrPage` over the parity probes, asserting the model handed to `performOCRWithBuffer`.

On `main`'s `ocr-processor-logic.ts`:
```
× language "latin" → gemini-3.1-flash-lite
× language "English" → gemini-3.1-flash-lite
× language "german" → gemini-3.1-flash-lite
× Latin on lite → retries on flash
× Tibetan on flash → does NOT step down to lite
Tests  5 failed | 9 passed (14)
```
After: `Tests 277 passed (277)` (this file + `translate-core-parity`). `npx tsc --noEmit` clean.

## Stays realtime, deliberately

`/api/jobs/queue-books` (user-triggered, already routed by book), `/api/jobs/[id]/retry` (re-enqueues an existing job with its model), `queue-efm-priority.mjs` (EFM/BPH — flash by policy, explicit), `realtime-ocr.mjs` (hand-run re-OCR; the model is part of its page selection, and 2,346 of its pages in the window were deliberate). Everything bulk goes through the orchestrator's dial-gated lite batch pool, which is unchanged.

## Out of scope (noted, not done)

- `translation-processor-logic.ts:94` projects `image_source.provider` but not `language`, so its `getModelForBook` always sees no language → flash. Handoff said don't touch translation routing; filed in the issue as a follow-up.
- Admin system-map copy (`src/app/admin/system-map/page.tsx`) still says the Lambda OCR queue is "preview only" — stale since #4432, separate concern.
- Two `import_preview` jobs (50 pages) are still `pending` in `jobs`; `scripts/maintenance/cancel-stuck-preview-ocr.mjs` exists for exactly that. Not run (data action).
- Thinking config: `performOCRWithBuffer` already sets `thinkingBudget: 0` (#4581); no new `generateContent` sites.

## After merge — the Lambda has no CI

1. From the **main** checkout: `./scripts/aws-lambda/build-lambda.sh`, then `UpdateFunctionCode` on `sourcelibrary-ocr-processor` with the deployed zip's `node_modules` + the new `index.js` (memory `project_lambda_deploy_and_verification`).
2. Byte-compare the deployed `index.js` against a fresh esbuild of main.
3. 24h later: `gemini_usage` `type: ocr` by `{model, mode}` — lite+batch dominant, Latin books absent from flash-realtime. Post the table on #4729.

**Before/after:** $3.42/1K (flash realtime, measured) → $0.85/1K (lite batch, measured). The same 125K pages ≈ $430 → ≈ $107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et4q2SUcUzRR58nbX1cVpR
