### PR TITLE
archiver: --newest-first + --hosts, and a laptop lane for MDZ (#4404)

### DIFF
--- a/.claude/handoffs/2026-09-11-laptop-archive-lane.md
+++ b/.claude/handoffs/2026-09-11-laptop-archive-lane.md
@@ -1,0 +1,54 @@
+# Laptop archive lane for MDZ, and the network guard that could not see the network — 2026-09-11
+
+PR: https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/pull/4739 (open, green, review-gated).
+Epic: #4404 (R2 growth). Side issue: #4737 (e-rara 403s the Mac; the Mac IIIF daemon archives nothing).
+
+## What was built
+- `scripts/catalog-coverage/archive-acquired.ts`: `--newest-first` (sort `_id:-1`, so a second lane meets
+  the Hetzner lane in the middle and fresh acquisitions stop waiting behind the June backlog) and
+  `--hosts a,b` (archive only books whose first un-archived page lives on those hosts; the queue's
+  `source` label is not the host — "iiif" rows point at MDZ, IA, Gallica and e-rara). Both off by default.
+- `scripts/catalog-coverage/archive-acquired-mac.sh` + `org.sourcelibrary.archive-acquired-mac.plist`:
+  launchd KeepAlive loop, MDZ only, bounded 50 min per cycle (perl `alarm` — macOS has no `timeout`),
+  falls back to the main checkout's `.env.production.local` from a worktree, re-checks the network guard
+  every minute and SIGTERMs the archiver on DENY (positive-controlled with `--park`), and sets
+  `BULK_NET_ALLOW_ONLY=1` so it runs only on an allow-listed network.
+
+## Why
+MDZ rate-limits per IP: a lone curl from Hetzner got 429 in 60 ms while the hourly archiver ran; that lane
+converges on ~0.2 pages/s (~21K MDZ pages/day) against a 3.85M-page MDZ backlog. Ten concurrent full-res
+fetches from the Mac at the same moment all returned 200 in 3–4 s. Measured lane rate from the Mac at the
+unchanged 2/s in-process cap: 1.8–1.9 pages/s (209 pages / 150 s smoke; 106 pages in the first launchd
+minute), 0 failures.
+
+## The incident inside the session
+The Mac's network guard (`~/bin/bulk-net-guard.sh`, per-machine, NOT in this repo) keys on the Wi-Fi name.
+macOS 26 redacts the SSID from `networksetup`, `ipconfig getsummary`, `system_profiler` and `ioreg` without
+Location permission, so the guard reported "ALLOW: not associated with a Wi-Fi network" on a live link.
+The lane ran ~15 min on LAX lounge wifi (top saved SSIDs "_LAX Free WiFi", "AF Lounge"; egress colo LAX;
+VMware-OUI gateway) under a deny-list that had just been widened with forty airline names and could never
+fire. Derek: "only do it on wifido."
+
+Guard now (all per-machine, backup `~/bin/bulk-net-guard.sh.bak-2026-09-11`):
+1. Allow-list `~/.config/bulk-net-allow` keyed on the network SIGNATURE (default gateway hardware address +
+   DHCP server), written by `--pin <name>` while on the network; shown by `--status`. Binds for every
+   caller once the file exists, and for `BULK_NET_ALLOW_ONLY=1` callers before it exists.
+2. Fails CLOSED on a Wi-Fi network whose name is redacted (negative control: DENY on the lounge).
+3. Tether check (default-route service name) unchanged; SSID deny-list kept for machines that can read it.
+
+## State at close
+- Lane PARKED (`DENY … no allow-list`, 0 archiver processes). Derek pins at home:
+  `~/bin/bulk-net-guard.sh --pin wifido`, then `--why` must print `allow-list: matched mac:…`; the lane
+  wakes within 10 min; log `/tmp/archive-acquired-mac.log`.
+- The agent runs from the worktree `.claude/worktrees/feat-archive-mac-lane` until #4739 merges; after
+  merge, re-point the plist's script path to `~/sourcelibrary/scripts/catalog-coverage/archive-acquired-mac.sh`,
+  `launchctl kickstart -k gui/$(id -u)/org.sourcelibrary.archive-acquired-mac`, then unlock/reap the worktree.
+- The older Mac launchd jobs (gallica/erara/harvard/iiif) call the same guard, so they inherit home-only once
+  wifido is pinned; they still check only once per cycle, not every minute.
+- Not done: raising MDZ's per-process rate above 2/s (needs evidence from a clean run — this lane produces it);
+  the BSB rate-allowance email (#4404 step 2); #4737.
+
+## Atlas (separate repo, deployed)
+`refresh-theme-data.mjs` (in-place map refresh, never `build-theme.mjs` on the built maps), re-parse of the
+197 no-author queue rows (168 back to pending), 2 more IA imports — all in
+`~/sourcelibrary-atlas/.claude/handoffs/2026-09-11-atlas-acquisition-wave.md` and on #4716.

--- a/scripts/catalog-coverage/archive-acquired-mac.sh
+++ b/scripts/catalog-coverage/archive-acquired-mac.sh
@@ -13,7 +13,14 @@
 # Logs to /tmp/archive-acquired-mac.log.
 set -u
 cd "$(dirname "$0")/../.." || exit 1
-set -a; source .env.production.local; set +a
+# A worktree checkout (.claude/worktrees/<name>) has no .env.production.local — the file is gitignored and
+# lives in the main checkout three levels up. Say which one was used: a silently wrong env is how a lane
+# reports an empty queue (credential-injection.md).
+ENV_FILE=".env.production.local"
+if [ ! -f "$ENV_FILE" ] && [ -f "../../../$ENV_FILE" ]; then ENV_FILE="../../../$ENV_FILE"; fi
+if [ ! -f "$ENV_FILE" ]; then echo "$(date -u +%FT%TZ) no .env.production.local here or in the main checkout — exiting"; exit 1; fi
+echo "$(date -u +%FT%TZ) env: $(cd "$(dirname "$ENV_FILE")" && pwd)/.env.production.local"
+set -a; source "$ENV_FILE"; set +a
 
 HOSTS="${ARCHIVE_HOSTS:-api.digitale-sammlungen.de}"
 BATCH="${ARCHIVE_BATCH:-120}"

--- a/scripts/catalog-coverage/archive-acquired-mac.sh
+++ b/scripts/catalog-coverage/archive-acquired-mac.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# PRIOR ART: scripts/catalog-coverage/archive-acquired-cron.sh (the Hetzner hourly runner — this is the same
+#   archiver on a second egress address, looping instead of cron'd, gated by the Mac's network guard);
+#   scripts/workers/archive-iiif-daemon.sh (the Mac's IIIF/e-codices loop — different worker, different backlog).
+#
+# Laptop archive lane (#4404 step 3, the throughput half): drain acquisition_queue rows whose page images live
+# on hosts that rate-limit the Hetzner address but serve a residential/WARP one, NEWEST FIRST so fresh
+# acquisitions never wait behind the backlog and the two lanes meet in the middle. Measured 2026-09-11: MDZ
+# answered 429 to Hetzner in 60 ms while ten concurrent full-res fetches from the Mac all returned 200 in 3–4 s.
+#
+# Runs as a launchd KeepAlive agent (scripts/catalog-coverage/org.sourcelibrary.archive-acquired-mac.plist).
+# Each cycle is bounded like the Hetzner runner, so a wedged run dies before it can hold the lane for hours.
+# Logs to /tmp/archive-acquired-mac.log.
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+set -a; source .env.production.local; set +a
+
+HOSTS="${ARCHIVE_HOSTS:-api.digitale-sammlungen.de}"
+BATCH="${ARCHIVE_BATCH:-120}"
+CONCURRENCY="${ARCHIVE_CONCURRENCY:-4}"
+PAGE_CONCURRENCY="${ARCHIVE_PAGE_CONCURRENCY:-4}"
+MAX_MINUTES="${ARCHIVE_MAX_MINUTES:-50}"
+# Per-machine metered-link guard (phone hotspot, in-flight wifi). Checked every cycle; FAILS OPEN when absent.
+GUARD="${BULK_NET_GUARD:-$HOME/bin/bulk-net-guard.sh}"
+# GNU timeout is `gtimeout` from coreutils on macOS. Without it, perl's alarm() survives exec, so the
+# archiver inherits a SIGALRM deadline it does not handle and is terminated at the ceiling.
+TIMEOUT=$(command -v gtimeout || command -v timeout || true)
+
+stamp() { date -u +%FT%TZ; }
+
+while true; do
+  if [ -x "$GUARD" ] && ! "$GUARD" --why; then
+    echo "$(stamp) PARKED — metered link, re-checking in 10m"; sleep 600; continue
+  fi
+  echo "$(stamp) archive-acquired-mac: hosts $HOSTS, batch $BATCH, concurrency $CONCURRENCY×$PAGE_CONCURRENCY, newest first, ceiling ${MAX_MINUTES}m"
+  if [ -n "$TIMEOUT" ]; then
+    "$TIMEOUT" --signal=TERM --kill-after=60s "${MAX_MINUTES}m" npx tsx scripts/catalog-coverage/archive-acquired.ts \
+      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS"
+  else
+    perl -e 'alarm shift; exec @ARGV' "$((MAX_MINUTES * 60))" npx tsx scripts/catalog-coverage/archive-acquired.ts \
+      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS"
+  fi
+  rc=$?
+  case "$rc" in
+    0)   echo "$(stamp) cycle finished; next in 5m"; sleep 300 ;;
+    3)   # HostBlocked (401/403): the source refused this address. Never auto-retry into a block.
+         echo "$(stamp) SOURCE BLOCKED (exit 3) — parking this lane for 6h; check the ABORTED line above and the institution before resuming"; sleep 21600 ;;
+    124|137|142) echo "$(stamp) cycle killed at the ${MAX_MINUTES}m ceiling; resuming"; sleep 30 ;;
+    *)   echo "$(stamp) cycle exited $rc; retry in 15m"; sleep 900 ;;
+  esac
+done

--- a/scripts/catalog-coverage/archive-acquired-mac.sh
+++ b/scripts/catalog-coverage/archive-acquired-mac.sh
@@ -40,14 +40,34 @@ while true; do
     echo "$(stamp) PARKED — metered link, re-checking in 10m"; sleep 600; continue
   fi
   echo "$(stamp) archive-acquired-mac: hosts $HOSTS, batch $BATCH, concurrency $CONCURRENCY×$PAGE_CONCURRENCY, newest first, ceiling ${MAX_MINUTES}m"
+  # Run the archiver in the background and re-check the guard every minute while it runs: the guard at
+  # cycle start is not enough when a cycle is 50 minutes long and a plane boards in the middle of it.
+  # On DENY the archiver gets SIGTERM, which it handles (in-flight pages are abandoned, the next cycle
+  # resumes from the pages still lacking archived_photo) — see its own shutdown note.
   if [ -n "$TIMEOUT" ]; then
     "$TIMEOUT" --signal=TERM --kill-after=60s "${MAX_MINUTES}m" npx tsx scripts/catalog-coverage/archive-acquired.ts \
-      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS"
+      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS" &
   else
     perl -e 'alarm shift; exec @ARGV' "$((MAX_MINUTES * 60))" npx tsx scripts/catalog-coverage/archive-acquired.ts \
-      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS"
+      --batch "$BATCH" --concurrency "$CONCURRENCY" --page-concurrency "$PAGE_CONCURRENCY" --newest-first --hosts "$HOSTS" &
   fi
+  child=$!
+  parked=0
+  while kill -0 "$child" 2>/dev/null; do
+    sleep 60
+    if [ -x "$GUARD" ] && ! "$GUARD" --why; then
+      echo "$(stamp) link became metered mid-cycle — stopping the archiver"
+      # $child is a wrapper (timeout/perl -> npx -> node); signal every process running the script
+      # so the node worker itself gets TERM, not just the wrapper. Only this lane runs it on the Mac.
+      pkill -TERM -f 'scripts/catalog-coverage/archive-acquired.ts' 2>/dev/null
+      kill -TERM "$child" 2>/dev/null
+      parked=1
+      break
+    fi
+  done
+  wait "$child"
   rc=$?
+  if [ "$parked" -eq 1 ]; then echo "$(stamp) PARKED mid-cycle — re-checking in 10m"; sleep 600; continue; fi
   case "$rc" in
     0)   echo "$(stamp) cycle finished; next in 5m"; sleep 300 ;;
     3)   # HostBlocked (401/403): the source refused this address. Never auto-retry into a block.

--- a/scripts/catalog-coverage/archive-acquired-mac.sh
+++ b/scripts/catalog-coverage/archive-acquired-mac.sh
@@ -27,8 +27,14 @@ BATCH="${ARCHIVE_BATCH:-120}"
 CONCURRENCY="${ARCHIVE_CONCURRENCY:-4}"
 PAGE_CONCURRENCY="${ARCHIVE_PAGE_CONCURRENCY:-4}"
 MAX_MINUTES="${ARCHIVE_MAX_MINUTES:-50}"
-# Per-machine metered-link guard (phone hotspot, in-flight wifi). Checked every cycle; FAILS OPEN when absent.
+# Per-machine network guard. Checked every cycle and every minute during one; FAILS OPEN when absent.
+# BULK_NET_ALLOW_ONLY=1 makes the guard deny everything except networks pinned in ~/.config/bulk-net-allow
+# (Derek 2026-09-11: "only do it on wifido"). Pinned by signature — gateway hardware address + DHCP
+# server — because macOS 15+ hides the SSID from tools without Location permission. Pin the home network
+# once with `~/bin/bulk-net-guard.sh --pin wifido` while on it; set ARCHIVE_ALLOW_ONLY=0 to go back to
+# the deny-list behaviour.
 GUARD="${BULK_NET_GUARD:-$HOME/bin/bulk-net-guard.sh}"
+export BULK_NET_ALLOW_ONLY="${ARCHIVE_ALLOW_ONLY:-1}"
 # GNU timeout is `gtimeout` from coreutils on macOS. Without it, perl's alarm() survives exec, so the
 # archiver inherits a SIGALRM deadline it does not handle and is terminated at the ceiling.
 TIMEOUT=$(command -v gtimeout || command -v timeout || true)

--- a/scripts/catalog-coverage/archive-acquired.ts
+++ b/scripts/catalog-coverage/archive-acquired.ts
@@ -58,6 +58,27 @@ const CONCURRENCY = intArg('concurrency', 6);
 // about buying throughput with memory, so the width stays where it was.
 const PAGE_CONCURRENCY = intArg('page-concurrency', 6);
 const BATCH = intArg('batch', 60);
+// A second archiver on a second egress address. The hourly Hetzner lane drains
+// the queue oldest-first and is rate-limited per IP by the source (MDZ answered
+// 429 to a lone curl from the box on 2026-09-11 while the archiver ran, and it
+// converged on ~0.2 pages/s, ~21K pages/day, against a 3.8M-page MDZ backlog).
+// A laptop on a different address is a separate budget — ten concurrent MDZ
+// fetches came back 200 in 3–4s from the Mac at the same moment. Two flags let
+// that lane share the queue without colliding with the first:
+//   --newest-first   take rows from the NEW end, so the two lanes meet in the
+//                    middle instead of fetching the same books; fresh
+//                    acquisitions no longer wait behind a three-month backlog.
+//   --hosts a,b      only archive books whose page images live on these hosts
+//                    (matched on the first un-archived page). The queue's
+//                    `source` label is not the host — "iiif" rows point at
+//                    MDZ, IA, Gallica and e-rara alike — and each host has its
+//                    own lane and its own blocks (e-rara 403s the Mac, IA times
+//                    out through its tunnel), so the filter is by host.
+// Both lanes are idempotent per page (archiveIiif fetches only pages lacking
+// archived_photo), so an overlap costs a duplicate fetch, never a bad write.
+const NEWEST_FIRST = process.argv.includes('--newest-first');
+const hostsIdx = process.argv.indexOf('--hosts');
+const HOSTS: Set<string> | null = hostsIdx > -1 && process.argv[hostsIdx + 1] ? new Set(process.argv[hostsIdx + 1].split(',').map(h => h.trim()).filter(Boolean)) : null;
 
 // A pool width is load-bearing: at 0 or NaN this script archives nothing and
 // says it succeeded. Fail at startup instead — a constructor that throws beats
@@ -310,10 +331,10 @@ async function main() {
     // existed sort first (missing < 0 in BSON), which is what we want — an
     // untried book outranks one we have already failed on.
     todo = await queue.find({ status: 'acquired', book_id: { $exists: true }, archived: { $ne: true } })
-      .sort({ archive_attempts: 1, _id: 1 })
+      .sort({ archive_attempts: 1, _id: NEWEST_FIRST ? -1 : 1 })
       .limit(BATCH).toArray();
   }
-  let ok = 0, partial = 0, stalled = 0;
+  let ok = 0, partial = 0, stalled = 0, hostSkipped = 0;
   // How many runs a book may make zero progress on before it is parked out of
   // the queue. Eight hours of hourly runs is long enough to ride out a source
   // outage and short enough that a permanently-dead book stops taking a slot.
@@ -327,6 +348,13 @@ async function main() {
   async function processBook(w: any) {
     const b = await books.findOne({ id: w.book_id }, { projection: { id: 1, pages_count: 1 } });
     if (!b) { await markQueue(w, { archived: true, archive_note: 'no-book' }); return; }
+    if (HOSTS) {
+      // Not this lane's host: leave the row untouched (no attempt counted, no
+      // note) so the other lane sees it exactly as before.
+      const p0 = await pages.findOne({ book_id: w.book_id, archived_photo: { $exists: false }, $or: [{ photo: /^https?:/ }, { photo_original: /^https?:/ }] }, { projection: { photo: 1, photo_original: 1 } });
+      const h = hostOf(p0?.photo_original || p0?.photo || '');
+      if (!HOSTS.has(h)) { hostSkipped++; return; }
+    }
     const have0 = await pages.countDocuments({ book_id: w.book_id, archived_photo: /^https?:/ });
     if (have0 < (b.pages_count || 0) * 0.99) {
       if (w.source === 'erara' || w.source === 'iiif' || w.source === 'mdz' || w.source === 'gallica') { await archiveIiif(w.book_id); }
@@ -366,7 +394,7 @@ async function main() {
   }
   let blocked: Error | null = null;
   workTotal = todo.length;
-  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} × ${PAGE_CONCURRENCY} pages — heartbeat every 60s`);
+  log(`starting: ${workTotal} book(s), concurrency ${CONCURRENCY} × ${PAGE_CONCURRENCY} pages${NEWEST_FIRST ? ', newest first' : ''}${HOSTS ? `, hosts ${[...HOSTS].join(',')}` : ''} — heartbeat every 60s`);
   // Books ran in fixed slices of CONCURRENCY behind `await Promise.all(slice)`.
   // A slice does not advance until its SLOWEST book finishes, and its finished
   // workers sit idle in the meantime — so a slice containing one book on a
@@ -410,7 +438,7 @@ async function main() {
     const throttled = [...hostThrottles.entries()].map(([h, n]) => `${h}:${n}`).join(' ');
     const runMins = (Date.now() - runStart) / 60000;
     const runRate = runMins > 0 ? pagesDone / (runMins * 60) : 0;
-    log(`archive-acquired (${reason}): complete ${ok}, partial ${partial}, stalled ${stalled} | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed, ${pagesSkipped} skipped${localFailures ? `, ${localFailures} local (store/encode)` : ''} in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s)${throttled ? ` | throttled ${throttled}` : ''}`);
+    log(`archive-acquired (${reason}): complete ${ok}, partial ${partial}, stalled ${stalled} | books ${booksDone}/${workTotal} | pages ${pagesDone} ok, ${pagesFailed} failed, ${pagesSkipped} skipped${hostSkipped ? `, ${hostSkipped} books on other hosts skipped` : ''}${localFailures ? `, ${localFailures} local (store/encode)` : ''} in ${runMins.toFixed(1)}m (${runRate.toFixed(2)} pages/s)${throttled ? ` | throttled ${throttled}` : ''}`);
     // Per-host triage. A failure count without the source's own answer beside
     // it is not a measurement — it is what made #4588 take three rounds of
     // diagnosis to reach a cause this table states outright.

--- a/scripts/catalog-coverage/org.sourcelibrary.archive-acquired-mac.plist
+++ b/scripts/catalog-coverage/org.sourcelibrary.archive-acquired-mac.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Laptop archive lane (see archive-acquired-mac.sh). Install:
+       cp scripts/catalog-coverage/org.sourcelibrary.archive-acquired-mac.plist ~/Library/LaunchAgents/
+       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/org.sourcelibrary.archive-acquired-mac.plist
+     Edit the script path below if the checkout lives elsewhere. -->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.sourcelibrary.archive-acquired-mac</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/dereklomas/sourcelibrary/scripts/catalog-coverage/archive-acquired-mac.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict><key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string></dict>
+  <key>KeepAlive</key><true/>
+  <key>RunAtLoad</key><true/>
+  <key>ThrottleInterval</key><integer>60</integer>
+  <key>StandardOutPath</key><string>/tmp/archive-acquired-mac.log</string>
+  <key>StandardErrorPath</key><string>/tmp/archive-acquired-mac.log</string>
+  <key>ProcessType</key><string>Background</string>
+  <key>LowPriorityIO</key><true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Why
MDZ (`api.digitale-sammlungen.de`) rate-limits Hetzner per IP: a lone curl from the box got a 429 in 60 ms while the hourly archiver ran, and that lane has converged on ~0.2 pages/s (~21K pages/day) against a 3.8M-page MDZ backlog (10,715 `mdz` + 4,809 `bsb` books un-archived). Derek's Mac is a different egress address: ten concurrent full-res MDZ fetches from it returned 200 in 3–4 s at the same moment. Step 3 of epic #4404 ("calibrate the MDZ rate") has a cheaper cousin: a second address.

## What
Two flags on `archive-acquired.ts`, both off by default, so the Hetzner cron is unchanged:
- `--newest-first` — sort `{archive_attempts: 1, _id: -1}`; the two lanes meet in the middle instead of fetching the same books, and fresh acquisitions (e.g. the atlas wave, #4716) stop waiting behind the June backlog.
- `--hosts a,b` — archive only books whose first un-archived page lives on one of these hosts. The queue's `source` label is not the host (60 newest "iiif"/"mdz" rows: 25 MDZ, 17 IA, 13 Gallica, 4 e-rara, 1 SBB), and each host has its own lane and its own blocks (e-rara 403s the Mac, #4737; IA times out through its tunnel). Skipped rows are left untouched (no attempt, no note).

`archive-acquired-mac.sh` + `org.sourcelibrary.archive-acquired-mac.plist`: a launchd KeepAlive loop for the lane — checks `~/bin/bulk-net-guard.sh` every cycle (fails open), bounds each cycle at 50 min (gtimeout or perl `alarm`, macOS has no `timeout`), parks 6 h on exit 3 (HostBlocked), MDZ only by default. Rate stays at the in-process `DOMAIN_LIMITS` 2/s.

## Measured
Smoke test from the Mac (`--batch 40 --concurrency 2 --page-concurrency 4 --newest-first --hosts api.digitale-sammlungen.de`, 150 s): **209 pages ok, 0 failed, 1.9 pages/s**, all MDZ. Hetzner's lane the same hour: 667 pages in 50 min (0.22 pages/s).

Both lanes are idempotent per page (`archiveIiif` only fetches pages lacking `archived_photo`), so an overlap costs a duplicate fetch, never a bad write. `npx tsc --noEmit` clean.

## Out of scope
- Raising MDZ's per-process rate above 2/s: the comment in `iiif-utils.mjs` says raise only with evidence from a clean run; this PR produces that evidence, it does not act on it.
- The e-rara 403 on the Mac (#4737) and the BSB rate-allowance email (#4404 step 2).
- The launchd agent is installed on Derek's Mac pointing at the worktree checkout until this merges; after merge, re-point the plist's script path to `~/sourcelibrary/scripts/catalog-coverage/archive-acquired-mac.sh` and `launchctl kickstart -k gui/$(id -u)/org.sourcelibrary.archive-acquired-mac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)