### PR TITLE
docs(build-order): paginate the kiosk leaf, and the empty second column

### DIFF
--- a/.claude/BUILD-ORDER.md
+++ b/.claude/BUILD-ORDER.md
@@ -39,6 +39,28 @@ English, see its plates in place, with no scan on disk and no network.
 wall app; the kiosk has its own column reader. Does the kiosk get the book, or does the
 wall become the reading surface? The audit assumed the kiosk, before this was found.
 
+**1a. Paginate the text into leaves.** The kiosk reader (sl-kiosk at `de8292d` on
+`spiral-timeline`) sets a cream leaf in Aldine with the apparatus correctly lifted out —
+but it is a PortalList, so the text scrolls off the foot and a scrollbar gives it away. A
+page whose text scrolls is a pane with a paper background. Cut each source page into as
+many leaves as it needs, both columns on the same span of source lines so they keep
+facing each other. Handoff, posture first, with six checks:
+`~/sourcelibrary-ops/handoffs/2026-09-12-kiosk-paginate-leaves.md`.
+
+Measured on the bundle, one page sampled per book over 502 books — **size the leaf from
+these, do not guess**: the median page is **10 lines** of original text, p75 **23**, p90
+**35**, p99 **92**, longest seen 221. So a leaf holding ~24 lines carries three quarters
+of all pages whole, and splitting is the exception — but a common one.
+
+**1b. The empty second column.** Measured on the same sample, positive-controlled:
+**55% of pages have no translation at all** (44% real, 1% tag-only blanks). The two-column
+reader shows an empty English column on the majority of pages in the corpus; it never
+showed in review because the demo book, PH150, is fully translated. Decide what one
+column looks like before this reaches a case. The `<summary>` the pipeline already
+writes — present on 31% of translated pages, e.g. *"the traditional opening of the Divine
+Office, based on Psalm 51 and Psalm 70"* — is written, paid for, and currently discarded;
+it is the one sentence a standing visitor most needs.
+
 ---
 
 ## Next, in this order

--- a/.claude/BUILD-ORDER.md
+++ b/.claude/BUILD-ORDER.md
@@ -35,9 +35,22 @@ page or a page we set ourselves.
 Definition of done: open any book from search, turn pages, read the original beside the
 English, see its plates in place, with no scan on disk and no network.
 
-**Open question for Derek, blocking the placement only:** the turning book lives in the
-wall app; the kiosk has its own column reader. Does the kiosk get the book, or does the
-wall become the reading surface? The audit assumed the kiosk, before this was found.
+**Settled 2026-09-12 by Derek: one experience, two surfaces — the wall searches
+visually, the kiosk (touchscreen) reads.** "I see them as the same... the wall for
+searching visually and the touch screen or kiosk for reading." So the turning book goes
+to the kiosk, and the wall keeps the picture plane. Do not build a second reader in the
+wall panels; do not build a second search on the kiosk.
+
+This is cheaper than it sounds, because they are **already one crate** —
+`~/makepad/apps/source-library-spiral`, four binaries over one `lib.rs`. `sl_kiosk.rs`
+already imports four shared modules (`backend`, `ask`, `kiosk`, `phone`); `wall` is
+public too. So "the kiosk gets the turning book" is not a port. It is lifting the leaf
+out of `wall.rs` into its own module both binaries use: the `DrawPage` leaf shader
+(`:301`, and it already takes a flat RGBA texture — no shader work), `Book`/`PageTurn`/
+`BookDrag`/`spread_view` (`:2245`–`:2420`), `open_book_of`/`close_book`/`turn_pages`
+(`:7310`–`:7420`) and `draw_book` (`:9053`). Roughly 600–800 lines, entangled with the
+wall's camera and tile state, so mechanical but not trivial — and it is wall-side work,
+so it belongs to whoever owns `wall.rs`.
 
 **1a. Paginate the text into leaves.** The kiosk reader (sl-kiosk at `de8292d` on
 `spiral-timeline`) sets a cream leaf in Aldine with the apparatus correctly lifted out —
@@ -100,7 +113,9 @@ Not "someday" — *not yet, on purpose*, because each is a second surface for a 
 page that does not exist:
 
 - **The local-mode web reader.** Branch `feat/local-web-reader` exists; leave it.
-- **A second reader in the wall panels.** The panel shows a passage and hands off.
+- **A second reader in the wall panels.** Now a permanent no, not a "not yet" — Derek
+  settled the split on 2026-09-12: the wall searches, the kiosk reads. The panel shows a
+  passage and hands off.
 - **Meaning search over pages, offline.** Needs the corpus re-embedded with an open
   model; a night of GPU time. Keyword and concept-alias search cover it for now.
 - **The experience-map rebuild.** Classification ran; the pages can wait.


### PR DESCRIPTION
The kiosk reading page has come a long way in a day — cream leaf, Aldine, the
image description lifted out as apparatus, folio number as furniture, the
language taken from the page rather than the (wrong) book record. Two things
it is not yet, both now on the build order under the reading page:

**1a — the leaf still scrolls.** It is a PortalList: one row per page, the row
as tall as its text. The edges dissolve so the cut is soft, but the text still
overflows and the scrollbar gives it away. A page whose text scrolls is a pane
with a paper background. The posture-first handoff (six checks, each with a
shot) is in the ops repo at `handoffs/2026-09-12-kiosk-paginate-leaves.md`.

**1b — the second column is empty on most pages.** This is the finding worth
your attention: **55% of pages in the bundle have no translation at all.** It
never showed in review because the demo book is fully translated.

### Measured, not guessed

One page sampled per book (my own rule — pages within a book are one
observation), 502 books, tags stripped before counting:

| | median | p75 | p90 | p99 | max |
|---|---|---|---|---|---|
| original, lines | 10 | 23 | 35 | 92 | 221 |
| original, chars | 838 | 1,852 | 2,548 | 5,385 | 24,468 |

So a leaf holding ~24 lines carries three quarters of all pages whole.
Splitting is the exception — but a common one, and the tail is long.

The translation figure was positive-controlled on a second independent
344-book sample, because a median of zero is exactly the shape a bad regex
produces: 55% null/blank, 44% real translation, 1% present-but-tag-only
(blank-page notes). The regex was not the cause.

### Not claimed

I also checked whether the 14 `Theatrum chemicum, praecipuos…` records are a
duplicate cluster. They are not — page counts run 376 to 2,281, consistent
with different volumes of a multi-volume set reissued across 1602/1613/1659.
Not filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)