### PR TITLE
page_terms: type the terms against the name tables + book-floored keep rule (#4695 steps 1–2)

### DIFF
--- a/scripts/lib/page-terms-keep.mjs
+++ b/scripts/lib/page-terms-keep.mjs
@@ -1,0 +1,60 @@
+// PRIOR ART: scripts/maintenance/aggregate-page-terms.mjs — held the pilot keep rule inline;
+// the rule now lives here so the typer, the aggregator and the unit tests apply ONE definition.
+// None of scripts/lib/* selects page-term rows by evidence strength.
+/**
+ * Keep rules for the global page-terms table (#4695): which term_keys become rows in Mongo
+ * `page_terms`. A rule is a pure function of ONE global row (as written by
+ * aggregate-page-terms.mjs) and returns the reason it keeps the row, or null.
+ *
+ * `pilot` — the original rule. Any gloss, any non-Latin term, <term>-tagged in ≥2 books,
+ *   verified original in ≥2 books, <vocab> in ≥3 books. Measured on the full corpus
+ *   (2026-09-11, 63,709 books): keeps 5.18M of 11.6M groups — it grows linearly with the
+ *   corpus because "has a gloss" and "non-Latin" are absolute filters, and most of what it
+ *   keeps is one-off names, mottoes and OCR fragments.
+ *
+ * `bridge` — the proposed rule, sized by /root/keep-rule-sweep.mjs on Hetzner over the same
+ *   table: 1,205,633 rows (281,682 non-Latin, 866,124 glossed). Keeps a row when ANY of:
+ *     - script bridge: non-Latin term with a Latin-script gloss, in ≥2 books
+ *     - synonym ring: ≥2 distinct glosses, in ≥3 books
+ *     - <term>-tagged in ≥3 books
+ *     - verified <note original> in ≥3 books
+ *     - any term in ≥10 books
+ *   The book floors are what stops the linear growth; samples confirmed it drops one-off
+ *   names and mottoes while keeping recurring terms (names included — typing is a
+ *   separate pass, scripts/lib/page-terms-type.mjs).
+ *
+ * The per-kind book counts the pilot rule needs (`term_books`, `orig_books`, `vocab_books`)
+ * exist only in the SQLite group path; a caller that has only the global row passes the
+ * total `books`, which is what the pilot rule always fell back to for glossed rows anyway.
+ */
+import { isLatinScript } from './page-terms-parse.mjs';
+
+/** A gloss written in Latin script (the bridge condition). Empty/absent gloss → false. */
+export const isLatinGloss = (g) => !!g && isLatinScript(g);
+
+export const KEEP_RULES = {
+  pilot(r, t = {}) {
+    const books = r.books || 0;
+    const glossed = (r.glosses?.length || 0) > 0;
+    const nonLatin = r.non_latin ?? !isLatinScript(r.term_key);
+    if (glossed) return 'gloss';
+    if (nonLatin && books >= (t.minNonLatinBooks ?? 1)) return 'nonLatin';
+    if ((r.kinds?.term || 0) > 0 && (r.term_books ?? books) >= (t.minTermBooks ?? 2)) return 'term2';
+    if ((r.original_verified || 0) > 0 && (r.orig_books ?? books) >= (t.minOrigBooks ?? 2)) return 'orig2';
+    if ((r.kinds?.vocab || 0) > 0 && (r.vocab_books ?? books) >= (t.minVocabBooks ?? 3)) return 'vocab3';
+    return null;
+  },
+  bridge(r) {
+    const books = r.books || 0;
+    const glosses = r.glosses || [];
+    const nonLatin = r.non_latin ?? !isLatinScript(r.term_key);
+    if (books >= 10) return 'books10';
+    if ((r.kinds?.term || 0) > 0 && books >= 3) return 'term3';
+    if ((r.original_verified || 0) > 0 && books >= 3) return 'orig3';
+    if (glosses.length >= 2 && books >= 3) return 'glosses2';
+    if (nonLatin && books >= 2 && glosses.some((g) => isLatinGloss(g.gloss))) return 'bridge';
+    return null;
+  },
+};
+
+export const RULE_NAMES = Object.keys(KEEP_RULES);

--- a/scripts/lib/page-terms-type.mjs
+++ b/scripts/lib/page-terms-type.mjs
@@ -89,3 +89,22 @@ export function typeTerm(termKeyStr, nameIndex) {
   if (ranked.length > 1 && top.weight < DOMINANCE * second) return { type: 'unknown', source: 'ambiguous', weight: top.weight, alt };
   return { type: topType, source: top.source, id: top.id, name: top.name, weight: top.weight, ...(ranked.length > 1 ? { alt } : {}) };
 }
+
+/**
+ * How much to trust a person/place verdict. Measured on the bridge-kept set (2026-09-11):
+ * 36,144 of 106,604 person/place verdicts rested on a SINGLE-book entity, and the samples of
+ * those were mostly concepts mis-extracted as names ("Certus → certain", "Bibula →
+ * absorbent", "Ostende → show", "tela → weapons"). A Wikidata-backed canonical entity is
+ * strong on its own; an extracted entity or author is strong only when ≥3 books named it
+ * AND those are ≥5% of the books the term occurs in — a true name gets extracted from a
+ * fair share of its books, a common word gets tagged as a name once by accident.
+ * Concept/unknown verdicts carry no confidence (null).
+ */
+export const STRONG_MIN_WEIGHT = 3;
+export const STRONG_MIN_RATIO = 0.05;
+export function typeConfidence(verdict, books) {
+  if (verdict.type !== 'person' && verdict.type !== 'place') return null;
+  if (verdict.source === 'canonical_entities') return 'strong';
+  const w = verdict.weight || 0;
+  return w >= STRONG_MIN_WEIGHT && w >= STRONG_MIN_RATIO * (books || 0) ? 'strong' : 'weak';
+}

--- a/scripts/lib/page-terms-type.mjs
+++ b/scripts/lib/page-terms-type.mjs
@@ -1,0 +1,91 @@
+// PRIOR ART: src/lib/entity-aliases.ts (variant → canonical NAME, one type at a time, no
+// weighting, no ambiguity verdict); src/lib/author-thesaurus.ts (`norm()` — NFD-strip +
+// lowercase on every script, which the non-Latin invariant forbids for our keys);
+// scripts/enrichment/dedup-entities.mjs (groups entity names into aliases; does not type a
+// free string). None answers "is this page term a person, a place, or a concept?".
+/**
+ * Type a page term (#4695, "type the terms — no model"). A folded term_key is joined
+ * against the three name tables we already hold — `canonical_entities` (Wikidata-backed
+ * person/place/concept), `entities` (per-book extractions, noisy, 1M rows) and `authors`
+ * (the thesaurus) — and the verdict is one of:
+ *
+ *   person | place   the name tables agree, by weight (book counts), that this is a name
+ *   concept          matched a concept-typed entity, OR matched nothing (`source: unmatched`
+ *                    — absence from the name tables is weak evidence, and a consumer reads
+ *                    `type_source` to tell the two apart)
+ *   unknown          the operation could not judge: the tables DISAGREE and neither type
+ *                    dominates (Mercury the god vs the metal; Sophia the person vs wisdom),
+ *                    or the key is too short to compare (Latin < 3 chars) or has no letters.
+ *
+ * `unknown` is its own bucket on purpose (non-latin-text-operations.md): an ambiguous or
+ * unjudgeable key must not be folded into either verdict.
+ *
+ * Folding: NFC everywhere; lowercase + diacritic-strip for Latin script ONLY — the same
+ * `termKey()` the harvest used, so the join is exact on both sides. Names of the shape
+ * "Last, First" are also indexed as "First Last".
+ */
+import { termKey, isLatinScript } from './page-terms-parse.mjs';
+
+/** Weight needed for one type to win over the runner-up (3:1). Below it → unknown. */
+export const DOMINANCE = 3;
+export const TYPES = ['person', 'place', 'concept'];
+
+/** Every folded key a name record should be found under. */
+export function nameKeys(name) {
+  if (!name || typeof name !== 'string') return [];
+  const out = new Set();
+  const k = termKey(name);
+  if (k) out.add(k);
+  const m = name.match(/^([^,()]+),\s*([^,()]+)$/); // "Cicero, Marcus Tullius" → "Marcus Tullius Cicero"
+  if (m) { const inv = termKey(`${m[2]} ${m[1]}`); if (inv) out.add(inv); }
+  return [...out];
+}
+
+/**
+ * Build the lookup from name records. Each record: { source, id, type, names: [], weight }.
+ * The index is Map<foldedKey, Map<type, { weight, source, id, name }>> — per type the
+ * summed weight and the heaviest contributing record.
+ */
+export function buildNameIndex(records) {
+  const index = new Map();
+  let indexed = 0;
+  for (const rec of records) {
+    if (!TYPES.includes(rec.type)) continue;
+    const w = Math.max(1, Number(rec.weight) || 1);
+    for (const name of rec.names || []) {
+      for (const key of nameKeys(name)) {
+        let byType = index.get(key);
+        if (!byType) { byType = new Map(); index.set(key, byType); }
+        const cur = byType.get(rec.type);
+        if (!cur) byType.set(rec.type, { weight: w, source: rec.source, id: rec.id, name, top: w });
+        else { cur.weight += w; if (w > cur.top) { cur.top = w; cur.source = rec.source; cur.id = rec.id; cur.name = name; } }
+        indexed++;
+      }
+    }
+  }
+  return { index, indexed, keys: index.size };
+}
+
+/** True when the key has too little signal to compare against a name table. */
+export function isUnjudgeable(termKeyStr) {
+  const s = String(termKeyStr || '');
+  if (!/[\p{L}\p{N}]/u.test(s)) return true; // punctuation, symbols
+  if (isLatinScript(s) && s.replace(/[^\p{L}\p{N}]/gu, '').length < 3) return true; // "ab", "x"
+  return false;
+}
+
+/**
+ * @returns {{ type, source, id?, name?, weight?, alt? }}
+ *   source: canonical_entities | entities | authors | unmatched | ambiguous | unjudgeable
+ */
+export function typeTerm(termKeyStr, nameIndex) {
+  if (isUnjudgeable(termKeyStr)) return { type: 'unknown', source: 'unjudgeable' };
+  const byType = nameIndex.index.get(termKeyStr);
+  if (!byType) return { type: 'concept', source: 'unmatched' };
+  const ranked = [...byType.entries()].sort((a, b) => b[1].weight - a[1].weight);
+  const [topType, top] = ranked[0];
+  const second = ranked[1]?.[1].weight || 0;
+  const alt = Object.fromEntries(ranked.map(([t, v]) => [t, v.weight]));
+  if (ranked.length > 1 && top.weight < DOMINANCE * second) return { type: 'unknown', source: 'ambiguous', weight: top.weight, alt };
+  return { type: topType, source: top.source, id: top.id, name: top.name, weight: top.weight, ...(ranked.length > 1 ? { alt } : {}) };
+}

--- a/scripts/maintenance/aggregate-page-terms.mjs
+++ b/scripts/maintenance/aggregate-page-terms.mjs
@@ -16,7 +16,7 @@
  *     langs: {Latin: n, …}, glosses: [{gloss, n}] (top 5), books: n, pages: n,
  *     original_verified: n, original_unverified: n,
  *     evidence: [{book_id, page_number, kind, gloss, context}] (≤5, distinct books; context = ≤120 chars of translation before a <term>/<note original>),
- *     type, type_source, type_id (with --types; see scripts/lib/page-terms-type.mjs),
+ *     type, type_source, type_confidence, type_id (with --types; scripts/lib/page-terms-type.mjs),
  *     field_provenance: {source, method, kept_because, rule, date} }
  *
  * Keep rules live in scripts/lib/page-terms-keep.mjs. `--rule pilot` (default) is the
@@ -79,6 +79,7 @@ const stampType = (row) => {
   const t = types.get(row.term_key);
   row.type = t?.type ?? 'concept';
   row.type_source = t?.type_source ?? 'unmatched';
+  row.type_confidence = t?.type_confidence ?? null;
   row.type_id = t?.type_id ?? null;
   return row;
 };

--- a/scripts/maintenance/aggregate-page-terms.mjs
+++ b/scripts/maintenance/aggregate-page-terms.mjs
@@ -16,99 +16,81 @@
  *     langs: {Latin: n, …}, glosses: [{gloss, n}] (top 5), books: n, pages: n,
  *     original_verified: n, original_unverified: n,
  *     evidence: [{book_id, page_number, kind, gloss, context}] (≤5, distinct books; context = ≤120 chars of translation before a <term>/<note original>),
- *     field_provenance: {source, method, date} }
+ *     type, type_source, type_id (with --types; see scripts/lib/page-terms-type.mjs),
+ *     field_provenance: {source, method, kept_because, rule, date} }
  *
- * Kept for Mongo (--apply) when ANY of: has a gloss; <term>-tagged in ≥2 books; verified
- * original in ≥2 books; <vocab> in ≥3 books; non-Latin script. Everything else stays in the
- * SQLite file (queryable there). Rows are upserted by term_key, so re-running after new
- * shards is safe.
+ * Keep rules live in scripts/lib/page-terms-keep.mjs. `--rule pilot` (default) is the
+ * original rule — any gloss, any non-Latin, <term> in ≥2 books, verified original in ≥2,
+ * <vocab> in ≥3 — which kept 5.18M of 11.6M groups on the full corpus and grows linearly
+ * with it. `--rule bridge` is the book-floored rule (1.21M rows measured 2026-09-11) and is
+ * what --apply should use; the default stays `pilot` so the flag change is reviewable.
+ *
+ * Two input modes:
+ *   shards (default)  --in-dir <dir>: load new shards into SQLite, group, emit. Hours on the
+ *                     full corpus — the per-group detail re-query dominates.
+ *   --from-global <global.jsonl>: re-read a table THIS script already wrote, re-apply the
+ *                     keep rule, re-stamp provenance (+ types), emit. Minutes, no SQLite.
+ *                     This is how a rule or typing change reaches Mongo without re-grouping.
  *
  *   node scripts/maintenance/aggregate-page-terms.mjs --in-dir <dir> [--db page-terms.sqlite] [--out global.jsonl]
- *   node scripts/maintenance/aggregate-page-terms.mjs --in-dir <dir> --apply
- *   thresholds: --min-term-books 2 --min-orig-books 2 --min-vocab-books 3 --min-nonlatin-books 1
+ *   node scripts/maintenance/aggregate-page-terms.mjs --from-global global.jsonl --rule bridge --types types.jsonl --out kept.jsonl --apply
+ *   pilot thresholds: --min-term-books 2 --min-orig-books 2 --min-vocab-books 3 --min-nonlatin-books 1
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
-import zlib from 'node:zlib';
+import readline from 'node:readline';
 import { MongoClient } from 'mongodb';
 import { isLatinScript } from '../lib/page-terms-parse.mjs';
+import { KEEP_RULES, RULE_NAMES } from '../lib/page-terms-keep.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (f) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : null; };
+const FROM_GLOBAL = getArg('--from-global');
 const IN_DIR = getArg('--in-dir') || 'scripts/output/page-terms';
 const DB_PATH = getArg('--db') || path.join(IN_DIR, '..', 'page-terms.sqlite');
-const OUT = getArg('--out') || path.join(IN_DIR, '..', 'page-terms-global.jsonl');
+const OUT = getArg('--out') || (FROM_GLOBAL ? FROM_GLOBAL.replace(/\.jsonl$/, '') + '-kept.jsonl' : path.join(IN_DIR, '..', 'page-terms-global.jsonl'));
 const APPLY = args.includes('--apply');
 const REBUILD = args.includes('--rebuild');
-const METHOD = 'aggregate-page-terms.mjs@2';
-// Keep thresholds (distinct books). Defaults reproduce the pilot rule; raise them on the
-// full corpus if the kept count is too large for Atlas — read the stats line first.
-const MIN_TERM_BOOKS = Number(getArg('--min-term-books') || 2);
-const MIN_ORIG_BOOKS = Number(getArg('--min-orig-books') || 2);
-const MIN_VOCAB_BOOKS = Number(getArg('--min-vocab-books') || 3);
-const MIN_NONLATIN_BOOKS = Number(getArg('--min-nonlatin-books') || 1);
+const RULE = getArg('--rule') || 'pilot';
+const TYPES = getArg('--types');
+const METHOD = 'aggregate-page-terms.mjs@3';
+// Pilot-rule thresholds (distinct books per kind). Ignored by --rule bridge.
+const PILOT_T = {
+  minTermBooks: Number(getArg('--min-term-books') || 2),
+  minOrigBooks: Number(getArg('--min-orig-books') || 2),
+  minVocabBooks: Number(getArg('--min-vocab-books') || 3),
+  minNonLatinBooks: Number(getArg('--min-nonlatin-books') || 1),
+};
 
-if (APPLY && !process.env.MONGODB_URI) {
-  console.error('MONGODB_URI not set.');
-  process.exit(1);
+if (!RULE_NAMES.includes(RULE)) { console.error(`--rule must be one of ${RULE_NAMES.join('|')}`); process.exit(1); }
+if (APPLY && !process.env.MONGODB_URI) { console.error('MONGODB_URI not set.'); process.exit(1); }
+if (FROM_GLOBAL && path.resolve(FROM_GLOBAL) === path.resolve(OUT)) { console.error('--out must differ from --from-global'); process.exit(1); }
+const keep = (row) => KEEP_RULES[RULE](row, PILOT_T);
+
+// ---- typing overlay (sparse: absent key = concept/unmatched) ----
+const types = new Map();
+if (TYPES) {
+  const rl = readline.createInterface({ input: fs.createReadStream(TYPES), crlfDelay: Infinity });
+  for await (const line of rl) { if (!line) continue; const t = JSON.parse(line); types.set(t.term_key, t); }
+  console.log(`types: ${types.size} overlay rows from ${TYPES}`);
 }
+const stampType = (row) => {
+  if (!TYPES) return row;
+  const t = types.get(row.term_key);
+  row.type = t?.type ?? 'concept';
+  row.type_source = t?.type_source ?? 'unmatched';
+  row.type_id = t?.type_id ?? null;
+  return row;
+};
 
-if (REBUILD && fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);
-const sql = new DatabaseSync(DB_PATH);
-sql.exec(`
-  PRAGMA journal_mode = OFF; PRAGMA synchronous = OFF; PRAGMA temp_store = FILE;
-  CREATE TABLE IF NOT EXISTS raw (term_key TEXT, term TEXT, kind TEXT, lang TEXT, gloss TEXT, book_id TEXT, page_number INTEGER, verified INTEGER, context TEXT);
-  CREATE TABLE IF NOT EXISTS loaded (book_id TEXT PRIMARY KEY);
-`);
-
-// ---- load shards (skip books already loaded) ----
-const shards = fs.readdirSync(IN_DIR).filter((f) => f.endsWith('.jsonl') || f.endsWith('.jsonl.gz'));
-const isLoaded = sql.prepare('SELECT 1 FROM loaded WHERE book_id = ?');
-const markLoaded = sql.prepare('INSERT INTO loaded (book_id) VALUES (?)');
-const ins = sql.prepare('INSERT INTO raw VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-let loaded = 0, rows = 0;
-for (const f of shards) {
-  const bookId = f.replace(/\.jsonl(\.gz)?$/, '');
-  if (isLoaded.get(bookId)) continue;
-  const buf = fs.readFileSync(path.join(IN_DIR, f));
-  const text = f.endsWith('.gz') ? zlib.gunzipSync(buf).toString('utf8') : buf.toString('utf8');
-  sql.exec('BEGIN');
-  for (const line of text.split('\n')) {
-    if (!line) continue;
-    const r = JSON.parse(line);
-    ins.run(r.term_key, r.term, r.kind, r.lang ?? null, r.gloss ?? null, r.book_id, r.page_number, r.verified === true ? 1 : r.verified === false ? 0 : null, r.context ?? null);
-    rows++;
-  }
-  markLoaded.run(bookId);
-  sql.exec('COMMIT');
-  loaded++;
-  if (loaded % 500 === 0) console.log(`loaded ${loaded} shards · ${rows} rows`);
-}
-console.log(`shards: ${shards.length} (${loaded} newly loaded, ${rows} rows)`);
-sql.exec('CREATE INDEX IF NOT EXISTS raw_key ON raw (term_key)');
-
-// ---- group ----
-const groups = sql.prepare(`
-  SELECT term_key,
-         COUNT(*) AS n,
-         COUNT(DISTINCT book_id) AS books,
-         COUNT(DISTINCT book_id || ':' || page_number) AS pages,
-         SUM(kind='vocab') AS k_vocab, SUM(kind='term') AS k_term, SUM(kind='keyword') AS k_keyword, SUM(kind='original') AS k_original,
-         SUM(kind='original' AND verified=1) AS ov, SUM(kind='original' AND verified=0) AS ou,
-         SUM(gloss IS NOT NULL) AS glossed
-  FROM raw GROUP BY term_key
-`);
-const detail = sql.prepare('SELECT term, kind, lang, gloss, book_id, page_number, verified, context FROM raw WHERE term_key = ? ORDER BY (gloss IS NULL), (context IS NULL)');
-const distinctBooksBy = sql.prepare("SELECT COUNT(DISTINCT book_id) AS b FROM raw WHERE term_key = ? AND kind = ? AND (? IS NULL OR verified = ?)");
-
-// fs.writeSync, NOT a WriteStream: the group loop outruns the disk and an un-awaited
-// stream.write() buffers everything in memory — the first corpus run was OOM-killed at
-// 9.8 GB RSS after 4 GiB of output (2026-09-11).
+// ---- output: fs.writeSync, NOT a WriteStream ----
+// The group loop outruns the disk and an un-awaited stream.write() buffers everything in
+// memory — the first corpus run was OOM-killed at 9.8 GB RSS after 4 GiB of output; a
+// WriteStream also fails at exactly 4 GiB (writev, Node 25). (2026-09-11)
 const outFd = fs.openSync(OUT, 'w');
-const stats = { groups: 0, kept: 0, why: { gloss: 0, term2: 0, orig2: 0, vocab3: 0, nonLatin: 0 } };
+const stats = { groups: 0, kept: 0, why: {}, types: {} };
 const now = new Date();
-// --apply streams upserts in batches of 1,000 as groups are produced; nothing is retained.
+// --apply streams upserts in batches of 1,000 as rows are produced; nothing is retained.
 let col = null, written = 0;
 const batch = [];
 async function flush() {
@@ -120,54 +102,134 @@ async function flush() {
     await col.createIndex({ term_key: 1 }, { unique: true });
     await col.createIndex({ books: -1 });
     await col.createIndex({ 'glosses.gloss': 1 });
+    await col.createIndex({ type: 1, books: -1 });
     process.on('exit', () => client.close());
   }
   const res = await col.bulkWrite(batch.splice(0), { ordered: false });
   written += res.upsertedCount + res.matchedCount;
 }
-for (const g of groups.iterate()) {
-  stats.groups++;
-  const nonLatin = !isLatinScript(g.term_key);
-  let why = null;
-  if (g.glossed > 0) why = 'gloss';
-  else if (nonLatin && g.books >= MIN_NONLATIN_BOOKS) why = 'nonLatin';
-  else if (g.k_term > 0 && distinctBooksBy.get(g.term_key, 'term', null, null).b >= MIN_TERM_BOOKS) why = 'term2';
-  else if (g.ov > 0 && distinctBooksBy.get(g.term_key, 'original', 1, 1).b >= MIN_ORIG_BOOKS) why = 'orig2';
-  else if (g.k_vocab > 0 && distinctBooksBy.get(g.term_key, 'vocab', null, null).b >= MIN_VOCAB_BOOKS) why = 'vocab3';
-  if (!why) continue;
-  stats.kept++; stats.why[why]++;
-
-  const surface = new Map(), langs = {}, glosses = new Map(), evidence = [], evBooks = new Set();
-  for (const d of detail.iterate(g.term_key)) {
-    surface.set(d.term, (surface.get(d.term) || 0) + 1);
-    if (d.lang) langs[d.lang] = (langs[d.lang] || 0) + 1;
-    if (d.gloss) glosses.set(d.gloss, (glosses.get(d.gloss) || 0) + 1);
-    if (evidence.length < 5 && !evBooks.has(d.book_id) && (d.kind !== 'original' || d.verified === 1)) {
-      evBooks.add(d.book_id);
-      evidence.push({ book_id: d.book_id, page_number: d.page_number, kind: d.kind, gloss: d.gloss, context: d.context });
-    }
-  }
-  const row = {
-    term_key: g.term_key,
-    term: [...surface.entries()].sort((a, b) => b[1] - a[1])[0][0],
-    kinds: { vocab: g.k_vocab, term: g.k_term, keyword: g.k_keyword, original: g.k_original },
-    langs,
-    glosses: [...glosses.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5).map(([gloss, n]) => ({ gloss, n })),
-    books: g.books, pages: g.pages,
-    original_verified: g.ov, original_unverified: g.ou,
-    non_latin: nonLatin,
-    evidence,
-    field_provenance: { source: 'ocr.data <vocab> + translation.data <term>/<gloss>/<keywords>/<note original>', method: METHOD, kept_because: why, date: now },
-  };
+async function emit(row, why) {
+  stats.kept++;
+  stats.why[why] = (stats.why[why] || 0) + 1;
+  stampType(row);
+  if (TYPES) stats.types[row.type] = (stats.types[row.type] || 0) + 1;
+  row.field_provenance = { ...row.field_provenance, method: METHOD, kept_because: why, rule: RULE, date: now };
   fs.writeSync(outFd, JSON.stringify(row) + '\n');
   if (APPLY) {
     batch.push({ replaceOne: { filter: { term_key: row.term_key }, replacement: row, upsert: true } });
     if (batch.length >= 1000) await flush();
   }
 }
+
+if (FROM_GLOBAL) {
+  // ---- re-filter an existing global table ----
+  const rl = readline.createInterface({ input: fs.createReadStream(FROM_GLOBAL), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line) continue;
+    const row = JSON.parse(line);
+    stats.groups++;
+    const why = keep(row);
+    if (why) await emit(row, why);
+    if (stats.groups % 1000000 === 0) console.log(`${stats.groups} rows · kept ${stats.kept}`);
+  }
+} else {
+  const { DatabaseSync } = await import('node:sqlite');
+  const zlib = await import('node:zlib');
+  if (REBUILD && fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);
+  const sql = new DatabaseSync(DB_PATH);
+  sql.exec(`
+    PRAGMA journal_mode = OFF; PRAGMA synchronous = OFF; PRAGMA temp_store = FILE;
+    CREATE TABLE IF NOT EXISTS raw (term_key TEXT, term TEXT, kind TEXT, lang TEXT, gloss TEXT, book_id TEXT, page_number INTEGER, verified INTEGER, context TEXT);
+    CREATE TABLE IF NOT EXISTS loaded (book_id TEXT PRIMARY KEY);
+  `);
+
+  // ---- load shards (skip books already loaded) ----
+  const shards = fs.readdirSync(IN_DIR).filter((f) => f.endsWith('.jsonl') || f.endsWith('.jsonl.gz'));
+  const isLoaded = sql.prepare('SELECT 1 FROM loaded WHERE book_id = ?');
+  const markLoaded = sql.prepare('INSERT INTO loaded (book_id) VALUES (?)');
+  const ins = sql.prepare('INSERT INTO raw VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+  let loaded = 0, rows = 0;
+  for (const f of shards) {
+    const bookId = f.replace(/\.jsonl(\.gz)?$/, '');
+    if (isLoaded.get(bookId)) continue;
+    const buf = fs.readFileSync(path.join(IN_DIR, f));
+    const text = f.endsWith('.gz') ? zlib.gunzipSync(buf).toString('utf8') : buf.toString('utf8');
+    sql.exec('BEGIN');
+    for (const line of text.split('\n')) {
+      if (!line) continue;
+      const r = JSON.parse(line);
+      ins.run(r.term_key, r.term, r.kind, r.lang ?? null, r.gloss ?? null, r.book_id, r.page_number, r.verified === true ? 1 : r.verified === false ? 0 : null, r.context ?? null);
+      rows++;
+    }
+    markLoaded.run(bookId);
+    sql.exec('COMMIT');
+    loaded++;
+    if (loaded % 500 === 0) console.log(`loaded ${loaded} shards · ${rows} rows`);
+  }
+  console.log(`shards: ${shards.length} (${loaded} newly loaded, ${rows} rows)`);
+  sql.exec('CREATE INDEX IF NOT EXISTS raw_key ON raw (term_key)');
+
+  // ---- group ----
+  const groups = sql.prepare(`
+    SELECT term_key,
+           COUNT(*) AS n,
+           COUNT(DISTINCT book_id) AS books,
+           COUNT(DISTINCT book_id || ':' || page_number) AS pages,
+           SUM(kind='vocab') AS k_vocab, SUM(kind='term') AS k_term, SUM(kind='keyword') AS k_keyword, SUM(kind='original') AS k_original,
+           SUM(kind='original' AND verified=1) AS ov, SUM(kind='original' AND verified=0) AS ou,
+           SUM(gloss IS NOT NULL) AS glossed, COUNT(DISTINCT gloss) AS glosses_distinct
+    FROM raw GROUP BY term_key
+  `);
+  const detail = sql.prepare('SELECT term, kind, lang, gloss, book_id, page_number, verified, context FROM raw WHERE term_key = ? ORDER BY (gloss IS NULL), (context IS NULL)');
+  const distinctBooksBy = sql.prepare("SELECT COUNT(DISTINCT book_id) AS b FROM raw WHERE term_key = ? AND kind = ? AND (? IS NULL OR verified = ?)");
+  const distinctGlosses = sql.prepare('SELECT DISTINCT gloss FROM raw WHERE term_key = ? AND gloss IS NOT NULL LIMIT 20');
+
+  /** The rule's view of a group, before the (slow) detail pass. Per-kind book counts and the
+   *  gloss strings are fetched lazily — only the branch that needs them pays for the query. */
+  const preRow = (g, nonLatin) => ({
+    term_key: g.term_key, books: g.books, non_latin: nonLatin,
+    kinds: { vocab: g.k_vocab, term: g.k_term, keyword: g.k_keyword, original: g.k_original },
+    original_verified: g.ov,
+    get glosses() { return g.glossed ? (nonLatin ? distinctGlosses.all(g.term_key) : Array.from({ length: g.glosses_distinct }, () => ({ gloss: null }))) : []; },
+    get term_books() { return distinctBooksBy.get(g.term_key, 'term', null, null).b; },
+    get orig_books() { return distinctBooksBy.get(g.term_key, 'original', 1, 1).b; },
+    get vocab_books() { return distinctBooksBy.get(g.term_key, 'vocab', null, null).b; },
+  });
+
+  for (const g of groups.iterate()) {
+    stats.groups++;
+    const nonLatin = !isLatinScript(g.term_key);
+    const why = keep(preRow(g, nonLatin));
+    if (!why) continue;
+
+    const surface = new Map(), langs = {}, glosses = new Map(), evidence = [], evBooks = new Set();
+    for (const d of detail.iterate(g.term_key)) {
+      surface.set(d.term, (surface.get(d.term) || 0) + 1);
+      if (d.lang) langs[d.lang] = (langs[d.lang] || 0) + 1;
+      if (d.gloss) glosses.set(d.gloss, (glosses.get(d.gloss) || 0) + 1);
+      if (evidence.length < 5 && !evBooks.has(d.book_id) && (d.kind !== 'original' || d.verified === 1)) {
+        evBooks.add(d.book_id);
+        evidence.push({ book_id: d.book_id, page_number: d.page_number, kind: d.kind, gloss: d.gloss, context: d.context });
+      }
+    }
+    await emit({
+      term_key: g.term_key,
+      term: [...surface.entries()].sort((a, b) => b[1] - a[1])[0][0],
+      kinds: { vocab: g.k_vocab, term: g.k_term, keyword: g.k_keyword, original: g.k_original },
+      langs,
+      glosses: [...glosses.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5).map(([gloss, n]) => ({ gloss, n })),
+      books: g.books, pages: g.pages,
+      original_verified: g.ov, original_unverified: g.ou,
+      non_latin: nonLatin,
+      evidence,
+      field_provenance: { source: 'ocr.data <vocab> + translation.data <term>/<gloss>/<keywords>/<note original>' },
+    }, why);
+  }
+  console.log(`sqlite → ${DB_PATH}`);
+}
+
 if (APPLY) await flush();
 fs.closeSync(outFd);
-console.log(JSON.stringify(stats));
-console.log(`global table → ${OUT}; sqlite → ${DB_PATH}`);
-
+console.log(JSON.stringify({ ...stats, rule: RULE, typed: !!TYPES }));
+console.log(`global table → ${OUT}`);
 if (APPLY) console.log(`page_terms: ${written} rows upserted`);

--- a/scripts/maintenance/type-page-terms.mjs
+++ b/scripts/maintenance/type-page-terms.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// PRIOR ART: scripts/enrichment/dedup-entities.mjs (merges entity NAMES into aliases — it
+// types nothing and needs Gemini for phase 2); src/lib/entity-aliases.ts (resolves a name to
+// its canonical form, caller supplies the type); src/lib/author-thesaurus.ts (people only,
+// read-path). None labels a free term as person/place/concept; #4695.
+/**
+ * type-page-terms — label every row of the global page-terms table as person | place |
+ * concept | unknown by joining its folded term_key against the name tables we already hold
+ * (no model call). The logic is scripts/lib/page-terms-type.mjs; this file is the I/O:
+ *
+ *   1. load name records from Mongo — canonical_entities (name + aliases, type), entities
+ *      (name + aliases, type, book_count), authors (canonical_name + variants + aliases,
+ *      person unless is_person === false) — and cache them to --names-out so a re-run
+ *      needs no database;
+ *   2. stream --in (the 4.4 GB global JSONL written by aggregate-page-terms.mjs) and write
+ *      a SPARSE overlay to --out: one line per term_key whose verdict is not the default
+ *      (concept/unmatched) — {term_key, type, type_source, type_id, type_name, type_weight}.
+ *      aggregate-page-terms.mjs --types <overlay> stamps these onto the rows it writes;
+ *   3. print a stats line (all rows, and the subset kept by --rule) plus 20 samples per
+ *      type, and run the positive controls (--check): aquilius → person, acraephia → place,
+ *      prima materia / 三昧 / ذكر → concept. A failed control is REPORTED, not fatal — the
+ *      first run found Acraephia in none of the three tables, which is a finding about the
+ *      tables, not the join.
+ *
+ *   node --env-file=.env.production.local scripts/maintenance/type-page-terms.mjs \
+ *     --in page-terms-global.jsonl --out page-terms-types.jsonl --rule bridge --check \
+ *     --names-out page-terms-names.json
+ *   node scripts/maintenance/type-page-terms.mjs --names page-terms-names.json --in … --out …
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+import { buildNameIndex, typeTerm } from '../lib/page-terms-type.mjs';
+import { KEEP_RULES, RULE_NAMES } from '../lib/page-terms-keep.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (f) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : null; };
+const IN = getArg('--in');
+const OUT = getArg('--out') || 'page-terms-types.jsonl';
+const NAMES = getArg('--names');
+const NAMES_OUT = getArg('--names-out');
+const RULE = getArg('--rule');
+const CHECK = args.includes('--check');
+const SAMPLES = Number(getArg('--samples') || 20);
+if (!IN) { console.error('--in <global.jsonl> is required'); process.exit(1); }
+if (RULE && !RULE_NAMES.includes(RULE)) { console.error(`--rule must be one of ${RULE_NAMES.join('|')}`); process.exit(1); }
+
+// ---- name records ----
+async function loadNamesFromMongo() {
+  if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set (or pass --names <cache.json>)'); process.exit(1); }
+  const { MongoClient } = await import('mongodb');
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const records = [];
+  for await (const d of db.collection('canonical_entities').find({}, { projection: { name: 1, aliases: 1, type: 1, book_count: 1 } })) {
+    records.push({ source: 'canonical_entities', id: String(d._id), type: d.type, names: [d.name, ...(d.aliases || [])].filter(Boolean), weight: d.book_count || 1 });
+  }
+  for await (const d of db.collection('entities').find({}, { projection: { name: 1, aliases: 1, type: 1, book_count: 1 } })) {
+    records.push({ source: 'entities', id: String(d._id), type: d.type, names: [d.name, ...(d.aliases || [])].filter(Boolean), weight: d.book_count || 1 });
+  }
+  for await (const d of db.collection('authors').find({ is_person: { $ne: false }, merged_into: { $exists: false } }, { projection: { canonical_name: 1, variants: 1, aliases: 1, book_count: 1 } })) {
+    records.push({ source: 'authors', id: String(d._id), type: 'person', names: [d.canonical_name, ...(d.variants || []), ...(d.aliases || [])].filter(Boolean), weight: d.book_count || 1 });
+  }
+  await client.close();
+  return records;
+}
+
+const t0 = Date.now();
+const records = NAMES ? JSON.parse(fs.readFileSync(NAMES, 'utf8')) : await loadNamesFromMongo();
+if (NAMES_OUT) fs.writeFileSync(NAMES_OUT, JSON.stringify(records));
+const bySource = {};
+for (const r of records) bySource[r.source] = (bySource[r.source] || 0) + 1;
+const nameIndex = buildNameIndex(records);
+console.log(`names: ${records.length} records ${JSON.stringify(bySource)} → ${nameIndex.keys} folded keys (${nameIndex.indexed} name→key entries) in ${((Date.now() - t0) / 1000).toFixed(0)}s`);
+
+// ---- stream the global table ----
+const bucket = () => ({ person: 0, place: 0, concept: 0, unknown: 0 });
+const stats = { rows: 0, all: bucket(), allSource: {}, kept: 0, keptType: bucket(), keptSource: {}, weight1: bucket() };
+const samples = { person: [], place: [], concept: [], unknown: [], weight1: [] };
+// Measurement only: would a gloss-shape heuristic recover names the tables miss?
+const PLACE_GLOSS = /\b(city|town|village|river|mountain|island|region|province|kingdom|country|port|lake|sea|valley|district|capital)\b/i;
+const PERSON_GLOSS = /\b(king|queen|emperor|philosopher|saint|bishop|pope|poet|prophet|son of|daughter of|disciple|abbot|monk|scholar|physician|general|prince|duke|caliph|sultan|rabbi|sage|master|teacher|author)\b/i;
+const hint = { place: 0, person: 0, samples: { place: [], person: [] } };
+const fmt = (r, t) => `${r.term} [${r.books}b${t.weight ? ` w${t.weight}` : ''}${t.source ? ` ${t.source}` : ''}]${t.name && t.name !== r.term ? ` =${t.name}` : ''} ${(r.glosses || []).slice(0, 2).map((g) => g.gloss).join(' / ')}`.slice(0, 140);
+const reservoir = (arr, s, n) => { if (arr.length < SAMPLES) arr.push(s); else if (Math.random() < SAMPLES / n) arr[Math.floor(Math.random() * SAMPLES)] = s; };
+
+const outFd = fs.openSync(OUT, 'w');
+let overlay = 0;
+const controls = new Map([['aquilius', 'person'], ['acraephia', 'place'], ['prima materia', 'concept'], ['三昧', 'concept'], ['ذكر', 'concept']]);
+const controlSeen = new Map();
+const rl = readline.createInterface({ input: fs.createReadStream(IN), crlfDelay: Infinity });
+for await (const line of rl) {
+  if (!line) continue;
+  const r = JSON.parse(line);
+  stats.rows++;
+  const t = typeTerm(r.term_key, nameIndex);
+  stats.all[t.type]++;
+  stats.allSource[t.source] = (stats.allSource[t.source] || 0) + 1;
+  if (controls.has(r.term_key)) controlSeen.set(r.term_key, t);
+  if (!(t.type === 'concept' && t.source === 'unmatched')) {
+    fs.writeSync(outFd, JSON.stringify({ term_key: r.term_key, type: t.type, type_source: t.source, type_id: t.id ?? null, type_name: t.name ?? null, type_weight: t.weight ?? null }) + '\n');
+    overlay++;
+  }
+  const kept = RULE ? KEEP_RULES[RULE](r) : true;
+  if (!kept) continue;
+  stats.kept++;
+  stats.keptType[t.type]++;
+  stats.keptSource[t.source] = (stats.keptSource[t.source] || 0) + 1;
+  reservoir(samples[t.type], fmt(r, t), stats.keptType[t.type]);
+  if ((t.type === 'person' || t.type === 'place') && t.weight === 1) { stats.weight1[t.type]++; reservoir(samples.weight1, fmt(r, t), stats.weight1.person + stats.weight1.place); }
+  if (t.source === 'unmatched') {
+    const g = (r.glosses || []).map((x) => x.gloss).join(' | ');
+    if (PLACE_GLOSS.test(g)) { hint.place++; reservoir(hint.samples.place, fmt(r, t), hint.place); }
+    else if (PERSON_GLOSS.test(g)) { hint.person++; reservoir(hint.samples.person, fmt(r, t), hint.person); }
+  }
+  if (stats.rows % 1000000 === 0) console.log(`${stats.rows} rows · kept ${stats.kept} · ${((Date.now() - t0) / 1000).toFixed(0)}s`);
+}
+fs.closeSync(outFd);
+
+console.log(JSON.stringify({ ...stats, rule: RULE || 'none', overlay_rows: overlay, seconds: Math.round((Date.now() - t0) / 1000) }));
+for (const k of ['person', 'place', 'concept', 'unknown']) console.log(`\n== ${k} (${RULE ? 'kept by ' + RULE : 'all'}) ==\n` + samples[k].map((s) => '  ' + s).join('\n'));
+console.log(`\n== person/place decided on weight 1 (single-book entity only) ==\n` + samples.weight1.map((s) => '  ' + s).join('\n'));
+console.log(`\n== gloss-shape hint on UNMATCHED kept rows (measurement only, not applied): place-like ${hint.place}, person-like ${hint.person} ==`);
+console.log('  place-like: ' + hint.samples.place.join(' | '));
+console.log('  person-like: ' + hint.samples.person.join(' | '));
+if (CHECK) {
+  console.log('\n== positive controls ==');
+  for (const [k, want] of controls) {
+    const got = controlSeen.get(k);
+    const ok = got && got.type === want;
+    console.log(`  ${ok ? 'PASS' : 'FAIL'} ${k} → ${got ? `${got.type}/${got.source}${got.weight ? ' w' + got.weight : ''}` : 'NOT IN TABLE'} (want ${want})`);
+  }
+}
+console.log(`overlay → ${OUT} (${overlay} rows; every other term_key is concept/unmatched)`);

--- a/scripts/maintenance/type-page-terms.mjs
+++ b/scripts/maintenance/type-page-terms.mjs
@@ -29,7 +29,7 @@
  */
 import fs from 'node:fs';
 import readline from 'node:readline';
-import { buildNameIndex, typeTerm } from '../lib/page-terms-type.mjs';
+import { buildNameIndex, typeTerm, typeConfidence } from '../lib/page-terms-type.mjs';
 import { KEEP_RULES, RULE_NAMES } from '../lib/page-terms-keep.mjs';
 
 const args = process.argv.slice(2);
@@ -75,8 +75,8 @@ console.log(`names: ${records.length} records ${JSON.stringify(bySource)} → ${
 
 // ---- stream the global table ----
 const bucket = () => ({ person: 0, place: 0, concept: 0, unknown: 0 });
-const stats = { rows: 0, all: bucket(), allSource: {}, kept: 0, keptType: bucket(), keptSource: {}, weight1: bucket() };
-const samples = { person: [], place: [], concept: [], unknown: [], weight1: [] };
+const stats = { rows: 0, all: bucket(), allSource: {}, kept: 0, keptType: bucket(), keptSource: {}, keptConfidence: { strong: 0, weak: 0 }, weight1: bucket() };
+const samples = { person: [], place: [], concept: [], unknown: [], weight1: [], strong: [], weak: [] };
 // Measurement only: would a gloss-shape heuristic recover names the tables miss?
 const PLACE_GLOSS = /\b(city|town|village|river|mountain|island|region|province|kingdom|country|port|lake|sea|valley|district|capital)\b/i;
 const PERSON_GLOSS = /\b(king|queen|emperor|philosopher|saint|bishop|pope|poet|prophet|son of|daughter of|disciple|abbot|monk|scholar|physician|general|prince|duke|caliph|sultan|rabbi|sage|master|teacher|author)\b/i;
@@ -94,11 +94,12 @@ for await (const line of rl) {
   const r = JSON.parse(line);
   stats.rows++;
   const t = typeTerm(r.term_key, nameIndex);
+  t.confidence = typeConfidence(t, r.books);
   stats.all[t.type]++;
   stats.allSource[t.source] = (stats.allSource[t.source] || 0) + 1;
   if (controls.has(r.term_key)) controlSeen.set(r.term_key, t);
   if (!(t.type === 'concept' && t.source === 'unmatched')) {
-    fs.writeSync(outFd, JSON.stringify({ term_key: r.term_key, type: t.type, type_source: t.source, type_id: t.id ?? null, type_name: t.name ?? null, type_weight: t.weight ?? null }) + '\n');
+    fs.writeSync(outFd, JSON.stringify({ term_key: r.term_key, type: t.type, type_source: t.source, type_confidence: t.confidence, type_id: t.id ?? null, type_name: t.name ?? null, type_weight: t.weight ?? null }) + '\n');
     overlay++;
   }
   const kept = RULE ? KEEP_RULES[RULE](r) : true;
@@ -106,6 +107,7 @@ for await (const line of rl) {
   stats.kept++;
   stats.keptType[t.type]++;
   stats.keptSource[t.source] = (stats.keptSource[t.source] || 0) + 1;
+  if (t.confidence) { stats.keptConfidence[t.confidence]++; reservoir(samples[t.confidence], fmt(r, t), stats.keptConfidence[t.confidence]); }
   reservoir(samples[t.type], fmt(r, t), stats.keptType[t.type]);
   if ((t.type === 'person' || t.type === 'place') && t.weight === 1) { stats.weight1[t.type]++; reservoir(samples.weight1, fmt(r, t), stats.weight1.person + stats.weight1.place); }
   if (t.source === 'unmatched') {
@@ -120,6 +122,7 @@ fs.closeSync(outFd);
 console.log(JSON.stringify({ ...stats, rule: RULE || 'none', overlay_rows: overlay, seconds: Math.round((Date.now() - t0) / 1000) }));
 for (const k of ['person', 'place', 'concept', 'unknown']) console.log(`\n== ${k} (${RULE ? 'kept by ' + RULE : 'all'}) ==\n` + samples[k].map((s) => '  ' + s).join('\n'));
 console.log(`\n== person/place decided on weight 1 (single-book entity only) ==\n` + samples.weight1.map((s) => '  ' + s).join('\n'));
+for (const k of ['strong', 'weak']) console.log(`\n== person/place with type_confidence=${k} ==\n` + samples[k].map((s) => '  ' + s).join('\n'));
 console.log(`\n== gloss-shape hint on UNMATCHED kept rows (measurement only, not applied): place-like ${hint.place}, person-like ${hint.person} ==`);
 console.log('  place-like: ' + hint.samples.place.join(' | '));
 console.log('  person-like: ' + hint.samples.person.join(' | '));

--- a/tests/unit/page-terms-type.test.ts
+++ b/tests/unit/page-terms-type.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #4695 — typing page terms against the name tables, and the keep rules. Positive controls
+ * in four non-Latin scripts because a join tested only on Latin passes while silently
+ * mis-typing everything else (non-latin-text-operations.md); `unknown` must stay its own
+ * bucket — an ambiguous or unjudgeable key is never folded into either verdict.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildNameIndex, typeTerm, nameKeys, isUnjudgeable } from '../../scripts/lib/page-terms-type.mjs';
+import { KEEP_RULES } from '../../scripts/lib/page-terms-keep.mjs';
+
+const index = buildNameIndex([
+  { source: 'entities', id: 'e1', type: 'person', names: ['Aquilius'], weight: 46 },
+  { source: 'entities', id: 'e2', type: 'place', names: ['Aquilius'], weight: 1 },
+  { source: 'canonical_entities', id: 'Q220', type: 'place', names: ['Rome', 'Roma'], weight: 6301 },
+  { source: 'authors', id: 'cicero', type: 'person', names: ['Cicero, Marcus Tullius', 'Cicero'], weight: 125 },
+  { source: 'canonical_entities', id: 'Qm1', type: 'person', names: ['Mercury'], weight: 849 },
+  { source: 'canonical_entities', id: 'Qm2', type: 'concept', names: ['Mercury'], weight: 630 },
+  { source: 'entities', id: 'e3', type: 'concept', names: ['Hesychia'], weight: 7 },
+  { source: 'entities', id: 'e4', type: 'person', names: ['Hesychia'], weight: 1 },
+  { source: 'entities', id: 'e5', type: 'concept', names: ['Prima Materia', 'First Matter'], weight: 112 },
+  // non-Latin names — exact NFC match, no case fold
+  { source: 'canonical_entities', id: 'Q956', type: 'place', names: ['北京'], weight: 40 },
+  { source: 'canonical_entities', id: 'Q1', type: 'person', names: ['ابن سينا'], weight: 30 },
+  { source: 'canonical_entities', id: 'Q2', type: 'place', names: ['ירושלים'], weight: 50 },
+  { source: 'canonical_entities', id: 'Q3', type: 'person', names: ['पतञ्जलि'], weight: 12 },
+  { source: 'authors', id: 'x', type: 'weird', names: ['Ignored'], weight: 9 },
+]);
+
+describe('nameKeys', () => {
+  it('folds Latin, keeps other scripts, inverts "Last, First"', () => {
+    expect(nameKeys('Samādhi')).toEqual(['samadhi']);
+    expect(nameKeys('Cicero, Marcus Tullius')).toEqual(['cicero, marcus tullius', 'marcus tullius cicero']);
+    expect(nameKeys('ابن سينا')).toEqual(['ابن سينا']);
+    expect(nameKeys('')).toEqual([]);
+  });
+});
+
+describe('typeTerm', () => {
+  it('positive controls from the handoff', () => {
+    expect(typeTerm('aquilius', index)).toMatchObject({ type: 'person', source: 'entities', id: 'e1', weight: 46 });
+    expect(typeTerm('prima materia', index)).toMatchObject({ type: 'concept', source: 'entities' });
+    expect(typeTerm('三昧', index)).toMatchObject({ type: 'concept', source: 'unmatched' });
+    expect(typeTerm('ذكر', index)).toMatchObject({ type: 'concept', source: 'unmatched' });
+  });
+  it('matches non-Latin names exactly (Chinese, Arabic, Hebrew, Devanagari)', () => {
+    expect(typeTerm('北京', index).type).toBe('place');
+    expect(typeTerm('ابن سينا', index).type).toBe('person');
+    expect(typeTerm('ירושלים', index).type).toBe('place');
+    expect(typeTerm('पतञ्जलि', index).type).toBe('person');
+  });
+  it('matches through aliases and inverted author forms', () => {
+    expect(typeTerm('roma', index)).toMatchObject({ type: 'place', id: 'Q220' });
+    expect(typeTerm('marcus tullius cicero', index)).toMatchObject({ type: 'person', id: 'cicero' });
+  });
+  it('decides by dominance and reports the alternatives', () => {
+    expect(typeTerm('hesychia', index)).toMatchObject({ type: 'concept', weight: 7, alt: { concept: 7, person: 1 } });
+  });
+  it('ambiguous → unknown, never a coin flip', () => {
+    expect(typeTerm('mercury', index)).toMatchObject({ type: 'unknown', source: 'ambiguous', alt: { person: 849, concept: 630 } });
+  });
+  it('unjudgeable keys → unknown, not concept', () => {
+    expect(isUnjudgeable('!')).toBe(true);
+    expect(isUnjudgeable('ab')).toBe(true);
+    expect(isUnjudgeable('道')).toBe(false); // a single CJK character is a word; judge it
+    expect(typeTerm('#', index)).toEqual({ type: 'unknown', source: 'unjudgeable' });
+  });
+  it('ignores records with a type outside person/place/concept', () => {
+    expect(typeTerm('ignored', index)).toMatchObject({ type: 'concept', source: 'unmatched' });
+  });
+});
+
+describe('KEEP_RULES.bridge', () => {
+  const row = (o: Record<string, unknown>) => ({ term_key: 'x', kinds: {}, glosses: [], books: 1, original_verified: 0, non_latin: false, ...o });
+  it('keeps a script bridge in ≥2 books, not in 1', () => {
+    expect(KEEP_RULES.bridge(row({ term_key: '三昧', non_latin: true, books: 2, glosses: [{ gloss: 'Samadhi', n: 2 }] }))).toBe('bridge');
+    expect(KEEP_RULES.bridge(row({ term_key: '三昧', non_latin: true, books: 1, glosses: [{ gloss: 'Samadhi', n: 1 }] }))).toBeNull();
+    // a non-Latin gloss on a non-Latin term is not a bridge
+    expect(KEEP_RULES.bridge(row({ term_key: '三昧', non_latin: true, books: 2, glosses: [{ gloss: '定', n: 2 }] }))).toBeNull();
+  });
+  it('keeps a synonym ring in ≥3 books', () => {
+    expect(KEEP_RULES.bridge(row({ books: 3, glosses: [{ gloss: 'a' }, { gloss: 'b' }] }))).toBe('glosses2');
+    expect(KEEP_RULES.bridge(row({ books: 2, glosses: [{ gloss: 'a' }, { gloss: 'b' }] }))).toBeNull();
+  });
+  it('keeps <term>-tagged / verified original in ≥3 books, anything in ≥10', () => {
+    expect(KEEP_RULES.bridge(row({ books: 3, kinds: { term: 1 } }))).toBe('term3');
+    expect(KEEP_RULES.bridge(row({ books: 3, original_verified: 2 }))).toBe('orig3');
+    expect(KEEP_RULES.bridge(row({ books: 10 }))).toBe('books10');
+    expect(KEEP_RULES.bridge(row({ books: 9 }))).toBeNull();
+  });
+  it('drops a one-off glossed motto that the pilot rule kept', () => {
+    const motto = row({ books: 1, glosses: [{ gloss: 'It leaves, yet does not desert the city' }] });
+    expect(KEEP_RULES.pilot(motto)).toBe('gloss');
+    expect(KEEP_RULES.bridge(motto)).toBeNull();
+  });
+});

--- a/tests/unit/page-terms-type.test.ts
+++ b/tests/unit/page-terms-type.test.ts
@@ -5,7 +5,7 @@
  * bucket — an ambiguous or unjudgeable key is never folded into either verdict.
  */
 import { describe, it, expect } from 'vitest';
-import { buildNameIndex, typeTerm, nameKeys, isUnjudgeable } from '../../scripts/lib/page-terms-type.mjs';
+import { buildNameIndex, typeTerm, nameKeys, isUnjudgeable, typeConfidence } from '../../scripts/lib/page-terms-type.mjs';
 import { KEEP_RULES } from '../../scripts/lib/page-terms-keep.mjs';
 
 const index = buildNameIndex([
@@ -66,6 +66,17 @@ describe('typeTerm', () => {
   });
   it('ignores records with a type outside person/place/concept', () => {
     expect(typeTerm('ignored', index)).toMatchObject({ type: 'concept', source: 'unmatched' });
+  });
+});
+
+describe('typeConfidence', () => {
+  it('canonical entities are strong; extracted names need weight and share', () => {
+    expect(typeConfidence({ type: 'place', source: 'canonical_entities', weight: 1 }, 500)).toBe('strong');
+    expect(typeConfidence({ type: 'person', source: 'entities', weight: 92 }, 153)).toBe('strong'); // Cajetan
+    expect(typeConfidence({ type: 'person', source: 'entities', weight: 1 }, 85)).toBe('weak'); // "Certus → certain"
+    expect(typeConfidence({ type: 'person', source: 'entities', weight: 15 }, 428)).toBe('weak'); // "sortes → lots"
+    expect(typeConfidence({ type: 'person', source: 'authors', weight: 1 }, 8)).toBe('weak'); // "Weijing → reed rhizome"
+    expect(typeConfidence({ type: 'concept', source: 'unmatched' }, 10)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Steps 1–2 of the page_terms improvement plan (#4695; handoff `sourcelibrary-ops/handoffs/2026-09-11-page-terms-improvements.md`). No model call, no Mongo write in this PR — `--apply` is run by hand on Hetzner after merge.

## What's in scope

**1. Type the terms (no model)** — `scripts/lib/page-terms-type.mjs` + `scripts/maintenance/type-page-terms.mjs`. Every `term_key` in the global table is joined (folded: NFC everywhere, lowercase + diacritic strip for Latin script only, the harvest's own `termKey()`) against the three name tables we already hold: `canonical_entities` (20,862, Wikidata-backed), `entities` (1,033,194 per-book extractions), `authors` (8,051 people). Verdict by weight dominance (3:1 on summed book counts):

| verdict | meaning |
|---|---|
| `person` / `place` | the tables agree it is a name |
| `concept` | matched a concept-typed entity (`type_source` = the table) **or matched nothing** (`type_source: unmatched`) |
| `unknown` | **the join could not judge**: the tables disagree with no dominant type (`ambiguous` — Mercury, Sophia, desert), or the key has no letters / is a Latin key under 3 chars (`unjudgeable`). Its own bucket per `non-latin-text-operations.md`; never folded into either verdict |

Plus `type_confidence` on person/place verdicts: `strong` = canonical entity, or an extracted entity/author named in ≥3 books that are ≥5% of the books the term occurs in; else `weak`.

**2. Keep rule + typed rows** — `scripts/lib/page-terms-keep.mjs` holds both rules; `aggregate-page-terms.mjs --rule bridge` is the book-floored rule from the handoff (default stays `pilot`, so the flag change is reviewable). `--types <overlay>` stamps `type`, `type_source`, `type_confidence`, `type_id` on every row it writes. `--from-global <table>` re-filters an existing global table in minutes instead of re-grouping 78.6M SQLite rows for hours.

## Measurements (full corpus, Hetzner, 2026-09-11)

Typing the 5,183,506-row global table takes 101 s (name index: 1,015,079 folded keys).

| bridge-kept rows (1,204,987) | count | share |
|---|---|---|
| person | 73,805 | 6.1% |
| place | 32,799 | 2.7% |
| concept | 1,087,722 | 90.3% |
| unknown (ambiguous 6,905 · unjudgeable 3,756) | 10,661 | 0.9% |

Of the 106,604 person/place verdicts, **53,783 strong / 52,821 weak**. 36,144 rested on a single-book entity, and the samples of those are mostly concepts mis-extracted as names — `Certus → certain`, `Bibula → absorbent`, `Ostende → show`, `tela → weapons` — which is why `type_confidence` exists. Strong samples read cleanly (Jakob Böhme, Guangdong, Medium Coeli, Epictete, Vallis Tellina); one miss in ~20 (`Nasse → wicker fish trap`, w3).

**Positive controls** (`--check`): `aquilius → person` (entities, w46) PASS · `prima materia → concept` (canonical_entities) PASS · `三昧 → concept` PASS · `ذكر → concept` PASS · **`acraephia → FAIL`: it is in none of the three name tables**, so no join can type it. Reported, not fatal — it is a fact about the tables (a Greek city absent from Wikidata-linked entities and from every per-book extraction), not the join. A gloss-shape heuristic was measured as a possible second signal (10,859 place-like / 15,064 person-like unmatched rows) and is **not applied**: precision by eye is ~50% (`Pygmæi`, `sea spurge`, `Sophora root` match "sea"/"root"-class words).

**Equivalence**: over 60 pass-1 shards the restructured SQLite path reproduces the old aggregator exactly — 16,058 rows, same `kept_because`, same counts/glosses/evidence, 0 diffs.

**A caveat on the 1.2M figure.** The sweep that sized the bridge rule (and `--from-global` here) re-filters the *pilot-kept* table (5.18M of 11.6M groups). On the 60-shard sample the bridge rule over ALL groups keeps 4,619 rows; over the pilot-kept subset 3,615 — **22% fewer** (Latin-script, unglossed terms that pilot dropped but bridge keeps via `term3`/`books10`). So the after-merge `--apply` should be a fresh SQLite pass with `--rule bridge` (running now as a dry run on Hetzner to `page-terms-bridge-exact.jsonl`; that file carries `books_text`/`books_by_kind` and can then be re-applied exactly with `--from-global`), not a re-filter of the old table.

## Run plan after merge (Hetzner, `/root/sourcelibrary`)

```
node --env-file=.env.production.local scripts/maintenance/aggregate-page-terms.mjs \
  --from-global /mnt/HC_Volume_105839809/page-terms-bridge-exact.jsonl --rule bridge \
  --types /mnt/HC_Volume_105839809/page-terms-types.jsonl --out /mnt/HC_Volume_105839809/page-terms-applied.jsonl --apply
```
then verify by READ: count by `type`, spot 10 rows. Indexes created on apply: unique `term_key`, `books`, `glosses.gloss`, `{type, books}`.

## Out of scope (deliberately)

- `--keywords-weight 0` (#3825 4a, `<keywords>` are page summaries) — stacked PR on this branch.
- Growing the vocabulary from the corpus (step 3, model-judged) — separate PR once the bridge index is rebuilt from the full table.
- A Wikidata label lookup for unmatched capitalised terms (the Acraephia class) — external, rate-limited; filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QaqWGkFtVwbiroUmbifwY
