### PR TITLE
concepts: SKOS + PROV-O export of the curated concept vocabulary

### DIFF
--- a/scripts/lib/concept-aliases-skos.mjs
+++ b/scripts/lib/concept-aliases-skos.mjs
@@ -1,0 +1,215 @@
+// PRIOR ART: src/lib/jsonld.ts (Schema.org JSON-LD for entities/books — different vocabulary,
+// no SKOS, no provenance); src/lib/concept-aliases.ts (reads the same data for SEARCH expansion,
+// emits nothing); scripts/lib/ has no RDF/Turtle writer of any kind (checked 2026-09-12).
+// None publishes the concept vocabulary as linked data, which is what a thesaurus is for.
+/**
+ * The curated concept vocabulary (#4725, `src/data/concept-aliases.json`) as SKOS + PROV-O.
+ *
+ * Why publish it at all: the vocabulary is the only machine-readable statement anyone outside this
+ * codebase can use of what "dhikr" and "remembrance of God" have to do with each other, and on what
+ * evidence. As JSON it is ours; as SKOS it joins the thesauri libraries already federate.
+ *
+ * The three tiers map onto SKOS honestly, and the mapping is the whole design:
+ *   variant    → skos:altLabel on the concept        (same word, other script/spelling/inflection)
+ *   equivalent → skos:closeMatch to a term resource  (a TRANSLATOR'S rendering — close, not same)
+ *   related    → skos:related to a term resource     (adjacent; never an expansion)
+ * Flattening equivalents into altLabel would assert that "remembrance of God" IS dhikr, which is
+ * exactly the claim the tiering exists to avoid.
+ *
+ * Language tags: a non-Latin term gets `und-<Script>` (BCP-47: undetermined language, known
+ * script) rather than a guessed language — ذكر in a Persian-tradition concept may be Arabic or
+ * Persian, and inventing `@fa` would be a fabrication in a file whose point is provenance. Latin
+ * script terms are romanisations of many languages, so they carry no tag.
+ *
+ * Every alias row is also emitted as a PROV-O entity carrying its confidence (prov:value), the
+ * judge run that produced it (prov:wasGeneratedBy) and its one-line reason; a row that carries an
+ * `evidence` URL (none do yet — the verdicts log keeps the quoted gloss, not the page) additionally
+ * gets prov:hadPrimarySource.
+ */
+
+export const NS = {
+  base: 'https://sourcelibrary.org/concept/',
+  scheme: 'https://sourcelibrary.org/concept/scheme/concept-aliases',
+  sl: 'https://sourcelibrary.org/ns/concept#',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+  prov: 'http://www.w3.org/ns/prov#',
+  dct: 'http://purl.org/dc/terms/',
+  rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+};
+
+/** Stable, readable slug for a term or concept; non-Latin terms keep their characters percent-encoded. */
+export function slug(term) {
+  const s = String(term).normalize('NFC').trim().toLowerCase().replace(/\s+/g, '-');
+  return encodeURIComponent(s).replace(/%2F/gi, '-');
+}
+
+const SCRIPTS = [
+  ['Arab', /\p{Script=Arabic}/u], ['Hebr', /\p{Script=Hebrew}/u], ['Grek', /\p{Script=Greek}/u],
+  ['Cyrl', /\p{Script=Cyrillic}/u], ['Deva', /\p{Script=Devanagari}/u], ['Tibt', /\p{Script=Tibetan}/u],
+  ['Hani', /\p{Script=Han}/u], ['Jpan', /[\p{Script=Hiragana}\p{Script=Katakana}]/u], ['Hang', /\p{Script=Hangul}/u],
+  ['Sinh', /\p{Script=Sinhala}/u], ['Thai', /\p{Script=Thai}/u], ['Copt', /\p{Script=Coptic}/u],
+  ['Syrc', /\p{Script=Syriac}/u], ['Armn', /\p{Script=Armenian}/u], ['Geor', /\p{Script=Georgian}/u],
+  ['Ethi', /\p{Script=Ethiopic}/u], ['Egyp', /\p{Script=Egyptian_Hieroglyphs}/u], ['Xsux', /\p{Script=Cuneiform}/u],
+];
+/** BCP-47 tag for a term, or null when it is Latin script (a romanisation of who knows what). */
+export function langTag(term) {
+  for (const [code, re] of SCRIPTS) if (re.test(term)) return `und-${code}`;
+  return null;
+}
+
+const TIER_PREDICATE = { variant: 'skos:altLabel', equivalent: 'skos:closeMatch', related: 'skos:related' };
+
+/**
+ * Build the graph as plain objects: { concepts, terms, assertions, activity } — the shape both
+ * serialisers walk, and the shape `fromJsonLd` reconstructs, so the round trip is testable.
+ */
+export function buildGraph(vocab, { minConfidence = 0 } = {}) {
+  const meta = vocab._meta || {};
+  const activity = {
+    id: `${NS.base}prov/judge-run-${(meta.built || 'undated').replace(/[^0-9a-z-]/gi, '')}`,
+    label: meta.source || 'concept-alias judge run',
+    endedAtTime: meta.built || null,
+  };
+  const headForms = new Map(); // folded head form / variant → concept URI, so a related term that IS a concept links to it
+  for (const c of vocab.concepts) {
+    headForms.set(c.concept.toLowerCase(), NS.base + slug(c.concept));
+    for (const v of c.variants || []) headForms.set(String(v.term).toLowerCase(), NS.base + slug(c.concept));
+  }
+  const terms = new Map(); const concepts = []; const assertions = [];
+  const termUri = (t) => headForms.get(String(t).toLowerCase()) || `${NS.base}term/${slug(t)}`;
+
+  for (const c of vocab.concepts) {
+    const uri = NS.base + slug(c.concept);
+    const entry = { id: uri, prefLabel: c.concept, lang: langTag(c.concept), theme: c.theme || null, tradition: c.tradition || null, altLabels: [], closeMatch: [], related: [] };
+    for (const tier of ['variants', 'equivalents', 'related']) {
+      for (const row of c[tier] || []) {
+        if ((row.confidence ?? 0) < minConfidence) continue;
+        const t = String(row.term);
+        const kind = tier === 'variants' ? 'variant' : tier === 'equivalents' ? 'equivalent' : 'related';
+        if (kind === 'variant') { if (t.toLowerCase() !== c.concept.toLowerCase()) entry.altLabels.push({ term: t, lang: langTag(t) }); }
+        else {
+          const tu = termUri(t);
+          if (tu !== uri) {
+            (kind === 'equivalent' ? entry.closeMatch : entry.related).push(tu);
+            if (!tu.startsWith(NS.base + 'term/')) { /* an existing concept: nothing to mint */ }
+            else if (!terms.has(tu)) terms.set(tu, { id: tu, prefLabel: t, lang: langTag(t) });
+          }
+        }
+        assertions.push({ id: `${uri}/alias/${slug(t)}`, concept: uri, term: t, tier: kind, confidence: row.confidence ?? null, reason: row.reason || null, note: row.note || null, evidence: row.evidence || null, predicate: TIER_PREDICATE[kind] });
+      }
+    }
+    concepts.push(entry);
+  }
+  return { activity, concepts, terms: [...terms.values()], assertions, meta };
+}
+
+// ---------------------------------------------------------------- JSON-LD
+export function toJsonLd(vocab, opts = {}) {
+  const g = buildGraph(vocab, opts);
+  const lit = (term, lang) => (lang ? { '@value': term, '@language': lang } : term);
+  const graph = [
+    { '@id': NS.scheme, '@type': 'skos:ConceptScheme', 'dct:title': 'Source Library concept aliases',
+      'dct:description': g.meta.source || undefined, ...(g.meta.built ? { 'dct:created': { '@value': g.meta.built, '@type': 'xsd:date' } } : {}), 'prov:wasGeneratedBy': { '@id': g.activity.id } },
+    { '@id': g.activity.id, '@type': 'prov:Activity', 'rdfs:label': g.activity.label, ...(g.activity.endedAtTime ? { 'prov:endedAtTime': { '@value': g.activity.endedAtTime, '@type': 'xsd:date' } } : {}) },
+  ];
+  for (const c of g.concepts) graph.push({
+    '@id': c.id, '@type': 'skos:Concept', 'skos:inScheme': { '@id': NS.scheme },
+    'skos:prefLabel': lit(c.prefLabel, c.lang),
+    ...(c.altLabels.length ? { 'skos:altLabel': c.altLabels.map((a) => lit(a.term, a.lang)) } : {}),
+    ...(c.closeMatch.length ? { 'skos:closeMatch': c.closeMatch.map((id) => ({ '@id': id })) } : {}),
+    ...(c.related.length ? { 'skos:related': c.related.map((id) => ({ '@id': id })) } : {}),
+    ...(c.theme ? { 'sl:theme': c.theme } : {}), ...(c.tradition ? { 'sl:tradition': c.tradition } : {}),
+  });
+  for (const t of g.terms) graph.push({ '@id': t.id, '@type': 'skos:Concept', 'skos:inScheme': { '@id': NS.scheme }, 'skos:prefLabel': lit(t.prefLabel, t.lang) });
+  for (const a of g.assertions) graph.push({
+    '@id': a.id, '@type': ['prov:Entity', 'sl:AliasAssertion'], 'sl:aboutConcept': { '@id': a.concept }, 'sl:term': a.term, 'sl:tier': a.tier,
+    ...(a.confidence != null ? { 'prov:value': { '@value': String(a.confidence), '@type': 'xsd:decimal' } } : {}),
+    ...(a.reason ? { 'rdfs:comment': a.reason } : {}), ...(a.note ? { 'skos:editorialNote': a.note } : {}),
+    ...(a.evidence ? { 'prov:hadPrimarySource': { '@id': a.evidence } } : {}),
+    'prov:wasGeneratedBy': { '@id': g.activity.id },
+  });
+  return { '@context': { skos: NS.skos, prov: NS.prov, dct: NS.dct, rdfs: NS.rdfs, xsd: NS.xsd, sl: NS.sl }, '@graph': graph };
+}
+
+/** Inverse of toJsonLd, back to the alias-JSON shape — the round trip the unit test asserts. */
+export function fromJsonLd(doc) {
+  const byId = new Map();
+  for (const n of doc['@graph']) byId.set(n['@id'], n);
+  const val = (v) => (v && typeof v === 'object' && '@value' in v ? v['@value'] : v);
+  const concepts = new Map();
+  for (const n of doc['@graph']) {
+    if (n['@type'] !== 'skos:Concept' || !n['@id'].startsWith(NS.base) || n['@id'].startsWith(NS.base + 'term/')) continue;
+    concepts.set(n['@id'], { concept: val(n['skos:prefLabel']), theme: n['sl:theme'] ?? undefined, tradition: n['sl:tradition'] ?? undefined, variants: [], equivalents: [], related: [] });
+  }
+  const meta = byId.get(NS.scheme) || {};
+  for (const n of doc['@graph']) {
+    const types = [].concat(n['@type'] || []);
+    if (!types.includes('sl:AliasAssertion')) continue;
+    const c = concepts.get(n['sl:aboutConcept']['@id']); if (!c) continue;
+    const row = { term: n['sl:term'], confidence: n['prov:value'] ? Number(val(n['prov:value'])) : null, reason: n['rdfs:comment'] || '' };
+    if (n['skos:editorialNote']) row.note = n['skos:editorialNote'];
+    (n['sl:tier'] === 'variant' ? c.variants : n['sl:tier'] === 'equivalent' ? c.equivalents : c.related).push(row);
+  }
+  return { _meta: { built: val(meta['dct:created']) || undefined, source: meta['dct:description'] || undefined }, concepts: [...concepts.values()] };
+}
+
+// ---------------------------------------------------------------- Turtle
+const ttlString = (s) => '"' + String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '') + '"';
+const ttlLit = (s, lang) => ttlString(s) + (lang ? `@${lang}` : '');
+export function toTurtle(vocab, opts = {}) {
+  const g = buildGraph(vocab, opts);
+  const L = [];
+  for (const [pfx, iri] of Object.entries({ skos: NS.skos, prov: NS.prov, dct: NS.dct, rdfs: NS.rdfs, xsd: NS.xsd, sl: NS.sl })) L.push(`@prefix ${pfx}: <${iri}> .`);
+  L.push('');
+  L.push(`<${NS.scheme}> a skos:ConceptScheme ;`);
+  L.push(`  dct:title ${ttlString('Source Library concept aliases')} ;`);
+  if (g.meta.source) L.push(`  dct:description ${ttlString(g.meta.source)} ;`);
+  if (g.meta.built) L.push(`  dct:created "${g.meta.built}"^^xsd:date ;`);
+  L.push(`  prov:wasGeneratedBy <${g.activity.id}> .`);
+  L.push('');
+  L.push(`<${g.activity.id}> a prov:Activity ;`);
+  L.push(`  rdfs:label ${ttlString(g.activity.label)}${g.activity.endedAtTime ? ' ;' : ' .'}`);
+  if (g.activity.endedAtTime) L.push(`  prov:endedAtTime "${g.activity.endedAtTime}"^^xsd:date .`);
+  L.push('');
+  for (const c of g.concepts) {
+    const parts = [`a skos:Concept`, `skos:inScheme <${NS.scheme}>`, `skos:prefLabel ${ttlLit(c.prefLabel, c.lang)}`];
+    if (c.altLabels.length) parts.push(`skos:altLabel ${c.altLabels.map((a) => ttlLit(a.term, a.lang)).join(', ')}`);
+    if (c.closeMatch.length) parts.push(`skos:closeMatch ${c.closeMatch.map((u) => `<${u}>`).join(', ')}`);
+    if (c.related.length) parts.push(`skos:related ${c.related.map((u) => `<${u}>`).join(', ')}`);
+    if (c.theme) parts.push(`sl:theme ${ttlString(c.theme)}`);
+    if (c.tradition) parts.push(`sl:tradition ${ttlString(c.tradition)}`);
+    L.push(`<${c.id}>\n  ` + parts.join(' ;\n  ') + ' .', '');
+  }
+  for (const t of g.terms) L.push(`<${t.id}>\n  a skos:Concept ;\n  skos:inScheme <${NS.scheme}> ;\n  skos:prefLabel ${ttlLit(t.prefLabel, t.lang)} .`, '');
+  for (const a of g.assertions) {
+    const parts = [`a prov:Entity, sl:AliasAssertion`, `sl:aboutConcept <${a.concept}>`, `sl:term ${ttlString(a.term)}`, `sl:tier ${ttlString(a.tier)}`];
+    if (a.confidence != null) parts.push(`prov:value "${a.confidence}"^^xsd:decimal`);
+    if (a.reason) parts.push(`rdfs:comment ${ttlString(a.reason)}`);
+    if (a.note) parts.push(`skos:editorialNote ${ttlString(a.note)}`);
+    if (a.evidence) parts.push(`prov:hadPrimarySource <${a.evidence}>`);
+    parts.push(`prov:wasGeneratedBy <${g.activity.id}>`);
+    L.push(`<${a.id}>\n  ` + parts.join(' ;\n  ') + ' .', '');
+  }
+  return L.join('\n');
+}
+
+/** Counts a consumer (or a test) can assert without a full parser. */
+export function graphStats(vocab, opts = {}) {
+  const g = buildGraph(vocab, opts);
+  return { concepts: g.concepts.length, minted_terms: g.terms.length, assertions: g.assertions.length,
+    altLabels: g.concepts.reduce((s, c) => s + c.altLabels.length, 0),
+    closeMatch: g.concepts.reduce((s, c) => s + c.closeMatch.length, 0),
+    related: g.concepts.reduce((s, c) => s + c.related.length, 0),
+    with_evidence: g.assertions.filter((a) => a.evidence).length };
+}
+
+// CLI: node scripts/lib/concept-aliases-skos.mjs [--format ttl|jsonld] [--min-confidence 0.7] > out
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const fs = await import('node:fs');
+  const arg = (k, d) => { const i = process.argv.indexOf(k); return i > 0 ? process.argv[i + 1] : d; };
+  const vocab = JSON.parse(fs.readFileSync(new URL('../../src/data/concept-aliases.json', import.meta.url), 'utf8'));
+  const opts = { minConfidence: +arg('--min-confidence', 0) };
+  process.stdout.write(arg('--format', 'ttl') === 'jsonld' ? JSON.stringify(toJsonLd(vocab, opts), null, 1) : toTurtle(vocab, opts));
+  console.error(JSON.stringify(graphStats(vocab, opts)));
+}

--- a/tests/unit/concept-aliases-skos.test.ts
+++ b/tests/unit/concept-aliases-skos.test.ts
@@ -1,0 +1,84 @@
+// The SKOS/PROV-O exporter must round-trip the alias vocabulary and keep the tier semantics apart:
+// a variant is an altLabel, an equivalent is a closeMatch, a related term is skos:related — never
+// flattened into one synonym ring. Also pins the concept URI scheme, which a downstream graph
+// (knowledge-graph synthesis) consumes as-is.
+import { describe, it, expect } from 'vitest';
+import vocab from '../../src/data/concept-aliases.json';
+import { NS, slug, langTag, buildGraph, toJsonLd, fromJsonLd, toTurtle, graphStats } from '../../scripts/lib/concept-aliases-skos.mjs';
+
+type Row = { term: string; confidence: number; reason: string; note?: string };
+type Concept = { concept: string; theme?: string; tradition?: string; variants: Row[]; equivalents: Row[]; related: Row[] };
+const V = vocab as unknown as { _meta: { built: string; source: string }; concepts: Concept[] };
+
+const strip = (c: Concept) => ({
+  concept: c.concept, theme: c.theme, tradition: c.tradition,
+  variants: c.variants.map((r) => [r.term, r.confidence, r.reason, r.note ?? undefined]),
+  equivalents: c.equivalents.map((r) => [r.term, r.confidence, r.reason, r.note ?? undefined]),
+  related: c.related.map((r) => [r.term, r.confidence, r.reason, r.note ?? undefined]),
+});
+
+describe('concept-aliases SKOS export', () => {
+  it('round-trips every concept, tier and row through JSON-LD', () => {
+    const back = fromJsonLd(toJsonLd(V));
+    expect(back.concepts.length).toBe(V.concepts.length);
+    expect(back._meta.built).toBe(V._meta.built);
+    for (let i = 0; i < V.concepts.length; i++) expect(strip(back.concepts[i] as Concept)).toEqual(strip(V.concepts[i]));
+  });
+
+  it('keeps the three tiers on three different predicates', () => {
+    const g = buildGraph(V);
+    const byTier = { variant: new Set<string>(), equivalent: new Set<string>(), related: new Set<string>() };
+    for (const a of g.assertions) byTier[a.tier as keyof typeof byTier].add(a.predicate);
+    expect([...byTier.variant]).toEqual(['skos:altLabel']);
+    expect([...byTier.equivalent]).toEqual(['skos:closeMatch']);
+    expect([...byTier.related]).toEqual(['skos:related']);
+    // an equivalent is never asserted as a label of the concept
+    for (const c of g.concepts) for (const e of V.concepts.find((x) => x.concept === c.prefLabel)!.equivalents) {
+      expect(c.altLabels.map((a) => a.term)).not.toContain(e.term);
+    }
+  });
+
+  it('pins the concept URI scheme consumers depend on', () => {
+    expect(NS.base).toBe('https://sourcelibrary.org/concept/');
+    expect(slug('dhikr')).toBe('dhikr');
+    expect(slug('remembrance of God')).toBe('remembrance-of-god');
+    expect(slug('坐忘')).toBe(encodeURIComponent('坐忘'));
+    const g = buildGraph(V);
+    for (const c of g.concepts) expect(c.id).toBe(NS.base + slug(c.prefLabel));
+  });
+
+  it('tags non-Latin labels by script only, never by a guessed language', () => {
+    expect(langTag('ذكر')).toBe('und-Arab');
+    expect(langTag('ἡσυχία')).toBe('und-Grek');
+    expect(langTag('坐忘')).toBe('und-Hani');
+    expect(langTag('བསམ་གཏན་')).toBe('und-Tibt');
+    expect(langTag('samādhi')).toBeNull();
+    const ttl = toTurtle(V);
+    expect(ttl).not.toMatch(/"@(ar|fa|el|zh|bo|he)\b/);
+  });
+
+  it('carries provenance on every assertion and evidence only when a row has it', () => {
+    const first = V.concepts[0];
+    const patched = { ...V, concepts: [{ ...first, variants: [{ ...first.variants[0], evidence: 'https://sourcelibrary.org/book/000000000000000000000000?page=1' }] }] };
+    const doc = toJsonLd(patched as never) as { '@graph': Array<Record<string, unknown>> };
+    const asserts = doc['@graph'].filter((n) => ([] as string[]).concat(n['@type'] as string | string[]).includes('sl:AliasAssertion'));
+    expect(asserts.length).toBeGreaterThan(0);
+    for (const a of asserts) expect((a['prov:wasGeneratedBy'] as { '@id': string })['@id']).toMatch(/judge-run-/);
+    expect(asserts.filter((a) => a['prov:hadPrimarySource']).length).toBe(1);
+    // the real vocabulary carries no evidence URLs yet — assert that honestly, so the day it does this is the line that changes
+    expect(graphStats(V).with_evidence).toBe(0);
+  });
+
+  it('emits Turtle whose subject count matches the graph, with prefixes declared', () => {
+    const g = buildGraph(V);
+    const ttl = toTurtle(V);
+    const subjects = ttl.split('\n').filter((l) => /^<https:\/\/sourcelibrary\.org\/concept\//.test(l)).length;
+    // scheme + activity + concepts + minted terms + assertions
+    expect(subjects).toBe(2 + g.concepts.length + g.terms.length + g.assertions.length);
+    expect(ttl).toMatch(/^@prefix skos: <http:\/\/www\.w3\.org\/2004\/02\/skos\/core#> \.$/m);
+    expect(ttl).toMatch(/^@prefix prov: <http:\/\/www\.w3\.org\/ns\/prov#> \.$/m);
+    // a reason containing a double quote must be escaped, not close the literal
+    const reasonWithQuote = g.assertions.find((a) => a.reason && a.reason.includes('"'));
+    if (reasonWithQuote) expect(ttl).toContain(reasonWithQuote.reason.replace(/\\/g, '\\\\').replace(/"/g, '\\"').slice(0, 40));
+  });
+});


### PR DESCRIPTION
## What

`scripts/lib/concept-aliases-skos.mjs`: the curated concept vocabulary (`src/data/concept-aliases.json`, #4725) as a SKOS thesaurus with PROV-O provenance — Turtle or JSON-LD (`node scripts/lib/concept-aliases-skos.mjs --format ttl|jsonld`).

- **Tiers stay apart.** variant → `skos:altLabel`; equivalent → `skos:closeMatch` to a minted term resource; related → `skos:related`. Flattening equivalents into altLabel would assert that "remembrance of God" *is* dhikr — the exact claim the tiering exists to avoid.
- **Provenance per row.** Every alias row is a `prov:Entity` with `prov:value` (confidence), `prov:wasGeneratedBy` (the 2026-09-11 judge run), its one-line reason, and `prov:hadPrimarySource` when a row carries an `evidence` URL. None do yet — the verdicts log kept the quoted gloss, not the page — and the test asserts that count is 0 so the day it changes, that line is what changes.
- **Language tags by script only** (`und-Arab`, `und-Grek`, `und-Hani`, `und-Tibt`…), never a guessed language; Latin-script romanisations carry none.
- **URI scheme pinned**: `https://sourcelibrary.org/concept/<slug>`. Another session (knowledge-graph synthesis handoff) consumes these URIs as-is.

## Verification

- `tests/unit/concept-aliases-skos.test.ts` (6 tests): full JSON → JSON-LD → JSON round trip over all 62 concepts / 1,504 rows; tier↔predicate separation; URI scheme; script tags; provenance; Turtle subject count.
- External instrument: rdflib parses both serialisations to **17,037 triples (1,197 `skos:Concept`) and finds them isomorphic** (one `xsd:date` datatype mismatch found and fixed by that check, not by the unit test).

## Out of scope

- Publishing the export at a URL (`/concept/<slug>` resolves nothing yet) — the exporter is the prerequisite, the route is a separate PR.
- The vocabulary JSON schema is untouched; the atlas copy of this exporter (`~/sourcelibrary-atlas/scripts/local-corpus/export-skos.mjs`) is committed there.

Part of the concept-search roadmap (memo step 2). PRIOR ART line in the file header: `src/lib/jsonld.ts` is Schema.org for entities, no SKOS/PROV anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)