### PR TITLE
docs: CLAUDE.md said everything non-BPH is on flash-lite; it has not been since May

### DIFF
--- a/.claude/docs/invariants/language-fields.md
+++ b/.claude/docs/invariants/language-fields.md
@@ -389,3 +389,43 @@ reappearance fails CI.
   real (`printed|handwritten|mixed`, declared in `src/lib/types/page.ts`, synced to Supabase by six
   scripts); the book one was a single stray document. Only the book-level field is retired. Check
   which COLLECTION a name lives on before treating two spellings as one family.
+
+## Model routing reads this field — and OCR and translation read it DIFFERENTLY (2026-09-12, #4762)
+
+`books.language` is not only a display and filter field. Two routers read it, and since #4762 they
+deliberately disagree:
+
+| | full flash (`gemini-3-flash-preview`) | flash-lite (`gemini-3.1-flash-lite`) |
+|---|---|---|
+| **OCR** — `getModelForBook`, `src/lib/types/ai-models.ts` | BPH provider, **any language outside the Latin-script allowlist**, unknown/null language | Latin-script allowlist only |
+| **Translation** — `getTranslateModelForBook`, `scripts/lib/translate-core.mjs` | BPH provider only | everything else |
+
+**Do not "restore the mirroring."** The two functions were identical until #4762 and the comments
+said so; they now differ on purpose, and the comments say that instead.
+
+**Why they differ.** #1726 carved non-Latin scripts out to full flash because flash-lite
+*hallucinates rather than fails* on low-resource scripts — it read a Bhutanese astrological text as a
+"ritual manual for weather control". The cited mechanism (Wu et al. 2025) is that vision models lean
+on linguistic priors **when visual decoding is hard**. That is a vision failure, and it is real: OCR
+keeps the carve-out. Translation never decodes an image; it reads `ocr.data` as text. The carve-out
+was applied to the translation worker in the same change with no translation evidence offered.
+The free observational read in #4759 (137 books, 303 within-book pairs matched on `ocr.model`, plus a
+blind judge over 30 pairs) found no fabrication and no comprehension failure on lite. Worth ~$12K over
+5.4M untranslated pages. Report: `scripts/eval/results/translation-model-obs-report.md`.
+
+**A policy's history is not the policy.** Three eras so far: everything non-BPH on lite
+(2026-03-27, #467) → non-Latin carved out for both lanes (2026-05-12, #1726) → translation carved
+back (2026-09-12, #4762). Rows written under an old era look exactly like a live violation of the
+current one. **Date the rows and `git log -S` the rule before calling anything drift** — a session
+reported the Mar–May lite translations of Tibetan books as a live bypass, and they were history.
+The retired `gemini-3.1-flash-lite-preview` id in a row is itself a date stamp.
+
+**A router only routes if the caller asks it.** #4762 also found four Lambda-lane producers
+(`bulk-translate-lambda`, `queue-translations`, `queue-translations-to-80pct`,
+`queue-efm-translations`) that hardcoded full flash and bypassed routing for every book, because
+`job.config.model` wins in the sink. When you change a routing policy, **find every producer**, not
+just the router. A split policy that half the writers honour is worse than either policy.
+
+**A mislabel now picks a model.** Judges in the #4759 read found Syriac and Avestan books carrying
+`language: hebrew` (#4766). Under the OCR table above, a non-Latin book mislabelled as a
+*Latin-script* language routes to flash-lite for OCR — precisely the case #1726 exists to prevent.

--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -539,3 +539,15 @@ The Derge-identity scorer (`kanjur_align.score_page` on clawdbot, `/root/tibetan
 - **Build positive controls from the INPUT distribution, not the reference's.** A two-page concatenation control scores 0.496 at the old window and 0.968 at the new one — that control now ships with the scorer (`control --span 2`).
 - **For any ratio with the read in the denominator, window the reference wider than the longest read.** Fix: `score_page(..., window=2)` (retrieved page ±2, now the default; `window=0` reproduces the old number and `identity1` carries it).
 - **Tell:** an external instrument predicts a magnitude you do not see (a 0.7%-CER model reading at 0.48 "identity"), and your gate still passes. That gap is the instrument until proven otherwise. Postmortem and numbers: #4722 comment 5640946736; lesson `lesson_alignment_identity_capped_by_window_span` in auto-memory.
+
+## flash-lite does not ground, and says it did (demoted from CLAUDE.md 2026-09-12)
+
+`gemini-3.1-flash-lite` returns empty `groundingMetadata` on every grounded-search call — 0 of 189
+measured 2026-08-10 — **while the response prose claims it made "extensive searches".** The prose is
+not evidence that a search happened; it is the failure mode.
+
+- Use `gemini-3-flash-preview` with an explicit **positive** `thinkingBudget` (512 → 6/6 grounded,
+  ~$0.003/book; unbounded ≈ $0.19/book). `thinkingBudget: -1` silently suppresses grounding.
+- **Verify groundedness from `queries[]` on the written rows, never from the response text.** Same
+  shape as every other entry in this file: read the artifact the mechanism produces, not the
+  narration of it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ public badges removed seven hours later, by a safety valve the evidence itself u
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
-- OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
+- **OCR and translation route DIFFERENTLY since #4762 — do not "fix" the divergence.** OCR: full flash for BPH, non-Latin scripts and unknown language; lite only for the Latin-script allowlist. Translation: lite for all but BPH. **Tell:** "everything non-BPH is on lite" is the Mar–May 2026 policy, three policies stale. Detail → `language-fields.md`.
 - **Gemini 3.x thinks by default and bills it at the output rate, invisibly** — every `generateContent` call site MUST set an explicit `thinkingConfig` (`thinkingBudget: 0` for OCR/translation/extraction — measured no quality loss) and count `thoughtsTokenCount` when metering. Six unconfigured call sites cost ~$2K/mo for months (#4581, 17× meter gap); sweep of remaining sites: #4599.
-- **Grounded search: flash-lite does NOT ground** (0/189 measured 2026-08-10 — empty `groundingMetadata` while the prose claims "extensive searches"). Use `gemini-3-flash-preview` with an explicit positive `thinkingBudget` (512 → 6/6 grounded, ~$0.003/book; unbounded ≈ $0.19/book; `-1` silently suppresses grounding). Verify groundedness from `queries[]` on written rows, never from response prose.
+- **Grounded search: flash-lite does NOT ground, silently** — read `measurement-instruments.md` before using grounding.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
 ## Conditional invariants — read the one matching what you're touching


### PR DESCRIPTION
The `/gnite` downward pass, which found a line that was not merely stale but actively misleading.

## What was wrong

> - OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper).

Two errors. It omitted the non-Latin-script carve-out added on **2026-05-12** (#1726) — four months stale. And since #4762 today, OCR and translation route *differently*, so one line cannot describe both.

This is not hypothetical harm. Derek read that line today and reasonably concluded production was already all flash-lite. The correction cost a round trip and nearly sent a $12K decision down the wrong path.

## Up

The body keeps the rule, compressed, plus a **TELL** aimed at exactly the mistake this line caused: *"everything non-BPH is on lite" is the Mar–May 2026 policy, three policies stale.*

## Down (the pass that is not optional)

- The **grounded-search** paragraph moves to `measurement-instruments.md`. It fires only when you use grounding — textbook conditional — and it belongs with the other "read the artifact, not the narration" entries, which is exactly its shape.
- The **routing detail** moves to `language-fields.md`, which is where a reader already lands when touching a language field: the two router functions and their table, why they differ, the three policy eras, the four Lambda producers that bypassed the router entirely, and the consequence of a mislabel now that this field picks a model.

**Net CLAUDE.md change: +3 words** (5,562 → 5,565), and it is now true rather than false.

## Out of scope

The routing behaviour itself — that shipped in #4762. This is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)