### PR TITLE
realtime-ocr: --model (lite|flash) and --max-consecutive-errors flags

### DIFF
--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -28,6 +28,11 @@
  *   --concurrency=N    Parallel API calls (default: 30)
  *   --dry-run          Show what would be processed, don't call Gemini
  *   --reason="..."     Why this run is being done by hand (recorded on the run, #4336)
+ *   --model=M          lite | flash | a full Gemini model id. Default: flash (the historical
+ *                      target). Pass lite for Latin-script books — the batch lane already
+ *                      routes there (scripts/lib/ocr-routing.mjs, OCR_LITE_ONLY).
+ *   --max-consecutive-errors=N  Stop after N consecutive failures (default 20). A small
+ *                      value (4) is the right guard for a one-off run outside the dial.
  */
 
 import fs from 'node:fs';
@@ -36,9 +41,11 @@ import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { extractPageType, extractColumns, parseDetectedImages } from '../lib/ocr-result-parse.mjs';
 import { parseInitiatedReason, initiatedReasonFields } from '../lib/initiated-reason.mjs';
+import { OCR_MODEL_LITE, OCR_MODEL_FLASH } from '../lib/ocr-routing.mjs';
 
 // --- Config ---
-const TARGET_MODEL = 'gemini-3-flash-preview';
+// TARGET_MODEL is resolved after arg parsing (--model); the constant name is kept
+// because the targeting queries and every write/meter row read it.
 const TARGET_PROMPT = 'v5.2026-02';
 const ACCEPTABLE_PROMPTS = ['v5.2026-02', 'v4.2026-02', 'v3.2026-02'];
 const SKIP_SOURCES = ['manual', 'manual-correction'];
@@ -62,6 +69,9 @@ const PIPELINE_STATUS = getArg('status');
 const PROVIDER = getArg('provider');
 const INITIATED_BY = 'script:realtime-ocr';
 const REASON = parseInitiatedReason(args, INITIATED_BY);
+const MODEL_ARG = getArg('model');
+const TARGET_MODEL = !MODEL_ARG || MODEL_ARG === 'flash' ? OCR_MODEL_FLASH : MODEL_ARG === 'lite' ? OCR_MODEL_LITE : MODEL_ARG;
+const MAX_CONSECUTIVE_ERRORS = parseInt(getArg('max-consecutive-errors') || '20', 10);
 
 // Targeting mode
 const MODE_NO_OCR = hasFlag('no-ocr');
@@ -414,8 +424,8 @@ async function processBatch(pages, promptText, db, runId) {
   for (const p of pages) pageBookMap[p.id] = p.book_id;
 
   for (let i = 0; i < pages.length; i += CONCURRENCY) {
-    if (consecutiveErrors >= 20) {
-      console.log(`\n  20 consecutive errors — stopping early`);
+    if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+      console.log(`\n  ${MAX_CONSECUTIVE_ERRORS} consecutive errors — stopping early`);
       break;
     }
 
@@ -526,7 +536,7 @@ async function main() {
   const db = client.db('bookstore');
 
   console.log(`=== Realtime OCR ===`);
-  console.log(`  mode=${targetMode} limit=${MAX_PAGES} concurrency=${CONCURRENCY} offset=${OFFSET}`);
+  console.log(`  mode=${targetMode} model=${TARGET_MODEL} limit=${MAX_PAGES} concurrency=${CONCURRENCY} offset=${OFFSET}`);
   if (SINGLE_BOOK) console.log(`  book=${SINGLE_BOOK}`);
   if (PIPELINE_STATUS) console.log(`  pipeline_status=${PIPELINE_STATUS}`);
   if (PROVIDER) console.log(`  provider=${PROVIDER}`);


### PR DESCRIPTION
## Why
The hand-run realtime OCR script (`scripts/batch/realtime-ocr.mjs`) hardcoded `gemini-3-flash-preview`, while the batch lane routes every Latin-script book to flash-lite (`scripts/lib/ocr-routing.mjs`, `OCR_LITE_ONLY`). Seeding Gemini reference pages for the 447 no-reference IA books (#4763, the gate in PR #4764 needs ≥5 model-OCR pages per book) needs the production write path at the production model. Rather than a bespoke caller with its own field shape, the model is now an argument resolved through ocr-routing's constants.

## What
- `--model=lite|flash|<id>` — default unchanged (`flash`), so existing invocations behave exactly as before.
- `--max-consecutive-errors=N` — default unchanged (20); a one-off run outside the processing dial passes 4.
- Startup banner prints the model.

## Used for
The 2026-09-12 seeding run on Hetzner: 3,576 pages (8 interior pages × 447 books), `--model=lite --concurrency=10 --max-consecutive-errors=4`, run id `vyuqySxyyAMcoM04o65uF` in `jobs`. Spend and gate result reported in the ops handoff `2026-09-12-ia-ocr-reference-seeding.md`.

## Out of scope
- Making the default route per book via `getOcrModelForBook` — that changes what a bare invocation does; left for a deliberate decision.
- The ingester itself (PR #4764).

🤖 Generated with [Claude Code](https://claude.com/claude-code)